### PR TITLE
Gingerbread pls go

### DIFF
--- a/res/layout/change_passphrase_activity.xml
+++ b/res/layout/change_passphrase_activity.xml
@@ -60,8 +60,7 @@
                           android:layout_height="wrap_content"
                           android:layout_marginTop="30dip">
 
-                <Button style="@android:style/Widget.Button"
-                        android:id="@+id/cancel_button"
+                <Button android:id="@+id/cancel_button"
                         android:text="@android:string/cancel"
                         android:layout_weight="1"
                         android:layout_width="0dp"
@@ -69,8 +68,7 @@
                         android:layout_marginRight="7dip"
                         android:textAppearance="?android:attr/textAppearanceMedium"/>
                 
-                <Button style="@android:style/Widget.Button"
-                        android:id="@+id/ok_button"
+                <Button android:id="@+id/ok_button"
                         android:text="@android:string/ok"
                         android:layout_weight="1"
                         android:layout_width="0dp"

--- a/res/layout/create_passphrase_activity.xml
+++ b/res/layout/create_passphrase_activity.xml
@@ -50,8 +50,7 @@
                       android:inputType="textPassword"
                       android:singleLine="true"/>
                         
-            <Button style="@android:style/Widget.Button"
-                    android:id="@+id/ok_button"
+            <Button android:id="@+id/ok_button"
                     android:text="@string/create_passphrase_activity__continue"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/res/layout/database_migration_activity.xml
+++ b/res/layout/database_migration_activity.xml
@@ -43,8 +43,7 @@
                           android:layout_height="wrap_content"
                           android:layout_marginTop="20dip">
 
-                <Button style="@android:style/Widget.Button"
-                        android:id="@+id/skip_button"
+                <Button android:id="@+id/skip_button"
                         android:text="@string/database_migration_activity__skip"
                         android:layout_weight="1"
                         android:layout_width="0dp"
@@ -52,8 +51,7 @@
                         android:layout_marginRight="7dip"
                         android:textAppearance="?android:attr/textAppearanceMedium"/>
                 
-                <Button style="@android:style/Widget.Button"
-                        android:id="@+id/import_button"
+                <Button android:id="@+id/import_button"
                         android:text="@string/database_migration_activity__import"
                         android:layout_weight="1"
                         android:layout_width="0dp"
@@ -112,7 +110,7 @@
 
             <ProgressBar
                 android:id="@+id/import_progress"
-                style="@android:style/Widget.ProgressBar.Horizontal"
+                style="@style/Widget.ProgressBar.Horizontal"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="14.0dip"

--- a/res/layout/prompt_apn_activity.xml
+++ b/res/layout/prompt_apn_activity.xml
@@ -38,8 +38,7 @@
                           android:layout_marginTop="10dip"
                           android:layout_marginBottom="20dip">
 
-                <Button style="@android:style/Widget.Button"
-                        android:id="@+id/cancel_button"
+                <Button android:id="@+id/cancel_button"
                         android:text="@android:string/cancel"
                         android:layout_weight="1"
                         android:layout_width="0dp"
@@ -47,8 +46,7 @@
                         android:layout_marginRight="7dip"
                         android:textAppearance="?android:attr/textAppearanceMedium"/>
                 
-                <Button style="@android:style/Widget.Button"
-                        android:id="@+id/ok_button"
+                <Button android:id="@+id/ok_button"
                         android:text="@android:string/ok"
                         android:layout_weight="1"
                         android:layout_width="0dp"

--- a/res/layout/prompt_passphrase_activity.xml
+++ b/res/layout/prompt_passphrase_activity.xml
@@ -45,8 +45,7 @@
                           android:layout_marginTop="20dip"
                           android:layout_marginRight="20dip">
                 
-                <Button style="@android:style/Widget.Button"
-                        android:id="@+id/ok_button"
+                <Button android:id="@+id/ok_button"
                         android:text="@string/prompt_passphrase_activity__unlock"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"

--- a/res/layout/registration_activity.xml
+++ b/res/layout/registration_activity.xml
@@ -69,8 +69,7 @@
 
             </LinearLayout>
 
-            <Button style="@android:style/Widget.Button"
-                    android:id="@+id/registerButton"
+            <Button android:id="@+id/registerButton"
                     android:text="Register"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/res/layout/registration_progress_activity.xml
+++ b/res/layout/registration_progress_activity.xml
@@ -536,7 +536,7 @@
 
             <ProgressBar
                     android:id="@+id/registration_progress"
-                    style="@android:style/Widget.ProgressBar.Horizontal"
+                    style="@style/Widget.ProgressBar.Horizontal"
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="14.0dip"

--- a/res/values-v11/styles.xml
+++ b/res/values-v11/styles.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="Widget.ProgressBar.Horizontal" parent="@android:style/Widget.Holo.ProgressBar.Horizontal">
+    </style>
+
+</resources>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -85,4 +85,7 @@
         <item name="android:textSize">14sp</item>
     </style>
 
+    <style name="Widget.ProgressBar.Horizontal" parent="@android:style/Widget.ProgressBar.Horizontal">
+    </style>
+
 </resources>


### PR DESCRIPTION
Look like an Android app from 2013.

Remove the redundant Gingerbread button styles from buttons to
automatically use the Holo theme on phones that don't run a 3+ year old
operating system.

Create a new style for horizontal progress bars that uses the Holo
progress bar style on v11 and above.
