### PR TITLE
Update to the latest Android Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.5.+'
+        classpath 'com.android.tools.build:gradle:0.6.+'
     }
 }
 


### PR DESCRIPTION
Somewhat related: perhaps the Gradle wrapper should be checked in to the repository? It's a bit of an headache to figure out how to get it there myself since it's required for importing to Android Studio with a newer system Gradle version.
