### PR TITLE
Make outgoing links readable

### DIFF
--- a/res/layout/conversation_item_sent.xml
+++ b/res/layout/conversation_item_sent.xml
@@ -56,6 +56,7 @@
                     android:textAppearance="?android:attr/textAppearanceSmall"
                     android:gravity="right"
                     android:textColor="?conversation_sent_text_primary_color"
+                    android:textColorLink="?conversation_sent_text_primary_color"
                     android:textSize="16sp" />
 
                 <ImageView


### PR DESCRIPTION
Before:
![before](https://f.cloud.github.com/assets/43280/2266435/0db0d194-9e99-11e3-963e-440d159cce2d.png)

After:
![after](https://f.cloud.github.com/assets/43280/2266437/10c26c94-9e99-11e3-9aca-5268f344d48f.png)

I noticed that the default link colour clashes on outgoing messages so I made it match the rest of the message’s colour. For consistency, maybe incoming messages should be the same, but they don’t have the same clashing problem so I left it alone.
