### PR TITLE
"Select Ringtone" preference to "Sound"

### DIFF
--- a/res/values-ar/strings.xml
+++ b/res/values-ar/strings.xml
@@ -307,7 +307,7 @@
   <string name="preferences__change_notification_blink_pattern">تغيير اسلوب وميض تنبيهات LED</string>
   <string name="preferences__pref_led_blink_dialogtitle">اختيار اسلوب وميض LED</string>
   <string name="preferences__select_led_color">اختيار لون ضوء التنبيه LED</string>
-  <string name="preferences__select_ringtone">اختر نغمة</string>
+  <string name="preferences__sound">اختر نغمة</string>
   <string name="preferences__vibrate">هزاز</string>
   <string name="preferences__also_vibrate_when_notified">شغل الهزاز عند وصول تنبيه</string>
   <string name="preferences__minutes">دقائق</string>

--- a/res/values-bg/strings.xml
+++ b/res/values-bg/strings.xml
@@ -321,7 +321,7 @@
   <string name="preferences__change_notification_blink_pattern">Промени известяването с LED мигане</string>
   <string name="preferences__pref_led_blink_dialogtitle">Избери LED мигане</string>
   <string name="preferences__select_led_color">Изберете LED цвят</string>
-  <string name="preferences__select_ringtone">Избери мелодия</string>
+  <string name="preferences__sound">Избери мелодия</string>
   <string name="preferences__vibrate">Вибрирай</string>
   <string name="preferences__also_vibrate_when_notified">Вибрирай после известявай</string>
   <string name="preferences__minutes">минути</string>

--- a/res/values-bo/strings.xml
+++ b/res/values-bo/strings.xml
@@ -256,7 +256,7 @@
   <string name="preferences__change_notification_blink_pattern">LED རྒྱན་རིས་ཀྱི་བརྡ་གཏོང་བརྗེས།</string>
   <string name="preferences__pref_led_blink_dialogtitle">LED ཡི་བཀོད་རིས་དེ་འདེམས། </string>
   <string name="preferences__select_led_color">LED ཡི་ཚོན་མདོག་དེ་འདེམས། </string>
-  <string name="preferences__select_ringtone">དྲིལ་སྒྲ་འདེམས། </string>
+  <string name="preferences__sound">དྲིལ་སྒྲ་འདེམས། </string>
   <string name="preferences__vibrate"> འདར་བཅུག</string>
   <string name="preferences__also_vibrate_when_notified">བརྡ་གཏོང་སྐབས་འདར་བཅུག</string>
   <string name="preferences__minutes">སྐར་མ།</string>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -322,7 +322,7 @@
   <string name="preferences__change_notification_blink_pattern">Ändern des LED Blinkmusters für Benachrichtigungen</string>
   <string name="preferences__pref_led_blink_dialogtitle">LED Blinkmuster auswählen</string>
   <string name="preferences__select_led_color">LED Farbe auswählen</string>
-  <string name="preferences__select_ringtone">Klingelton auswählen</string>
+  <string name="preferences__sound">Klingelton auswählen</string>
   <string name="preferences__vibrate">Vibrieren</string>
   <string name="preferences__also_vibrate_when_notified">Bei Benachrichtigung vibrieren</string>
   <string name="preferences__minutes">Minuten</string>

--- a/res/values-el/strings.xml
+++ b/res/values-el/strings.xml
@@ -321,7 +321,7 @@
   <string name="preferences__change_notification_blink_pattern">Αλλάξτε το πώς αναβοσβήνει το LED</string>
   <string name="preferences__pref_led_blink_dialogtitle">Επιλογή τρόπου αναβοσβήματος του LED</string>
   <string name="preferences__select_led_color">Επιλέξτε χρώμα LED</string>
-  <string name="preferences__select_ringtone">Επιλέξτε κουδούνισμα</string>
+  <string name="preferences__sound">Επιλέξτε κουδούνισμα</string>
   <string name="preferences__vibrate">Δόνηση</string>
   <string name="preferences__also_vibrate_when_notified">Δόνηση και κατά την ειδοποίηση</string>
   <string name="preferences__minutes">λεπτά</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -321,7 +321,7 @@
   <string name="preferences__change_notification_blink_pattern">Cambiar el patrón de parpadeo de la notificación LED</string>
   <string name="preferences__pref_led_blink_dialogtitle">Seleccionar un patrón e parpadeo del LED</string>
   <string name="preferences__select_led_color">Seleccionar color LED</string>
-  <string name="preferences__select_ringtone">Seleccionar tono</string>
+  <string name="preferences__sound">Seleccionar tono</string>
   <string name="preferences__vibrate">Vibración</string>
   <string name="preferences__also_vibrate_when_notified">También vibrar con notificaciones</string>
   <string name="preferences__minutes">minutos</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -322,7 +322,7 @@
   <string name="preferences__change_notification_blink_pattern">Modifier le rythme de clignotement de la LED de notification</string>
   <string name="preferences__pref_led_blink_dialogtitle">Choisir le rythme de clignotement de la LED</string>
   <string name="preferences__select_led_color">Choisir la couleur de la LED</string>
-  <string name="preferences__select_ringtone">Choisir une sonnerie</string>
+  <string name="preferences__sound">Choisir une sonnerie</string>
   <string name="preferences__vibrate">Vibrer</string>
   <string name="preferences__also_vibrate_when_notified">Vibrer aussi lors des notifications</string>
   <string name="preferences__minutes">minutes</string>

--- a/res/values-he/strings.xml
+++ b/res/values-he/strings.xml
@@ -321,7 +321,7 @@
   <string name="preferences__change_notification_blink_pattern">שנה את תבנית הבהוב הLED בהתראה</string>
   <string name="preferences__pref_led_blink_dialogtitle">בחר תבנית הבהוב ה-LED</string>
   <string name="preferences__select_led_color">בחר צבע LED</string>
-  <string name="preferences__select_ringtone">בחר רינגטון</string>
+  <string name="preferences__sound">בחר רינגטון</string>
   <string name="preferences__vibrate">רטט</string>
   <string name="preferences__also_vibrate_when_notified">הפעל רטט בקבלת התראה</string>
   <string name="preferences__minutes">דקות</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -276,7 +276,7 @@
   <string name="preferences__change_notification_blink_pattern">Cambia il lampeggio del LED di notifica</string>
   <string name="preferences__pref_led_blink_dialogtitle">Seleziona un impostazione per il LED di notifica</string>
   <string name="preferences__select_led_color">Selezione il colore del LED</string>
-  <string name="preferences__select_ringtone">Seleziona una suoneria</string>
+  <string name="preferences__sound">Seleziona una suoneria</string>
   <string name="preferences__vibrate">Vibrazione</string>
   <string name="preferences__also_vibrate_when_notified">Vibra anche durante l\'arrivo di una notifica</string>
   <string name="preferences__minutes">minuti</string>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -321,7 +321,7 @@
   <string name="preferences__change_notification_blink_pattern">通知LED点滅パターンの変更</string>
   <string name="preferences__pref_led_blink_dialogtitle">LED点滅パターンを選択</string>
   <string name="preferences__select_led_color">LED色を選択</string>
-  <string name="preferences__select_ringtone">着信音を選択</string>
+  <string name="preferences__sound">着信音を選択</string>
   <string name="preferences__vibrate">振動</string>
   <string name="preferences__also_vibrate_when_notified">通知する時に振動もする</string>
   <string name="preferences__minutes">分</string>

--- a/res/values-my/strings.xml
+++ b/res/values-my/strings.xml
@@ -253,7 +253,7 @@
   <string name="preferences__change_notification_blink_pattern">အချက်ပြ LED လင်းမည့်ပုံစံကိုရွေးချယ်ပါ</string>
   <string name="preferences__pref_led_blink_dialogtitle">LED လင်းမည့်ပုံစံရွေးချယ်ပါ</string>
   <string name="preferences__select_led_color">LED အရောင်ရွေးချယ်ပါ</string>
-  <string name="preferences__select_ringtone">သံစဉ်ရွေးချယ်ပါ</string>
+  <string name="preferences__sound">သံစဉ်ရွေးချယ်ပါ</string>
   <string name="preferences__vibrate">တုန်ခါမှု</string>
   <string name="preferences__also_vibrate_when_notified">အချက်ပြစဉ်တုန်ခါပါ</string>
   <string name="preferences__minutes">မိနစ်</string>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -322,7 +322,7 @@
   <string name="preferences__change_notification_blink_pattern">Verander notificatie LED knipperpatroon</string>
   <string name="preferences__pref_led_blink_dialogtitle">Selecteer LED Knipperpatroon</string>
   <string name="preferences__select_led_color">Selecteer LED Kleur</string>
-  <string name="preferences__select_ringtone">Selecteer ringtone</string>
+  <string name="preferences__sound">Selecteer ringtone</string>
   <string name="preferences__vibrate">Trillen</string>
   <string name="preferences__also_vibrate_when_notified">Ook trillen bij notificaties</string>
   <string name="preferences__minutes">minuten</string>

--- a/res/values-no/strings.xml
+++ b/res/values-no/strings.xml
@@ -329,7 +329,7 @@
   <string name="preferences__change_notification_blink_pattern">Endre LED-varslingens blinkemønster</string>
   <string name="preferences__pref_led_blink_dialogtitle">Velg LED blinkemønster</string>
   <string name="preferences__select_led_color">Velg LED farge</string>
-  <string name="preferences__select_ringtone">Velg varslingstone</string>
+  <string name="preferences__sound">Velg varslingstone</string>
   <string name="preferences__vibrate">Vibrasjon</string>
   <string name="preferences__also_vibrate_when_notified">Også vibrere ved varsling</string>
   <string name="preferences__minutes">minutter</string>

--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -321,7 +321,7 @@
   <string name="preferences__change_notification_blink_pattern">Alterar padrão de pisca do LED</string>
   <string name="preferences__pref_led_blink_dialogtitle">Seleccionar padrão de pisca do LED</string>
   <string name="preferences__select_led_color">Seleccionar cor do LED</string>
-  <string name="preferences__select_ringtone">Seleccionar toque</string>
+  <string name="preferences__sound">Seleccionar toque</string>
   <string name="preferences__vibrate">Vibrar</string>
   <string name="preferences__also_vibrate_when_notified">Vibrar também quando notificado</string>
   <string name="preferences__minutes">minutos</string>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -317,7 +317,7 @@
   <string name="preferences__change_notification_blink_pattern">Alterar padrão de pisca do LED</string>
   <string name="preferences__pref_led_blink_dialogtitle">Seleccionar padrão de pisca do LED</string>
   <string name="preferences__select_led_color">Seleccionar cor do LED</string>
-  <string name="preferences__select_ringtone">Seleccionar toque</string>
+  <string name="preferences__sound">Seleccionar toque</string>
   <string name="preferences__vibrate">Vibrar</string>
   <string name="preferences__also_vibrate_when_notified">Vibrar também quando notificado</string>
   <string name="preferences__minutes">minutos</string>

--- a/res/values-ro/strings.xml
+++ b/res/values-ro/strings.xml
@@ -321,7 +321,7 @@
   <string name="preferences__change_notification_blink_pattern">Schimba sablonul de clipire a LED-ului de notificare</string>
   <string name="preferences__pref_led_blink_dialogtitle">Selecteaza sablonul de clipire a LED-ului</string>
   <string name="preferences__select_led_color">Alege culoarea LED-ului</string>
-  <string name="preferences__select_ringtone">Alege sunet de apel</string>
+  <string name="preferences__sound">Alege sunet de apel</string>
   <string name="preferences__vibrate">Vibreaza</string>
   <string name="preferences__also_vibrate_when_notified">Vibreaza si cand esti notificat</string>
   <string name="preferences__minutes">minute</string>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -255,7 +255,7 @@
   <string name="preferences__change_notification_blink_pattern">Поменяй мигания светодиода</string>
   <string name="preferences__pref_led_blink_dialogtitle">Выберите мигания светодиода</string>
   <string name="preferences__select_led_color">Выберите Цвет светодиода</string>
-  <string name="preferences__select_ringtone">Выбор Мелодии</string>
+  <string name="preferences__sound">Выбор Мелодии</string>
   <string name="preferences__vibrate">Вибрировать</string>
   <string name="preferences__also_vibrate_when_notified">Вибрировать при уведомлении</string>
   <string name="preferences__minutes">мин.</string>

--- a/res/values-sk/strings.xml
+++ b/res/values-sk/strings.xml
@@ -228,7 +228,7 @@
   <string name="preferences__change_notification_blink_pattern">Zmena vzoru blikania LED hlásení</string>
   <string name="preferences__pref_led_blink_dialogtitle">Vyberte vzor blikania LED</string>
   <string name="preferences__select_led_color">Vyber farbu LED</string>
-  <string name="preferences__select_ringtone">Vyber zvonenie</string>
+  <string name="preferences__sound">Vyber zvonenie</string>
   <string name="preferences__vibrate">Vybruj</string>
   <string name="preferences__also_vibrate_when_notified">Počas hlásenia tiež vibruj</string>
   <string name="preferences__minutes">minúty</string>

--- a/res/values-sl/strings.xml
+++ b/res/values-sl/strings.xml
@@ -329,7 +329,7 @@
   <string name="preferences__change_notification_blink_pattern">Spremeni vzorec utripanja LED za obvestila</string>
   <string name="preferences__pref_led_blink_dialogtitle">Izveri vzorec utripanja LED</string>
   <string name="preferences__select_led_color">Izberi barvo LED</string>
-  <string name="preferences__select_ringtone">Izberi zvonenje</string>
+  <string name="preferences__sound">Izberi zvonenje</string>
   <string name="preferences__vibrate">Vibriranje</string>
   <string name="preferences__also_vibrate_when_notified">Vibriranje ob obvestilu</string>
   <string name="preferences__minutes">minut</string>

--- a/res/values-sv/strings.xml
+++ b/res/values-sv/strings.xml
@@ -321,7 +321,7 @@
   <string name="preferences__change_notification_blink_pattern">Ändra LED-blinkmönster för notifikationer</string>
   <string name="preferences__pref_led_blink_dialogtitle">Välj LED-blinkmönster</string>
   <string name="preferences__select_led_color">Välj LED-färg</string>
-  <string name="preferences__select_ringtone">Välj rington</string>
+  <string name="preferences__sound">Välj rington</string>
   <string name="preferences__vibrate">Vibrera</string>
   <string name="preferences__also_vibrate_when_notified">Vibrera också vid notifikation</string>
   <string name="preferences__minutes">minuter</string>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -218,7 +218,7 @@
   <string name="preferences__change_notification_blink_pattern">更改通知 LED 闪烁模式</string>
   <string name="preferences__pref_led_blink_dialogtitle">选择 LED 闪烁模式</string>
   <string name="preferences__select_led_color">选择 LED 颜色</string>
-  <string name="preferences__select_ringtone">选择铃声</string>
+  <string name="preferences__sound">选择铃声</string>
   <string name="preferences__vibrate">振动</string>
   <string name="preferences__also_vibrate_when_notified">通知时同时振动</string>
   <string name="preferences__minutes">分钟</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -436,7 +436,7 @@
     <string name="preferences__change_notification_blink_pattern">Change notification LED blink pattern</string>
     <string name="preferences__pref_led_blink_dialogtitle">Select LED Blink Pattern</string>
     <string name="preferences__select_led_color">Select LED Color</string>
-    <string name="preferences__select_ringtone">Sound</string>
+    <string name="preferences__sound">Sound</string>
     <string name="preferences__vibrate">Vibrate</string>
     <string name="preferences__also_vibrate_when_notified">Also vibrate when notified</string>
     <string name="preferences__minutes">minutes</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -47,7 +47,7 @@
         <RingtonePreference android:layout="?android:attr/preferenceLayoutChild"
                             android:dependency="pref_key_enable_notifications"
                             android:key="pref_key_ringtone"
-                            android:title="@string/preferences__select_ringtone"
+                            android:title="@string/preferences__sound"
                             android:ringtoneType="notification"
                             android:defaultValue="content://settings/system/notification_sound" />
         <CheckBoxPreference android:layout="?android:attr/preferenceLayoutChild"


### PR DESCRIPTION
In response to issue #353 

TextSecure settings contain a preference labelled "Select Ringtone" which spawns a prompt containing a list of system notification sounds. Changed the wording in "Notifications" section of TextSecure settings from "Select Ringtone" to "Sound".
