### PR TITLE
Show the time on messages always.

### DIFF
--- a/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -383,7 +383,7 @@ public class ThreadDatabase extends Database {
       MessageRecord record = null;
 
       if (reader != null && (record = reader.getNext()) != null) {
-        updateThread(threadId, count, record.getBody().getBody(), record.getDateSent(), record.getType());
+        updateThread(threadId, count, record.getBody().getBody(), record.getDateReceived(), record.getType());
       } else {
         deleteThread(threadId);
       }


### PR DESCRIPTION
Personally, I find it better, to always show the receive time of a message.
Event if it was not sent on the same day.
