### PR TITLE
translatable msg details: status format strings (not yet timestamp format string which will be done in a separate commit)

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -85,8 +85,8 @@
   <string name="ConversationActivity_are_you_sure_you_want_to_leave_this_group">Sind Sie sicher, dass Sie die Gruppe verlassen wollen?</string>
   <!--ConversationFragment-->
   <string name="ConversationFragment_message_details">Nachrichtendetails</string>
-  <string name="ConversationFragment_transport_s_sent_received_s">Übertragung: %1$s\nGesendet/Empfangen: %2$s</string>
-  <string name="ConversationFragment_sender_s_transport_s_sent_s_received_s">Absender: %1$s\nÜbertragung: %2$s\nGesendet: %3$s\nEmpfangen: %4$s</string>
+  <string name="ConversationFragment_transport_s_sent_received_s">Übertragung: %1$s\n\nGesendet/Empfangen: %2$s</string>
+  <string name="ConversationFragment_sender_s_transport_s_sent_s_received_s">Absender: %1$s\n\nÜbertragung: %2$s\n\nGesendet: %3$s\n\nEmpfangen: %4$s</string>
   <string name="ConversationFragment_confirm_message_delete">Nachricht löschen bestätigen</string>
   <string name="ConversationFragment_are_you_sure_you_want_to_permanently_delete_this_message">Sind Sie sicher, dass Sie diese Nachricht unwiderruflich löschen möchten?</string>
   <!--ConversationListAdapter-->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -98,10 +98,14 @@
 
     <!-- ConversationFragment -->
     <string name="ConversationFragment_message_details">Message details</string>
-    <string name="ConversationFragment_transport_s_sent_received_s">Transport: %1$s\nSent/Received: %2$s</string>
-    <string name="ConversationFragment_sender_s_transport_s_sent_s_received_s">Sender: %1$s\nTransport: %2$s\nSent: %3$s\nReceived: %4$s</string>
-	<string name="ConversationFragment_confirm_message_delete">Confirm Message Delete</string>
-	<string name="ConversationFragment_are_you_sure_you_want_to_permanently_delete_this_message">Are you sure that you want to permanently delete this message?</string>
+    <string name="ConversationFragment_transport_status_pending">pending</string>
+    <string name="ConversationFragment_transport_method_push">PUSH</string>
+    <string name="ConversationFragment_transport_method_mms">MMS</string>
+    <string name="ConversationFragment_transport_method_sms">SMS</string>
+    <string name="ConversationFragment_transport_s_sent_received_s">Transport: %1$s\n\nSent/Received: %2$s</string>
+    <string name="ConversationFragment_sender_s_transport_s_sent_s_received_s">Sender: %1$s\n\nTransport: %2$s\n\nSent: %3$s\n\nReceived: %4$s</string>
+    <string name="ConversationFragment_confirm_message_delete">Confirm Message Delete</string>
+    <string name="ConversationFragment_are_you_sure_you_want_to_permanently_delete_this_message">Are you sure that you want to permanently delete this message?</string>
 
     <!-- ConversationListAdapter -->
     <string name="ConversationListAdapter_key_exchange_message">Key exchange message...</string>

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -154,10 +154,10 @@ public class ConversationFragment extends SherlockListFragment
 
     String transport;
 
-    if      (message.isPending()) transport = "pending";
-    else if (message.isPush())    transport = "push";
-    else if (message.isMms())     transport = "mms";
-    else                          transport = "sms";
+    if      (message.isPending()) transport = getString(R.string.ConversationFragment_transport_status_pending);
+    else if (message.isPush())    transport = getString(R.string.ConversationFragment_transport_method_push);
+    else if (message.isMms())     transport = getString(R.string.ConversationFragment_transport_method_mms);
+    else                          transport = getString(R.string.ConversationFragment_transport_method_sms);
 
     SimpleDateFormat dateFormatter = new SimpleDateFormat("EEE MMM d, yyyy 'at' hh:mm:ss a zzz");
     AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
@@ -168,13 +168,13 @@ public class ConversationFragment extends SherlockListFragment
     if (dateReceived == dateSent || message.isOutgoing()) {
       builder.setMessage(String.format(getSherlockActivity()
                                        .getString(R.string.ConversationFragment_transport_s_sent_received_s),
-                                       transport.toUpperCase(),
+                                       transport,
                                        dateFormatter.format(new Date(dateSent))));
     } else {
       builder.setMessage(String.format(getSherlockActivity()
                                        .getString(R.string.ConversationFragment_sender_s_transport_s_sent_s_received_s),
                                        message.getIndividualRecipient().getNumber(),
-                                       transport.toUpperCase(),
+                                       transport,
                                        dateFormatter.format(new Date(dateSent)),
                                        dateFormatter.format(new Date(dateReceived))));
     }


### PR DESCRIPTION
- strings for the message details allow i10n/i18n
- transport method strings ("PUSH", "MMS", "SMS")
- transport status ("pending")
- #562 partial fix: additional new lines in message details to improve readabilty
- ~~localization of the timestamp string~~

[UPDATED: removed the localization for the timestamp]
