### PR TITLE
use aspect-preserving bitmap scalers with MMS images

### DIFF
--- a/src/org/thoughtcrime/securesms/mms/ImageSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/ImageSlide.java
@@ -72,7 +72,7 @@ public class ImageSlide extends Slide {
       InputStream measureStream = getPartDataInputStream();
       InputStream dataStream    = getPartDataInputStream();
 
-      thumbnail = BitmapUtil.createScaledBitmap(measureStream, dataStream, maxWidth, maxHeight);
+      thumbnail = BitmapUtil.createScaledBitmapWithAspect(measureStream, dataStream, maxWidth, maxHeight);
       thumbnailCache.put(part.getDataUri(), new SoftReference<Bitmap>(thumbnail));
 
       return thumbnail;
@@ -159,7 +159,7 @@ public class ImageSlide extends Slide {
       throws IOException, BitmapDecodingException
   {
     PduPart part = new PduPart();
-    byte[] data  = BitmapUtil.createScaledBytes(context, uri, 640, 480, (300 * 1024) - 5000);
+    byte[] data  = BitmapUtil.createScaledBytesWithAspect(context, uri, 640, 480, (300 * 1024) - 5000);
 
     part.setData(data);
     part.setDataUri(uri);


### PR DESCRIPTION
This fixes issue #246 where portrait photos are incorrectly resized/stretched when used with MMS messages.

These new aspect-preserving routines are used when creating a thumbnail for the image in the composition text field, when creating a thumbnail for a decrypted received MMS image that shows in the conversation, and most importantly, when resizing the image to 640x480 to send out.
