### PR TITLE
Cancel batch mode when pressing the hardware/capacitive back arrow

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -270,10 +270,7 @@ public class ConversationListFragment extends SherlockListFragment
   @Override
   public void onDestroyActionMode(ActionMode mode) {
     ((ConversationListAdapter)getListAdapter()).initializeBatchMode(false);
-    if (actionMode != null) {
-      actionMode = null;
-      batchMode  = false;
-    }
+    batchMode  = false;
   }
 
 }


### PR DESCRIPTION
Bug fix: https://github.com/WhisperSystems/TextSecure/issues/257

Batch mode was only cancelled after deleting the selected message(s). Now batch mode is cancelled after deleting and after pressing the back arrow.
