### PR TITLE
outgoing group MMS should not be encrypted and considered push

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -93,6 +93,7 @@ import org.thoughtcrime.securesms.util.BitmapDecodingException;
 import org.thoughtcrime.securesms.util.BitmapUtil;
 import org.thoughtcrime.securesms.util.CharacterCalculator;
 import org.thoughtcrime.securesms.util.Dialogs;
+import org.thoughtcrime.securesms.util.DirectoryHelper;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicTheme;
 import org.thoughtcrime.securesms.util.EncryptedCharacterCalculator;
@@ -564,7 +565,7 @@ public class ConversationActivity extends PassphraseRequiredSherlockFragmentActi
   }
 
   private void handleAddAttachment() {
-    if (this.isMmsEnabled || isPushDestination()) {
+    if (this.isMmsEnabled || DirectoryHelper.isPushDestination(this, getRecipients())) {
       AlertDialog.Builder builder = new AlertDialog.Builder(new ContextThemeWrapper(this, R.style.TextSecure_Light_Dialog));
       builder.setIcon(R.drawable.ic_dialog_attach);
       builder.setTitle(R.string.ConversationActivity_add_attachment);
@@ -691,7 +692,7 @@ public class ConversationActivity extends PassphraseRequiredSherlockFragmentActi
       this.characterCalculator         = new CharacterCalculator();
     }
 
-    if (isPushDestination()) {
+    if (DirectoryHelper.isPushDestination(this, getRecipients())) {
       sendButton.setImageDrawable(drawables.getDrawable(0));
     } else if (isEncryptedConversation) {
       sendButton.setImageDrawable(drawables.getDrawable(1));
@@ -1005,30 +1006,6 @@ public class ConversationActivity extends PassphraseRequiredSherlockFragmentActi
 
   private boolean isPushGroupConversation() {
     return getRecipients() != null && getRecipients().isGroupRecipient();
-  }
-
-  private boolean isPushDestination() {
-    try {
-      if (!TextSecurePreferences.isPushRegistered(this))
-        return false;
-
-      if (getRecipients() == null)
-        return false;
-
-      if (isPushGroupConversation())
-        return true;
-
-      String number     = getRecipients().getPrimaryRecipient().getNumber();
-      String e164number = org.thoughtcrime.securesms.util.Util.canonicalizeNumber(this, number);
-
-      return Directory.getInstance(this).isActiveNumber(e164number);
-    } catch (InvalidNumberException e) {
-      Log.w(TAG, e);
-      return false;
-    } catch (NotInDirectoryException e) {
-      Log.w(TAG, e);
-      return false;
-    }
   }
 
   private Recipients getRecipients() {

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -210,7 +210,7 @@ public class ConversationFragment extends SherlockListFragment
       this.setListAdapter(new ConversationAdapter(getActivity(), masterSecret,
                                                   new FailedIconClickHandler(),
                                                   (!this.recipients.isSingleRecipient()) || this.recipients.isGroupRecipient(),
-                                                  DirectoryHelper.isPushDestination(getActivity(), this.recipients.getPrimaryRecipient())));
+                                                  DirectoryHelper.isPushDestination(getActivity(), this.recipients)));
       getListView().setRecyclerListener((ConversationAdapter)getListAdapter());
       getLoaderManager().initLoader(0, null, this);
     }

--- a/src/org/thoughtcrime/securesms/util/DirectoryHelper.java
+++ b/src/org/thoughtcrime/securesms/util/DirectoryHelper.java
@@ -7,6 +7,7 @@ import android.widget.Toast;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.push.PushServiceSocketFactory;
 import org.thoughtcrime.securesms.recipients.Recipient;
+import org.thoughtcrime.securesms.recipients.Recipients;
 import org.whispersystems.textsecure.directory.Directory;
 import org.whispersystems.textsecure.directory.NotInDirectoryException;
 import org.whispersystems.textsecure.push.ContactTokenDetails;
@@ -77,15 +78,22 @@ public class DirectoryHelper {
     }
   }
 
-  public static boolean isPushDestination(Context context, Recipient recipient) {
-    if (recipient == null) return false;
+  public static boolean isPushDestination(Context context, Recipients recipients) {
     try {
-      final String number = recipient.getNumber();
+      if (recipients == null) {
+        return false;
+      }
+      if (!TextSecurePreferences.isPushRegistered(context)) {
+        return false;
+      }
+      if (!recipients.isSingleRecipient()) {
+        return false;
+      }
+      if (recipients.isGroupRecipient()) {
+        return true;
+      }
 
-      if (number == null)                                   return false;
-      if (!TextSecurePreferences.isPushRegistered(context)) return false;
-      if (GroupUtil.isEncodedGroup(number))                 return true;
-
+      final String number     = recipients.getPrimaryRecipient().getNumber();
       final String e164number = Util.canonicalizeNumber(context, number);
 
       return Directory.getInstance(context).isActiveNumber(e164number);


### PR DESCRIPTION
Hit a bug when responding to friend's group MMS and it came up encrypted.
