### PR TITLE
- Fix #913: Message ID has to be set when called from listener

### DIFF
--- a/src/org/thoughtcrime/securesms/service/SmsSender.java
+++ b/src/org/thoughtcrime/securesms/service/SmsSender.java
@@ -81,7 +81,6 @@ public class SmsSender {
 
       while (reader != null && (record = reader.getNext()) != null) {
         try {
-          messageId = record.getId();
           database.markAsSending(record.getId());
 
           transport.deliver(record);


### PR DESCRIPTION
Message-id is marked as  "sending" but after the try the message-id is (-1) because of the initial value. So the message is still marked as "sending" and not "outbox".
