### PR TITLE
preserve aspect ratio of images when resizing for mms

### DIFF
--- a/src/org/thoughtcrime/securesms/util/BitmapUtil.java
+++ b/src/org/thoughtcrime/securesms/util/BitmapUtil.java
@@ -67,7 +67,7 @@ public class BitmapUtil {
       throw new BitmapDecodingException("Decoded stream was null.");
     }
 
-    if (imageWidth > maxWidth || imageHeight > maxHeight) {
+    if (roughThumbnail.getWidth() > maxWidth || roughThumbnail.getHeight() > maxHeight) {
       float aspectWidth, aspectHeight;
 
       if (imageWidth == 0 || imageHeight == 0) {


### PR DESCRIPTION
This is a re-do of https://github.com/WhisperSystems/TextSecure/pull/359 that just adds the aspect preservation in the final `Bitmap.createScaledBitmap()` call without adding new functions.

Should fix issue #246.
