### PR TITLE
ActionBarSherlock versions now stored as tags

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -3,7 +3,8 @@ Building TextSecure
 
 Fetch ActionBarSherlock:
 
-    git clone --branch 4.2.0 git://github.com/JakeWharton/ActionBarSherlock.git ../ActionBarSherlock
+    git clone git://github.com/JakeWharton/ActionBarSherlock.git ../ActionBarSherlock
+    pushd ../ActionBarSherlock && git checkout 4.2.0 && popd
 
 Configure ActionBarSherlock for your android target:
 


### PR DESCRIPTION
The current release of `ActionBarSherlock` uses tags to store its relases, so the clone command throws up a warning `warning: Remote branch 4.2.0 not found in upstream origin, using HEAD instead`. Instead, clone HEAD and switch to the 4.2.0 tag.
