### PR TITLE
Partial Fix For APN Issues

### DIFF
--- a/src/org/thoughtcrime/securesms/mms/ApnDefaults.java
+++ b/src/org/thoughtcrime/securesms/mms/ApnDefaults.java
@@ -13,7 +13,7 @@ import static org.thoughtcrime.securesms.mms.MmsCommunication.MmsConnectionParam
  * the event that the system APN DB is unavailable and the user has not provided
  * local MMSC configuration details of their own.
  */
-public class InAppApnDB {
+public class ApnDefaults {
 
   private static final Map<String, MmsConnectionParameters> paramMap =
           new HashMap<String, MmsConnectionParameters>(){{

--- a/src/org/thoughtcrime/securesms/mms/MmsCommunication.java
+++ b/src/org/thoughtcrime/securesms/mms/MmsCommunication.java
@@ -74,14 +74,19 @@ public class MmsCommunication {
   protected static MmsConnectionParameters getLocalMmsConnectionParameters(Context context)
           throws ApnUnavailableException {
 
-    try {
+    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+
+    //Need to check the preference here because the user's configuration should take precedence
+    //over the in-app source if they have enabled it.
+    if (preferences.getBoolean(ApplicationPreferencesActivity.USE_LOCAL_MMS_APNS_PREF, false)) {
       return getLocallyConfiguredMmsConnectionParameters(context);
-    } catch (ApnUnavailableException e) {
-      MmsConnectionParameters params = InAppApnDB.getMmsConnectionParameters(context);
+    } else {
+      MmsConnectionParameters params = ApnDefaults.getMmsConnectionParameters(context);
       if(params == null) {
-        throw new ApnUnavailableException("No parameters available from InAppApnDb.", e);
+        throw new ApnUnavailableException("No parameters available from InAppApnDb.");
+      } else {
+        return params;
       }
-      return params;
     }
   }
 


### PR DESCRIPTION
Provides an in-app source for APN info for use in the case that the device store is unavailable and the user hasn't provided local connection parameters.

Only covers T-Moble USA, AT&T, and Verizon right now. Only T-Mobile is tested. Other carriers can be added and tested on an ongoing basis.
