### PR TITLE
Change draw selector to background

### DIFF
--- a/res/layout/conversation_fragment.xml
+++ b/res/layout/conversation_fragment.xml
@@ -10,7 +10,7 @@
               android:layout_width="fill_parent"
               android:layout_height="0dp"
               android:layout_weight="1.0"
-              android:drawSelectorOnTop="true"
+              android:drawSelectorOnTop="false"
               android:transcriptMode="normal"
               android:scrollbarAlwaysDrawVerticalTrack="false"
               android:scrollbarStyle="insideOverlay"


### PR DESCRIPTION
Precondition:
Have a mobile with an option to navigate without touching (like the "Samsung Galaxy Y Pro").

Problem:
In the conversation is a selected item overdrawn with a blue bar. The message isn't readable and you have to scroll with touch or scroll to another item to read a message.
(Picture could be possible but tricky... so just try to select an item in a conversation, there is also this blue bar over the conversation item before context menu appears)

Solution:
Change the draw selector from top to background.

Alternative:
Also we could change the color of the selector with android:listSelector.... but this could be a feature

Question:
Was there a special intention to have the drawSelectorOnTop else I would see this as a bug!?
