### PR TITLE
Option to intercept "flash" (Type 0) SMS messages

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -308,9 +308,11 @@
     
     <string name="preferences__use_settings">Use Settings</string>
     <string name="preferences__pref_all_sms_title">Use for all SMS</string>
-    <string name="preferences__pref_all_mms_title">Use for all MMS</string> 
+    <string name="preferences__pref_all_mms_title">Use for all MMS</string>
+    <string name="preferences__pref_intercept_flash_messages_title">Intercept \"flash\" SMS</string> 
     <string name="preferences__use_textsecure_for_viewing_and_storing_all_incoming_text_messages">Use TextSecure for viewing and storing all incoming text messages</string>
     <string name="preferences__use_textsecure_for_viewing_and_storing_all_incoming_multimedia_messages">Use TextSecure for viewing and storing all incoming multimedia messages</string>
+	<string name="preferences__let_textsecure_intercept_type_0_messages">Let TextSecure intercept Type 0 (\"flash\") messages</string>
     <string name="preferences__input_settings">Input Settings</string>
     <string name="preferences__pref_enter_sends_title">Enter sends</string>
     <string name="preferences__pressing_the_enter_key_will_send_text_messages">Pressing the enter key will send text messages</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -29,6 +29,11 @@
                       android:summary="@string/preferences__use_textsecure_for_viewing_and_storing_all_incoming_multimedia_messages"
                       android:title="@string/preferences__pref_all_mms_title" />
 
+    <CheckBoxPreference android:defaultValue="true"
+                      android:key="pref_intercept_flash_messages"
+                      android:summary="@string/preferences__let_textsecure_intercept_type_0_messages"
+                      android:title="@string/preferences__pref_intercept_flash_messages_title" />
+    
    </PreferenceCategory>
 
   <PreferenceCategory android:title="@string/preferences__input_settings">

--- a/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -65,6 +65,7 @@ public class ApplicationPreferencesActivity extends SherlockPreferenceActivity {
   public static final String PASSPHRASE_TIMEOUT_INTERVAL_PREF = "pref_timeout_interval";
   public static final String PASSPHRASE_TIMEOUT_PREF          = "pref_timeout_passphrase";
   public static final String AUTO_KEY_EXCHANGE_PREF           = "pref_auto_complete_key_exchange";
+  public static final String INTERCEPT_FLASH_MESSAGES_PREF    = "pref_intercept_flash_messages";
 
   private static final String DISPLAY_CATEGORY_PREF        = "pref_display_category";
 

--- a/src/org/thoughtcrime/securesms/service/SmsListener.java
+++ b/src/org/thoughtcrime/securesms/service/SmsListener.java
@@ -74,10 +74,15 @@ public class SmsListener extends BroadcastReceiver {
       return false;
 		
     if (isExemption(message, messageBody))
-      return false;
-			
+      return false;   
+     
+	if(message.getMessageClass() == SmsMessage.MessageClass.CLASS_0) {
+        if (!PreferenceManager.getDefaultSharedPreferences(context).getBoolean("pref_intercept_flash_messages", true))
+          return false;	 
+	}
+    
     if (PreferenceManager.getDefaultSharedPreferences(context).getBoolean("pref_all_sms", true))
-      return true;		
+      return true;	
 
     return WirePrefix.isEncryptedMessage(messageBody) || WirePrefix.isKeyExchange(messageBody);
   }


### PR DESCRIPTION
The remote access solution we use sends OTP via type 0 messages; having this option means that we can view these one time passwords without having to fiddle with TextSecure.
