### PR TITLE
Notifications don't get removed when a thread marked with unread messages is deleted and a notification is active

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -161,6 +161,7 @@ private void initializeSearch(android.widget.SearchView searchView) {
           DatabaseFactory.getThreadDatabase(getActivity())
             .deleteConversations(selectedConversations);
         }
+        MessageNotifier.updateNotification(getActivity(), false);
       }
     });
 


### PR DESCRIPTION
Reproduce by getting an SMS, then open TextSecure (rather than going via the notification). Delete the thread with the unread message. The notification doesn't go away.
