### PR TITLE
Preference for disabling the unlocked permanent unlocked notifiction

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -648,8 +648,8 @@
     <string name="preferences__automatically_complete_key_exchanges_for_new_sessions_or_for_existing_sessions_with_the_same_identity_key">Automatically complete key exchanges for new sessions or for existing sessions with the same identity key</string>
     <string name="preferences__forget_passphrase_from_memory_after_some_interval">Forget passphrase from memory after some interval</string>
     <string name="preferences__timeout_passphrase">Timeout passphrase</string>
-    <string name="preferences__enable_unlocked_notification">Enable unlock notification</string>
-    <string name="preferences__enable_notification_if_passphrase_is_set">Display notification if passphrase is set</string>
+    <string name="preferences__disable_unlock_notification">Disable unlock notification</string>
+    <string name="preferences__disable_unlock_notification_if_unlocked">Disable notification if TextSecure is unlocked</string>
     <string name="preferences__pref_timeout_interval_dialogtitle">Select Passphrase Timeout</string>
     <string name="preferences__pref_timeout_interval_title">Timeout interval</string>
     <string name="preferences__the_amount_of_time_to_wait_before_forgetting_passphrase">The amount of time to wait before forgetting passphrase from memory</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -148,10 +148,10 @@
                            android:summary="@string/preferences__disable_local_encryption_of_messages_and_keys"
                            android:disableDependentsState="true"/>
 
-       <CheckBoxPreference android:key="pref_enable_unlocked_notification"
-           android:defaultValue="true"
-           android:title="@string/preferences__enable_unlocked_notification"
-           android:summary="@string/preferences__enable_notification_if_passphrase_is_set"
+       <CheckBoxPreference android:key="pref_disable_unlocked_notification"
+           android:defaultValue="false"
+           android:title="@string/preferences__disable_unlock_notification"
+           android:summary="@string/preferences__disable_unlock_notification_if_unlocked"
            android:dependency="pref_disable_passphrase"/>
 
        <CheckBoxPreference android:defaultValue="false"

--- a/src/org/thoughtcrime/securesms/service/KeyCachingService.java
+++ b/src/org/thoughtcrime/securesms/service/KeyCachingService.java
@@ -237,8 +237,8 @@ public class KeyCachingService extends Service {
       return;
     }
 
-    if (!TextSecurePreferences.isUnlockedNotificationEnabled(this)) {
-      //stopForeground(true);
+    if (TextSecurePreferences.isUnlockedNotificationDisabled(this)) {
+      //Don't do anything, notification is disabled in preferences
       return;
     }
 

--- a/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -9,7 +9,7 @@ public class TextSecurePreferences {
   public  static final String IDENTITY_PREF                    = "pref_choose_identity";
   public  static final String CHANGE_PASSPHRASE_PREF           = "pref_change_passphrase";
   public  static final String DISABLE_PASSPHRASE_PREF          = "pref_disable_passphrase";
-  public  static final String ENABLE_UNLOCKED_NOTIFICATION     = "pref_enable_unlocked_notification"
+  public  static final String DISABLE_UNLOCKED_NOTIFICATION    = "pref_disable_unlocked_notification";
   public  static final String THEME_PREF                       = "pref_theme";
   public  static final String LANGUAGE_PREF                    = "pref_language";
   public  static final String MMSC_HOST_PREF                   = "pref_apn_mmsc_host";
@@ -111,12 +111,12 @@ public class TextSecurePreferences {
     setBooleanPreference(context, DISABLE_PASSPHRASE_PREF, disabled);
   }
 
-  public static boolean isUnlockedNotificationEnabled(Context context) {
-    return getBooleanPreference(context, ENABLE_UNLOCKED_NOTIFICATION, true);
+  public static boolean isUnlockedNotificationDisabled(Context context) {
+    return getBooleanPreference(context, DISABLE_UNLOCKED_NOTIFICATION, true);
   }
 
-  public static boolean setUnlockedNotificationEnabled(Context context, boolean state) {
-    setBooleanPreference(context, ENABLE_UNLOCKED_NOTIFICATION, state);
+  public static void setUnlockedNotificationDisabled(Context context, boolean state) {
+    setBooleanPreference(context, DISABLE_UNLOCKED_NOTIFICATION, state);
   }
 
   public static String getMmscUrl(Context context) {


### PR DESCRIPTION
Me and some friends think it is annoying to have the "unlocked notification" visible all the time. Thus I added a preference to let the user decide if he wants it displayed or not. Default is still to display it. 
