### PR TITLE
Adding contact photo cache

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -52,7 +52,6 @@ import org.thoughtcrime.securesms.mms.Slide;
 import org.thoughtcrime.securesms.mms.SlideDeck;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.service.SendReceiveService;
-import org.thoughtcrime.securesms.util.BitmapUtil;
 import org.thoughtcrime.securesms.util.DateUtils;
 import org.thoughtcrime.securesms.util.Emoji;
 import org.thoughtcrime.securesms.util.Dialogs;
@@ -405,7 +404,9 @@ public class ConversationItem extends LinearLayout {
 
   private void setContactPhotoForRecipient(final Recipient recipient) {
     if (contactPhoto == null) return;
-    contactPhoto.setImageBitmap(BitmapUtil.getCircleCroppedBitmap(recipient.getContactPhoto()));
+
+    contactPhoto.setImageBitmap(recipient.getCircleCroppedContactPhoto());
+
     contactPhoto.setOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View v) {

--- a/src/org/thoughtcrime/securesms/ConversationListItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationListItem.java
@@ -30,7 +30,6 @@ import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.text.style.StyleSpan;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
@@ -39,7 +38,6 @@ import android.widget.TextView;
 import org.thoughtcrime.securesms.database.model.ThreadRecord;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.Recipients;
-import org.thoughtcrime.securesms.util.BitmapUtil;
 import org.thoughtcrime.securesms.util.DateUtils;
 import org.thoughtcrime.securesms.util.Emoji;
 
@@ -131,7 +129,8 @@ public class ConversationListItem extends RelativeLayout
   private void setContactPhoto(final Recipient recipient) {
     if (recipient == null) return;
 
-    contactPhotoImage.setImageBitmap(BitmapUtil.getCircleCroppedBitmap(recipient.getContactPhoto()));
+    contactPhotoImage.setImageBitmap(recipient.getCircleCroppedContactPhoto());
+
     if (!recipient.isGroupRecipient()) {
       contactPhotoImage.setOnClickListener(new View.OnClickListener() {
         @Override

--- a/src/org/thoughtcrime/securesms/contacts/ContactPhotoFactory.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactPhotoFactory.java
@@ -19,11 +19,15 @@ import java.util.Map;
 
 public class ContactPhotoFactory {
 
-  private static final Object defaultPhotoLock      = new Object();
-  private static final Object defaultGroupPhotoLock = new Object();
+  private static final Object defaultPhotoLock              = new Object();
+  private static final Object defaultGroupPhotoLock         = new Object();
+  private static final Object defaultPhotoCroppedLock       = new Object();
+  private static final Object defaultGroupPhotoCroppedLock  = new Object();
 
   private static Bitmap defaultContactPhoto;
   private static Bitmap defaultGroupContactPhoto;
+  private static Bitmap defaultContactPhotoCropped;
+  private static Bitmap defaultGroupContactPhotoCropped;
 
   private static final Map<Uri,Bitmap> localUserContactPhotoCache =
       Collections.synchronizedMap(new LRUCache<Uri,Bitmap>(2));
@@ -49,6 +53,24 @@ public class ContactPhotoFactory {
         defaultGroupContactPhoto =  BitmapFactory.decodeResource(context.getResources(),
                                                                  R.drawable.ic_group_photo);
       return defaultGroupContactPhoto;
+    }
+  }
+
+  public static Bitmap getDefaultContactPhotoCropped(Context context) {
+    synchronized (defaultPhotoCroppedLock) {
+      if (defaultContactPhotoCropped == null)
+        defaultContactPhotoCropped = BitmapUtil.getCircleCroppedBitmap(getDefaultContactPhoto(context));
+
+      return defaultContactPhotoCropped;
+    }
+  }
+
+  public static Bitmap getDefaultGroupPhotoCropped(Context context) {
+    synchronized (defaultGroupPhotoCroppedLock) {
+      if (defaultGroupContactPhotoCropped == null)
+        defaultGroupContactPhotoCropped = BitmapUtil.getCircleCroppedBitmap(getDefaultGroupPhoto(context));
+
+      return defaultGroupContactPhotoCropped;
     }
   }
 

--- a/src/org/thoughtcrime/securesms/recipients/Recipient.java
+++ b/src/org/thoughtcrime/securesms/recipients/Recipient.java
@@ -25,6 +25,7 @@ import android.util.Log;
 
 import org.thoughtcrime.securesms.contacts.ContactPhotoFactory;
 import org.thoughtcrime.securesms.recipients.RecipientProvider.RecipientDetails;
+import org.thoughtcrime.securesms.util.BitmapUtil;
 import org.thoughtcrime.securesms.util.GroupUtil;
 import org.whispersystems.textsecure.storage.CanonicalRecipient;
 import org.whispersystems.textsecure.util.FutureTaskListener;
@@ -52,15 +53,19 @@ public class Recipient implements Parcelable, CanonicalRecipient {
   private final long   recipientId;
 
   private String name;
+
   private Bitmap contactPhoto;
+  private Bitmap circleCroppedContactPhoto;
+
   private Uri    contactUri;
 
-  Recipient(String number, Bitmap contactPhoto, long recipientId,
+  Recipient(String number, Bitmap defautPhoto, Bitmap defaultCroppedPhoto, long recipientId,
             ListenableFutureTask<RecipientDetails> future)
   {
-    this.number       = number;
-    this.contactPhoto = contactPhoto;
-    this.recipientId  = recipientId;
+    this.number                     = number;
+    this.circleCroppedContactPhoto  = defaultCroppedPhoto;
+    this.contactPhoto               = defautPhoto;
+    this.recipientId                = recipientId;
 
     future.setListener(new FutureTaskListener<RecipientDetails>() {
       @Override
@@ -69,10 +74,11 @@ public class Recipient implements Parcelable, CanonicalRecipient {
           HashSet<RecipientModifiedListener> localListeners;
 
           synchronized (Recipient.this) {
-            Recipient.this.name         = result.name;
-            Recipient.this.contactUri   = result.contactUri;
-            Recipient.this.contactPhoto = result.avatar;
-            localListeners              = (HashSet<RecipientModifiedListener>)listeners.clone();
+            Recipient.this.name                         = result.name;
+            Recipient.this.contactUri                   = result.contactUri;
+            Recipient.this.contactPhoto                 = result.avatar;
+            Recipient.this.circleCroppedContactPhoto    = result.croppedAvatar;
+            localListeners                              = (HashSet<RecipientModifiedListener>)listeners.clone();
             listeners.clear();
           }
 
@@ -172,6 +178,10 @@ public class Recipient implements Parcelable, CanonicalRecipient {
 
   public synchronized Bitmap getContactPhoto() {
     return contactPhoto;
+  }
+
+  public synchronized Bitmap getCircleCroppedContactPhoto() {
+    return this.circleCroppedContactPhoto;
   }
 
   public static Recipient getUnknownRecipient(Context context) {

--- a/src/org/thoughtcrime/securesms/recipients/RecipientProvider.java
+++ b/src/org/thoughtcrime/securesms/recipients/RecipientProvider.java
@@ -30,6 +30,7 @@ import org.thoughtcrime.securesms.contacts.ContactPhotoFactory;
 import org.thoughtcrime.securesms.database.CanonicalAddressDatabase;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.GroupDatabase;
+import org.thoughtcrime.securesms.util.BitmapUtil;
 import org.thoughtcrime.securesms.util.GroupUtil;
 import org.thoughtcrime.securesms.util.LRUCache;
 import org.whispersystems.textsecure.util.ListenableFutureTask;
@@ -103,10 +104,17 @@ public class RecipientProvider {
 
     asyncRecipientResolver.submit(future);
 
-    final Bitmap defaultPhoto = isGroupRecipient
-        ? ContactPhotoFactory.getDefaultGroupPhoto(context)
-        : ContactPhotoFactory.getDefaultContactPhoto(context);
-    Recipient recipient = new Recipient(number, defaultPhoto, recipientId, future);
+    Bitmap contactPhoto;
+    Bitmap contactPhotoCropped;
+
+    if (isGroupRecipient) {
+      contactPhoto = ContactPhotoFactory.getDefaultGroupPhoto(context);
+      contactPhotoCropped = ContactPhotoFactory.getDefaultGroupPhotoCropped(context);
+    } else {
+      contactPhoto = ContactPhotoFactory.getDefaultContactPhoto(context);
+      contactPhotoCropped = ContactPhotoFactory.getDefaultContactPhotoCropped(context);
+    }
+    Recipient recipient = new Recipient(number, contactPhoto, contactPhotoCropped, recipientId, future);
     recipientCache.put(recipientId, recipient);
 
     return recipient;
@@ -132,7 +140,8 @@ public class RecipientProvider {
         Bitmap contactPhoto = ContactPhotoFactory.getContactPhoto(context, Uri.withAppendedPath(Contacts.CONTENT_URI,
                                                                                                 cursor.getLong(2)+""));
 
-        return new RecipientDetails(cursor.getString(0), contactUri, contactPhoto);
+        return new RecipientDetails(cursor.getString(0), contactUri, contactPhoto,
+                              BitmapUtil.getCircleCroppedBitmap(contactPhoto));
       }
     } finally {
       if (cursor != null)
@@ -154,7 +163,7 @@ public class RecipientProvider {
         if (avatarBytes == null) avatar = ContactPhotoFactory.getDefaultGroupPhoto(context);
         else                     avatar = BitmapFactory.decodeByteArray(avatarBytes, 0, avatarBytes.length);
 
-        return new RecipientDetails(record.getTitle(), null, avatar);
+        return new RecipientDetails(record.getTitle(), null, avatar, BitmapUtil.getCircleCroppedBitmap(avatar));
       }
 
       return null;
@@ -167,12 +176,14 @@ public class RecipientProvider {
   public static class RecipientDetails {
     public final String name;
     public final Bitmap avatar;
+    public final Bitmap croppedAvatar;
     public final Uri contactUri;
 
-    public RecipientDetails(String name, Uri contactUri, Bitmap avatar) {
-      this.name       = name;
-      this.avatar     = avatar;
-      this.contactUri = contactUri;
+    public RecipientDetails(String name, Uri contactUri, Bitmap avatar, Bitmap croppedAvatar) {
+      this.name           = name;
+      this.avatar         = avatar;
+      this.croppedAvatar  = croppedAvatar;
+      this.contactUri     = contactUri;
     }
   }
 


### PR DESCRIPTION
TS is creating a lot of throw-away bitmaps for creating those cropped avatars, even if it's the same avatar all the time. This takes time and if I scroll a conversation really fast, it "hangs" for short periods of time. This is not only because of the bitmaps, but also because of them. This cache should inprove that and reduce CPU overhead.

Also I prepared this for #1027 making it into mainline. If you like this, but dislike #1027, I'll take the (now usused) "colored" flag out.
