### PR TITLE
pending messages more accurately conveyed to user

### DIFF
--- a/res/drawable/conversation_item_sent_pending_shape.xml
+++ b/res/drawable/conversation_item_sent_pending_shape.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item>
+        <shape  android:shape="rectangle">
+            <solid android:color="#09000000" />
+            <corners android:radius="@dimen/conversation_item_corner_radius" />
+        </shape>
+    </item>
+
+    <item android:bottom="@dimen/conversation_item_drop_shadow_dist">
+        <shape xmlns:android="http://schemas.android.com/apk/res/android">
+            <solid android:color="@color/conversation_item_sent_pending_background_light" />
+            <!--stroke android:width="0.5dp" android:color="#03000000" /-->
+            <corners android:radius="@dimen/conversation_item_corner_radius" />
+        </shape>
+    </item>
+
+</layer-list>

--- a/res/drawable/conversation_item_sent_pending_shape_dark.xml
+++ b/res/drawable/conversation_item_sent_pending_shape_dark.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item>
+        <shape  android:shape="rectangle">
+            <solid android:color="#09000000" />
+            <corners android:radius="@dimen/conversation_item_corner_radius" />
+        </shape>
+    </item>
+
+    <item android:bottom="@dimen/conversation_item_drop_shadow_dist">
+        <shape xmlns:android="http://schemas.android.com/apk/res/android">
+            <solid android:color="@color/conversation_item_sent_pending_background_dark" />
+            <!--stroke android:width="0.5dp" android:color="#03000000" /-->
+            <corners android:radius="@dimen/conversation_item_corner_radius" />
+        </shape>
+    </item>
+
+</layer-list>

--- a/res/drawable/conversation_item_sent_pending_triangle_shape.xml
+++ b/res/drawable/conversation_item_sent_pending_triangle_shape.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item>
+        <rotate
+            android:fromDegrees="45"
+            android:toDegrees="45"
+            android:pivotX="0%"
+            android:pivotY="-30%" >
+            <shape
+                android:shape="rectangle" >
+                <solid
+                    android:color="@color/conversation_item_sent_pending_background_light" />
+            </shape>
+        </rotate>
+    </item>
+</layer-list>

--- a/res/drawable/conversation_item_sent_pending_triangle_shape_dark.xml
+++ b/res/drawable/conversation_item_sent_pending_triangle_shape_dark.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item>
+        <rotate
+            android:fromDegrees="45"
+            android:toDegrees="45"
+            android:pivotX="0%"
+            android:pivotY="-30%" >
+            <shape
+                android:shape="rectangle" >
+                <solid
+                    android:color="@color/conversation_item_sent_pending_background_dark" />
+            </shape>
+        </rotate>
+    </item>
+</layer-list>

--- a/res/drawable/conversation_item_sent_push_pending_shape.xml
+++ b/res/drawable/conversation_item_sent_push_pending_shape.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item>
+        <shape  android:shape="rectangle">
+            <solid android:color="#09000000" />
+            <corners android:radius="@dimen/conversation_item_corner_radius" />
+        </shape>
+    </item>
+
+    <item android:bottom="@dimen/conversation_item_drop_shadow_dist">
+        <shape xmlns:android="http://schemas.android.com/apk/res/android">
+            <solid android:color="@color/conversation_item_sent_push_pending_background_light" />
+            <corners android:radius="@dimen/conversation_item_corner_radius" />
+        </shape>
+    </item>
+
+</layer-list>

--- a/res/drawable/conversation_item_sent_push_pending_shape_dark.xml
+++ b/res/drawable/conversation_item_sent_push_pending_shape_dark.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item>
+        <shape  android:shape="rectangle">
+            <solid android:color="#09000000" />
+            <corners android:radius="@dimen/conversation_item_corner_radius" />
+        </shape>
+    </item>
+
+    <item android:bottom="@dimen/conversation_item_drop_shadow_dist">
+        <shape xmlns:android="http://schemas.android.com/apk/res/android">
+            <solid android:color="@color/conversation_item_sent_push_pending_background_dark" />
+            <corners android:radius="@dimen/conversation_item_corner_radius" />
+        </shape>
+    </item>
+
+</layer-list>

--- a/res/drawable/conversation_item_sent_push_pending_triangle_shape.xml
+++ b/res/drawable/conversation_item_sent_push_pending_triangle_shape.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item>
+        <rotate
+            android:fromDegrees="45"
+            android:toDegrees="45"
+            android:pivotX="0%"
+            android:pivotY="-30%" >
+            <shape
+                android:shape="rectangle" >
+                <solid
+                    android:color="@color/conversation_item_sent_push_pending_background_light" />
+            </shape>
+        </rotate>
+    </item>
+</layer-list>

--- a/res/drawable/conversation_item_sent_push_pending_triangle_shape_dark.xml
+++ b/res/drawable/conversation_item_sent_push_pending_triangle_shape_dark.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item>
+        <rotate
+            android:fromDegrees="45"
+            android:toDegrees="45"
+            android:pivotX="0%"
+            android:pivotY="-30%" >
+            <shape
+                android:shape="rectangle" >
+                <solid
+                    android:color="@color/conversation_item_sent_push_pending_background_dark" />
+            </shape>
+        </rotate>
+    </item>
+</layer-list>

--- a/res/layout/conversation_item_sent.xml
+++ b/res/layout/conversation_item_sent.xml
@@ -148,6 +148,7 @@
 		                android:autoLink="none"
 		                android:layout_width="wrap_content"
 		                android:layout_height="wrap_content"
+		                android:minWidth="15sp"
 		                android:linksClickable="false"
 		                android:textAppearance="?android:attr/textAppearanceSmall"
 		                android:layout_gravity="right"

--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -33,10 +33,14 @@
     <attr name="conversation_item_received_triangle_background" format="reference" />
     <attr name="conversation_item_sent_background" format="reference" />
     <attr name="conversation_item_sent_triangle_background" format="reference" />
+    <attr name="conversation_item_sent_pending_background" format="reference" />
+    <attr name="conversation_item_sent_pending_triangle_background" format="reference" />
     <attr name="conversation_item_sent_push_background" format="reference" />
     <attr name="conversation_item_sent_push_triangle_background" format="reference" />
     <attr name="dialog_info_icon" format="reference" />
     <attr name="dialog_alert_icon" format="reference" />
+    <attr name="conversation_item_sent_push_pending_background" format="reference" />
+    <attr name="conversation_item_sent_push_pending_triangle_background" format="reference" />
 
     <attr name="contact_selection_push_user" format="reference|color" />
     <attr name="contact_selection_lay_user" format="reference|color" />

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -15,8 +15,12 @@
 
     <color name="conversation_item_sent_background_dark">#ff284e0a</color>
     <color name="conversation_item_sent_background_light">#ff64a926</color>
+    <color name="conversation_item_sent_pending_background_light">#5564A926</color>
+    <color name="conversation_item_sent_pending_background_dark">#55284e0a</color>
     <color name="conversation_item_sent_push_background_light">#ff3a7ef2</color>
     <color name="conversation_item_sent_push_background_dark">#ff213b77</color>
+    <color name="conversation_item_sent_push_pending_background_light">#ff7bacf2</color>
+    <color name="conversation_item_sent_push_pending_background_dark">#55213b77</color>
     <color name="conversation_item_received_background_dark">#ff284e0a</color>
     <color name="conversation_item_received_background_light">#ff284e0a</color>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -47,7 +47,6 @@
     <string name="ConversationItem_message_size_d_kb">Message size: %d KB</string>
     <string name="ConversationItem_expires_s">Expires: %s</string>
     <string name="ConversationItem_error_sending_message">Error sending message</string>
-    <string name="ConversationItem_sending">Sending...</string>
     <string name="ConversationItem_saving_attachment">Saving Attachment</string>
     <string name="ConversationItem_saving_attachment_to_sd_card">Saving attachment to SD card...</string>
     <string name="ConversationItem_save_to_sd_card">Save to SD Card?</string>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -41,6 +41,10 @@
         <item name="conversation_item_sent_push_triangle_background">@drawable/conversation_item_sent_push_triangle_shape</item>
         <item name="dialog_info_icon">@drawable/ic_dialog_info_light</item>
         <item name="dialog_alert_icon">@drawable/ic_dialog_alert_light</item>
+        <item name="conversation_item_sent_pending_background">@drawable/conversation_item_sent_pending_shape</item>
+        <item name="conversation_item_sent_pending_triangle_background">@drawable/conversation_item_sent_pending_triangle_shape</item>
+        <item name="conversation_item_sent_push_pending_background">@drawable/conversation_item_sent_push_pending_shape</item>
+        <item name="conversation_item_sent_push_pending_triangle_background">@drawable/conversation_item_sent_push_pending_triangle_shape</item>
 
         <item name="menu_new_conversation_icon">@drawable/ic_action_new_holo_light</item>
         <item name="menu_new_group_icon">@drawable/ic_action_add_group_holo_light</item>
@@ -98,6 +102,10 @@
         <item name="conversation_item_sent_push_triangle_background">@drawable/conversation_item_sent_push_triangle_shape_dark</item>
         <item name="dialog_info_icon">@drawable/ic_dialog_info_dark</item>
         <item name="dialog_alert_icon">@drawable/ic_dialog_alert_dark</item>
+        <item name="conversation_item_sent_pending_background">@drawable/conversation_item_sent_pending_shape_dark</item>
+        <item name="conversation_item_sent_pending_triangle_background">@drawable/conversation_item_sent_pending_triangle_shape_dark</item>
+        <item name="conversation_item_sent_push_pending_background">@drawable/conversation_item_sent_push_pending_shape_dark</item>
+        <item name="conversation_item_sent_push_pending_triangle_background">@drawable/conversation_item_sent_push_pending_triangle_shape_dark</item>
 
         <item name="actionbar_icon">@drawable/actionbar_icon_holo_dark</item>
         <item name="lower_right_divet">@drawable/divet_lower_right_light</item>

--- a/src/org/thoughtcrime/securesms/ConversationAdapter.java
+++ b/src/org/thoughtcrime/securesms/ConversationAdapter.java
@@ -61,16 +61,18 @@ public class ConversationAdapter extends CursorAdapter implements AbsListView.Re
   private final Context context;
   private final MasterSecret masterSecret;
   private final boolean groupThread;
+  private final boolean pushDestination;
   private final LayoutInflater inflater;
 
   public ConversationAdapter(Context context, MasterSecret masterSecret,
-                             Handler failedIconClickHandler, boolean groupThread)
+                             Handler failedIconClickHandler, boolean groupThread, boolean pushDestination)
   {
     super(context, null);
     this.context                = context;
     this.masterSecret           = masterSecret;
     this.failedIconClickHandler = failedIconClickHandler;
     this.groupThread            = groupThread;
+    this.pushDestination        = pushDestination;
     this.inflater               = (LayoutInflater)context
                                     .getSystemService(Context.LAYOUT_INFLATER_SERVICE);
   }
@@ -82,7 +84,7 @@ public class ConversationAdapter extends CursorAdapter implements AbsListView.Re
     String type                 = cursor.getString(cursor.getColumnIndexOrThrow(MmsSmsDatabase.TRANSPORT));
     MessageRecord messageRecord = getMessageRecord(id, cursor, type);
 
-    item.set(masterSecret, messageRecord, failedIconClickHandler, groupThread);
+    item.set(masterSecret, messageRecord, failedIconClickHandler, groupThread, pushDestination);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -21,6 +21,8 @@ import android.widget.CursorAdapter;
 import com.actionbarsherlock.app.SherlockListFragment;
 
 import org.thoughtcrime.securesms.recipients.RecipientFactory;
+import org.thoughtcrime.securesms.util.DirectoryHelper;
+import org.thoughtcrime.securesms.util.Util;
 import org.whispersystems.textsecure.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.loaders.ConversationLoader;
@@ -197,7 +199,8 @@ public class ConversationFragment extends SherlockListFragment
     if (this.recipients != null && this.threadId != -1) {
       this.setListAdapter(new ConversationAdapter(getActivity(), masterSecret,
                                                   new FailedIconClickHandler(),
-                                                  (!this.recipients.isSingleRecipient()) || this.recipients.isGroupRecipient()));
+                                                  (!this.recipients.isSingleRecipient()) || this.recipients.isGroupRecipient(),
+                                                  DirectoryHelper.isPushDestination(getActivity(), this.recipients.getPrimaryRecipient())));
       getListView().setRecyclerListener((ConversationAdapter)getListAdapter());
       getLoaderManager().initLoader(0, null, this);
     }

--- a/src/org/thoughtcrime/securesms/service/SmsSender.java
+++ b/src/org/thoughtcrime/securesms/service/SmsSender.java
@@ -119,10 +119,9 @@ public class SmsSender {
       Cursor             cursor   = database.getMessage(messageId);
       SmsDatabase.Reader reader   = database.readerFor(cursor);
 
-      database.markAsSent(messageId);
-
-      if (upgraded) database.markAsSecure(messageId);
       if (push)     database.markAsPush(messageId);
+      if (upgraded) database.markAsSecure(messageId);
+      database.markAsSent(messageId);
 
       SmsMessageRecord record = reader.getNext();
 

--- a/src/org/thoughtcrime/securesms/util/DirectoryHelper.java
+++ b/src/org/thoughtcrime/securesms/util/DirectoryHelper.java
@@ -1,18 +1,23 @@
 package org.thoughtcrime.securesms.util;
 
 import android.content.Context;
+import android.util.Log;
 
 import org.thoughtcrime.securesms.push.PushServiceSocketFactory;
+import org.thoughtcrime.securesms.recipients.Recipient;
 import org.whispersystems.textsecure.directory.Directory;
+import org.whispersystems.textsecure.directory.NotInDirectoryException;
 import org.whispersystems.textsecure.push.ContactTokenDetails;
 import org.whispersystems.textsecure.push.PushServiceSocket;
 import org.whispersystems.textsecure.util.DirectoryUtil;
+import org.whispersystems.textsecure.util.InvalidNumberException;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public class DirectoryHelper {
+  private static final String TAG = DirectoryHelper.class.getSimpleName();
 
   public static void refreshDirectory(final Context context) {
     refreshDirectory(context, PushServiceSocketFactory.create(context));
@@ -36,6 +41,23 @@ public class DirectoryHelper {
       }
 
       directory.setNumbers(activeTokens, eligibleContactNumbers);
+    }
+  }
+
+  public static boolean isPushDestination(Context context, Recipient recipient) {
+    try {
+      if (!TextSecurePreferences.isPushRegistered(context)) return false;
+      if (GroupUtil.isEncodedGroup(recipient.getNumber()))  return true;
+
+      String number     = recipient.getNumber();
+      String e164number = Util.canonicalizeNumber(context, number);
+
+      return Directory.getInstance(context).isActiveNumber(e164number);
+    } catch (InvalidNumberException e) {
+      Log.w(TAG, e);
+      return false;
+    } catch (NotInDirectoryException e) {
+      return false;
     }
   }
 }


### PR DESCRIPTION
Fix for #750.

During pending state, messages will be colored a faded:
- **blue** if the local user is registered for push and the destination address is either a push group or a single recipient in the push directory
- **green** otherwise

![pending](https://f.cloud.github.com/assets/373823/2276891/0ea3db78-9f39-11e3-8273-6d77da3edc09.png)
![notsent](https://f.cloud.github.com/assets/373823/2276892/1218e76c-9f39-11e3-8e7d-a4f955ed4880.png)
