### PR TITLE
Fix for Abort Session notification

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -45,6 +45,7 @@
     <string name="ConversationItem_received_and_processed_key_exchange_message">Received and processed key exchange message.</string>
     <string name="ConversationItem_error_received_stale_key_exchange_message">Error, received stale key exchange message.</string>
     <string name="ConversationItem_received_key_exchange_message_click_to_process">Received key exchange message, click to process</string>
+    <string name="ConversationItem_aborting_session">Aborting secure session</string>
     
     <!-- ConversationActivity -->
     <string name="ConversationActivity_initiate_secure_session_question">Initiate Secure Session?</string>

--- a/src/org/bouncycastle/crypto/params/ECDomainParameters.java
+++ b/src/org/bouncycastle/crypto/params/ECDomainParameters.java
@@ -78,4 +78,26 @@ public class ECDomainParameters
     {
         return seed;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null)
+            return false;
+
+        if (!(o instanceof ECDomainParameters))
+            return false;
+
+        ECDomainParameters otherParams = (ECDomainParameters)o;
+
+        //In the case where either seed is null, default to true
+        boolean checkSeed = true;
+        if (this.getSeed() != null && otherParams.getSeed() != null)
+            checkSeed = this.getSeed().equals(otherParams.getSeed());
+
+        return this.getCurve().equals(otherParams.getCurve()) &&
+                this.getG().equals(otherParams.getG()) &&
+                this.getN().equals(otherParams.getN()) &&
+                this.getH().equals(otherParams.getH()) &&
+                checkSeed;
+    }
 }

--- a/src/org/bouncycastle/crypto/params/ECPublicKeyParameters.java
+++ b/src/org/bouncycastle/crypto/params/ECPublicKeyParameters.java
@@ -19,4 +19,16 @@ public class ECPublicKeyParameters
     {
         return Q;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null)
+            return false;
+
+        if (!(o instanceof ECPublicKeyParameters))
+            return false;
+
+        ECPublicKeyParameters otherParams = (ECPublicKeyParameters)o;
+        return this.getParameters().equals(otherParams.getParameters());
+    }
 }

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -56,6 +56,7 @@ import org.thoughtcrime.securesms.components.EmojiToggle;
 import org.thoughtcrime.securesms.components.RecipientsPanel;
 import org.thoughtcrime.securesms.crypto.KeyExchangeInitiator;
 import org.thoughtcrime.securesms.crypto.KeyExchangeProcessor;
+import org.thoughtcrime.securesms.crypto.AbortSessionProcessor;
 import org.thoughtcrime.securesms.crypto.KeyUtil;
 import org.thoughtcrime.securesms.crypto.MasterCipher;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
@@ -364,7 +365,7 @@ public class ConversationActivity extends PassphraseRequiredSherlockFragmentActi
       @Override
       public void onClick(DialogInterface dialog, int which) {
         if (isSingleConversation()) {
-          KeyUtil.abortSessionFor(ConversationActivity.this, getRecipients().getPrimaryRecipient());
+          KeyUtil.abortSessionFor(ConversationActivity.this, getRecipients().getPrimaryRecipient(), masterSecret);
           initializeSecurity();
           initializeTitleBar();
         }
@@ -655,6 +656,10 @@ public class ConversationActivity extends PassphraseRequiredSherlockFragmentActi
 
     registerReceiver(securityUpdateReceiver,
                      new IntentFilter(KeyExchangeProcessor.SECURITY_UPDATE_EVENT),
+                     KeyCachingService.KEY_PERMISSION, null);
+
+    registerReceiver(securityUpdateReceiver,
+                     new IntentFilter(AbortSessionProcessor.ABORT_SESSION_EVENT),
                      KeyCachingService.KEY_PERMISSION, null);
   }
 

--- a/src/org/thoughtcrime/securesms/crypto/AbortSessionMessage.java
+++ b/src/org/thoughtcrime/securesms/crypto/AbortSessionMessage.java
@@ -1,0 +1,108 @@
+/** 
+ * Copyright (C) 2011 Whisper Systems
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms.crypto;
+
+import android.content.Context;
+import android.util.Log;
+
+import org.thoughtcrime.securesms.database.keys.LocalKeyRecord;
+import org.thoughtcrime.securesms.protocol.Message;
+import org.thoughtcrime.securesms.util.Base64;
+import org.thoughtcrime.securesms.util.Conversions;
+
+import java.io.IOException;
+
+public class AbortSessionMessage {
+  private final int         messageVersion;
+  private final int         supportedVersion;
+  private final PublicKey   publicKey;
+  private final String      serialized;
+  private       IdentityKey identityKey;
+
+  public AbortSessionMessage(Context context, MasterSecret masterSecret, int messageVersion, LocalKeyRecord record, int highIdBits) {
+    this.publicKey        = record.getCurrentKeyPair().getPublicKey();
+    this.messageVersion   = messageVersion;
+    this.supportedVersion = Message.SUPPORTED_VERSION;
+
+    publicKey.setId(publicKey.getId() | (highIdBits << 12));
+
+    byte[] publicKeyBytes   = publicKey.serialize();
+    byte[] keyExchangeBytes = new byte[1 + publicKeyBytes.length];
+
+    keyExchangeBytes[0]     = Conversions.intsToByteHighAndLow(messageVersion, supportedVersion);
+    System.arraycopy(publicKeyBytes, 0, keyExchangeBytes, 1, publicKeyBytes.length);
+
+    if (includeIdentitySignature(messageVersion, context))
+      keyExchangeBytes = IdentityKeyUtil.getSignedKeyExchange(context, masterSecret, keyExchangeBytes);
+
+    if (messageVersion < 1)
+      this.serialized = Base64.encodeBytes(keyExchangeBytes);
+    else
+      this.serialized = Base64.encodeBytesWithoutPadding(keyExchangeBytes);
+  }
+
+  public AbortSessionMessage(String messageBody) throws InvalidVersionException, InvalidKeyException {
+    try {
+      byte[] keyBytes       = Base64.decode(messageBody);
+      this.messageVersion   = Conversions.highBitsToInt(keyBytes[0]);
+      this.supportedVersion = Conversions.lowBitsToInt(keyBytes[0]);
+      this.serialized       = messageBody;
+
+      if (messageVersion >= 1)
+        keyBytes = Base64.decodeWithoutPadding(messageBody);
+
+      this.publicKey  = new PublicKey(keyBytes, 1);
+
+      if (keyBytes.length <= PublicKey.KEY_SIZE + 1) {
+        this.identityKey = null;
+      } else {
+        try {
+          this.identityKey = IdentityKeyUtil.verifySignedKeyExchange(keyBytes);
+        } catch (InvalidKeyException ike) {
+          Log.w("AbortSessionMessage", ike);
+          this.identityKey = null;
+        }
+      }
+    } catch (IOException ioe) {
+      throw new InvalidKeyException(ioe);
+    }
+  }
+
+  private static boolean includeIdentitySignature(int messageVersion, Context context) {
+    return IdentityKeyUtil.hasIdentityKey(context) && (messageVersion >= 1);
+  }
+
+  public PublicKey getPublicKey() {
+    return publicKey;
+  }
+
+  public IdentityKey getIdentityKey() {
+    return identityKey;
+  }
+
+  public int getMaxVersion() {
+    return supportedVersion;
+  }
+
+  public boolean hasIdentityKey() {
+    return identityKey != null;
+  }
+
+  public String serialize() {
+    return serialized;
+  }
+}

--- a/src/org/thoughtcrime/securesms/crypto/AbortSessionProcessor.java
+++ b/src/org/thoughtcrime/securesms/crypto/AbortSessionProcessor.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2011 Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms.crypto;
+
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import org.thoughtcrime.securesms.database.keys.LocalKeyRecord;
+import org.thoughtcrime.securesms.database.keys.RemoteKeyRecord;
+import org.thoughtcrime.securesms.database.keys.SessionRecord;
+import org.thoughtcrime.securesms.recipients.Recipient;
+import org.thoughtcrime.securesms.service.KeyCachingService;
+
+/**
+ * This class processes abort session interactions.
+ *
+ * @author Moxie Marlinspike
+ */
+
+public class AbortSessionProcessor {
+  public static final String ABORT_SESSION_EVENT = "org.thoughtcrime.securesms.KEY_EXCHANGE_ABORT_SESSION";
+
+  private Context context;
+  private Recipient recipient;
+
+  public AbortSessionProcessor(Context context, Recipient recipient) {
+    this.context         = context;
+    this.recipient       = recipient;
+  }
+
+  public void processAbortSessionMessage(AbortSessionMessage abortSessionMessage, long threadId) {
+    RemoteKeyRecord remoteKeyRecord = new RemoteKeyRecord(context, recipient);
+
+    if (!RemoteKeyRecord.hasRecord(context, recipient)) {
+        Log.w("AbortSessionProcessor", "Unknown abort message. Dropping message...");
+        return;
+    }
+
+    PublicKey storedPublicKey = remoteKeyRecord.getCurrentRemoteKey();
+    if (storedPublicKey.equals(abortSessionMessage.getPublicKey())) {
+        Log.w("AbortSessionProcessor", "deleting local keys");
+        LocalKeyRecord.delete(context, recipient);
+        RemoteKeyRecord.delete(context, recipient);
+        SessionRecord.delete(context, recipient);
+
+        Intent intent = new Intent(ABORT_SESSION_EVENT);
+        intent.putExtra("thread_id", threadId);
+        intent.setPackage(context.getPackageName());
+        context.sendBroadcast(intent, KeyCachingService.KEY_PERMISSION);
+    } else {
+        Log.w("AbortSessionProcessor", "Failed to abort session due to invalid public key");
+    }
+  }
+}

--- a/src/org/thoughtcrime/securesms/crypto/KeyExchangeProcessor.java
+++ b/src/org/thoughtcrime/securesms/crypto/KeyExchangeProcessor.java
@@ -85,7 +85,7 @@ public class KeyExchangeProcessor {
       (localKeyRecord.getCurrentKeyPair() != null && localKeyRecord.getCurrentKeyPair().getId() != responseKeyId);
   }
 
-  public boolean processKeyExchangeMessage(KeyExchangeMessage message, long threadId) {
+  public void processKeyExchangeMessage(KeyExchangeMessage message, long threadId) {
     int initiateKeyId = Conversions.lowBitsToMedium(message.getPublicKey().getId());
     message.getPublicKey().setId(initiateKeyId);
 
@@ -121,9 +121,7 @@ public class KeyExchangeProcessor {
     Intent intent = new Intent(SECURITY_UPDATE_EVENT);
     intent.putExtra("thread_id", threadId);
     intent.setPackage(context.getPackageName());
+
     context.sendBroadcast(intent, KeyCachingService.KEY_PERMISSION);
-
-    return true;
   }
-
 }

--- a/src/org/thoughtcrime/securesms/crypto/PublicKey.java
+++ b/src/org/thoughtcrime/securesms/crypto/PublicKey.java
@@ -29,17 +29,17 @@ import android.util.Log;
 public class PublicKey {
   public  static final int POINT_SIZE = 33;
   public  static final int KEY_SIZE   = 3 + POINT_SIZE;
-	
+
   private ECPublicKeyParameters publicKey;
   private int id;
-	
+
   public PublicKey(PublicKey publicKey) {
     this.id        = publicKey.id;
-		
+
     // FIXME :: This not strictly an accurate copy constructor.
     this.publicKey = publicKey.publicKey;
   }
-	
+
   public PublicKey(int id, ECPublicKeyParameters publicKey) {
     this.publicKey = publicKey;
     this.id        = id;
@@ -49,27 +49,27 @@ public class PublicKey {
     Log.w("PublicKey", "PublicKey Length: " + (bytes.length - offset));
     if ((bytes.length - offset) < KEY_SIZE)
       throw new InvalidKeyException("Provided bytes are too short.");
-			
+
     this.id           = Conversions.byteArrayToMedium(bytes, offset);
     byte[] pointBytes = new byte[POINT_SIZE];
-		
+
     System.arraycopy(bytes, offset+3, pointBytes, 0, pointBytes.length);
-		
+
     ECPoint Q;
-		
+
     try {
       Q = KeyUtil.decodePoint(pointBytes);
     } catch (RuntimeException re) {
       throw new InvalidKeyException(re);
     }
-		
+
     this.publicKey = new ECPublicKeyParameters(Q, KeyUtil.domainParameters);
   }
-	
+
   public PublicKey(byte[] bytes) throws InvalidKeyException {
     this(bytes, 0);
   }
-	
+
   public void setId(int id) {
     this.id = id;
   }
@@ -77,15 +77,15 @@ public class PublicKey {
   public int getId() {
     return id;
   }
-	
+
   public ECPublicKeyParameters getKey() {
     return publicKey;
   }
-	
+
   public String getFingerprint() {
     return Hex.toString(getFingerprintBytes());
   }
-	
+
   public byte[] getFingerprintBytes() {
     try {
       MessageDigest md = MessageDigest.getInstance("SHA-1");
@@ -95,16 +95,28 @@ public class PublicKey {
       throw new IllegalArgumentException("SHA-1 isn't supported!");
     }
   }
-	
+
   public byte[] serialize() {
     byte[] complete        = new byte[KEY_SIZE];
     byte[] serializedPoint = KeyUtil.encodePoint(publicKey.getQ());
-				
+
     Log.w("PublicKey", "Serializing public key point: " + Hex.toString(serializedPoint));
-		
+
     Conversions.mediumToByteArray(complete, 0, id);
     System.arraycopy(serializedPoint, 0, complete, 3, serializedPoint.length);
-		
+
     return complete;
-  }	
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null)
+      return false;
+
+    if (!(o instanceof PublicKey))
+      return false;
+
+    PublicKey otherKey = (PublicKey)o;
+    return this.getKey().equals(otherKey.getKey());
+  }
 }

--- a/src/org/thoughtcrime/securesms/database/MmsSmsColumns.java
+++ b/src/org/thoughtcrime/securesms/database/MmsSmsColumns.java
@@ -31,6 +31,9 @@ public interface MmsSmsColumns {
     protected static final long KEY_EXCHANGE_STALE_BIT     = 0x4000;
     protected static final long KEY_EXCHANGE_PROCESSED_BIT = 0x2000;
 
+    // Abort Session Information
+    protected static final long ABORT_SESSION_BIT = 0x1000;
+
     // Secure Message Information
     protected static final long SECURE_MESSAGE_BIT = 0x800000;
 
@@ -41,6 +44,7 @@ public interface MmsSmsColumns {
     protected static final long ENCRYPTION_REMOTE_BIT            = 0x20000000;
     protected static final long ENCRYPTION_REMOTE_FAILED_BIT     = 0x10000000;
     protected static final long ENCRYPTION_REMOTE_NO_SESSION_BIT = 0x08000000;
+
 
     public static boolean isFailedMessageType(long type) {
       return (type & BASE_TYPE_MASK) == BASE_SENT_FAILED_TYPE;
@@ -79,6 +83,10 @@ public interface MmsSmsColumns {
 
     public static boolean isProcessedKeyExchange(long type) {
       return (type & KEY_EXCHANGE_PROCESSED_BIT) != 0;
+    }
+
+    public static boolean isAbortSessionType(long type) {
+      return (type & ABORT_SESSION_BIT) != 0;
     }
 
     public static boolean isSymmetricEncryption(long type) {

--- a/src/org/thoughtcrime/securesms/database/SmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/SmsDatabase.java
@@ -237,6 +237,8 @@ public class SmsDatabase extends Database implements MmsSmsColumns {
       type |= Types.KEY_EXCHANGE_BIT;
       if      (((IncomingKeyExchangeMessage)message).isStale())     type |= Types.KEY_EXCHANGE_STALE_BIT;
       else if (((IncomingKeyExchangeMessage)message).isProcessed()) type |= Types.KEY_EXCHANGE_PROCESSED_BIT;
+    } else if (message.isAbortSession()) {
+      type |= Types.ABORT_SESSION_BIT;
     } else if (message.isSecureMessage()) {
       type |= Types.SECURE_MESSAGE_BIT;
       type |= Types.ENCRYPTION_REMOTE_BIT;
@@ -278,7 +280,8 @@ public class SmsDatabase extends Database implements MmsSmsColumns {
   }
 
   protected List<Long> insertMessageOutbox(long threadId, OutgoingTextMessage message, long type) {
-    if      (message.isKeyExchange())   type |= Types.KEY_EXCHANGE_BIT;
+    if (message.isKeyExchange())type |= Types.KEY_EXCHANGE_BIT;
+    else if (message.isAbortMessage()) type |= Types.ABORT_SESSION_BIT;
     else if (message.isSecureMessage()) type |= Types.SECURE_MESSAGE_BIT;
 
     long date             = System.currentTimeMillis();

--- a/src/org/thoughtcrime/securesms/database/model/DisplayRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/DisplayRecord.java
@@ -80,6 +80,10 @@ public abstract class DisplayRecord {
     return SmsDatabase.Types.isKeyExchangeType(type);
   }
 
+  public boolean isAbortSession() {
+    return SmsDatabase.Types.isAbortSessionType(type);
+  }
+
   public static class Body {
     private final String body;
     private final boolean plaintext;

--- a/src/org/thoughtcrime/securesms/database/model/SmsMessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/SmsMessageRecord.java
@@ -60,6 +60,8 @@ public class SmsMessageRecord extends MessageRecord {
       return emphasisAdded(context.getString(R.string.ConversationListAdapter_key_exchange_message));
     } else if (isKeyExchange() && !isOutgoing()) {
       return emphasisAdded(context.getString(R.string.ConversationItem_received_key_exchange_message_click_to_process));
+    } else if (isAbortSession()) {
+      return emphasisAdded(context.getString(R.string.ConversationItem_aborting_session));
     } else if (SmsDatabase.Types.isFailedDecryptType(type)) {
       return emphasisAdded(context.getString(R.string.MessageDisplayHelper_bad_encrypted_message));
     } else if (SmsDatabase.Types.isDecryptInProgressType(type)) {

--- a/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
@@ -56,6 +56,8 @@ public class ThreadRecord extends DisplayRecord {
       return emphasisAdded(context.getString(R.string.MessageDisplayHelper_decrypting_please_wait));
     } else if (isKeyExchange()) {
       return emphasisAdded(context.getString(R.string.ConversationListItem_key_exchange_message));
+    } else if (isAbortSession()) {
+      return emphasisAdded(context.getString(R.string.ConversationItem_aborting_session));
     } else if (SmsDatabase.Types.isFailedDecryptType(type)) {
       return emphasisAdded(context.getString(R.string.MessageDisplayHelper_bad_encrypted_message));
     } else if (SmsDatabase.Types.isNoRemoteSessionType(type)) {

--- a/src/org/thoughtcrime/securesms/protocol/AbortSessionWirePrefix.java
+++ b/src/org/thoughtcrime/securesms/protocol/AbortSessionWirePrefix.java
@@ -1,0 +1,25 @@
+/** 
+ * Copyright (C) 2011 Whisper Systems
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms.protocol;
+
+public class AbortSessionWirePrefix extends WirePrefix {
+
+  @Override
+  public String calculatePrefix(String message) {
+    return super.calculateAbortSessionPrefix(message);
+  }
+}

--- a/src/org/thoughtcrime/securesms/protocol/WirePrefix.java
+++ b/src/org/thoughtcrime/securesms/protocol/WirePrefix.java
@@ -43,12 +43,20 @@ public abstract class WirePrefix {
     return verifyPrefix("?TSK", message);
   }
 
+  public static boolean isAbortSession(String message) {
+    return verifyPrefix("?TSA", message);
+  }
+
   public static boolean isEncryptedMessage(String message) {
     return verifyPrefix("?TSM", message);
   }
 
   public static String calculateKeyExchangePrefix(String message) {
     return calculatePrefix(("?TSK" + message).getBytes(), PREFIX_BYTES);
+  }
+
+  public static String calculateAbortSessionPrefix(String message) {
+    return calculatePrefix(("?TSA" + message).getBytes(), PREFIX_BYTES);
   }
 
   public static String calculateEncryptedMesagePrefix(String message) {

--- a/src/org/thoughtcrime/securesms/service/KeyCachingService.java
+++ b/src/org/thoughtcrime/securesms/service/KeyCachingService.java
@@ -54,6 +54,7 @@ public class KeyCachingService extends Service {
   public static final int SERVICE_RUNNING_ID = 4141;
 
   public  static final String KEY_PERMISSION           = "org.thoughtcrime.securesms.ACCESS_SECRETS";
+  public  static final String ABORT_SESSION            = "org.thoughtcrime.securesms.ABORT_SESSION";
   public  static final String NEW_KEY_EVENT            = "org.thoughtcrime.securesms.service.action.NEW_KEY_EVENT";
   public  static final String CLEAR_KEY_EVENT          = "org.thoughtcrime.securesms.service.action.CLEAR_KEY_EVENT";
   private static final String PASSPHRASE_EXPIRED_EVENT = "org.thoughtcrime.securesms.service.action.PASSPHRASE_EXPIRED_EVENT";

--- a/src/org/thoughtcrime/securesms/service/SmsListener.java
+++ b/src/org/thoughtcrime/securesms/service/SmsListener.java
@@ -102,7 +102,7 @@ public class SmsListener extends BroadcastReceiver {
     if (PreferenceManager.getDefaultSharedPreferences(context).getBoolean("pref_all_sms", true))
       return true;
 
-    return WirePrefix.isEncryptedMessage(messageBody) || WirePrefix.isKeyExchange(messageBody);
+    return WirePrefix.isEncryptedMessage(messageBody) || WirePrefix.isKeyExchange(messageBody) || WirePrefix.isAbortSession(messageBody);
   }
 
   private boolean isChallenge(Context context, Intent intent) {

--- a/src/org/thoughtcrime/securesms/sms/IncomingAbortSessionMessage.java
+++ b/src/org/thoughtcrime/securesms/sms/IncomingAbortSessionMessage.java
@@ -1,0 +1,18 @@
+package org.thoughtcrime.securesms.sms;
+
+public class IncomingAbortSessionMessage extends IncomingTextMessage {
+
+  IncomingAbortSessionMessage(IncomingTextMessage base, String newBody) {
+    super(base, newBody);
+  }
+
+  @Override
+  public IncomingTextMessage withMessageBody(String messageBody) {
+    return new IncomingAbortSessionMessage(this, messageBody);
+  }
+
+  @Override
+  public boolean isAbortSession() {
+    return true;
+  }
+}

--- a/src/org/thoughtcrime/securesms/sms/IncomingTextMessage.java
+++ b/src/org/thoughtcrime/securesms/sms/IncomingTextMessage.java
@@ -122,6 +122,10 @@ public class IncomingTextMessage implements Parcelable {
     return false;
   }
 
+  public boolean isAbortSession() {
+    return false;
+  }
+
   public boolean isSecureMessage() {
     return false;
   }

--- a/src/org/thoughtcrime/securesms/sms/MultipartSmsMessageHandler.java
+++ b/src/org/thoughtcrime/securesms/sms/MultipartSmsMessageHandler.java
@@ -56,6 +56,8 @@ public class MultipartSmsMessageHandler {
 
     if (message.getWireType() == MultipartSmsTransportMessage.WIRETYPE_KEY) {
       return new IncomingKeyExchangeMessage(message.getBaseMessage(), strippedMessage);
+    } else if (message.getWireType() == MultipartSmsTransportMessage.WIRETYPE_ABORT) {
+      return new IncomingAbortSessionMessage(message.getBaseMessage(), strippedMessage);
     } else {
       return new IncomingEncryptedMessage(message.getBaseMessage(), strippedMessage);
     }
@@ -67,6 +69,8 @@ public class MultipartSmsMessageHandler {
 
     if (message.getWireType() == MultipartSmsTransportMessage.WIRETYPE_KEY) {
       return new IncomingKeyExchangeMessage(message.getBaseMessage(), strippedMessage);
+    } else if (message.getWireType() == MultipartSmsTransportMessage.WIRETYPE_ABORT) {
+      return new IncomingAbortSessionMessage(message.getBaseMessage(), strippedMessage);
     } else {
       return new IncomingEncryptedMessage(message.getBaseMessage(), strippedMessage);
     }

--- a/src/org/thoughtcrime/securesms/sms/OutgoingAbortSessionMessage.java
+++ b/src/org/thoughtcrime/securesms/sms/OutgoingAbortSessionMessage.java
@@ -1,0 +1,24 @@
+package org.thoughtcrime.securesms.sms;
+
+import org.thoughtcrime.securesms.recipients.Recipient;
+
+public class OutgoingAbortSessionMessage extends OutgoingTextMessage {
+
+  public OutgoingAbortSessionMessage(Recipient recipient, String message) {
+    super(recipient, message);
+  }
+
+  private OutgoingAbortSessionMessage(OutgoingAbortSessionMessage base, String body) {
+    super(base, body);
+  }
+
+  @Override
+  public boolean isAbortMessage() {
+    return true;
+  }
+
+  @Override
+  public OutgoingTextMessage withBody(String body) {
+    return new OutgoingAbortSessionMessage(this, body);
+  }
+}

--- a/src/org/thoughtcrime/securesms/sms/OutgoingTextMessage.java
+++ b/src/org/thoughtcrime/securesms/sms/OutgoingTextMessage.java
@@ -35,6 +35,10 @@ public class OutgoingTextMessage {
     return false;
   }
 
+  public boolean isAbortMessage() {
+    return false;
+  }
+
   public boolean isSecureMessage() {
     return false;
   }
@@ -44,6 +48,8 @@ public class OutgoingTextMessage {
       return new OutgoingEncryptedMessage(record.getIndividualRecipient(), record.getBody().getBody());
     } else if (record.isKeyExchange()) {
       return new OutgoingKeyExchangeMessage(record.getIndividualRecipient(), record.getBody().getBody());
+    } else if (record.isAbortSession()) {
+      return new OutgoingAbortSessionMessage(record.getIndividualRecipient(), record.getBody().getBody());
     } else {
       return new OutgoingTextMessage(record.getIndividualRecipient(), record.getBody().getBody());
     }

--- a/src/org/thoughtcrime/securesms/transport/SmsTransport.java
+++ b/src/org/thoughtcrime/securesms/transport/SmsTransport.java
@@ -32,7 +32,7 @@ public class SmsTransport {
   }
 
   public void deliver(SmsMessageRecord message) throws UndeliverableMessageException {
-    if (message.isSecure() || message.isKeyExchange()) {
+    if (message.isSecure() || message.isKeyExchange() || message.isAbortSession()) {
       deliverSecureMessage(message);
     } else {
       deliverPlaintextMessage(message);


### PR DESCRIPTION
When user A aborts a secure session with user B, clear the keys
  as before, then send a message to user B notifying them that
  the secure session has been closed. Upon receiving the abort
  session message, user B's keys will automatically be cleared
  and they will be put back into an insecure state.

Fixes Issue #143
