### PR TITLE
fix for #792 (crash on attaching image)

### DIFF
--- a/src/org/thoughtcrime/securesms/util/BitmapUtil.java
+++ b/src/org/thoughtcrime/securesms/util/BitmapUtil.java
@@ -88,7 +88,7 @@ public class BitmapUtil {
 
       Log.w("BitmapUtil", "Scaling to max width and height: " + aspectWidth + "," + aspectHeight);
       Bitmap scaledThumbnail = Bitmap.createScaledBitmap(roughThumbnail, (int)aspectWidth, (int)aspectHeight, true);
-      roughThumbnail.recycle();
+      if (roughThumbnail != scaledThumbnail) roughThumbnail.recycle();
       return scaledThumbnail;
     } else {
       return roughThumbnail;


### PR DESCRIPTION
createScaledBitmap returns the source image if height and width of the scaled image are identical to source. So it's not a good idea to recycle the source...

I'm not 100% sure if reassigning roughThumbnail is unproblematic. 
Alternative would be to check if scaledThumbnail != roughThumbnail before recycle.

This change fixes #792 for me. Tested even with the original white test image sized 640x539 :-)

(my first try on a pull request - hope everything is correct)
