### PR TITLE
Updated path to ABS library and added clarification of directory location

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -5,15 +5,15 @@ All commands are executed from inside of the TextSecure directory
 
 Fetch ActionBarSherlock:
 
-    git clone --branch 4.2.0 git://github.com/JakeWharton/ActionBarSherlock.git ../ActionBarSherlock
+    git clone git://github.com/JakeWharton/ActionBarSherlock.git ../ActionBarSherlock
 
 Configure ActionBarSherlock for your android target:
 
-    android update project --path ../ActionBarSherlock/actionbarsherlock --target 1
+    android update project --path ../ActionBarSherlock/actionbarsherlock --target android-15
 
 Configure TextSecure for your android target, linking to ASB:
 
-    android update project --path . --target 1 --library ../ActionBarSherlock/actionbarsherlock
+    android update project --path . --target android-15 --library ../ActionBarSherlock/actionbarsherlock
 
 Finally, both codebases must share the android-support jar. As TextSecure's is newer, use it:
 


### PR DESCRIPTION
ABS library directory was moved from library to actionbarsherlock, per commit from @JakeWharton https://github.com/JakeWharton/ActionBarSherlock/commit/2c40e6fa1846c2af73d48ea1760387e0aea07e12

Added clarification of the directory location where the commands are executed from

Build-target has to be at least 13 or ABS dependencies will cause the build to fail

ABS branch 4.2.0 doesn't exist

Great document and was very helpful - minor corrections overall to https://github.com/WhisperSystems/TextSecure/pull/208
