### PR TITLE
Implementing Quickreply

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -398,7 +398,7 @@
     <string name="SmsReceiver_currently_unable_to_send_your_sms_message">Currently unable to send your SMS message. It will be sent once service becomes available.</string>
 
     <!-- QuickResponseService -->
-    <string name="QuickResponseService_sorry_quick_response_is_not_yet_supported_by_textsecure">Sorry, Quick Response is not yet supported by TextSecure!</string>
+    <string name="QuickResponseService_the_quick_response_will_be_sent_when_textsecure_will_be_unlocked">The Quick Response will be sent when TextSecure will be unlocked!</string>
 
     <!-- auto_initiate_activity -->
     <string name="auto_initiate_activity__you_have_received_a_message_from_someone_who_supports_textsecure_encrypted_sessions_would_you_like_to_initiate_a_secure_session">You have received a message from someone who supports TextSecure encrypted sessions.  Would you like to initiate a secure session?</string>

--- a/src/org/thoughtcrime/securesms/service/MasterSecretTaskService.java
+++ b/src/org/thoughtcrime/securesms/service/MasterSecretTaskService.java
@@ -1,0 +1,218 @@
+package org.thoughtcrime.securesms.service;
+
+import android.app.Service;
+import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.ServiceConnection;
+import android.os.IBinder;
+import android.util.Log;
+
+import org.thoughtcrime.securesms.util.WorkerThread;
+import org.whispersystems.textsecure.crypto.MasterSecret;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Created by asafh on 3/3/14.
+ * This class is a base for a service that executes tasks that depend on the MasterSecret.
+ * Inheritors should take care to call super.onCreate and onDestroy if they override them.
+ */
+public abstract class MasterSecretTaskService extends Service {
+  private final String tag;
+
+  private MasterSecret masterSecret;
+  private boolean hasSecret;
+  private NewKeyReceiver newKeyReceiver;
+  private ClearKeyReceiver clearKeyReceiver;
+
+  private List<Runnable> workQueue;
+  private List<Runnable> pendingSecretList;
+
+
+  public MasterSecretTaskService() {
+    tag = getClass().getName();
+  }
+
+  public boolean hasSecret() {
+    return hasSecret;
+  }
+
+  @Override
+  public IBinder onBind(Intent intent) {
+    return null;
+  }
+
+  @Override
+  public void onCreate() {
+    initializeWorkQueue();
+    initializeMasterSecret();
+  }
+
+  @Override
+  public void onDestroy() {
+    Log.w(tag, "onDestroy()...");
+    super.onDestroy();
+
+    if (newKeyReceiver != null)
+      unregisterReceiver(newKeyReceiver);
+
+    if (clearKeyReceiver != null)
+      unregisterReceiver(clearKeyReceiver);
+  }
+
+  private void initializeWorkQueue() {
+    pendingSecretList = new LinkedList<Runnable>();
+    workQueue = new LinkedList<Runnable>();
+
+    Thread workerThread = new WorkerThread(workQueue, tag + "-WorkerThread");
+    workerThread.start();
+  }
+
+  public void clearSecret() {
+    synchronized (workQueue) {
+      MasterSecretTaskService.this.hasSecret = false;
+      workQueue.add(new Runnable() {
+        @Override
+        public void run() {
+          Log.w(tag, "Running clear key work item...");
+
+          synchronized (workQueue) {
+            if (!MasterSecretTaskService.this.hasSecret) {
+              Log.w(tag, "Actually clearing key...");
+              MasterSecretTaskService.this.masterSecret = null;
+            }
+          }
+        }
+      });
+
+      workQueue.notifyAll();
+    }
+  }
+
+  private ServiceConnection serviceConnection = new ServiceConnection() {
+    @Override
+    public void onServiceConnected(ComponentName className, IBinder service) {
+      KeyCachingService keyCachingService = ((KeyCachingService.KeyCachingBinder) service).getService();
+      MasterSecret masterSecret = keyCachingService.getMasterSecret();
+
+      initializeWithMasterSecret(masterSecret);
+
+      MasterSecretTaskService.this.unbindService(this);
+    }
+
+    @Override
+    public void onServiceDisconnected(ComponentName name) {
+    }
+  };
+
+
+  private void initializeMasterSecret() {
+    hasSecret = false;
+    newKeyReceiver = new NewKeyReceiver();
+    clearKeyReceiver = new ClearKeyReceiver();
+
+    IntentFilter newKeyFilter = new IntentFilter(KeyCachingService.NEW_KEY_EVENT);
+    registerReceiver(newKeyReceiver, newKeyFilter, KeyCachingService.KEY_PERMISSION, null);
+
+    IntentFilter clearKeyFilter = new IntentFilter(KeyCachingService.CLEAR_KEY_EVENT);
+    registerReceiver(clearKeyReceiver, clearKeyFilter, KeyCachingService.KEY_PERMISSION, null);
+
+    Intent bindIntent = new Intent(this, KeyCachingService.class);
+    startService(bindIntent);
+    bindService(bindIntent, serviceConnection, Context.BIND_AUTO_CREATE);
+  }
+
+  private void initializeWithMasterSecret(MasterSecret masterSecret) {
+    Log.w(tag, "Service got master secret.");
+
+    if (masterSecret != null) {
+      synchronized (workQueue) {
+        this.masterSecret = masterSecret;
+        this.hasSecret = true;
+
+        Iterator<Runnable> iterator = pendingSecretList.iterator();
+        while (iterator.hasNext())
+          workQueue.add(iterator.next());
+
+        pendingSecretList.clear(); //Added by asafh, I can't see where the pending secret
+        // list is cleared otherwise, this place makes sense.
+
+        workQueue.notifyAll();
+      }
+    }
+  }
+
+  public void scheduleSecretOptionalWork(MasterSecretTask task) {
+    RunnableMasterSecretTaskWrapper work = new RunnableMasterSecretTaskWrapper(task);
+    synchronized (workQueue) {
+      workQueue.add(work);
+      workQueue.notifyAll();
+    }
+  }
+
+  public void scheduleSecretRequiredWork(MasterSecretTask task) {
+    RunnableMasterSecretTaskWrapper work = new RunnableMasterSecretTaskWrapper(task);
+    synchronized (workQueue) {
+      if (hasSecret) {
+        workQueue.add(work);
+        workQueue.notifyAll();
+      } else {
+        pendingSecretList.add(work);
+      }
+    }
+  }
+
+  private class RunnableMasterSecretTaskWrapper implements Runnable {
+    private final MasterSecretTask work;
+
+    public RunnableMasterSecretTaskWrapper(MasterSecretTask work) {
+      this.work = work;
+    }
+
+    @Override
+    public void run() {
+      work.call(MasterSecretTaskService.this.masterSecret);
+    }
+  }
+
+  public static interface MasterSecretTask {
+    void call(MasterSecret masterSecret);
+  }
+
+  private class NewKeyReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+      Log.w(tag, "Got a MasterSecret broadcast...");
+      initializeWithMasterSecret((MasterSecret) intent.getParcelableExtra("master_secret"));
+    }
+  }
+
+  /**
+   * This class receives broadcast notifications to clear the MasterSecret.
+   * <p/>
+   * We don't want to clear it immediately, since there are potentially jobs
+   * in the work queue which require the master secret.  Instead, we reset a
+   * flag so that new incoming jobs will be evaluated as if no mastersecret is
+   * present.
+   * <p/>
+   * Then, we add a job to the end of the queue which actually clears the masterSecret
+   * value.  That way all jobs before this moment will be processed correctly, and all
+   * jobs after this moment will be evaluated as if no mastersecret is present (and potentially
+   * held).
+   * <p/>
+   * When we go to actually clear the mastersecret, we ensure that the flag is still false.
+   * This allows a new mastersecret broadcast to come in correctly without us clobbering it.
+   */
+  private class ClearKeyReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+      Log.w(tag, "Got a clear mastersecret broadcast...");
+      clearSecret();
+    }
+  }
+}

--- a/src/org/thoughtcrime/securesms/service/QuickResponseService.java
+++ b/src/org/thoughtcrime/securesms/service/QuickResponseService.java
@@ -1,31 +1,113 @@
 package org.thoughtcrime.securesms.service;
 
-import android.app.Service;
+import android.content.Context;
 import android.content.Intent;
-import android.os.IBinder;
+import android.net.Uri;
+import android.os.Bundle;
 import android.telephony.TelephonyManager;
+import android.text.TextUtils;
 import android.util.Log;
 import android.widget.Toast;
 
+
 import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.recipients.Recipient;
+import org.thoughtcrime.securesms.recipients.RecipientFactory;
+import org.thoughtcrime.securesms.recipients.RecipientFormattingException;
+import org.thoughtcrime.securesms.recipients.Recipients;
+import org.thoughtcrime.securesms.sms.MessageSender;
+import org.thoughtcrime.securesms.sms.OutgoingEncryptedMessage;
+import org.thoughtcrime.securesms.sms.OutgoingTextMessage;
+import org.whispersystems.textsecure.crypto.MasterSecret;
+import org.whispersystems.textsecure.storage.Session;
 
-public class QuickResponseService extends Service {
 
-  public int onStartCommand(Intent intent, int flags, int startId) {
-    if (!TelephonyManager.ACTION_RESPOND_VIA_MESSAGE.equals(intent.getAction())) {
-      Log.w("QuickResponseService", "Received unknown intent: " + intent.getAction());
+public class QuickResponseService extends MasterSecretTaskService {
+  public static final String TAG = "QuickResponseService";
+
+
+  public Recipients getRecipients(Uri uri) throws RecipientFormattingException {
+    String base = uri.getSchemeSpecificPart();
+    int pos = base.indexOf('?');
+    String str = (pos == -1) ? base : base.substring(0, pos);
+    String rawText = str.replace(';', ','); //Normalizing to TextSecure format.
+    return RecipientFactory.getRecipientsFromString(getApplicationContext(), rawText, false);
+  }
+
+  public int onStartCommand(final Intent intent, int flags, final int startId) {
+    String action = intent.getAction();
+    if (!TelephonyManager.ACTION_RESPOND_VIA_MESSAGE.equals(action)) {
+      Log.w(TAG, "Received unknown intent: " + intent.getAction());
       return START_NOT_STICKY;
     }
 
-    Toast.makeText(this,
-                   getString(R.string.QuickResponseService_sorry_quick_response_is_not_yet_supported_by_textsecure),
-                   Toast.LENGTH_LONG).show();
+    Bundle extras = intent.getExtras();
+    if (extras == null) {
+      Log.w(TAG, "Called to send SMS but no extras");
+      return START_NOT_STICKY;
+    }
+
+    final String body = extras.getString(Intent.EXTRA_TEXT);
+
+    Uri intentUri = intent.getData();
+
+    final Recipients recipients;
+    final Recipient recipient;
+    try {
+      recipients = getRecipients(intentUri);
+      recipient = recipients.getPrimaryRecipient();
+    } catch (RecipientFormattingException e) {
+      Log.w(TAG, "Bad recipients format");
+      return START_NOT_STICKY;
+    }
+
+    if (recipients.isEmpty()) {
+      Log.w(TAG, "Recipient(s) cannot be empty");
+      return START_NOT_STICKY;
+    }
+    if (!recipients.isSingleRecipient()) {
+      Log.w(TAG, "Quick reply must be sent to single recipient");
+      return START_NOT_STICKY;
+    }
+
+    if (TextUtils.isEmpty(body)) {
+      Log.w(TAG, "Message cannot be empty");
+      return START_NOT_STICKY;
+    }
+
+    final Context context = getApplicationContext();
+    final boolean forcePlaintext = false;
+    if (!hasSecret()) {
+      //TODO: Currently sending will be queued until unlocked. Alternatively we let the user configure that we will either:
+      // 1. Not send an SMS when locked
+      // 2. Add for QuickResponse to force plaintext when locked (set forcePlaintext=true)
+      Toast.makeText(this,
+              getString(R.string.QuickResponseService_the_quick_response_will_be_sent_when_textsecure_will_be_unlocked),
+              Toast.LENGTH_LONG).show();
+
+    }
+    scheduleSecretRequiredWork(new MasterSecretTask() {
+      @Override
+      public void call(MasterSecret masterSecret) {
+        long threadId = -1;
+        boolean isEncryptedConversation = Session.hasSession(QuickResponseService.this, masterSecret, recipient);
+
+
+        OutgoingTextMessage message;
+        if (isEncryptedConversation && !forcePlaintext) {
+          message = new OutgoingEncryptedMessage(recipients, body);
+        } else {
+          message = new OutgoingTextMessage(recipients, body);
+        }
+
+        Log.i(TAG, "Sending quick reply...");
+
+        MessageSender.send(context, masterSecret, message, threadId);
+      }
+    });
 
     return START_NOT_STICKY;
   }
 
-  @Override
-  public IBinder onBind(Intent intent) {
-    return null;
-  }
+
 }


### PR DESCRIPTION
I've implemented the feature, right now the way it works if TextSecure is locked is it will queue the sending of the message until it is unlocked.
However, if the service is killed before that the message will be lost. We can avoid this using START_REDELIVER_INTENT but this gives some slight chance of resending messages if the service is killed between the sending of the message and the stopSelf call. I opted to avoid this for now.

I tried adhering to your code guidelines but this is my first look into this project, and frankly I'm not a major Android developer though I think I did alright.

I avoided duplicating the "run tasks when you get the master secret" logic in SendReceiveService by extracting it a parent class "MasterSecretTaskService".

Let me know what you think about the way I implemented this.

Issue #299 
