### PR TITLE
Prevent crash on missing theme

### DIFF
--- a/src/org/thoughtcrime/securesms/util/DynamicTheme.java
+++ b/src/org/thoughtcrime/securesms/util/DynamicTheme.java
@@ -3,9 +3,7 @@ package org.thoughtcrime.securesms.util;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Build;
-import android.preference.PreferenceManager;
 
-import org.thoughtcrime.securesms.ApplicationPreferencesActivity;
 import org.thoughtcrime.securesms.ConversationActivity;
 import org.thoughtcrime.securesms.ConversationListActivity;
 import org.thoughtcrime.securesms.R;
@@ -40,17 +38,16 @@ public class DynamicTheme {
   private static int getSelectedTheme(Activity activity) {
     String theme = TextSecurePreferences.getTheme(activity);
 
-    if (theme.equals("light")) {
-      if (activity instanceof ConversationListActivity) return R.style.TextSecure_LightTheme_NavigationDrawer;
-      else if (activity instanceof ConversationActivity) return R.style.TextSecure_LightTheme_ConversationActivity;
-      else                                              return R.style.TextSecure_LightTheme;
-    } else if (theme.equals("dark")) {
+    if (theme.equals("dark")) {
       if (activity instanceof ConversationListActivity) return R.style.TextSecure_DarkTheme_NavigationDrawer;
       else if (activity instanceof ConversationActivity) return R.style.TextSecure_DarkTheme_ConversationActivity;
       else                                              return R.style.TextSecure_DarkTheme;
+    } else { // "light"
+      if (activity instanceof ConversationListActivity) return R.style.TextSecure_LightTheme_NavigationDrawer;
+      else if (activity instanceof ConversationActivity) return R.style.TextSecure_LightTheme_ConversationActivity;
+      else                                              return R.style.TextSecure_LightTheme;
     }
 
-    return R.style.TextSecure_LightTheme;
   }
 
   private static final class OverridePendingTransition {


### PR DESCRIPTION
Changed the default return path (light theme) to always check for the activity instance. If a theme is not found the returning of R.style.TextSecure_LightTheme leads to a crash on loading the ConversationListActivity at startup.
// FREEBIE
