### PR TITLE
Add possibility to delete contact's identity and directory entry

### DIFF
--- a/library/src/org/whispersystems/textsecure/directory/Directory.java
+++ b/library/src/org/whispersystems/textsecure/directory/Directory.java
@@ -82,6 +82,16 @@ public class Directory {
     }
   }
 
+  public boolean delete(String e164number) {
+    if (e164number == null || e164number.length() == 0) {
+      return false;
+    }
+
+    SQLiteDatabase db = databaseHelper.getWritableDatabase();
+
+    return (db.delete(TABLE_NAME, NUMBER + " = ?", new String[] {e164number}) == 1);
+  }
+
   public boolean isActiveNumber(String e164number) throws NotInDirectoryException {
     if (e164number == null || e164number.length() == 0) {
       return false;

--- a/res/menu/review_identity.xml
+++ b/res/menu/review_identity.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:title="@string/ViewIdentity__menu_delete_identity"
+          android:id="@+id/menu_delete_identity"
+          android:icon="@android:drawable/ic_menu_delete" />
+
+</menu>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -607,6 +607,11 @@
     <!-- review_identities -->
     <string name="review_identities__you_don_t_currently_have_any_identity_keys_in_your_trust_database">You don\'t currently have any identity keys in your trust database.</string>
 
+    <!-- review identity activity -->
+    <string name="ViewIdentity__menu_delete_identity">Delete Identity</string>
+    <string name="ViewIdentity__alert_end_session_first">End Session First</string>
+    <string name="ViewIdentity__alert_please_end_your_session_first">Please first end your secure session with this contact from the conversation with this contact.</string>
+
     <!-- verify_identity_activity -->
     <string name="verify_identity_activity__their_identity_they_read">Their identity (they read):</string>
     <string name="verify_identity_activity__your_identity_you_read">Your identity (you read):</string>

--- a/src/org/thoughtcrime/securesms/ReviewIdentitiesFragment.java
+++ b/src/org/thoughtcrime/securesms/ReviewIdentitiesFragment.java
@@ -41,8 +41,8 @@ public class ReviewIdentitiesFragment extends SherlockListFragment
   public void onListItemClick(ListView listView, View view, int position, long id) {
     Intent viewIntent = new Intent(getActivity(), ViewIdentityActivity.class);
     viewIntent.putExtra("identity_key", ((IdentityKeyView)view).getIdentityKey());
-    viewIntent.putExtra("title", ((IdentityKeyView)view).getRecipient().toShortString() + " " +
-                                 getString(R.string.ViewIdentityActivity_identity_fingerprint));
+    viewIntent.putExtra("recipient", ((IdentityKeyView)view).getRecipient());
+    viewIntent.putExtra("master_secret", this.masterSecret);
     startActivity(viewIntent);
   }
 

--- a/src/org/thoughtcrime/securesms/database/IdentityDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/IdentityDatabase.java
@@ -130,6 +130,13 @@ public class IdentityDatabase extends Database {
     context.getContentResolver().notifyChange(CHANGE_URI, null);
   }
 
+  public void deleteByRecipient(long recipientId) {
+    SQLiteDatabase database = databaseHelper.getWritableDatabase();
+    database.delete(TABLE_NAME, RECIPIENT + " = ?", new String[] {recipientId+""});
+
+    context.getContentResolver().notifyChange(CHANGE_URI, null);
+  }
+
   public void deleteIdentity(long id) {
     SQLiteDatabase database = databaseHelper.getWritableDatabase();
     database.delete(TABLE_NAME, ID_WHERE, new String[] {id+""});


### PR DESCRIPTION
This solves #274 and could be a way to remedy #791 (deleting the wrong number from the directory, adding the next one on the next sync)

Since currently nothing important (i.e. that cannot be reconstructed automatically) is being deleted, I do not show a "are you really sure"-dialog...
