### PR TITLE
new string ViewIdentityActivity_my_identity_fingerprint

### DIFF
--- a/src/org/thoughtcrime/securesms/ViewLocalIdentityActivity.java
+++ b/src/org/thoughtcrime/securesms/ViewLocalIdentityActivity.java
@@ -45,8 +45,7 @@ public class ViewLocalIdentityActivity extends ViewIdentityActivity {
     this.masterSecret = getIntent().getParcelableExtra("master_secret");
 
     getIntent().putExtra("identity_key", IdentityKeyUtil.getIdentityKey(this, Curve.DJB_TYPE));
-    getIntent().putExtra("title", getString(R.string.ApplicationPreferencesActivity_my) + " " +
-        getString(R.string.ViewIdentityActivity_identity_fingerprint));
+    getIntent().putExtra("title", getString(R.string.ViewIdentityActivity_my_identity_fingerprint));
     super.onCreate(bundle);
   }
 


### PR DESCRIPTION
introducing a new string key ViewIdentityActivity_my_identity_fingerprint which replaces the previous simple concatenation of "my" (possesive pronoun) and "fingerprint". Facilitates translation into non-English languages where possesive pronouns have to be declined.
- English: "My key's fingerpint"
- German: "Mein Fingerabdruck"

to solve the "Meine Fingerabdruck" issue, and to allow smooth translations into other languages.
