### PR TITLE
ConversationFragment: enable back button to dismiss message detail dialog

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -153,7 +153,7 @@ public class ConversationFragment extends SherlockListFragment
     AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
     builder.setTitle(R.string.ConversationFragment_message_details);
     builder.setIcon(Dialogs.resolveIcon(getActivity(), R.attr.dialog_info_icon));
-    builder.setCancelable(false);
+    builder.setCancelable(true);
 
     if (dateReceived == dateSent || message.isOutgoing()) {
       builder.setMessage(String.format(getSherlockActivity()


### PR DESCRIPTION
The ConversationFragment has a AlertDialog for showing the message details, which sets the cancelable property to be false. This stops the user from being able to use the back button to dismiss the dialog.

By setting it to true, the back button can be used. Tested on Android 4.4.2 on Nexus 5.
