### PR TITLE
group and contact list fixes

### DIFF
--- a/res/layout/new_conversation_activity.xml
+++ b/res/layout/new_conversation_activity.xml
@@ -5,10 +5,6 @@
               android:orientation="vertical"
               xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <org.thoughtcrime.securesms.components.SingleRecipientPanel android:id="@+id/recipients"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content" />
-
     <fragment
         xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"

--- a/res/layout/push_contact_selection_list_activity.xml
+++ b/res/layout/push_contact_selection_list_activity.xml
@@ -4,16 +4,28 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
 
+    <EditText android:id="@+id/filter"
+        android:inputType="textPersonName"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/recipients_panel__to"
+        android:paddingRight="45dip"
+        android:paddingLeft="15dp"
+        android:paddingTop="12dp"
+        android:paddingBottom="12dp"
+        android:textColor="?conversation_editor_text_color"
+        android:background="?conversation_editor_background" />
+
     <se.emilsjolander.stickylistheaders.StickyListHeadersListView android:id="@android:id/list"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
 
     <TextView android:id="@android:id/empty"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:gravity="center|center_vertical"
-            android:layout_marginTop="15dp"
-            android:text="@string/contact_selection_group_activity__finding_contacts"
-            android:textSize="20sp" />
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center|center_vertical"
+        android:layout_marginTop="15dp"
+        android:text="@string/contact_selection_group_activity__finding_contacts"
+        android:textSize="20sp" />
 
 </LinearLayout>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -147,7 +147,6 @@
     <string name="GroupCreateActivity_actionbar_mms_title">New MMS Group</string>
     <string name="GroupCreateActivity_contacts_dont_support_push">You have selected a contact that doesn\'t support TextSecure groups, so this group will be MMS.</string>
     <string name="GroupCreateActivity_you_dont_support_push">You\'re not registered for using the data channel, so TextSecure groups are disabled.</string>
-    <string name="GroupCreateActivity_you_dont_own_this_group">You\'re not the owner of this group, so you cannot edit the title or picture.</string>
     <string name="GroupCreateActivity_contacts_mms_exception">An unexpected error happened that has made group creation fail.</string>
     <string name="GroupCreateActivity_contacts_no_members">You need at least one person in your group!</string>
     <string name="GroupCreateActivity_contacts_invalid_number">One of the members of your group has a number that can\'t be read correctly. Please fix or remove that contact and try again.</string>
@@ -155,6 +154,7 @@
     <string name="GroupCreateActivity_avatar_content_description">Group Avatar</string>
     <string name="GroupCreateActivity_menu_create_title">Create Group</string>
     <string name="GroupCreateActivity_creating_group">Creating %1$s&#8230;</string>
+    <string name="GroupCreateActivity_cannot_add_non_push_to_existing_group">Cannot add non-TextSecure contacts to an existing TextSecure group</string>
 
     <!-- ImportFragment -->
     <string name="ImportFragment_import_system_sms_database">Import System SMS Database?</string>
@@ -765,6 +765,7 @@
     <string name="contact_selection_list__menu_unselect_all">Unselect All</string>
     <string name="contact_selection_list__header_textsecure_users">TEXTSECURE USERS</string>
     <string name="contact_selection_list__header_other">ALL CONTACTS</string>
+    <string name="contact_selection_list__unknown_contact">New message to...</string>
 
     <!-- contact_selection -->
     <string name="contact_selection__menu_finished">Finished</string>

--- a/src/org/thoughtcrime/securesms/NewConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/NewConversationActivity.java
@@ -20,6 +20,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
+import android.widget.EditText;
 import android.widget.Toast;
 
 import com.actionbarsherlock.app.ActionBar;
@@ -62,7 +63,6 @@ public class NewConversationActivity extends PassphraseRequiredSherlockFragmentA
   private final DynamicTheme dynamicTheme = new DynamicTheme();
   private       MasterSecret masterSecret;
 
-  private SingleRecipientPanel             recipientsPanel;
   private PushContactSelectionListFragment contactsFragment;
 
   @Override
@@ -106,7 +106,6 @@ public class NewConversationActivity extends PassphraseRequiredSherlockFragmentA
   }
 
   private void initializeResources() {
-    recipientsPanel  = (SingleRecipientPanel)             findViewById(R.id.recipients);
     contactsFragment = (PushContactSelectionListFragment) getSupportFragmentManager().findFragmentById(R.id.contact_selection_list_fragment);
     contactsFragment.setOnContactSelectedListener(new PushContactSelectionListFragment.OnContactSelectedListener() {
       @Override
@@ -116,15 +115,6 @@ public class NewConversationActivity extends PassphraseRequiredSherlockFragmentA
         openNewConversation(recipients);
       }
     });
-
-    recipientsPanel.setPanelChangeListener(new SingleRecipientPanel.RecipientsPanelChangedListener() {
-      @Override
-      public void onRecipientsPanelUpdate(Recipients recipients) {
-        Log.i(TAG, "Choosing contact from autocompletion.");
-        openNewConversation(recipients);
-      }
-    });
-
   }
 
   private void handleSelectionFinished() {

--- a/src/org/thoughtcrime/securesms/PushContactSelectionActivity.java
+++ b/src/org/thoughtcrime/securesms/PushContactSelectionActivity.java
@@ -56,7 +56,8 @@ import static org.thoughtcrime.securesms.contacts.ContactAccessor.ContactData;
  *
  */
 public class PushContactSelectionActivity extends PassphraseRequiredSherlockFragmentActivity {
-  private final static String TAG                 = "ContactSelectActivity";
+  private final static String TAG             = "ContactSelectActivity";
+  public  final static String PUSH_ONLY_EXTRA = "push_only";
 
   private final DynamicTheme dynamicTheme = new DynamicTheme();
 

--- a/src/org/thoughtcrime/securesms/contacts/ContactAccessor.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactAccessor.java
@@ -82,8 +82,12 @@ public class ContactAccessor {
                             null, null, null, ContactsContract.Groups.TITLE + " ASC");
   }
 
-  public Loader<Cursor> getCursorLoaderForContacts(Context context) {
-    return new ContactsCursorLoader(context);
+  public Loader<Cursor> getCursorLoaderForContacts(Context context, String filter) {
+    return new ContactsCursorLoader(context, filter, false);
+  }
+
+  public Loader<Cursor> getCursorLoaderForPushContacts(Context context, String filter) {
+    return new ContactsCursorLoader(context, filter, true);
   }
 
   public Cursor getCursorForContactsWithNumbers(Context context) {

--- a/src/org/thoughtcrime/securesms/contacts/ContactSelectionListAdapter.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactSelectionListAdapter.java
@@ -30,6 +30,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CheckBox;
+import android.widget.FilterQueryProvider;
 import android.widget.ImageView;
 import android.widget.TextView;
 

--- a/src/org/thoughtcrime/securesms/contacts/ContactsCursorLoader.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactsCursorLoader.java
@@ -28,22 +28,25 @@ import android.support.v4.content.CursorLoader;
 public class ContactsCursorLoader extends CursorLoader {
 
   private final Context          context;
+  private final String           filter;
+  private final boolean          pushOnly;
   private       ContactsDatabase db;
 
-  public ContactsCursorLoader(Context context) {
+  public ContactsCursorLoader(Context context, String filter, boolean pushOnly) {
     super(context);
-    this.context       = context;
+    this.context  = context;
+    this.filter   = filter;
+    this.pushOnly = pushOnly;
   }
 
   @Override
   public Cursor loadInBackground() {
-    db = new ContactsDatabase(context);
-    return db.getAllContacts();
+    db = ContactsDatabase.getInstance(context);
+    return db.query(filter, pushOnly);
   }
 
   @Override
   public void onReset() {
     super.onReset();
-    db.close();
   }
 }


### PR DESCRIPTION
1) Updating a group without changing the avatar will keep that
   avatar

2) Prohibit adding non-push users to an existing push group

3) Add Android contacts to the same database. Takes a small amount
   more time and memory, but allows queries to not be a hack, and
   enables us to dedupe numbers in JB and higher devices.

Memory testing with my decently large contacts list only showed the SQL database taking up about 150k memory, so not much of an increase. Tested on GB as well, and the fallback to the non-normalized number appears to work just fine.
