### PR TITLE
Show same timestamp in overview like in messages

### DIFF
--- a/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -383,7 +383,7 @@ public class ThreadDatabase extends Database {
       MessageRecord record = null;
 
       if (reader != null && (record = reader.getNext()) != null) {
-        updateThread(threadId, count, record.getBody().getBody(), record.getDateReceived(), record.getType());
+        updateThread(threadId, count, record.getBody().getBody(), record.getDateSent(), record.getType());
       } else {
         deleteThread(threadId);
       }


### PR DESCRIPTION
After this commit:
"Display send date for incoming messages"
7ceaf59bccbbf2bddba80dc17d4c9fdb01a3d95f

There are two different timestamps used.
In the overview the "received date" is shown, as in the conversation thread, like the changelog already says, the "send date" is shown.

The different views should use the same values.
