### PR TITLE
Add option to disable screen security

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="delete">Delete</string>
 
     <!-- ApplicationPreferencesActivity -->
-    <string name="ApplicationPreferencesActivity_currently_s">Currently: %s</string>    
+    <string name="ApplicationPreferencesActivity_currently_s">Currently: %s</string>
     <string name="ApplicationPreferenceActivity_you_need_to_have_entered_your_passphrase_before_managing_keys">You need to have entered your passphrase before managing keys...</string>
     <string name="ApplicationPreferenceActivity_you_havent_set_a_passphrase_yet">You haven\'t set a passphrase yet!</string>
     <string name="ApplicationPreferencesActivity_messages_per_conversation">messages per conversation</string>
@@ -33,7 +33,7 @@
     <string name="AttachmentTypeSelectorAdapter_picture">Picture</string>
     <string name="AttachmentTypeSelectorAdapter_video">Video</string>
     <string name="AttachmentTypeSelectorAdapter_audio">Audio</string>
-    
+
     <!-- ConversationItem -->
     <string name="ConversationItem_message_size_d_kb">Message size: %d KB</string>
     <string name="ConversationItem_expires_s">Expires: %s</string>
@@ -90,7 +90,7 @@
     <string name="ConversationFragment_sender_s_transport_s_sent_s_received_s">Sender: %1$s\nTransport: %2$s\nSent: %3$s\nReceived:%4$s</string>
 	<string name="ConversationFragment_confirm_message_delete">Confirm Message Delete</string>
 	<string name="ConversationFragment_are_you_sure_you_want_to_permanently_delete_this_message">Are you sure that you want to permanently delete this message?</string>
-    
+
     <!-- ConversationListAdapter -->
     <string name="ConversationListAdapter_key_exchange_message">Key exchange message...</string>
 
@@ -99,7 +99,7 @@
     <string name="ConversationListFragment_are_you_sure_you_wish_to_delete_all_selected_conversation_threads">Are you sure you wish to delete ALL selected conversation threads?</string>
     <string name="ConversationListFragment_deleting">Deleting</string>
     <string name="ConversationListFragment_deleting_selected_threads">Deleting selected threads...</string>
-    
+
     <!-- ConversationListItem -->
     <string name="ConversationListItem_key_exchange_message">Key exchange message...</string>
 
@@ -173,7 +173,6 @@
     <string name="ImportFragment_no_encrypted_backup_found">No encrypted backup found!</string>
     <string name="ImportFragment_restore_complete">Restore complete!</string>
 
-
     <!-- KeyScanningActivity -->
     <string name="KeyScanningActivity_no_scanned_key_found_exclamation">No scanned key found!</string>
 
@@ -189,19 +188,19 @@
     <!-- PassphraseChangeActivity -->
     <string name="PassphraseChangeActivity_passphrases_dont_match_exclamation">Passphrases Don\'t Match!</string>
     <string name="PassphraseChangeActivity_incorrect_old_passphrase_exclamation">Incorrect old passphrase!</string>
-    
+
     <!-- PassphraseCreateActivity -->
     <string name="PassphraseCreateActivity_passphrases_dont_match">Passphrases don\'t match</string>
     <string name="PassphraseCreateActivity_you_must_specify_a_password">You must specify a password</string>
-    
+
     <!-- PassphrasePromptActivity -->
     <string name="PassphrasePromptActivity_invalid_passphrase_exclamation">Invalid Passphrase!</string>
-    
+
     <!-- PromptMmsActivity -->
     <string name="PromptMmsActivity_you_must_specify_an_mmsc_url_for_your_carrier">You must specify an MMSC URL for your carrier.</string>
     <string name="PromptMmsActivity_mms_settings_updated">MMS Settings Updated</string>
     <string name="PromptMmsActivity_you_can_modify_these_values_from_the_textsecure_settings_menu_at_any_time_">You can modify these values from the TextSecure settings menu at any time.</string>
-    
+
     <!-- ReceiveKeyActivity -->
     <string name="ReceiveKeyActivity_the_signature_on_this_key_exchange_is_different">The
         signature on this key exchange is different than what you\'ve previously received from this
@@ -313,7 +312,7 @@
     <string name="VerifyKeysActivity_not_verified_exclamation">NOT Verified!</string>
     <string name="VerifyKeysActivity_their_key_is_correct_it_is_also_necessary_to_get_your_fingerprint_scanned_as_well">Their key is correct. It is also necessary to get your fingerprint scanned as well.</string>
     <string name="VerifyKeysActivity_verified_exclamation">Verified!</string>
-    
+
     <!-- ViewIdentityActivity -->
     <string name="ViewIdentityActivity_you_do_not_have_an_identity_key">You do not have an identity key.</string>
     <string name="ViewIdentityActivity_scan_to_compare">Scan to compare</string>
@@ -328,7 +327,7 @@
     <string name="KeyExchangeInitiator_initiate_despite_existing_request_question">Initiate Despite Existing Request?</string>
     <string name="KeyExchangeInitiator_youve_already_sent_a_session_initiation_request_to_this_recipient_are_you_sure">You\'ve already sent a session initiation request to this recipient, are you sure you\'d like to send another?  This will invalidate the first request.</string>
     <string name="KeyExchangeInitiator_send">Send</string>
-    
+
     <!-- MessageDisplayHelper -->
     <string name="MessageDisplayHelper_bad_encrypted_message">Bad encrypted message...</string>
     <string name="MessageDisplayHelper_decrypting_please_wait">Decrypting, please wait...</string>
@@ -346,22 +345,22 @@
     <string name="MmsMessageRecord_bad_encrypted_mms_message">Bad encrypted MMS message...</string>
     <string name="MmsMessageRecord_mms_message_encrypted_for_non_existing_session">MMS message encrypted for non-existing session...</string>
 
-    <!-- MmsSender -->    
+    <!-- MmsSender -->
     <string name="MmsSender_currently_unable_to_send_your_mms_message">Currently unable to send your MMS message.</string>
-    
+
     <!-- ApplicationMigrationService -->
     <string name="ApplicationMigrationService_import_in_progress">Import in progress</string>
     <string name="ApplicationMigrationService_importing_text_messages">Importing Text Messages</string>
-    
+
     <!-- KeyCachingService -->
     <string name="KeyCachingService_textsecure_passphrase_cached">Touch to open.</string>
     <string name="KeyCachingService_textsecure_passphrase_cached_with_lock">Touch to open, or touch the lock to close.</string>
     <string name="KeyCachingService_passphrase_cached">TextSecure is unlocked</string>
     <string name="KeyCachingService_lock">Lock with passphrase</string>
-    
+
     <!-- MessageNotifier -->
     <string name="MessageNotifier_d_new_messages">%d new messages</string>
-    <string name="MessageNotifier_most_recent_from_s">Most recent from: %s</string>    
+    <string name="MessageNotifier_most_recent_from_s">Most recent from: %s</string>
     <string name="MessageNotifier_encrypted_message">Encrypted message...</string>
     <string name="MessageNotifier_no_subject">(No Subject)</string>
     <string name="MessageNotifier_message_delivery_failed">Message delivery failed.</string>
@@ -385,7 +384,6 @@
     <string name="ViewLocalIdentityActivity_cancel">Cancel</string>
     <string name="ViewLocalIdentityActivity_continue">Continue</string>
 
-
     <!-- SmsReceiver -->
     <string name="SmsReceiver_currently_unable_to_send_your_sms_message">Currently unable to send your SMS message. It will be sent once service becomes available.</string>
 
@@ -395,12 +393,12 @@
     <!-- auto_initiate_activity -->
     <string name="auto_initiate_activity__you_have_received_a_message_from_someone_who_supports_textsecure_encrypted_sessions_would_you_like_to_initiate_a_secure_session">You have received a message from someone who supports TextSecure encrypted sessions.  Would you like to initiate a secure session?</string>
     <string name="auto_initiate_activity__initiate_exchange">Initiate Exchange</string>
-    
+
     <!-- change_passphrase_activity -->
     <string name="change_passphrase_activity__old_passphrase">OLD PASSPHRASE:</string>
     <string name="change_passphrase_activity__new_passphrase">NEW PASSPHRASE:</string>
     <string name="change_passphrase_activity__repeat_new_passphrase">REPEAT NEW PASSPHRASE:</string>
-    
+
     <!-- contact_selection_group_activity -->
     <!-- contact_selection_list_activity -->
     <string name="contact_selection_group_activity__no_contacts">No contacts.</string>
@@ -411,23 +409,23 @@
 
     <!-- ContactSelectionListFragment-->
     <string name="ContactSelectionlistFragment_select_for">Select for</string>
-    
+
     <!-- contact_selection_recent_activity -->
     <string name="contact_selection_recent_activity__no_recent_calls">No recent calls.</string>
-    
+
     <!-- conversation_activity -->
     <string name="conversation_activity__type_message"><small>Send a message</small></string>
     <string name="conversation_activity__send">Send</string>
-    <string name="conversation_activity__remove">Remove</string>    
-    
+    <string name="conversation_activity__remove">Remove</string>
+
     <!-- conversation_item_sent -->
     <string name="conversation_item_sent__download">Download</string>
     <string name="conversation_item_sent__downloading">Downloading</string>
 
     <!-- conversation_item_received -->
     <string name="conversation_item_received__download">Download</string>
-    <string name="conversation_item_received__downloading">Downloading</string>    
-    
+    <string name="conversation_item_received__downloading">Downloading</string>
+
     <!-- conversation_fragment_cab -->
     <string name="conversation_fragment_cab__batch_selection_mode">Batch Selection Mode</string>
 
@@ -489,18 +487,17 @@
     <!-- mms_preferences_activity -->
     <string name="mms_preferences_activity__manual_mms_settings_are_required">Manual MMS settings are required for your phone.</string>
 
-
     <!-- prompt_passphrase_activity -->
     <string name="prompt_passphrase_activity__textsecure_passphrase">TEXTSECURE PASSPHRASE</string>
     <string name="prompt_passphrase_activity__unlock">Unlock</string>
-    
+
     <!-- prompt_mms_activity -->
     <string name="prompt_mms_activity__textsecure_requires_mms_settings_to_deliver_media_and_group_messages">TextSecure requires MMS settings to deliver media and group messages through your wireless carrier. Your device does not make this information available, which is occasionally true for locked devices and other restrictive configurations.</string>
     <string name="prompt_mms_activity__to_send_media_and_group_messages_click_ok">To send media and group messages, click \'OK\' and complete the requested settings. The MMS settings for your carrier can generally be located by searching for \'your carrier APN\'. You will only need to do this once.</string>
     <string name="prompt_mms_activity__mmsc_url_required">MMSC URL (REQUIRED):</string>
     <string name="prompt_mms_activity__mms_proxy_host_optional">MMS PROXY HOST (OPTIONAL):</string>
     <string name="prompt_mms_activity__mms_proxy_port_optional">MMS PROXY PORT (OPTIONAL):</string>
-    
+
     <!-- receive_key_activity -->
     <string name="receive_key_activity__complete">Complete</string>
 
@@ -596,19 +593,19 @@
     <!-- verify_identity_activity -->
     <string name="verify_identity_activity__their_identity_they_read">Their identity (they read):</string>
     <string name="verify_identity_activity__your_identity_you_read">Your identity (you read):</string>
-    
+
     <!-- verify_import_identity_activity -->
     <string name="verify_import_identity_activity__identity_name_n">Identity name:\\n</string>
     <string name="verify_import_identity_activity__imported_identity_n">Imported identity:\\n</string>
     <string name="verify_import_identity_activity__verified">Verified!</string>
     <string name="verify_import_identity_activity__compare">Compare</string>
-    
+
     <!-- verify_keys_activity -->
     <string name="verify_keys_activity__they_read_this">They read this:</string>
     <string name="verify_keys_activity__you_read_this">You read this:</string>
 
     <!-- AndroidManifest.xml -->
-    
+
     <string name="AndroidManifest__create_passphrase">Create Passphrase</string>
     <string name="AndroidManifest__enter_passphrase">Enter Passphrase</string>
     <string name="AndroidManifest__select_contacts">Select Contacts</string>
@@ -630,7 +627,7 @@
     <!-- preferences.xml -->
     <string name="preferences__general">General</string>
     <string name="preferences__pref_all_sms_title">Use for all SMS</string>
-    <string name="preferences__pref_all_mms_title">Use for all MMS</string> 
+    <string name="preferences__pref_all_mms_title">Use for all MMS</string>
     <string name="preferences__use_textsecure_for_viewing_and_storing_all_incoming_text_messages">Use TextSecure for viewing and storing all incoming text messages</string>
     <string name="preferences__use_textsecure_for_viewing_and_storing_all_incoming_multimedia_messages">Use TextSecure for viewing and storing all incoming multimedia messages</string>
     <string name="preferences__enable_enter_key_title">Enable Enter key</string>
@@ -645,7 +642,9 @@
     <string name="preferences__complete_key_exchanges">Complete key exchanges</string>
     <string name="preferences__disable_passphrase">Disable passphrase</string>
     <string name="preferences__disable_local_encryption_of_messages_and_keys">Disable local encryption of messages and keys</string>
+    <string name="preferences__screen_security">Screen security</string>
     <string name="preferences__automatically_complete_key_exchanges_for_new_sessions_or_for_existing_sessions_with_the_same_identity_key">Automatically complete key exchanges for new sessions or for existing sessions with the same identity key</string>
+    <string name="preferences__disable_screen_security_to_allow_screen_shots">Disable screen security to allow screen shots</string>
     <string name="preferences__forget_passphrase_from_memory_after_some_interval">Forget passphrase from memory after some interval</string>
     <string name="preferences__timeout_passphrase">Timeout passphrase</string>
     <string name="preferences__pref_timeout_interval_dialogtitle">Select Passphrase Timeout</string>
@@ -715,38 +714,37 @@
     <string name="preferences__refresh_push_directory">Refresh Push Directory</string>
     <string name="preferences__submit_debug_log">Submit debug log</string>
 
-
     <!-- **************************************** -->
     <!-- menus -->
     <!-- **************************************** -->
-    
+
     <!-- contact_selection_list -->
     <string name="contact_selection_list__menu_select_all">Select All</string>
     <string name="contact_selection_list__menu_unselect_all">Unselect All</string>
-    
+
     <!-- contact_selection -->
     <string name="contact_selection__menu_finished">Finished</string>
-    
+
     <!-- conversation_button_context -->
     <string name="conversation_button_context__menu_send_unencrypted">Send unencrypted</string>
-    
+
     <!-- conversation_callable -->
     <string name="conversation_callable__menu_call">Call</string>
-    
+
     <!-- conversation_context -->
-    <string name="conversation_context__menu_message_details">Message details</string>    
+    <string name="conversation_context__menu_message_details">Message details</string>
     <string name="conversation_context__menu_copy_text">Copy text</string>
     <string name="conversation_context__menu_delete_message">Delete message</string>
     <string name="conversation_context__menu_forward_message">Forward message</string>
     <string name="conversation_context__menu_resend_message">Resend message</string>
-    
+
     <!-- conversation_insecure -->
     <string name="conversation_insecure__menu_start_secure_session">Start Secure Session</string>
-    
+
     <!-- conversation_list_batch -->
     <string name="conversation_list_batch__menu_delete_selected">Delete Selected</string>
     <string name="conversation_list_batch__menu_select_all">Select All</string>
-    
+
     <!-- conversation_list -->
     <string name="conversation_list__menu_search">Search</string>
     <string name="conversation_list__drawer_open">Open navigation drawer</string>
@@ -757,14 +755,14 @@
     <string name="conversation_secure_verified__menu_no_identity">No Identity Available</string>
     <string name="conversation_secure_verified__menu_verify_recipient">Verify Recipient</string>
     <string name="conversation_secure_verified__menu_abort_secure_session">End Secure Session</string>
-    
+
     <!-- conversation -->
     <string name="conversation__menu_add_attachment">Add attachment</string>
     <string name="conversation__menu_update_group">Update Group</string>
     <string name="conversation__menu_leave_group">Leave Group</string>
     <string name="conversation__menu_add_contact_info">Add contact info</string>
     <string name="conversation__menu_delete_thread">Delete thread</string>
-    
+
     <!-- conversation_group_options -->
     <string name="convesation_group_options__recipients_list">Recipients list</string>
     <string name="conversation_group_options__delivery">Delivery</string>
@@ -775,10 +773,10 @@
     <string name="key_scanning__menu_compare">Compare</string>
     <string name="key_scanning__menu_get_scanned_to_compare">Get scanned to compare</string>
     <string name="key_scanning__menu_scan_to_compare">Scan to compare</string>
-    
+
     <!-- text_secure_locked -->
     <string name="text_secure_locked__menu_unlock">Unlock</string>
-    
+
     <!-- text_secure_normal -->
     <string name="text_secure_normal__menu_new_message">New Message</string>
     <string name="text_secure_normal__menu_new_group">New Group</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -31,7 +31,7 @@
                             android:key="pref_delivery_report_sms"
                             android:summary="@string/preferences__request_a_delivery_report_for_each_sms_message_you_send"
                             android:title="@string/preferences__sms_delivery_reports" />
-        
+
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/preferences__notifications">
         <CheckBoxPreference android:key="pref_key_enable_notifications"
@@ -54,7 +54,6 @@
                           android:entries="@array/pref_led_blink_pattern_entries"
                           android:entryValues="@array/pref_led_blink_pattern_values" />
 
-
         <RingtonePreference android:layout="?android:attr/preferenceLayoutChild"
                             android:dependency="pref_key_enable_notifications"
                             android:key="pref_key_ringtone"
@@ -76,8 +75,7 @@
                             android:defaultValue="true"
                             android:title="@string/preferences__vibrate"
                             android:summary="@string/preferences__also_vibrate_when_notified" />
-        
-        
+
   </PreferenceCategory>
 
   <PreferenceCategory android:title="Input Settings">
@@ -119,13 +117,13 @@
                         android:title="@string/preferences__conversation_length_limit"
                         android:inputType="number"
                         android:dependency="pref_trim_threads" />
-    
+
     <Preference android:key="pref_trim_now"
                 android:title="@string/preferences__trim_all_threads_now"
                 android:summary="@string/preferences__scan_through_all_conversation_threads_and_enforce_conversation_length_limits"
                 android:dependency="pref_trim_threads" />
 
-   </PreferenceCategory>  
+   </PreferenceCategory>
 
   <PreferenceCategory android:title="@string/preferences__display_settings" android:key="pref_display_category">
 
@@ -162,7 +160,6 @@
                android:dependency="pref_timeout_passphrase"
                android:dialogTitle="@string/preferences__pref_timeout_interval_dialogtitle" />
 
-
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/preferences__advanced">
@@ -170,6 +167,11 @@
                            android:key="pref_auto_complete_key_exchange"
                            android:title="@string/preferences__complete_key_exchanges"
                            android:summary="@string/preferences__automatically_complete_key_exchanges_for_new_sessions_or_for_existing_sessions_with_the_same_identity_key" />
+
+       <CheckBoxPreference android:defaultValue="true"
+                           android:key="pref_screen_security"
+                           android:title="@string/preferences__screen_security"
+                           android:summary="@string/preferences__disable_screen_security_to_allow_screen_shots" />
 
         <Preference android:key="pref_mms_preferences"
                     android:title="@string/preferences__advanced_mms_access_point_names"/>

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -270,7 +270,7 @@ public class ConversationActivity extends PassphraseRequiredSherlockFragmentActi
       } else {
         inflater.inflate(R.menu.conversation_secure_no_identity, menu);
       }
-      
+
       inflater.inflate(R.menu.conversation_secure_sms, menu.findItem(R.id.menu_security).getSubMenu());
     } else if (isSingleConversation() && !pushRegistered) {
       inflater.inflate(R.menu.conversation_insecure, menu);
@@ -476,7 +476,6 @@ public class ConversationActivity extends PassphraseRequiredSherlockFragmentActi
     intent.putExtra(GroupCreateActivity.GROUP_RECIPIENT_EXTRA, recipients);
     startActivityForResult(intent, GROUP_EDIT);
   }
-
 
   private void handleDistributionBroadcastEnabled(MenuItem item) {
     distributionType = ThreadDatabase.DistributionTypes.BROADCAST;
@@ -749,7 +748,7 @@ public class ConversationActivity extends PassphraseRequiredSherlockFragmentActi
 
     registerForContextMenu(sendButton);
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB && TextSecurePreferences.isScreenSecurityEnabled(this)) {
       getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
     }
 
@@ -805,7 +804,6 @@ public class ConversationActivity extends PassphraseRequiredSherlockFragmentActi
     registerReceiver(groupUpdateReceiver,
                      new IntentFilter(GroupDatabase.DATABASE_UPDATE_ACTION));
   }
-
 
   //////// Helper Methods
 

--- a/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -29,6 +29,7 @@ public class TextSecurePreferences {
   private static final String PASSPHRASE_TIMEOUT_INTERVAL_PREF = "pref_timeout_interval";
   private static final String PASSPHRASE_TIMEOUT_PREF          = "pref_timeout_passphrase";
   private static final String AUTO_KEY_EXCHANGE_PREF           = "pref_auto_complete_key_exchange";
+  private static final String SCREEN_SECURITY_PREF             = "pref_screen_security";
   private static final String ENTER_SENDS_PREF                 = "pref_enter_sends";
   private static final String ENTER_PRESENT_PREF               = "pref_enter_key";
   private static final String SMS_DELIVERY_REPORT_PREF         = "pref_delivery_report_sms";
@@ -132,6 +133,10 @@ public class TextSecurePreferences {
 
   public static boolean isAutoRespondKeyExchangeEnabled(Context context) {
     return getBooleanPreference(context, AUTO_KEY_EXCHANGE_PREF, true);
+  }
+
+  public static boolean isScreenSecurityEnabled(Context context) {
+    return getBooleanPreference(context, SCREEN_SECURITY_PREF, true);
   }
 
   public static boolean isUseLocalApnsEnabled(Context context) {


### PR DESCRIPTION
Allow WindowManager.LayoutParams to be toggled between being FLAG_SECURE and default to allow for user screenshots.

See WhisperSystems/TextSecure#788

Also might have `git strip-space`-ed each file... sorry about the extra lines in the diff. Tested on an HTC One. Might want to force it to upate the display when the option is toggled as well, but I wasn't sure (as it could be accidentally toggled and you might not want it to update right away).
