### PR TITLE
Allow ignoring unencrypted messages on Android 4.4. (Issue #670)

### DIFF
--- a/src/org/thoughtcrime/securesms/service/SmsReceiver.java
+++ b/src/org/thoughtcrime/securesms/service/SmsReceiver.java
@@ -41,6 +41,7 @@ import org.thoughtcrime.securesms.sms.IncomingTextMessage;
 import org.thoughtcrime.securesms.sms.MultipartSmsMessageHandler;
 import org.thoughtcrime.securesms.sms.SmsTransportDetails;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
+import org.thoughtcrime.securesms.util.Util;
 import org.whispersystems.textsecure.crypto.InvalidKeyException;
 import org.whispersystems.textsecure.crypto.InvalidMessageException;
 import org.whispersystems.textsecure.crypto.InvalidVersionException;
@@ -93,6 +94,10 @@ public class SmsReceiver {
   }
 
   private Pair<Long, Long> storeStandardMessage(MasterSecret masterSecret, IncomingTextMessage message) {
+    if (!Util.isDefaultSmsProvider(context)) {
+        return null;
+    }
+
     EncryptingSmsDatabase encryptingDatabase = DatabaseFactory.getEncryptingSmsDatabase(context);
     SmsDatabase           plaintextDatabase  = DatabaseFactory.getSmsDatabase(context);
 
@@ -210,6 +215,9 @@ public class SmsReceiver {
 
     if (message != null) {
       Pair<Long, Long> messageAndThreadId = storeMessage(masterSecret, message);
+      if (messageAndThreadId == null) {
+        return;
+      }
       MessageNotifier.updateNotification(context, masterSecret, messageAndThreadId.second);
     }
   }


### PR DESCRIPTION
The preference will only be shown on Android versions >= 4.4, and only be
enabled when TextSecure is not the default message application. 
