### PR TITLE
Update to newest gradle version, needed for Android Studio 0.5.0+.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:0.9.+'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Dec 21 23:48:05 PST 2013
+#Mon Mar 10 09:55:41 CET 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:0.9.+'
     }
 }
 


### PR DESCRIPTION
Won't work with the newest Android Studio (0.5.0+) otherwise:

```
Failed to refresh Gradle project 'TextSecure'
         The project is using an unsupported version of the Android Gradle plug-in (0.8.3).
         Version 0.9.0 introduced incompatible changes in the build language.
         Please read the migration guide to learn how to update your project.
         Open migration guide, fix plug-in version and re-import project
(http://tools.android.com/tech-docs/new-build-system/migrating_to_09)
```
