### PR TITLE
Finish activity before restarting it

### DIFF
--- a/src/org/thoughtcrime/securesms/util/DynamicLanguage.java
+++ b/src/org/thoughtcrime/securesms/util/DynamicLanguage.java
@@ -21,16 +21,13 @@ public class DynamicLanguage {
 
   public void onResume(Activity activity) {
     if (!currentLocale.equals(getSelectedLocale(activity))) {
-      Intent intent = activity.getIntent();
-      intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
-
-      activity.finish();
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ECLAIR) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+        activity.recreate();
+      } else {
+        Intent intent = activity.getIntent();
+        activity.finish();
         OverridePendingTransition.invoke(activity);
-      }
-
-      activity.startActivity(intent);
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ECLAIR) {
+        activity.startActivity(intent);
         OverridePendingTransition.invoke(activity);
       }
     }

--- a/src/org/thoughtcrime/securesms/util/DynamicTheme.java
+++ b/src/org/thoughtcrime/securesms/util/DynamicTheme.java
@@ -21,19 +21,15 @@ public class DynamicTheme {
 
   public void onResume(Activity activity) {
     if (currentTheme != getSelectedTheme(activity)) {
-      Intent intent = activity.getIntent();
-      intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
-
-      activity.finish();
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ECLAIR) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+        activity.recreate();
+      } else {
+        Intent intent = activity.getIntent();
+        activity.finish();
+        OverridePendingTransition.invoke(activity);
+        activity.startActivity(intent);
         OverridePendingTransition.invoke(activity);
       }
-
-      activity.startActivity(intent);
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ECLAIR) {
-        OverridePendingTransition.invoke(activity);
-      }
-
     }
   }
 


### PR DESCRIPTION
The current activity needs to be finished before calling startActivity. 
Otherwise, activities with launchMode singleTask (ConversationListActivity) 
will receive a new Intent instead of getting restarted. And in response to the
new Intent, they will run onResume once again and trigger a second restart.

Fixes #1292
