### PR TITLE
Delete leading zero from fragment timestamp

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -159,7 +159,7 @@ public class ConversationFragment extends SherlockListFragment
     else if (message.isMms())     transport = "mms";
     else                          transport = "sms";
 
-    SimpleDateFormat dateFormatter = new SimpleDateFormat("EEE MMM d, yyyy 'at' hh:mm:ss a zzz");
+    SimpleDateFormat dateFormatter = new SimpleDateFormat("EEE MMM d, yyyy 'at' h:mm:ss a zzz");
     AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
     builder.setTitle(R.string.ConversationFragment_message_details);
     builder.setIcon(Dialogs.resolveIcon(getActivity(), R.attr.dialog_info_icon));


### PR DESCRIPTION
The current timestamp in the ConversationFragment dateFormatter is in AM/PM format. It would most likely be expected therefore that there would not be a zero padding on the hour for this time.

This change removes the zero padding from the hour in the dateFormatter so that instead of "09:12:45 pm", the representation would now be "9:12:44 pm".

Format documented here:
http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html#number
