### PR TITLE
Use black theme without actionbar for RoutingActivity

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -46,7 +46,7 @@
                  android:theme="@style/TextSecure.LightTheme">
 
         <activity android:name=".RoutingActivity"
-                  android:theme="@style/NoAnimation.Theme.Sherlock.Light.DarkActionBar"
+                  android:theme="@style/NoAnimation.Theme.BlackScreen"
                   android:launchMode="singleTask"
                   android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize">
 

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="NoAnimation.Theme.Sherlock.Light.DarkActionBar" parent="@style/Theme.Sherlock.Light.DarkActionBar">
-        <item name="android:windowAnimationStyle">@null</item>        
+    <style name="NoAnimation.Theme.BlackScreen" parent="@style/Theme.Sherlock.NoActionBar">
+        <item name="android:windowAnimationStyle">@null</item>
+        <item name="android:windowBackground">@android:color/black</item>
     </style>
-    
+
+    <style name="NoAnimation.Theme.Sherlock.Light.DarkActionBar" parent="@style/Theme.Sherlock.Light.DarkActionBar">
+        <item name="android:windowAnimationStyle">@null</item>
+    </style>
+
 	<style name="transparent_progress">
 	    <item name="android:windowFrame">@null</item>
 	    <item name="android:windowBackground">@android:color/transparent</item>


### PR DESCRIPTION
The theme from the manifest is used for the startup animation.
Previously light background with a dark actionbar and the
green icon was displayed during the startup animation, then
the theme switched to whatever is configured in settings.
Now a black background without actionbar is used for the
startup animation. This was chosen because a black "flash" when
using the light theme is visually less distracting than a white
flash when using the dark theme.
