### PR TITLE
Fix receiving utf-8 characters in media push messages

### DIFF
--- a/src/org/thoughtcrime/securesms/mms/IncomingMediaMessage.java
+++ b/src/org/thoughtcrime/securesms/mms/IncomingMediaMessage.java
@@ -9,6 +9,7 @@ import org.whispersystems.textsecure.push.PushMessageProtos.PushMessageContent;
 import org.whispersystems.textsecure.util.Base64;
 import org.whispersystems.textsecure.util.Hex;
 
+import ws.com.google.android.mms.pdu.CharacterSets;
 import ws.com.google.android.mms.pdu.EncodedStringValue;
 import ws.com.google.android.mms.pdu.PduBody;
 import ws.com.google.android.mms.pdu.PduHeaders;
@@ -50,8 +51,9 @@ public class IncomingMediaMessage {
 
     if (!org.whispersystems.textsecure.util.Util.isEmpty(messageContent.getBody())) {
       PduPart text = new PduPart();
-      text.setData(Util.toIsoBytes(messageContent.getBody()));
+      text.setData(Util.toUtf8Bytes(messageContent.getBody()));
       text.setContentType(Util.toIsoBytes("text/plain"));
+      text.setCharset(CharacterSets.UTF_8);
       body.addPart(text);
     }
 

--- a/src/org/thoughtcrime/securesms/util/Util.java
+++ b/src/org/thoughtcrime/securesms/util/Util.java
@@ -98,9 +98,7 @@ public class Util {
     try {
       return new String(bytes, CharacterSets.MIMENAME_ISO_8859_1);
     } catch (UnsupportedEncodingException e) {
-      // Impossible to reach here!
-      Log.e("MmsDatabase", "ISO_8859_1 must be supported!", e);
-      return "";
+      throw new AssertionError("ISO_8859_1 must be supported!");
     }
   }
 
@@ -108,8 +106,15 @@ public class Util {
     try {
       return isoString.getBytes(CharacterSets.MIMENAME_ISO_8859_1);
     } catch (UnsupportedEncodingException e) {
-      Log.w("Util", "ISO_8859_1 must be supported!", e);
-      return new byte[0];
+      throw new AssertionError("ISO_8859_1 must be supported!");
+    }
+  }
+
+  public static byte[] toUtf8Bytes(String utf8String) {
+    try {
+      return utf8String.getBytes(CharacterSets.MIMENAME_UTF_8);
+    } catch (UnsupportedEncodingException e) {
+      throw new AssertionError("UTF_8 must be supported!");
     }
   }
 


### PR DESCRIPTION
When receiving a media message via push, that contains unicode characters (e.g. emoji) in the body, the unicode characters are shown as ??.
This is because the received body is converted to a ISO_8859_1 byte array.
I changed it to convert it to a utf-8 byte array and set the encoding appropriately. Then the unicode characters are received correctly.

Message with wrong encoding:
![screenshot_2014-04-21-11-49-26](https://cloud.githubusercontent.com/assets/2340865/2753724/7919787c-c93d-11e3-98c6-9eaec561bed1.png)

Message with my patch applied:
![screenshot_2014-04-21-11-50-11](https://cloud.githubusercontent.com/assets/2340865/2753723/74c62a04-c93d-11e3-86cd-e59a1108d467.png)
