### PR TITLE
Fix issue #410: DecryptingPartInputStream could return more data than re...

### DIFF
--- a/src/org/thoughtcrime/securesms/crypto/DecryptingPartInputStream.java
+++ b/src/org/thoughtcrime/securesms/crypto/DecryptingPartInputStream.java
@@ -125,23 +125,22 @@ public class DecryptingPartInputStream extends FileInputStream {
 	
   private int readIncremental(byte[] buffer, int offset, int length) throws IOException {
     int readLength = 0;
-    //Use data from overflow buffer first if present
     if (null != overflowBuffer) {
-        if (overflowBuffer.length > length) {
-            System.arraycopy(overflowBuffer, 0, buffer, offset, length);
-            overflowBuffer = Arrays.copyOfRange(overflowBuffer, length, overflowBuffer.length);
-            return length;
-        } else if (overflowBuffer.length == length) {
-            System.arraycopy(overflowBuffer, 0, buffer, offset, length);
-            overflowBuffer = null;
-            return length;
-        } else {
-            System.arraycopy(overflowBuffer, 0, buffer, offset, overflowBuffer.length);
-            readLength += overflowBuffer.length;
-            offset += readLength;
-            length -= readLength;
-            overflowBuffer = null;
-        }
+      if (overflowBuffer.length > length) {
+        System.arraycopy(overflowBuffer, 0, buffer, offset, length);
+        overflowBuffer = Arrays.copyOfRange(overflowBuffer, length, overflowBuffer.length);
+        return length;
+      } else if (overflowBuffer.length == length) {
+        System.arraycopy(overflowBuffer, 0, buffer, offset, length);
+        overflowBuffer = null;
+        return length;
+      } else {
+        System.arraycopy(overflowBuffer, 0, buffer, offset, overflowBuffer.length);
+        readLength += overflowBuffer.length;
+        offset += readLength;
+        length -= readLength;
+        overflowBuffer = null;
+      }
     }
 
     if (length + totalRead > totalDataSize)
@@ -154,7 +153,6 @@ public class DecryptingPartInputStream extends FileInputStream {
     try {
       mac.update(internalBuffer, 0, read);
 
-      //data retrieved using cipher.update doesn't always match cipher.getOutputSize (but should never be larger)
       int outputLen = cipher.getOutputSize(read);
 
       if (outputLen <= length) {


### PR DESCRIPTION
This change buffers data coming from a _cipher.update_ call if more data is returned than requested (larger than the _length_ passed to the _read_ call) and uses the buffer on subsequent _read_ calls (until empty).
I'm not that great with Java so there may be a much more efficient way of doing the array handling, but it does work on KK.
