### PR TITLE
Display "send" button on the soft keyboard if "enter sends" is activated in the preferences

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -713,6 +713,12 @@ public class ConversationActivity extends PassphraseRequiredSherlockFragmentActi
     } else {
       composeText.setInputType(composeText.getInputType() | (InputType.TYPE_TEXT_VARIATION_SHORT_MESSAGE));
     }
+    if (TextSecurePreferences.isEnterSendsEnabled(this)) {
+      composeText.setInputType(composeText.getInputType() & (~InputType.TYPE_TEXT_FLAG_MULTI_LINE));
+      composeText.setHorizontallyScrolling(false);
+      composeText.setMaxLines(4);
+      composeText.setImeOptions(EditorInfo.IME_ACTION_SEND);
+    }
   }
 
   private void initializeResources() {
@@ -1180,7 +1186,6 @@ public class ConversationActivity extends PassphraseRequiredSherlockFragmentActi
     public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
       if (actionId == EditorInfo.IME_ACTION_SEND) {
         sendButton.performClick();
-        composeText.clearFocus();
         return true;
       }
       return false;


### PR DESCRIPTION
When "enter sends" is enabled in the preferences, it would be nice to show this to the user by replacing the enter button by a send button.
However, this doesn't work for multiline EditTexts. Fortunately, multiline is not really needed, as the same behavior can be achieved by disabling horizontal scrolling and setting the maximum number of lines (again).
See also (answer by HYS): http://stackoverflow.com/questions/2986387/multi-line-edittext-with-done-action-button

composeText.clearFocus(); had to be removed, because otherwise, after sending a message using the send button, composeText loses focus.
