### PR TITLE
Removed the word "at" in message details timestamp

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -159,7 +159,7 @@ public class ConversationFragment extends SherlockListFragment
     else if (message.isMms())     transport = "mms";
     else                          transport = "sms";
 
-    SimpleDateFormat dateFormatter = new SimpleDateFormat("EEE MMM d, yyyy 'at' hh:mm:ss a zzz");
+    SimpleDateFormat dateFormatter = new SimpleDateFormat("EEE MMM d, yyyy hh:mm:ss a zzz");
     AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
     builder.setTitle(R.string.ConversationFragment_message_details);
     builder.setIcon(Dialogs.resolveIcon(getActivity(), R.attr.dialog_info_icon));


### PR DESCRIPTION
Rationale for this PR:

> 1. We currently do _not_ have a safe method which allows to translate and adapt the timestamp format and "at" string (which separates timestamps in the message details à la "SENT: <date> at <time>"). A wrongly "translated" timestamp currently breaks and crashes TextSecure as discussed in https://github.com/WhisperSystems/TextSecure/pull/1309 , so that it cannot be allowed at the moment.
> 2. The word "at" was not localized, which makes localized (non-English) timestamps looking strange

Therefore I propose _for the moment_ - until we sanitize translation inputs for the timestamp string -  to simply drop the "at" word.

Dropping "at" simply avoids the need of translation.
