### PR TITLE
Hide advanced options in their own screen

### DIFF
--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -165,7 +165,8 @@
 
     </PreferenceCategory>
 
-    <PreferenceCategory android:title="@string/preferences__advanced">
+    <PreferenceScreen android:key="preferences__advanced"
+                      android:title="@string/preferences__advanced">
        <CheckBoxPreference android:defaultValue="true"
                            android:key="pref_auto_complete_key_exchange"
                            android:title="@string/preferences__complete_key_exchanges"
@@ -180,5 +181,5 @@
         <Preference android:key="pref_submit_debug_logs"
                     android:title="@string/preferences__submit_debug_log"/>
 
-    </PreferenceCategory>
+    </PreferenceScreen>
 </PreferenceScreen>


### PR DESCRIPTION
Hides advanced options in their own sub-menu as suggested by @mcginty [here](https://github.com/WhisperSystems/TextSecure/pull/794#issuecomment-36191045).

I did not add an option to enable/disable advanced options. It seems that just putting them in their own sub-screen serves the purpose to me; the people who don't want or care about the advanced options can safely ignore them, and those who use them won't have to jump through hoops to get to them. Thoughts?
