### PR TITLE
add option to disable audible inthread notifications

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -437,6 +437,8 @@
     <string name="preferences__pref_led_blink_dialogtitle">Select LED Blink Pattern</string>
     <string name="preferences__select_led_color">Select LED Color</string>
     <string name="preferences__sound">Sound</string>
+    <string name="preferences__inthread_notifications">In thread notifications</string>
+    <string name="preferences__play_inthread_notifications">Play notification sound while in thread.</string>
     <string name="preferences__vibrate">Vibrate</string>
     <string name="preferences__also_vibrate_when_notified">Also vibrate when notified</string>
     <string name="preferences__minutes">minutes</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -50,12 +50,22 @@
                             android:title="@string/preferences__sound"
                             android:ringtoneType="notification"
                             android:defaultValue="content://settings/system/notification_sound" />
+
+        <CheckBoxPreference android:key="pref_key_inthread_notifications"
+            				android:title="@string/preferences__inthread_notifications"
+							android:summary="@string/preferences__play_inthread_notifications"
+							android:layout="?android:attr/preferenceLayoutChild"
+							android:dependency="pref_key_enable_notifications"
+							android:defaultValue="true" />
+
         <CheckBoxPreference android:layout="?android:attr/preferenceLayoutChild"
                             android:dependency="pref_key_enable_notifications"
                             android:key="pref_key_vibrate"
                             android:defaultValue="true"
                             android:title="@string/preferences__vibrate"
                             android:summary="@string/preferences__also_vibrate_when_notified" />
+        
+        
   </PreferenceCategory>
 
   <PreferenceCategory android:title="Input Settings">

--- a/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -58,6 +58,7 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredSherlockPr
   private static final int ENABLE_PASSPHRASE_ACTIVITY   = 2;
 
   public static final String RINGTONE_PREF                    = "pref_key_ringtone";
+  public static final String IN_THREAD_NOTIFICATION_PREF      = "pref_key_inthread_notifications";
   public static final String VIBRATE_PREF                     = "pref_key_vibrate";
   public static final String NOTIFICATION_PREF                = "pref_key_enable_notifications";
   public static final String LED_COLOR_PREF                   = "pref_led_color";

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -228,6 +228,11 @@ public class MessageNotifier {
   private static void sendInThreadNotification(Context context) {
     try {
       SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
+      
+      if (!sp.getBoolean(ApplicationPreferencesActivity.IN_THREAD_NOTIFICATION_PREF, true)) {
+    	  return;
+      }
+      
       String ringtone      = sp.getString(ApplicationPreferencesActivity.RINGTONE_PREF, null);
 
       if (ringtone == null)


### PR DESCRIPTION
Having the notification sound of an incoming message playing while you are currently in conversation with that person may be undesired sometimes. This change adds a simple toggle in the options to disable it.
