### PR TITLE
Replaced Theme.Sherlock.Light.Dialog with Theme.Dialog

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -116,7 +116,7 @@
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
     <activity android:name=".AutoInitiateActivity"
-              android:theme="@style/Theme.Sherlock.Light.Dialog"
+              android:theme="@android:style/Theme.Dialog"
               android:label="@string/AndroidManifest__textsecure_detected"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
@@ -141,7 +141,7 @@
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
     <activity android:name=".ReceiveKeyActivity" 
-              android:theme="@style/Theme.Sherlock.Light.Dialog" 
+              android:theme="@android:style/Theme.Dialog" 
               android:label="@string/AndroidManifest__complete_key_exchange" 
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
     


### PR DESCRIPTION
Unable to build against the latest version of ABS 4.3.1 due to removal of Dialogs from ABS in version 4.3.0

ABS removed dialog themes 6 months ago in version 4.3.0: https://github.com/JakeWharton/ActionBarSherlock/commit/601bde214b56b8fad0b4fc5aaed5af0b531b6135

Also similar issue/solution for reference: http://stackoverflow.com/a/16586113
