### PR TITLE
Update src/org/thoughtcrime/securesms/service/SmsListener.java

### DIFF
--- a/src/org/thoughtcrime/securesms/service/SmsListener.java
+++ b/src/org/thoughtcrime/securesms/service/SmsListener.java
@@ -31,6 +31,10 @@ public class SmsListener extends BroadcastReceiver {
   private static final String SMS_RECEIVED_ACTION = "android.provider.Telephony.SMS_RECEIVED";
 
   private boolean isExemption(SmsMessage message, String messageBody) {
+    // Sparebank1 OTP SMS
+    if(messageBody.startsWith("Sparebank1://otp?")) {
+    	return(true);
+    }
     // Sprint Visual Voicemail
     return 
       message.getOriginatingAddress().length() < 7 && 


### PR DESCRIPTION
I am not sure if this is the correct place in the code, but I'm 
making a wild guess. In Norway, http://www.sparebank1.no provides a 
one-time password application that parses a URL received via SMS.

The SMS starts with "Sparebank1://otp?"; so without some sort of 
exemption in TextSecure, the OTP application will not work when 
TextSecure is configured for "all messages".

Hope you can incorporate a fix (even if my attempt is not to your
liking).

Tor
