### PR TITLE
Fix Share Intent behaviour 

### DIFF
--- a/src/org/thoughtcrime/securesms/RoutingActivity.java
+++ b/src/org/thoughtcrime/securesms/RoutingActivity.java
@@ -248,7 +248,7 @@ public class RoutingActivity extends PassphraseRequiredSherlockActivity {
     Uri streamExtra = getIntent().getParcelableExtra(Intent.EXTRA_STREAM);
 
     if (streamExtra != null) {
-        type = getMimeType(streamExtra);
+      type = getMimeType(streamExtra);
     }
 
     if (type != null && type.startsWith("image/")) {


### PR DESCRIPTION
This commit fixes odd textsecure behavior with share intents:
- when share intents with mime type "*/*" were handled (containing multiple types, for example a text and an image), the contents were completely ignored and the user saw an empty text field.
- share intents with typ "image/*" (or other media types) would attach the image to the draft correctly, but ignored any text that was possibly included. 

This commit changes the behaviour in the following ways:
- the EXTRA_TEXT string from the intent is always included
- the mime-type of the Uri passed in EXTRA_STREAM is deduced via ContentResolver or File extension, depending on the Uri type which makes handling of "*/*"-type intents possible (and possibly makes textsecure more robust against wrong intent types)

This behaviour is the same as in most other apps (tested Hangouts, several mail apps, G+ and others)
