### PR TITLE
Add option for custom vibration pattern

### DIFF
--- a/res/layout/vibration_pattern_dialog.xml
+++ b/res/layout/vibration_pattern_dialog.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/CustomVibrationLinearLayout"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:orientation="vertical"
+    android:paddingLeft="5dp"
+    android:paddingRight="5dp" >
+
+    <ScrollView
+        android:id="@+id/CustomVibrationScrollView"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent" >
+
+        <LinearLayout
+            android:id="@+id/CustomVibrationLinearLayout2"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" >
+
+            <TextView
+                android:id="@+id/CustomVibrationTextView"
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent"
+                android:paddingBottom="4dp"
+                android:text="@string/preferences__vibration_pattern_help" />
+
+            <EditText
+                android:id="@+id/CustomVibrationEditText"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="3dp"
+                android:layout_marginRight="3dp"
+                android:imeOptions="actionDone"
+                android:inputType="text|textNoSuggestions"
+                android:maxLines="1"
+                android:selectAllOnFocus="true"
+                android:singleLine="true"
+                android:text="0,200,300,200" />
+        </LinearLayout>
+    </ScrollView>
+
+</LinearLayout>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -130,4 +130,25 @@
     <item>@drawable/my_identity_dark</item>
     <item>@drawable/contacts_identities_dark</item>
   </string-array>
+
+  <string-array name="pref_vibration_pattern_entries">
+    <item>@string/preferences__default</item>
+    <item>@string/preferences__vibration_pattern_3_short</item>
+    <item>@string/preferences__vibration_pattern_3_long</item>
+    <item>@string/preferences__vibration_pattern_2_short_2_short</item>
+    <item>@string/preferences__vibration_pattern_2_short_2_long</item>
+    <item>@string/preferences__vibration_pattern_2_long_2_long</item>
+    <item>@string/preferences__custom</item>
+  </string-array>
+
+  <string-array name="pref_vibration_pattern_values">
+    <item>default</item>
+    <item>0,200,300,200,300,600</item>
+    <item>0,600,300,600,300,600</item>
+    <item>0,200,300,200,600,200,300,200</item>
+    <item>0,200,300,200,600,600,300,600</item>
+    <item>0,600,300,600,600,600,300,600</item>
+    <item>custom</item>
+  </string-array>
+
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -653,6 +653,23 @@
         Use the data channel for communication with other TextSecure users
     </string>
                                     
+    <!-- Vibrate Preferences -->
+    <string name="preferences__vibrate_title">Vibrate</string>
+    <string name="preferences__vibrate_on">Vibrate is on</string>
+    <string name="preferences__vibrate_off">Vibrate is off</string>
+
+    <string name="preferences__vibration_pattern_title">Vibration Pattern</string>
+    <string name="preferences__set_vibration_pattern">Set the vibration pattern</string>
+    <string name="preferences__vibration_pattern_set">Custom vibration pattern set!</string>
+    <string name="preferences__vibration_pattern_invalid">Vibration pattern is invalid</string>
+    <string name="preferences__vibration_pattern_help">Enter a custom vibration pattern, in the format:\nmillisOff, millisOn, etc.\n\nFor example:\n0,1000\n0,500,200,500,200,500</string>
+
+    <string name="preferences__vibration_pattern_3_short">3 Short</string>
+    <string name="preferences__vibration_pattern_3_long">3 Long</string>
+    <string name="preferences__vibration_pattern_2_short_2_short">2 Short, 2 Short</string>
+    <string name="preferences__vibration_pattern_2_short_2_long">2 Short, 2 Long</string>
+    <string name="preferences__vibration_pattern_2_long_2_long">2 Long, 2 Long</string>
+
     <!-- **************************************** -->
     <!-- menus -->
     <!-- **************************************** -->

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -70,7 +70,14 @@
                             android:defaultValue="true"
                             android:title="@string/preferences__vibrate"
                             android:summary="@string/preferences__also_vibrate_when_notified" />
-        
+
+        <org.thoughtcrime.securesms.preferences.VibrationPatternListPreference
+                            android:key="pref_key_vibration_pattern"
+                            android:defaultValue="default"
+                            android:title="@string/preferences__vibration_pattern_title"
+                            android:dependency="pref_key_vibrate"
+                            android:entries="@array/pref_vibration_pattern_entries"
+                            android:entryValues="@array/pref_vibration_pattern_values" />
         
   </PreferenceCategory>
 

--- a/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -118,10 +118,13 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredSherlockPr
       .setOnPreferenceChangeListener(new ListSummaryListener());
     this.findPreference(TextSecurePreferences.RINGTONE_PREF)
       .setOnPreferenceChangeListener(new RingtoneSummaryListener());
+    this.findPreference(TextSecurePreferences.VIBRATION_PATTERN_PREF)
+      .setOnPreferenceChangeListener(new ListSummaryListener());
 
     initializeListSummary((ListPreference) findPreference(TextSecurePreferences.LED_COLOR_PREF));
     initializeListSummary((ListPreference) findPreference(TextSecurePreferences.LED_BLINK_PREF));
     initializeRingtoneSummary((RingtonePreference) findPreference(TextSecurePreferences.RINGTONE_PREF));
+    initializeListSummary((ListPreference) findPreference(TextSecurePreferences.VIBRATION_PATTERN_PREF));
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -352,21 +352,54 @@ public class MessageNotifier {
     String ledColor              = TextSecurePreferences.getNotificationLedColor(context);
     String ledBlinkPattern       = TextSecurePreferences.getNotificationLedPattern(context);
     String ledBlinkPatternCustom = TextSecurePreferences.getNotificationLedPatternCustom(context);
-    String[] blinkPatternArray   = parseBlinkPattern(ledBlinkPattern, ledBlinkPatternCustom);
+    String vibrationPattern      = TextSecurePreferences.getNotificationVibrationPattern(context);
+    String vibrationPatternCustom  = TextSecurePreferences.getNotificationVibrationPatternCustom(context);
 
     builder.setSound(TextUtils.isEmpty(ringtone) || !signal ? null : Uri.parse(ringtone));
 
     if (signal && vibrate)
-      builder.setDefaults(Notification.DEFAULT_VIBRATE);
+    {
+      if ( vibrationPattern.equals("default") ) {
+        builder.setDefaults(Notification.DEFAULT_VIBRATE);
+      }
+      else {
+        long[] vibrationPatternArray;
+        if ( vibrationPattern.equals("custom") ) {
+          vibrationPatternArray = parsePattern(vibrationPatternCustom);
+        }
+        else {
+          vibrationPatternArray = parsePattern(vibrationPattern);
+        }
+        if ( vibrationPatternArray.length > 1)
+          builder.setVibrate( vibrationPatternArray );
+      }
+    }
 
-    builder.setLights(Color.parseColor(ledColor), Integer.parseInt(blinkPatternArray[0]),
-                      Integer.parseInt(blinkPatternArray[1]));
+    long[] ledPatternArray;
+    if (ledBlinkPattern.equals("custom")) {
+      ledPatternArray = parsePattern(ledBlinkPatternCustom);
+    }
+    else {
+      ledPatternArray = parsePattern(ledBlinkPattern);
+    }
+    builder.setLights(Color.parseColor(ledColor), (int)ledPatternArray[0], (int)ledPatternArray[1] );
   }
 
-  private static String[] parseBlinkPattern(String blinkPattern, String blinkPatternCustom) {
-    if (blinkPattern.equals("custom"))
-      blinkPattern = blinkPatternCustom;
+  private static long[] parsePattern(String pattern) {
 
-    return blinkPattern.split(",");
+    if ( pattern == null || pattern.isEmpty() || pattern.equals("") || !pattern.matches("[,0-9]+") )
+    {
+      long[] retval={0,0};
+      return retval;
+    }
+
+    String [] strArray = pattern.split(",");
+
+    long[] intArray = new long[ strArray.length ];
+
+    for (int i=0; i< strArray.length; i++)
+      intArray[i] = Integer.parseInt(strArray[i]);
+
+    return intArray;
   }
 }

--- a/src/org/thoughtcrime/securesms/preferences/VibrationPatternListPreference.java
+++ b/src/org/thoughtcrime/securesms/preferences/VibrationPatternListPreference.java
@@ -1,0 +1,140 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms.preferences;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.database.Cursor;
+import android.os.Parcelable;
+import android.preference.ListPreference;
+import android.text.InputType;
+import android.text.method.NumberKeyListener;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.Toast;
+
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
+
+/**
+ * List preference for Vibrate pattern notification.
+ *
+ * @author Jeff Doozan
+ */
+
+public class VibrationPatternListPreference extends ListPreference {
+
+  private Context context;
+  private boolean dialogInProgress;
+  private EditText editText;
+
+  public VibrationPatternListPreference(Context context) {
+    super(context);
+    this.context = context;
+  }
+
+  public VibrationPatternListPreference(Context context, AttributeSet attrs) {
+    super(context, attrs);
+    this.context = context;
+  }
+
+  @Override
+  protected void onDialogClosed(boolean positiveResult) {
+    super.onDialogClosed(positiveResult);
+    
+    if (positiveResult) {
+      String pattern = TextSecurePreferences.getNotificationVibrationPattern(context);
+      if (pattern.equals("custom")) showDialog();
+    }
+  }
+
+  private void initializeEditText() {
+    String vibratePattern  = TextSecurePreferences.getNotificationVibrationPatternCustom(context);
+    this.editText.setText(vibratePattern);
+    this.editText.setKeyListener(new NumberKeyListener() {
+      @Override
+      public int getInputType() {
+        return InputType.TYPE_MASK_VARIATION;
+      }
+
+      @Override
+      protected char[] getAcceptedChars() {
+        return new char[]{',', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0'};
+      }
+    });
+  }
+
+  private void initializeDialog(View view) {
+    AlertDialog.Builder builder = new AlertDialog.Builder(context);
+    builder.setIcon(android.R.drawable.ic_dialog_info);
+    builder.setTitle(R.string.preferences__vibration_pattern_title);
+    builder.setView(view);
+    builder.setOnCancelListener(new CustomDialogCancelListener());
+    builder.setNegativeButton(android.R.string.cancel, new CustomDialogCancelListener());
+    builder.setPositiveButton(android.R.string.ok, new CustomDialogClickListener());
+    builder.show();
+  }
+
+  private void showDialog() {
+    LayoutInflater inflater = (LayoutInflater)context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+    View view               = inflater.inflate(R.layout.vibration_pattern_dialog, null);
+
+    this.editText = (EditText) view.findViewById(R.id.CustomVibrationEditText);
+
+    initializeEditText();
+    initializeDialog(view);
+    dialogInProgress = true;
+  }
+
+  @Override
+  protected void onRestoreInstanceState(Parcelable state) {
+    super.onRestoreInstanceState(state);
+    if (dialogInProgress) {
+      showDialog();
+    }
+  }
+
+  @Override
+  protected View onCreateDialogView() {
+    dialogInProgress = false;
+    return super.onCreateDialogView();
+  }
+
+  private class CustomDialogCancelListener implements DialogInterface.OnClickListener, DialogInterface.OnCancelListener {
+    public void onClick(DialogInterface dialog, int which) {
+      dialogInProgress = false;
+    }
+
+    public void onCancel(DialogInterface dialog) {
+      dialogInProgress = false;
+    }
+  }
+
+  private class CustomDialogClickListener implements DialogInterface.OnClickListener {
+
+    public void onClick(DialogInterface dialog, int which) {
+      String pattern   = editText.getText().toString();
+      dialogInProgress = false;
+
+      TextSecurePreferences.setNotificationVibrationPatternCustom(context, pattern);
+      Toast.makeText(context,R.string.preferences__vibration_pattern_set, Toast.LENGTH_LONG).show();
+    }
+
+  }
+
+}

--- a/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -20,6 +20,8 @@ public class TextSecurePreferences {
 
   public  static final String RINGTONE_PREF                    = "pref_key_ringtone";
   private static final String VIBRATE_PREF                     = "pref_key_vibrate";
+  public  static final String VIBRATION_PATTERN_PREF           = "pref_key_vibration_pattern";
+  private static final String VIBRATION_PATTERN_PREF_CUSTOM    = "pref_key_vibration_pattern_custom";
   private static final String NOTIFICATION_PREF                = "pref_key_enable_notifications";
   public  static final String LED_COLOR_PREF                   = "pref_led_color";
   public  static final String LED_BLINK_PREF                   = "pref_led_blink";
@@ -202,6 +204,22 @@ public class TextSecurePreferences {
 
   public static boolean isNotificationVibrateEnabled(Context context) {
     return getBooleanPreference(context, VIBRATE_PREF, true);
+  }
+
+  public static String getNotificationVibrationPattern(Context context) {
+    return getStringPreference(context, VIBRATION_PATTERN_PREF, "default");
+  }
+
+  public static void setNotificationVibrationPattern(Context context, String pattern) {
+    setStringPreference(context, VIBRATION_PATTERN_PREF, pattern);
+  }
+
+  public static String getNotificationVibrationPatternCustom(Context context) {
+    return getStringPreference(context, VIBRATION_PATTERN_PREF_CUSTOM, "0,200,300,200");
+  }
+
+  public static void setNotificationVibrationPatternCustom(Context context, String pattern) {
+    setStringPreference(context, VIBRATION_PATTERN_PREF_CUSTOM, pattern);
   }
 
   public static String getNotificationLedColor(Context context) {


### PR DESCRIPTION
This adds an option to lets users adjust the vibration notification pattern by selecting a per-defined pattern from a short list or create their own pattern in the form millisecond-off, milliseconds-on, etc

The default list of vibrate patterns is:

Default (system default, seems to be close to 0,200,300,200)
3 Short (0,200,300,200,300,200)
3 Long (0,600,300,600,300,600)
2 Short, 2 Short (0,200,300,200,600,200,300,200)
2 Short, 2 Long (0,200,300,200,600,600,300,600)
2 Long, 2 Long (0,600,300,600,600,600,300,600)
