### PR TITLE
Adding an "About application" page

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -87,7 +87,7 @@
 
     <activity android:name=".PromptMmsActivity"
               android:label="Configure MMS Settings"
-              android:windowSoftInputMode="stateUnchanged"              
+              android:windowSoftInputMode="stateUnchanged"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
     <activity android:name=".MmsPreferencesActivity"
@@ -176,11 +176,11 @@
               android:label="@string/AndroidManifest__manage_identity_keys"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
-    <activity android:name=".ReceiveKeyActivity" 
+    <activity android:name=".ReceiveKeyActivity"
               android:label="@string/AndroidManifest__complete_key_exchange"
               android:theme="@style/TextSecure.Light.Dialog"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
-    
+
     <activity android:name=".ApplicationPreferencesActivity"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
@@ -206,6 +206,9 @@
               android:stateNotNeeded="true"
               android:clearTaskOnLaunch="true"
               android:finishOnTaskLaunch="true" />
+
+    <activity android:name="org.thoughtcrime.securesms.AboutActivity"
+              android:label="@string/preferences__about" />
 
     <service android:enabled="true" android:name=".service.ApplicationMigrationService"/>
     <service android:enabled="true" android:name=".service.KeyCachingService"/>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -760,6 +760,14 @@
     <string name="preferences__sms_fallback_ask_fallback">Ask before sending SMS</string>
     <string name="preferences__sms_fallback_non_push_users">Non-TextSecure users</string>
     <string name="preferences__sms_fallback_nobody">Nobody</string>
+    <string name="preferences__about">About</string>
+    <string name="preferences__version">Version</string>
+
+    <string name="about__title_version">Version</string>
+    <string name="about__title_support">Support Center</string>
+    <string name="about__title_source_code">Source code</string>
+    <string name="about__title_license">License</string>
+
 
     <!-- **************************************** -->
     <!-- menus -->

--- a/res/xml/about.xml
+++ b/res/xml/about.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" >
+
+  <Preference android:key="about_version"
+              android:title="@string/about__title_version" />
+  <Preference android:summary="©2012-2014 Open Whisper Systems"
+              android:title="Copyright" />
+  <Preference android:key="about_support"
+              android:title="@string/about__title_support" />
+  <Preference android:key="about_source_code"
+              android:title="@string/about__title_source_code" />
+  <Preference android:key="about_license"
+              android:title="@string/about__title_license" />
+
+</PreferenceScreen>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -177,4 +177,10 @@
                     android:title="@string/preferences__submit_debug_log"/>
 
     </PreferenceCategory>
-</PreferenceScreen>
+
+    <PreferenceCategory android:key="pref_key_about_application" android:title="@string/preferences__about">
+      <org.thoughtcrime.securesms.preferences.AboutApplicationPreference android:key="pref_key_about_application_version"
+                                                                         android:title="@string/preferences__version" />
+    </PreferenceCategory>
+
+ </PreferenceScreen>

--- a/src/org/thoughtcrime/securesms/AboutActivity.java
+++ b/src/org/thoughtcrime/securesms/AboutActivity.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2014 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.thoughtcrime.securesms;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.preference.Preference;
+import android.preference.PreferenceScreen;
+import android.content.Context;
+
+import com.actionbarsherlock.app.ActionBar;
+import com.actionbarsherlock.app.SherlockPreferenceActivity;
+import com.actionbarsherlock.view.MenuItem;
+
+import org.thoughtcrime.securesms.ApplicationListener;
+import org.thoughtcrime.securesms.Constants;
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.util.Util;
+import org.thoughtcrime.securesms.util.DynamicLanguage;
+import org.thoughtcrime.securesms.util.DynamicTheme;
+
+public final class AboutActivity extends SherlockPreferenceActivity {
+
+  private final DynamicTheme    dynamicTheme    = new DynamicTheme   ();
+  private final DynamicLanguage dynamicLanguage = new DynamicLanguage();
+
+  private static final String KEY_ABOUT_VERSION = "about_version";
+  private static final String KEY_ABOUT_SOURCE = "about_source_code";
+  private static final String KEY_ABOUT_SUPPORT = "about_support";
+  private static final String KEY_ABOUT_LICENSE = "about_license";
+
+  @Override
+  protected void onCreate(final Bundle savedInstanceState) {
+
+    dynamicTheme.onCreate(this);
+    dynamicLanguage.onCreate(this);
+    super.onCreate(savedInstanceState);
+
+    addPreferencesFromResource(R.xml.about);
+
+    final ActionBar actionBar = getSupportActionBar();
+    actionBar.setDisplayHomeAsUpEnabled(true);
+
+    Context context = AboutActivity.this;
+    findPreference(KEY_ABOUT_VERSION).setSummary(Util.getAppAndVersionName(context));
+    findPreference(KEY_ABOUT_SOURCE).setSummary(Constants.SOURCE_URL);
+    findPreference(KEY_ABOUT_SUPPORT).setSummary(Constants.SUPPORT_URL);
+    findPreference(KEY_ABOUT_LICENSE).setSummary(Constants.LICENSE_URL);
+
+  }
+
+
+  @Override
+  public boolean onOptionsItemSelected(final MenuItem item) {
+
+    switch (item.getItemId()) {
+      case android.R.id.home:
+        finish();
+        return true;
+    }
+
+    return super.onOptionsItemSelected(item);
+  }
+
+
+  @Override
+  public boolean onPreferenceTreeClick(final PreferenceScreen preferenceScreen, final Preference preference) {
+
+    final String key = preference.getKey();
+
+    if (KEY_ABOUT_SOURCE.equals(key)) {
+      startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(Constants.SOURCE_URL)));
+    } else if (KEY_ABOUT_SUPPORT.equals(key)) {
+      startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(Constants.SUPPORT_URL)));
+    } else if (KEY_ABOUT_LICENSE.equals(key)) {
+      startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(Constants.LICENSE_URL)));
+    }
+
+    return false;
+
+  }
+
+}

--- a/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -16,6 +16,7 @@
  */
 package org.thoughtcrime.securesms;
 
+
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
@@ -61,6 +62,7 @@ import org.thoughtcrime.securesms.util.MemoryCleaner;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.util.Trimmer;
 import org.thoughtcrime.securesms.util.Util;
+import org.thoughtcrime.securesms.AboutActivity;
 import org.whispersystems.textsecure.crypto.MasterSecret;
 import org.whispersystems.textsecure.push.AuthorizationFailedException;
 import org.whispersystems.textsecure.push.PushServiceSocket;
@@ -128,6 +130,8 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredSherlockPr
         .setOnPreferenceClickListener(new SubmitDebugLogListener());
     this.findPreference(OUTGOING_SMS_PREF)
         .setOnPreferenceChangeListener(new OutgoingSmsPreferenceListener());
+    this.findPreference(TextSecurePreferences.ABOUT_APPLICATION)
+      .setOnPreferenceClickListener(new AboutApplicationListener());
 
     initializeOutgoingSmsSummary((OutgoingSmsPreference) findPreference(OUTGOING_SMS_PREF));
     initializeListSummary((ListPreference) findPreference(TextSecurePreferences.LED_COLOR_PREF));
@@ -606,6 +610,20 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredSherlockPr
           if (((PreferenceScreen)preference).getDialog()!=null)
             ((PreferenceScreen)preference).getDialog().getWindow().getDecorView().setBackgroundDrawable(this.getWindow().getDecorView().getBackground().getConstantState().newDrawable());
     return false;
+  }
+
+
+  private class AboutApplicationListener implements Preference.OnPreferenceClickListener {
+    @Override
+    public boolean onPreferenceClick(Preference preference) {
+
+      Context context = ApplicationPreferencesActivity.this;
+      startActivity(new Intent(context, AboutActivity.class));
+
+      return true;
+
+    }
+
   }
 
 }

--- a/src/org/thoughtcrime/securesms/Constants.java
+++ b/src/org/thoughtcrime/securesms/Constants.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2014 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.thoughtcrime.securesms;
+
+public class Constants {
+  public static final String LICENSE_URL = "http://www.gnu.org/licenses/gpl-3.0.txt";
+  public static final String SUPPORT_URL = "http://support.whispersystems.org";
+  public static final String BUGREPORTS_URL = "https://github.com/WhisperSystems/TextSecure/issues";
+  public static final String SOURCE_URL = "https://github.com/WhisperSystems/TextSecure";
+}

--- a/src/org/thoughtcrime/securesms/preferences/AboutApplicationPreference.java
+++ b/src/org/thoughtcrime/securesms/preferences/AboutApplicationPreference.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2014 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.thoughtcrime.securesms.preferences;
+
+import android.content.Context;
+import android.preference.Preference;
+import android.util.AttributeSet;
+
+import org.thoughtcrime.securesms.util.Util;
+
+public class AboutApplicationPreference extends Preference {
+
+  public AboutApplicationPreference(Context context, AttributeSet attrs) {
+    super(context, attrs);
+
+    setTitle(Util.getAppAndVersionName(context));
+
+  }
+
+}

--- a/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -49,6 +49,8 @@ public class TextSecurePreferences {
   private static final String SMS_FALLBACK_ASK_PREF            = "pref_sms_fallback_ask";
   private static final String ALLOW_SMS_NON_DATA_PREF          = "pref_sms_non_data_out";
 
+  public  static final String ABOUT_APPLICATION                = "pref_key_about_application_version";
+
   public static boolean isSmsFallbackEnabled(Context context) {
     return getBooleanPreference(context, ALLOW_SMS_FALLBACK_PREF, true);
   }

--- a/src/org/thoughtcrime/securesms/util/Util.java
+++ b/src/org/thoughtcrime/securesms/util/Util.java
@@ -25,6 +25,7 @@ import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.style.StyleSpan;
 import android.util.Log;
+import android.content.pm.PackageManager;
 
 import org.whispersystems.textsecure.util.InvalidNumberException;
 import org.whispersystems.textsecure.util.PhoneNumberFormatter;
@@ -39,6 +40,8 @@ import java.util.concurrent.TimeUnit;
 
 import ws.com.google.android.mms.pdu.CharacterSets;
 import ws.com.google.android.mms.pdu.EncodedStringValue;
+
+import org.thoughtcrime.securesms.R;
 
 public class Util {
 
@@ -176,5 +179,22 @@ public class Util {
   ////
   ////  return BitmapFactory.decodeStream(src, null, options);
   //  }
+
+  public static String getVersionName(Context context) {
+    String versionName;
+    try {
+      versionName = context.getPackageManager()
+                      .getPackageInfo(context.getPackageName(), 0)
+                      .versionName;
+    } catch (PackageManager.NameNotFoundException e) {
+      throw new AssertionError(e);
+    }
+    return versionName;
+  }
+
+
+  public static String getAppAndVersionName(Context context) {
+    return context.getString(R.string.app_name)+" "+getVersionName(context);
+  }
 
 }


### PR DESCRIPTION
@Moxie et al.: as a new initiative, I propose this renewed pull request, which has been rebased to master. A link to a changelog has been removed, as suggested by you. I hope, this PR pleases you.

Introducing:
- version number read from Manifest
- urls for license and support
- based on concepts as found in https://github.com/schildbach/bitcoin-wallet
- theme-aware page (dark/light design)
- returns correctly from web pages (like source code, support forum) to the About page
- (C) 2014 Open Whisper Systems
- obeying code style guidelines
