### PR TITLE
fix send icon merge botch, encryption icons logic

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -679,24 +679,23 @@ public class ConversationActivity extends PassphraseRequiredSherlockFragmentActi
 
   private void initializeSecurity() {
 
-    TypedArray drawables = obtainStyledAttributes(SEND_ATTRIBUTES);
-    if ((getRecipients() != null && getRecipients().isGroupRecipient()) ||
+    TypedArray drawables         = obtainStyledAttributes(SEND_ATTRIBUTES);
+    boolean    isPushDestination = DirectoryHelper.isPushDestination(this, getRecipients());
+    if (isPushDestination || (getRecipients() != null && getRecipients().isGroupRecipient()) ||
         (isSingleConversation() && Session.hasSession(this, masterSecret, getRecipients().getPrimaryRecipient())))
     {
       this.isEncryptedConversation     = true;
       this.isAuthenticatedConversation = Session.hasRemoteIdentityKey(this, masterSecret, getRecipients().getPrimaryRecipient());
       this.characterCalculator         = new EncryptedCharacterCalculator();
+      if (isPushDestination) {
+        sendButton.setImageDrawable(drawables.getDrawable(0));
+      } else {
+        sendButton.setImageDrawable(drawables.getDrawable(1));
+      }
     } else {
       this.isEncryptedConversation     = false;
       this.isAuthenticatedConversation = false;
       this.characterCalculator         = new CharacterCalculator();
-    }
-
-    if (DirectoryHelper.isPushDestination(this, getRecipients())) {
-      sendButton.setImageDrawable(drawables.getDrawable(0));
-    } else if (isEncryptedConversation) {
-      sendButton.setImageDrawable(drawables.getDrawable(1));
-    } else {
       sendButton.setImageDrawable(drawables.getDrawable(2));
     }
 

--- a/src/org/thoughtcrime/securesms/util/DirectoryHelper.java
+++ b/src/org/thoughtcrime/securesms/util/DirectoryHelper.java
@@ -93,7 +93,11 @@ public class DirectoryHelper {
         return true;
       }
 
-      final String number     = recipients.getPrimaryRecipient().getNumber();
+      final String number = recipients.getPrimaryRecipient().getNumber();
+      if (number == null) {
+        return false;
+      }
+
       final String e164number = Util.canonicalizeNumber(context, number);
 
       return Directory.getInstance(context).isActiveNumber(e164number);


### PR DESCRIPTION
inlined the isPushDestination check to explicitly tie encrypted icons to the isEncryptedConversation variable

the git rebase ate up an important change from the protocol branch, fixed that and confirmed reality matched expectation.
