### PR TITLE
proguard enabled, lint disabled, library gradle deps updated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,8 +54,15 @@ android {
     signingConfigs {
         release
     }
+
     buildTypes {
+        debug {
+            runProguard true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard.cfg'
+        }
         release {
+            runProguard true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard.cfg'
             signingConfig signingConfigs.release
         }
     }

--- a/proguard.cfg
+++ b/proguard.cfg
@@ -1,0 +1,8 @@
+-dontobfuscate
+-dontwarn com.actionbarsherlock.internal.**
+
+-keep class android.support.v4.app.** { *; }
+-keep interface android.support.v4.app.** { *; }
+-keep class com.actionbarsherlock.** { *; }
+-keep interface com.actionbarsherlock.** { *; }
+-keepattributes *Annotation*


### PR DESCRIPTION
- proguard enabled for both debug and release for now (it helps to identify proguard problems early)
- update library build.gradle to use the same android buildtool as the main project
- basic proguard.cfg that disables obfuscation (reported stacktraces should be unaffected) and has basic rules for ActionBarSherlock projects

Overall it cuts the APK size pretty significantly (3.4MB -> 2.6MB).
