### PR TITLE
Fix issue #433

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/MarkReadReceiver.java
+++ b/src/org/thoughtcrime/securesms/notifications/MarkReadReceiver.java
@@ -5,7 +5,6 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.AsyncTask;
-import android.util.Log;
 
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
@@ -19,11 +18,9 @@ public class MarkReadReceiver extends BroadcastReceiver {
     if (!intent.getAction().equals(CLEAR_ACTION))
       return;
 
-    final long[]       threadIds    = intent.getLongArrayExtra("thread_ids");
     final MasterSecret masterSecret = intent.getParcelableExtra("master_secret");
 
-    if (threadIds != null && masterSecret != null) {
-      Log.w("MarkReadReceiver", "threadIds length: " + threadIds.length);
+    if (masterSecret != null) {
 
       ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
           .cancel(MessageNotifier.NOTIFICATION_ID);
@@ -31,10 +28,7 @@ public class MarkReadReceiver extends BroadcastReceiver {
       new AsyncTask<Void, Void, Void>() {
         @Override
         protected Void doInBackground(Void... params) {
-          for (long threadId : threadIds) {
-            Log.w("MarkReadReceiver", "Marking as read: " + threadId);
-            DatabaseFactory.getThreadDatabase(context).setRead(threadId);
-          }
+          DatabaseFactory.getThreadDatabase(context).setAllThreadsRead();
 
           MessageNotifier.updateNotification(context, masterSecret);
           return null;

--- a/src/org/thoughtcrime/securesms/notifications/NotificationItem.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationItem.java
@@ -72,7 +72,6 @@ public class NotificationItem {
 
     if (recipients != null) {
       intent.putExtra("recipients", recipients);
-      intent.putExtra("thread_id", threadId);
     }
 
     intent.setData((Uri.parse("custom://"+System.currentTimeMillis())));

--- a/src/org/thoughtcrime/securesms/notifications/NotificationState.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationState.java
@@ -4,7 +4,6 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
-import android.util.Log;
 
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 
@@ -43,24 +42,9 @@ public class NotificationState {
   }
 
   public PendingIntent getMarkAsReadIntent(Context context, MasterSecret masterSecret) {
-    long[] threadArray = new long[threads.size()];
-    int index          = 0;
-
-    for (long thread : threads) {
-      Log.w("NotificationState", "Added thread: " + thread);
-      threadArray[index++] = thread;
-    }
-
     Intent intent = new Intent(MarkReadReceiver.CLEAR_ACTION);
-    intent.putExtra("thread_ids", threadArray);
     intent.putExtra("master_secret", masterSecret);
     intent.setPackage(context.getPackageName());
-
-    // XXX : This is an Android bug.  If we don't pull off the extra
-    // once before handing off the PendingIntent, the array will be
-    // truncated to one element when the PendingIntent fires.  Thanks guys!
-    Log.w("NotificationState", "Pending array off intent length: " +
-        intent.getLongArrayExtra("thread_ids").length);
 
     return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
   }


### PR DESCRIPTION
use PendingIntent.FLAG_UPDATE_CURRENT in calls to PendingIntent.getActivity() to avoid re-using the same extra data on every intent.
