### PR TITLE
Don't display sender in outgoing message details

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -86,7 +86,7 @@
 
     <!-- ConversationFragment -->
     <string name="ConversationFragment_message_details">Message details</string>
-    <string name="ConversationFragment_sender_s_transport_s_sent_received_s">Sender: %1$s\nTransport: %2$s\nSent/Received:%3$s</string>
+    <string name="ConversationFragment_sender_s_transport_s_sent_received_s">Transport: %1$s\nSent/Received:%2$s</string>
     <string name="ConversationFragment_sender_s_transport_s_sent_s_received_s">Sender: %1$s\nTransport: %2$s\nSent: %3$s\nReceived:%4$s</string>
 	<string name="ConversationFragment_confirm_message_delete">Confirm Message Delete</string>
 	<string name="ConversationFragment_are_you_sure_you_want_to_permanently_delete_this_message">Are you sure that you want to permanently delete this message?</string>

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -136,7 +136,6 @@ public class ConversationFragment extends SherlockListFragment
   }
 
   private void handleDisplayDetails(MessageRecord message) {
-    String sender     = message.getIndividualRecipient().getNumber();
     long dateReceived = message.getDateReceived();
     long dateSent     = message.getDateSent();
 
@@ -156,12 +155,13 @@ public class ConversationFragment extends SherlockListFragment
     if (dateReceived == dateSent || message.isOutgoing()) {
       builder.setMessage(String.format(getSherlockActivity()
                                        .getString(R.string.ConversationFragment_sender_s_transport_s_sent_received_s),
-                                       sender, transport.toUpperCase(),
+                                       transport.toUpperCase(),
                                        dateFormatter.format(new Date(dateSent))));
     } else {
       builder.setMessage(String.format(getSherlockActivity()
                                        .getString(R.string.ConversationFragment_sender_s_transport_s_sent_s_received_s),
-                                       sender, transport.toUpperCase(),
+                                       message.getIndividualRecipient().getNumber(),
+                                       transport.toUpperCase(),
                                        dateFormatter.format(new Date(dateSent)),
                                        dateFormatter.format(new Date(dateReceived))));
     }


### PR DESCRIPTION
This brings the behavior on-par with the default Messaging app (rather than just being wrong). Is a pseudo-fix for #711 (details there on why).
