### PR TITLE
Use ACTION_OPEN_DOCUMENT for Android >= KitKat. Fixes #926.

### DIFF
--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -20,6 +20,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
@@ -94,7 +95,14 @@ public class AttachmentManager {
   }
 
   private static void selectMediaType(Activity activity, String type, int requestCode) {
-    Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+    final Intent intent;
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+      intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+    } else {
+      intent = new Intent(Intent.ACTION_GET_CONTENT);
+    }
+
     intent.setType(type);
     activity.startActivityForResult(intent, requestCode);
   }


### PR DESCRIPTION
We have to do this, since with the new Storage Access Framework, otherwise we can open the Uri only _once_. This would work well unless someone saves a draft and goes back to the conversation - then the Uri is opened again without the required permissions. See

https://developer.android.com/guide/topics/providers/document-provider.html#client

for details.
