### PR TITLE
Fix for screen security options

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -660,7 +660,7 @@
     <string name="preferences__disable_local_encryption_of_messages_and_keys">Disable local encryption of messages and keys</string>
     <string name="preferences__screen_security">Screen security</string>
     <string name="preferences__automatically_complete_key_exchanges_for_new_sessions_or_for_existing_sessions_with_the_same_identity_key">Automatically complete key exchanges for new sessions or for existing sessions with the same identity key</string>
-    <string name="preferences__disable_screen_security_to_allow_screenshots">Disable screen security to allow screenshots</string>
+    <string name="preferences__enable_screen_security_to_prevent_other_apps_from_screen_capture">Enable screen security to prevent other apps from screen capture</string>
     <string name="preferences__forget_passphrase_from_memory_after_some_interval">Forget passphrase from memory after some interval</string>
     <string name="preferences__timeout_passphrase">Timeout passphrase</string>
     <string name="preferences__pref_timeout_interval_dialogtitle">Select Passphrase Timeout</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -165,10 +165,10 @@
                            android:title="@string/preferences__complete_key_exchanges"
                            android:summary="@string/preferences__automatically_complete_key_exchanges_for_new_sessions_or_for_existing_sessions_with_the_same_identity_key" />
 
-       <CheckBoxPreference android:defaultValue="false"
+       <CheckBoxPreference android:defaultValue="true"
                            android:key="pref_screen_security"
                            android:title="@string/preferences__screen_security"
-                           android:summary="@string/preferences__disable_screen_security_to_allow_screenshots" />
+                           android:summary="@string/preferences__enable_screen_security_to_prevent_other_apps_from_screen_capture" />
 
         <Preference android:key="pref_mms_preferences"
                     android:title="@string/preferences__advanced_mms_access_point_names"/>

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -759,7 +759,7 @@ public class ConversationActivity extends PassphraseRequiredSherlockFragmentActi
 
     registerForContextMenu(sendButton);
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB && !TextSecurePreferences.isScreenSecurityDisabled(this)) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB && TextSecurePreferences.isScreenSecurityEnabled(this)) {
       getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
     }
 

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -280,7 +280,7 @@ public class ConversationListActivity extends PassphraseRequiredSherlockFragment
   }
 
   private void initializeResources() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB && !TextSecurePreferences.isScreenSecurityDisabled(this)) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB && TextSecurePreferences.isScreenSecurityEnabled(this)) {
       getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
     }
 

--- a/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -135,8 +135,8 @@ public class TextSecurePreferences {
     return getBooleanPreference(context, AUTO_KEY_EXCHANGE_PREF, true);
   }
 
-  public static boolean isScreenSecurityDisabled(Context context) {
-    return getBooleanPreference(context, SCREEN_SECURITY_PREF, false);
+  public static boolean isScreenSecurityEnabled(Context context) {
+    return getBooleanPreference(context, SCREEN_SECURITY_PREF, true);
   }
 
   public static boolean isUseLocalApnsEnabled(Context context) {


### PR DESCRIPTION
Now screen security options must work properly. I also have added missed check in conversations and changed string resource because of: https://en.wiktionary.org/wiki/screenshot
