### PR TITLE
Fix overdraw issues in the conversation view

### DIFF
--- a/res/layout/conversation_activity.xml
+++ b/res/layout/conversation_activity.xml
@@ -3,6 +3,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
+    android:background="?conversation_background"
     android:orientation="vertical">
 
     <org.thoughtcrime.securesms.components.RecipientsPanel
@@ -17,7 +18,6 @@
             android:layout_height="fill_parent"
             android:layout_weight="1"
             android:orientation="vertical"
-            android:background="?conversation_background"
             android:gravity="bottom">
 
         <fragment
@@ -33,8 +33,7 @@
                 android:id="@id/bottom_container"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:background="?conversation_background">
+                android:orientation="vertical">
 
             <ScrollView android:layout_width="fill_parent"
                         android:layout_height="wrap_content"

--- a/res/layout/conversation_fragment.xml
+++ b/res/layout/conversation_fragment.xml
@@ -18,6 +18,7 @@
               android:fadingEdge="none"
               android:divider="@android:color/transparent"
               android:dividerHeight="0dp"
-              android:layout_marginBottom="1dip"/>
+              android:layout_marginBottom="1dip"
+              android:cacheColorHint="?conversation_background" />
 
 </LinearLayout>

--- a/res/layout/conversation_item_activity.xml
+++ b/res/layout/conversation_item_activity.xml
@@ -5,7 +5,6 @@
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:background="?conversation_background"
     android:padding="8dp">
 
     <TextView android:id="@+id/conversation_item_body"

--- a/res/layout/conversation_item_received.xml
+++ b/res/layout/conversation_item_received.xml
@@ -4,7 +4,6 @@
     android:layout_height="wrap_content"
     android:paddingRight="10dip"
     android:orientation="vertical"
-    android:background="?conversation_background"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <TextView android:id="@+id/group_message_status"

--- a/res/layout/conversation_item_sent.xml
+++ b/res/layout/conversation_item_sent.xml
@@ -4,8 +4,7 @@
     android:id="@+id/conversation_item"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
-    android:background="?conversation_background">
+    android:orientation="horizontal">
 
     <RelativeLayout android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -145,6 +145,16 @@
         <item name="navigation_drawer_shadow">@drawable/drawer_shadow_dark</item>
     </style>
 
+    <style name="TextSecure.LightTheme.ConversationActivity"
+           parent="@style/TextSecure.LightTheme">
+        <item name="android:windowBackground">@null</item>
+    </style>
+
+    <style name="TextSecure.DarkTheme.ConversationActivity"
+           parent="@style/TextSecure.DarkTheme">
+        <item name="android:windowBackground">@null</item>
+    </style>
+
     <style name="TextSecure.Light.Dialog"
            parent="@android:style/Theme.Dialog"
            tools:ignore="NewApi">

--- a/src/org/thoughtcrime/securesms/util/DynamicTheme.java
+++ b/src/org/thoughtcrime/securesms/util/DynamicTheme.java
@@ -6,6 +6,7 @@ import android.os.Build;
 import android.preference.PreferenceManager;
 
 import org.thoughtcrime.securesms.ApplicationPreferencesActivity;
+import org.thoughtcrime.securesms.ConversationActivity;
 import org.thoughtcrime.securesms.ConversationListActivity;
 import org.thoughtcrime.securesms.R;
 
@@ -41,9 +42,11 @@ public class DynamicTheme {
 
     if (theme.equals("light")) {
       if (activity instanceof ConversationListActivity) return R.style.TextSecure_LightTheme_NavigationDrawer;
+      else if (activity instanceof ConversationActivity) return R.style.TextSecure_LightTheme_ConversationActivity;
       else                                              return R.style.TextSecure_LightTheme;
     } else if (theme.equals("dark")) {
       if (activity instanceof ConversationListActivity) return R.style.TextSecure_DarkTheme_NavigationDrawer;
+      else if (activity instanceof ConversationActivity) return R.style.TextSecure_DarkTheme_ConversationActivity;
       else                                              return R.style.TextSecure_DarkTheme;
     }
 


### PR DESCRIPTION
Remove the redundant window background and row backgrounds to improve drawing performance.

Before and after (red is bad):

![before-after](https://f.cloud.github.com/assets/124223/2319818/7b19d006-a384-11e3-9320-421d0884b366.png)
