### PR TITLE
Fix for timeout interval bug

### DIFF
--- a/src/org/thoughtcrime/securesms/preferences/PassphraseTimeoutPreference.java
+++ b/src/org/thoughtcrime/securesms/preferences/PassphraseTimeoutPreference.java
@@ -60,8 +60,6 @@ public class PassphraseTimeoutPreference extends DialogPreference {
     // Can't figure out how to style a DialogPreference.
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
       this.timeoutText.setTextColor(Color.parseColor("#cccccc"));
-    } else {
-      this.timeoutText.setTextColor(Color.parseColor("#000000"));
     }
 
     initializeDefaults();


### PR DESCRIPTION
Regardless of which theme is used, the text color for the timeout
  interval was being set to black. This made it difficult to
  read when using the Dark Theme.

Fixes Issue #279
