### PR TITLE
Fix crash when no SMS package is set

### DIFF
--- a/src/org/thoughtcrime/securesms/util/Util.java
+++ b/src/org/thoughtcrime/securesms/util/Util.java
@@ -188,7 +188,7 @@ public class Util {
 
   public static boolean isDefaultSmsProvider(Context context){
     return (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) ||
-      (Telephony.Sms.getDefaultSmsPackage(context).equals(context.getPackageName()));
+      (context.getPackageName().equals(Telephony.Sms.getDefaultSmsPackage(context)));
   }
 
   //  public static Bitmap loadScaledBitmap(InputStream src, int targetWidth, int targetHeight) {


### PR DESCRIPTION
I'm not even sure how I triggered this at first, but it happened. Can be reproduced by disabling any other SMS apps installed), uninstalling TextSecure and reinstalling.
