### PR TITLE
Fix empty contact filter not working properly

### DIFF
--- a/src/org/thoughtcrime/securesms/contacts/ContactsDatabase.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactsDatabase.java
@@ -128,7 +128,7 @@ public class ContactsDatabase {
 
   private Cursor queryAndroidDb(String filter) {
     final Uri baseUri;
-    if (filter != null) {
+    if (!Util.isEmpty(filter)) {
       baseUri = Uri.withAppendedPath(ContactsContract.CommonDataKinds.Phone.CONTENT_FILTER_URI,
                                      Uri.encode(filter));
     } else {


### PR DESCRIPTION
If you want to start a new conversation with the "+" button, the "Select Contacts" window is shown. When you enter part of the name the filter is working as expected. But if you delete the filter again, just the TextSecure users are shown, not the rest of the contacts.

The filter needs to be checked for an empty string aswell, not just for null.
