### PR TITLE
added "not connected to a google account" to registration problems list

### DIFF
--- a/res/layout/registration_progress_activity.xml
+++ b/res/layout/registration_progress_activity.xml
@@ -260,6 +260,36 @@
                                 style="@style/Registration.Description"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
+                                android:text="@string/registration_progress_activity__no_google_account"
+                                android:textStyle="bold" />
+
+                        <TextView
+                                style="@style/Registration.Description"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:paddingRight="10dip"
+                                android:text="@string/registration_progress_activity__your_device_needs_to_be_connected_to_a_google_account" />
+                    </LinearLayout>
+                </TableRow>
+
+                <TableRow>
+
+                    <TextView
+                            style="@style/Registration.Description"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:paddingRight="10dip"
+                            android:text="•" />
+
+                    <LinearLayout
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical" >
+
+                        <TextView
+                                style="@style/Registration.Description"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
                                 android:text="@string/registration_progress_activity__restrictive_firewall"
                                 android:textStyle="bold" />
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -589,6 +589,11 @@
     <string name="registration_progress_activity__some_possible_problems_include">Some possible
         problems include:
     </string>
+    <string name="registration_progress_activity__no_google_account">No Google account connected.
+    </string>
+    <string name="registration_progress_activity__your_device_needs_to_be_connected_to_a_google_account">Your
+        device needs to be connected to a Google account.
+    </string>
     <string name="registration_progress_activity__no_network_connectivity">No network
         connectivity.
     </string>


### PR DESCRIPTION
This commit adds a third point to the list of possible problems in registration step 4 (*) => if the registration with the push server (here: Google) fails this can have the reason that you have no Google account attached to your device. 

I had this problem on all my devices (which were not connected to Google), such a hint would have saved me 10 hours of search & rescue. Perhaps other users have encountered the same problem.... my commit is a help to spot this problem.

See Support question and answer: http://support.whispersystems.org/customer/portal/questions/6290806-verifying-number-hangs-in-step-4-registering-with-server-

(*) text on the screen is:

```

1. Connecting (ok)
2. Waiting for SMS verification (ok)
3. Generating keys (ok)
4. Registering with server... (fails: It hangs, spinning wheel turning)
```
