### PR TITLE
Use standard intent to select group avatar.

### DIFF
--- a/src/org/thoughtcrime/securesms/util/BitmapUtil.java
+++ b/src/org/thoughtcrime/securesms/util/BitmapUtil.java
@@ -106,21 +106,29 @@ public class BitmapUtil {
 
   public static Bitmap getCircleCroppedBitmap(Bitmap bitmap) {
     if (bitmap == null) return null;
-    Bitmap output = Bitmap.createBitmap(bitmap.getWidth(),
-        bitmap.getHeight(), Bitmap.Config.ARGB_8888);
+    final int srcSize = Math.min(bitmap.getWidth(), bitmap.getHeight());
+    return getScaledCircleCroppedBitmap(bitmap, srcSize);
+  }
+
+  public static Bitmap getScaledCircleCroppedBitmap(Bitmap bitmap, int destSize) {
+    if (bitmap == null) return null;
+    Bitmap output = Bitmap.createBitmap(destSize, destSize, Bitmap.Config.ARGB_8888);
     Canvas canvas = new Canvas(output);
 
+    final int srcSize = Math.min(bitmap.getWidth(), bitmap.getHeight());
+    final int srcX = (bitmap.getWidth() - srcSize) / 2;
+    final int srcY = (bitmap.getHeight() - srcSize) / 2;
+    final Rect srcRect = new Rect(srcX, srcY, srcX + srcSize, srcY + srcSize);
+    final Rect destRect = new Rect(0, 0, destSize, destSize);
     final int color = 0xff424242;
     final Paint paint = new Paint();
-    final Rect rect = new Rect(0, 0, bitmap.getWidth(), bitmap.getHeight());
 
     paint.setAntiAlias(true);
     canvas.drawARGB(0, 0, 0, 0);
     paint.setColor(color);
-    canvas.drawCircle(bitmap.getWidth() / 2, bitmap.getHeight() / 2,
-        bitmap.getWidth() / 2, paint);
+    canvas.drawCircle(destSize / 2, destSize / 2, destSize / 2, paint);
     paint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_IN));
-    canvas.drawBitmap(bitmap, rect, rect, paint);
+    canvas.drawBitmap(bitmap, srcRect, destRect, paint);
     return output;
   }
 


### PR DESCRIPTION
The ACTION_GET_CONTENT used with cropping is not supported on all devices.
To make this work more reliably I removed the cropping and MediaStore.EXTRA_OUTPUT.
The image is now read via getContentResolver().openInputStream() which should work on all device including KitKat/CM11.

Please test if this fixes #641 for everyone.
