### PR TITLE
Change default behaviour for "flash" messages

### DIFF
--- a/src/org/thoughtcrime/securesms/service/SmsListener.java
+++ b/src/org/thoughtcrime/securesms/service/SmsListener.java
@@ -31,6 +31,11 @@ public class SmsListener extends BroadcastReceiver {
   private static final String SMS_RECEIVED_ACTION = "android.provider.Telephony.SMS_RECEIVED";
 
   private boolean isExemption(SmsMessage message, String messageBody) {
+
+	// ignore CLASS0 ("flash") messages
+	if (message.getMessageClass() == SmsMessage.MessageClass.CLASS_0)
+	  return false;
+
 	// ignore OTP messages from Sparebank1 (Norwegian bank)
     if (messageBody.startsWith("Sparebank1://otp?")) {
       return (true);
@@ -74,9 +79,6 @@ public class SmsListener extends BroadcastReceiver {
       return false;
 		
     if (isExemption(message, messageBody))
-      return false;
-    
-    if(message.getMessageClass() == SmsMessage.MessageClass.CLASS_0)
       return false;
 			
     if (PreferenceManager.getDefaultSharedPreferences(context).getBoolean("pref_all_sms", true))


### PR DESCRIPTION
CLASS0 messages are now passed on to the default Android messaging
application (in line with standard behaviour for such messages).
