### PR TITLE
Have Message Details better reflect dynamic message information.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -78,7 +78,7 @@
     <string name="ConversationFragment_to_s_type_s_sent_s">To: %1$s\nType: %2$s\nSent: %3$s</string>
     <string name="ConversationFragment_from_s_type_s_sent_s_received_s">From: %1$s\nType: %2$s\nSent: %3$s\nReceived: %4$s</string>
     <string name="ConversationFragment_confirm_message_delete">Confirm Message Delete</string>
-	<string name="ConversationFragment_are_you_sure_you_want_to_permanently_delete_this_message">Are you sure that you want to permanently delete this message?</string>
+	  <string name="ConversationFragment_are_you_sure_you_want_to_permanently_delete_this_message">Are you sure that you want to permanently delete this message?</string>
     <string name="ConversationFragment_message_pending">Message is pending...</string>
     <string name="ConversationFragment_message_failed">Message failed to send.</string>
     

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -135,14 +135,16 @@ public class ConversationFragment extends SherlockListFragment
   }
 
   private void handleDisplayDetails(MessageRecord message) {
-    String sender     = recipients.isSingleRecipient() ? message.getIndividualRecipient().getNumber() :
-                                                         recipients.toShortString();
-    String messageType  = message.isMms() ? "mms" : "sms";
-    long dateReceived = message.getDateReceived();
-    long dateSent     = message.getDateSent();
+    String sender  = recipients.isSingleRecipient() ? message.getIndividualRecipient().getNumber() :
+                                                      recipients.toShortString();
+    String messageStatus     = message.isSecure() ? "Secured " : "Unsecured ";
+    String messageType       = message.isMms() ? "MMS" : "SMS";
+    String messageStatusType = messageStatus + messageType;
+    long   dateReceived      = message.getDateReceived();
+    long   dateSent          = message.getDateSent();
 
     SimpleDateFormat dateFormatter = new SimpleDateFormat("EEE MMM d, yyyy 'at' hh:mm a");
-    AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+    AlertDialog.Builder builder    = new AlertDialog.Builder(getActivity());
     builder.setTitle(R.string.ConversationFragment_message_details);
     builder.setIcon(android.R.drawable.ic_dialog_info);
     builder.setCancelable(false);
@@ -153,18 +155,18 @@ public class ConversationFragment extends SherlockListFragment
                                                     this.getString(R.string.ConversationFragment_message_failed);
         builder.setMessage(String.format(getSherlockActivity()
                                          .getString(R.string.ConversationFragment_to_s_type_s_sent_s),
-                                         sender, messageType.toUpperCase(),
+                                         sender, messageStatusType,
                                          sendErrorMsg));
       } else {
         builder.setMessage(String.format(getSherlockActivity()
                                          .getString(R.string.ConversationFragment_to_s_type_s_sent_s),
-                                         sender, messageType.toUpperCase(),
+                                         sender, messageStatusType,
                                          dateFormatter.format(new Date(dateSent))));
       }
     } else {
       builder.setMessage(String.format(getSherlockActivity()
                                        .getString(R.string.ConversationFragment_from_s_type_s_sent_s_received_s),
-                                       sender, messageType.toUpperCase(),
+                                       sender, messageStatusType,
                                        dateFormatter.format(new Date(dateSent)),
                                        dateFormatter.format(new Date(dateReceived))));
     }


### PR DESCRIPTION
The current Message Details are ambiguous when displaying details. As well,  @c00w noticed that pending messages are being shown as sent in the message details when in fact they haven't been ( #519 ) which I have been able to reproduce.
This pull request does the following:

-Distinguishes between sent and received messages.
-Displays whether message is sent, pending, or failed.
-Replaces 'Sender:' label with 'To:' and 'From:' labels, depending on whether message is sent or received.
-Replaces 'Sent/Received: ' with respective 'Sent': and 'Received:' labels
-Replaces 'Transport:' label with 'Type:' label. 
-Lists recipients of group messages. (currently listed as 'Unknown').
-Removed timezone and seconds strings from date/time details.
