### PR TITLE
Fix reference to "forward" prefix

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -436,7 +436,7 @@ public class ConversationActivity extends SherlockFragmentActivity
     registerForContextMenu(sendButton);
 
     if (getIntent().getStringExtra("forwarded_message") != null)
-      composeText.setText(R.string.ConversationActivity_forward_message_prefix+": " + getIntent().getStringExtra("forwarded_message"));
+      composeText.setText(getString(R.string.ConversationActivity_forward_message_prefix)+": " + getIntent().getStringExtra("forwarded_message"));
   }
 
   private void initializeRecipientsInput() {


### PR DESCRIPTION
Code was erroneously referencing the string ID, rather than the contents of the string (sorry!); forwarded messages would have e.g. "15672355: blah" rather than "FWD: blah" in them.
