### PR TITLE
fix custom blink patter background on Android 2.3

### DIFF
--- a/src/org/thoughtcrime/securesms/preferences/LedBlinkPatternListPreference.java
+++ b/src/org/thoughtcrime/securesms/preferences/LedBlinkPatternListPreference.java
@@ -88,6 +88,7 @@ public class LedBlinkPatternListPreference extends ListPreference implements OnS
     builder.setOnCancelListener(new CustomDialogCancelListener());
     builder.setNegativeButton(android.R.string.cancel, new CustomDialogCancelListener());
     builder.setPositiveButton(android.R.string.ok, new CustomDialogClickListener());
+    builder.setInverseBackgroundForced(true);
     builder.show();
   }
 


### PR DESCRIPTION
I noticed in the 2.3 emulator, that the background while chosing the custom led blink pattern is wrong. There is dark text on a black background.

Before and after the patch screenshots:
![before patch 2 3](https://f.cloud.github.com/assets/5296073/2467546/03f19646-afc1-11e3-9755-737753ba3639.jpg) ![after patch 2 3](https://f.cloud.github.com/assets/5296073/2467547/08e76f9a-afc1-11e3-945d-d6e75cb50c42.jpg)
