### PR TITLE
Add sorting by default phone number

### DIFF
--- a/src/org/thoughtcrime/securesms/contacts/ContactAccessor.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactAccessor.java
@@ -368,7 +368,9 @@ public class ContactAccessor {
       ContentResolver mContentResolver)
   {
     final String SORT_ORDER = Contacts.TIMES_CONTACTED + " DESC," +
-                              Contacts.DISPLAY_NAME + "," + Phone.TYPE;
+                              Contacts.DISPLAY_NAME + "," +
+                              Contacts.Data.IS_SUPER_PRIMARY + " DESC," +
+                              Phone.TYPE;
 
     final String[] PROJECTION_PHONE = {
         Phone._ID,                  // 0


### PR DESCRIPTION
Currently the order of numbers is times contacted -> displayName ->
phone type (mobile vs. home, etc.). This adds whether the number has
been saved as the default number for a contact to sort numbers belonging
to the same contact.

This fixes Issue #580
