### PR TITLE
Move picture attachment save listener to standard long click menu

### DIFF
--- a/res/menu/conversation_context_image.xml
+++ b/res/menu/conversation_context_image.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:title="@string/conversation_context_image__menu_save"
+          android:id="@+id/menu_context_save_image" />
+</menu>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -47,13 +47,6 @@
     <string name="ConversationItem_message_size_d_kb">Message size: %d KB</string>
     <string name="ConversationItem_expires_s">Expires: %s</string>
     <string name="ConversationItem_error_sending_message">Error sending message</string>
-    <string name="ConversationItem_saving_attachment">Saving Attachment</string>
-    <string name="ConversationItem_saving_attachment_to_sd_card">Saving attachment to SD card...</string>
-    <string name="ConversationItem_save_to_sd_card">Save to SD Card?</string>
-    <string name="ConversationItem_this_media_has_been_stored_in_an_encrypted_database_warning">This media has been stored in an encrypted database. The version you save to the SD card will no longer be encrypted. Would you like to continue?</string>
-    <string name="ConversationItem_error_while_saving_attachment_to_sd_card">Error while saving attachment to SD card!</string>
-    <string name="ConversationItem_success_exclamation">Success!</string>
-    <string name="ConversationItem_unable_to_write_to_sd_card_exclamation">Unable to write to SD Card!</string>
     <string name="ConversationItem_view_secure_media_question">View secure media?</string>
     <string name="ConversationItem_this_media_has_been_stored_in_an_encrypted_database_external_viewer_warning">This media has been stored in an encrypted database. Unfortunately, to view it with an external content viewer currently requires the data to be temporarily decrypted and written to disk. Are you sure that you would like to do this?</string>
     <string name="ConversationItem_received_and_processed_key_exchange_message">Received and processed key exchange message.</string>
@@ -98,6 +91,13 @@
     <string name="ConversationFragment_sender_s_transport_s_sent_s_received_s">Sender: %1$s\nTransport: %2$s\nSent: %3$s\nReceived: %4$s</string>
 	<string name="ConversationFragment_confirm_message_delete">Confirm Message Delete</string>
 	<string name="ConversationFragment_are_you_sure_you_want_to_permanently_delete_this_message">Are you sure that you want to permanently delete this message?</string>
+    <string name="ConversationFragment_saving_attachment">Saving Attachment</string>
+    <string name="ConversationFragment_saving_attachment_to_sd_card">Saving attachment to SD card...</string>
+    <string name="ConversationFragment_save_to_sd_card">Save to SD Card?</string>
+    <string name="ConversationFragment_this_media_has_been_stored_in_an_encrypted_database_warning">This media has been stored in an encrypted database. The version you save to the SD card will no longer be encrypted. Would you like to continue?</string>
+    <string name="ConversationFragment_error_while_saving_attachment_to_sd_card">Error while saving attachment to SD card!</string>
+    <string name="ConversationFragment_success_exclamation">Success!</string>
+    <string name="ConversationFragment_unable_to_write_to_sd_card_exclamation">Unable to write to SD Card!</string>
 
     <!-- ConversationListAdapter -->
     <string name="ConversationListAdapter_key_exchange_message">Key exchange message...</string>
@@ -758,6 +758,9 @@
     <string name="conversation_context__menu_delete_message">Delete message</string>
     <string name="conversation_context__menu_forward_message">Forward message</string>
     <string name="conversation_context__menu_resend_message">Resend message</string>
+
+    <!-- conversation_context_image -->
+    <string name="conversation_context_image__menu_save">Save image</string>
 
     <!-- conversation_insecure -->
     <string name="conversation_insecure__menu_start_secure_session">Start Secure Session</string>

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -16,20 +16,18 @@
  */
 package org.thoughtcrime.securesms;
 
+import android.app.Activity;
 import android.app.AlertDialog;
-import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
-import android.media.MediaScannerConnection;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.Build;
-import android.os.Environment;
 import android.os.Handler;
 import android.os.Message;
 import android.provider.Contacts.Intents;
@@ -63,11 +61,6 @@ import org.whispersystems.textsecure.storage.Session;
 import org.whispersystems.textsecure.util.FutureTaskListener;
 import org.whispersystems.textsecure.util.ListenableFutureTask;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 
 /**
  * A view that displays an individual conversation item within a conversation
@@ -160,6 +153,8 @@ public class ConversationItem extends LinearLayout {
     setOnClickListener(clickListener);
     if (failedImage != null)       failedImage.setOnClickListener(failedIconClickListener);
     if (mmsDownloadButton != null) mmsDownloadButton.setOnClickListener(mmsDownloadClickListener);
+
+    this.mmsThumbnail.setOnCreateContextMenuListener((Activity)getContext());
   }
 
   public void set(MasterSecret masterSecret, MessageRecord messageRecord,
@@ -350,7 +345,6 @@ public class ConversationItem extends LinearLayout {
                 slide.setThumbnailOn(mmsThumbnail);
 //                mmsThumbnail.setImageBitmap(slide.getThumbnail());
                 mmsThumbnail.setOnClickListener(new ThumbnailClickListener(slide));
-                mmsThumbnail.setOnLongClickListener(new ThumbnailSaveListener(slide));
                 mmsThumbnail.setVisibility(View.VISIBLE);
                 return;
               }
@@ -417,127 +411,6 @@ public class ConversationItem extends LinearLayout {
     intent.putExtra("master_secret", masterSecret);
     intent.putExtra("sent", messageRecord.isOutgoing());
     context.startActivity(intent);
-  }
-
-  private class ThumbnailSaveListener extends Handler implements View.OnLongClickListener, Runnable, MediaScannerConnection.MediaScannerConnectionClient {
-    private static final int SUCCESS              = 0;
-    private static final int FAILURE              = 1;
-    private static final int WRITE_ACCESS_FAILURE = 2;
-
-    private final Slide slide;
-    private ProgressDialog progressDialog;
-    private MediaScannerConnection mediaScannerConnection;
-    private File mediaFile;
-
-    public ThumbnailSaveListener(Slide slide) {
-      this.slide = slide;
-    }
-
-    public void run() {
-      if (!Environment.getExternalStorageDirectory().canWrite()) {
-        this.obtainMessage(WRITE_ACCESS_FAILURE).sendToTarget();
-        return;
-      }
-
-      try {
-        mediaFile                 = constructOutputFile();
-        InputStream inputStream   = slide.getPartDataInputStream();
-        OutputStream outputStream = new FileOutputStream(mediaFile);
-
-        byte[] buffer = new byte[4096];
-        int read;
-
-        while ((read = inputStream.read(buffer)) != -1) {
-          outputStream.write(buffer, 0, read);
-        }
-
-        outputStream.close();
-        inputStream.close();
-
-        mediaScannerConnection = new MediaScannerConnection(context, this);
-        mediaScannerConnection.connect();
-      } catch (IOException ioe) {
-        Log.w("ConversationItem", ioe);
-        this.obtainMessage(FAILURE).sendToTarget();
-      }
-    }
-
-    private File constructOutputFile() throws IOException {
-      File sdCard = Environment.getExternalStorageDirectory();
-      File outputDirectory;
-
-      if (slide.hasVideo())
-        outputDirectory = new File(sdCard.getAbsoluteFile() + File.separator + "Movies");
-      else if (slide.hasAudio())
-        outputDirectory = new File(sdCard.getAbsolutePath() + File.separator + "Music");
-      else
-        outputDirectory = new File(sdCard.getAbsolutePath() + File.separator + "Pictures");
-      outputDirectory.mkdirs();
-
-      MimeTypeMap mimeTypeMap = MimeTypeMap.getSingleton();
-      String extension = mimeTypeMap.getExtensionFromMimeType(slide.getContentType());
-      if (extension == null)
-          extension = "attach";
-
-      return File.createTempFile("textsecure", "." + extension, outputDirectory);
-    }
-
-    private void saveToSdCard() {
-      progressDialog = new ProgressDialog(context);
-      progressDialog.setTitle(context.getString(R.string.ConversationItem_saving_attachment));
-      progressDialog.setMessage(context.getString(R.string.ConversationItem_saving_attachment_to_sd_card));
-      progressDialog.setCancelable(false);
-      progressDialog.setIndeterminate(true);
-      progressDialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
-      progressDialog.show();
-      new Thread(this).start();
-    }
-
-    public boolean onLongClick(View v) {
-      AlertDialog.Builder builder = new AlertDialog.Builder(context);
-      builder.setTitle(R.string.ConversationItem_save_to_sd_card);
-      builder.setIcon(Dialogs.resolveIcon(context, R.attr.dialog_alert_icon));
-      builder.setCancelable(true);
-      builder.setMessage(R.string.ConversationItem_this_media_has_been_stored_in_an_encrypted_database_warning);
-      builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
-        public void onClick(DialogInterface dialog, int which) {
-          saveToSdCard();
-        }
-      });
-      builder.setNegativeButton(R.string.no, null);
-      builder.show();
-
-      return true;
-    }
-
-    @Override
-    public void handleMessage(Message message) {
-      switch (message.what) {
-      case FAILURE:
-        Toast.makeText(context, R.string.ConversationItem_error_while_saving_attachment_to_sd_card,
-                       Toast.LENGTH_LONG).show();
-        break;
-      case SUCCESS:
-        Toast.makeText(context, R.string.ConversationItem_success_exclamation,
-                       Toast.LENGTH_LONG).show();
-        break;
-      case WRITE_ACCESS_FAILURE:
-        Toast.makeText(context, R.string.ConversationItem_unable_to_write_to_sd_card_exclamation,
-                       Toast.LENGTH_LONG).show();
-        break;
-      }
-
-      progressDialog.dismiss();
-    }
-
-    public void onMediaScannerConnected() {
-      mediaScannerConnection.scanFile(mediaFile.getAbsolutePath(), slide.getContentType());
-    }
-
-    public void onScanCompleted(String path, Uri uri) {
-      mediaScannerConnection.disconnect();
-      this.obtainMessage(SUCCESS).sendToTarget();
-    }
   }
 
   private class ThumbnailClickListener implements View.OnClickListener {


### PR DESCRIPTION
When long-clicking a message with an image attachment, add a "Save Image" menu item to the context menu.
This context menu also applies to the image, so long-clicking the image opens the messages context menu. This is particularly useful for picture messages without text.
