### PR TITLE
Only receive text/plain.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -69,7 +69,7 @@
                 <category android:name="android.intent.category.DEFAULT"/>
                 <data android:mimeType="audio/*" />
                 <data android:mimeType="image/*" />
-                <data android:mimeType="text/*" />
+                <data android:mimeType="text/plain" />
                 <data android:mimeType="video/*" />
             </intent-filter>            
 


### PR DESCRIPTION
At the moment only text/plain is handled in RoutingActivity, so set filter in manifest accordingly.
This prevents #316. But at some point sharing text/calendar or better _/_ would be nice...

// FREEBIE
