### PR TITLE
use Intent.FLAG_ACTIVITY_CLEAR_TOP when creating the convervation intent...

### DIFF
--- a/src/org/thoughtcrime/securesms/RoutingActivity.java
+++ b/src/org/thoughtcrime/securesms/RoutingActivity.java
@@ -141,6 +141,7 @@ public class RoutingActivity extends PassphraseRequiredSherlockActivity {
     intent.putExtra(ConversationActivity.DRAFT_TEXT_EXTRA, parameters.draftText);
     intent.putExtra(ConversationActivity.DRAFT_IMAGE_EXTRA, parameters.draftImage);
     intent.putExtra(ConversationActivity.DRAFT_AUDIO_EXTRA, parameters.draftAudio);
+    intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
     return intent;
   }


### PR DESCRIPTION
so that multiple notifications don't create new activities that stack in the context, and you only need to hit back the once to get back to the conversation list (issue #851)
