### PR TITLE
Use the "screen security" preference for the conversation list

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -280,7 +280,7 @@ public class ConversationListActivity extends PassphraseRequiredSherlockFragment
   }
 
   private void initializeResources() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB && TextSecurePreferences.isScreenSecurityEnabled(this)) {
       getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,
                            WindowManager.LayoutParams.FLAG_SECURE);
     }


### PR DESCRIPTION
It was previously only used for ConversationListActivity. This should be all
the locations (according to a grep for FLAG_SECURE).

FREEBIE
