### PR TITLE
Tint default avatars in group chats. Fixes #969

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -132,5 +132,4 @@
     <item>@drawable/my_identity_dark</item>
     <item>@drawable/contacts_identities_dark</item>
   </string-array>
-
 </resources>

--- a/src/org/thoughtcrime/securesms/util/BitmapUtil.java
+++ b/src/org/thoughtcrime/securesms/util/BitmapUtil.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
-import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;


### PR DESCRIPTION
We probably want some more colors.. I tried to select 16 "as distinct as possible" colors, but I'm not a graphics guy, this was more of a mathematical thing.

The coloring done is based on the contact's name, i.e. it should be consistent across multiple group chats.
