### PR TITLE
Improve password caching notification UI & UX

### DIFF
--- a/res/layout/key_caching_notification.xml
+++ b/res/layout/key_caching_notification.xml
@@ -28,7 +28,7 @@
         android:singleLine="true"
         android:fadingEdge="horizontal"
         android:ellipsize="marquee"
-        android:text="@string/KeyCachingService_textsecure_passphrase_cached"
+        android:text="@string/KeyCachingService_textsecure_passphrase_cached_with_lock"
         />
     </LinearLayout>
     

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -246,8 +246,10 @@
     <string name="ApplicationMigrationService_importing_text_messages">Importing Text Messages</string>
     
     <!-- KeyCachingService -->
-    <string name="KeyCachingService_textsecure_passphrase_cached">TextSecure Passphrase Cached</string>
-    <string name="KeyCachingService_passphrase_cached">Passphrase Cached</string>
+    <string name="KeyCachingService_textsecure_passphrase_cached">Touch to open.</string>
+    <string name="KeyCachingService_textsecure_passphrase_cached_with_lock">Touch to open, or touch the lock to close.</string>
+    <string name="KeyCachingService_passphrase_cached">TextSecure is unlocked</string>
+    <string name="KeyCachingService_lock">Lock with passphrase</string>
     
     <!-- MessageNotifier -->
     <string name="MessageNotifier_d_new_messages">%d new messages</string>
@@ -547,7 +549,7 @@
     <!-- text_secure_normal -->
     <string name="text_secure_normal__menu_new_message">New Message</string>
     <string name="text_secure_normal__menu_settings">Settings</string>
-    <string name="text_secure_normal__menu_clear_passphrase">Clear Passphrase</string>
+    <string name="text_secure_normal__menu_clear_passphrase">Lock</string>
     <string name="text_secure_normal__mark_all_as_read">Mark All Read</string>
 
     <!-- verify_keys -->


### PR DESCRIPTION
On Jelly Bean and above:
- Use the standard notification style for a better and consistent visual
  appearance
- Use the JB notification actions API for the locking action
- Use a lower notification priority to prioritize other notifications
  over TextSecure

On ICS:
- Use the existing custom notification layout

Everywhere:
- Allow opening the app itself from the notification
- Simplify strings: don't talk about a "cached passphrase" but about the
  app being "unlocked"/"locked"

Here's what the new notification looks like on a modern Android device, alongside other notifications:

![screenshot_2013-12-22-04-51-59](http://i.imgur.com/N6NdpNE.png)
