### PR TITLE
Disable preview windows to avoid showing the wrong theme

### DIFF
--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -5,6 +5,7 @@
         <item name="actionBarStyle">@style/TextSecure.LightActionBar</item>
         <item name="android:windowContentOverlay">@null</item>
         <item name="windowContentOverlay">@null</item>
+        <item name="android:windowDisablePreview">true</item>
         <item name="conversation_list_item_background_read">@drawable/conversation_list_item_background_read_light</item>
         <item name="conversation_list_item_background_unread">@drawable/conversation_list_item_background_unread_light</item>
         <item name="conversation_list_item_background_selected">@drawable/list_selected_holo_light</item>


### PR DESCRIPTION
This fixes the flash of the light theme when you change the theme or
language settings, as @McLoo described in #1322.
