### PR TITLE
Fix missing localozation strings for custom LED blink pattern.

### DIFF
--- a/res/layout/led_pattern_dialog.xml
+++ b/res/layout/led_pattern_dialog.xml
@@ -29,7 +29,7 @@
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:id="@+id/SeekBarOnLabel"
-          android:text="On For:"
+          android:text="@string/preferences__pref_led_blink_custom_pattern_on_for"
           android:paddingTop="5sp" />
         <TextView
           android:id="@+id/SeekBarOnMsLabel"
@@ -65,7 +65,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:id="@+id/SeekBarOffLabel"
-        android:text="Off For:"
+        android:text="@string/preferences__pref_led_blink_custom_pattern_off_for"
         android:paddingTop="5sp" />
       <TextView
         android:id="@+id/SeekBarOffMsLabel"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -644,6 +644,10 @@
     <string name="preferences__display_message_notifications_in_status_bar">Display message notifications in status bar</string>
     <string name="preferences__led_color">LED color</string>
     <string name="preferences__pref_led_blink_title">LED blink pattern</string>
+    <string name="preferences__pref_led_blink_custom_pattern_title">Set custom LED Blink Pattern</string>
+    <string name="preferences__pref_led_blink_custom_pattern_on_for">On For:</string>
+    <string name="preferences__pref_led_blink_custom_pattern_off_for">Off For:</string>
+    <string name="preferences__pref_led_blink_custom_pattern_set">Custom LED blink pattern set!</string>
     <string name="preferences__sound">Sound</string>
     <string name="preferences__change_notification_sound">Change notification sound</string>
     <string name="preferences__inthread_notifications">In-thread notifications</string>

--- a/src/org/thoughtcrime/securesms/preferences/LedBlinkPatternListPreference.java
+++ b/src/org/thoughtcrime/securesms/preferences/LedBlinkPatternListPreference.java
@@ -82,7 +82,7 @@ public class LedBlinkPatternListPreference extends ListPreference implements OnS
   private void initializeDialog(View view) {
     AlertDialog.Builder builder = new AlertDialog.Builder(context);
     builder.setIcon(android.R.drawable.ic_dialog_info);
-    builder.setTitle("Set Custom LED Blink Pattern");
+    builder.setTitle(R.string.preferences__pref_led_blink_custom_pattern_title);
     builder.setView(view);
     builder.setOnCancelListener(new CustomDialogCancelListener());
     builder.setNegativeButton(android.R.string.cancel, new CustomDialogCancelListener());
@@ -154,7 +154,7 @@ public class LedBlinkPatternListPreference extends ListPreference implements OnS
       dialogInProgress = false;
 
       TextSecurePreferences.setNotificationLedPatternCustom(context, pattern);
-      Toast.makeText(context, "Custom LED blink pattern set!", Toast.LENGTH_LONG).show();
+      Toast.makeText(context, R.string.preferences__pref_led_blink_custom_pattern_set, Toast.LENGTH_LONG).show();
     }
 
   }


### PR DESCRIPTION
I realized that this part is not translated properly and is in fact hardcoded.
Tried to stick to naming conventions as close as possible.
