### PR TITLE
SMS broadcast receiver wasn't checking relevant permission.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -137,7 +137,8 @@
 
     <receiver android:name=".service.SmsListener"
               android:enabled="true"
-              android:exported="true">
+              android:exported="true"
+              android:permission="android.permission.BROADCAST_SMS">
              <intent-filter android:priority="1001">
                  <action android:name="android.provider.Telephony.SMS_RECEIVED"></action>
              </intent-filter>


### PR DESCRIPTION
This should prevent other applications from sending spoofed SMS messages
via a broadcast intent.
