### PR TITLE
Add Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: android
+android:
+  components:
+    - platform-tools
+    - build-tools-19.0.2
+    - android-19
+    - extra-android-m2repository
+script: ./gradlew build -q

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-TextSecure
+TextSecure [![Build Status](https://travis-ci.org/WhisperSystems/TextSecure.svg?branch=master)](https://travis-ci.org/WhisperSystems/TextSecure)
 =================
 
 A secure text messaging application for Android.


### PR DESCRIPTION
Since there was no reaction in #475 for a while, I went ahead and had a look at that.

Travis has added explicit support for Android, so the build script is quite simple. Listing the components in `.travis.yml` is not strictly needed (they are [installed by default](http://docs.travis-ci.com/user/languages/android/#Overview)), but I thought it might save some time in the future when the defaults are changed. I also updated the build tools to the latest version and added a travis build status image (will look like [![Build Status](https://travis-ci.org/fwalch/TextSecure.svg?branch=travis)](https://travis-ci.org/fwalch/TextSecure)) to the readme.

You can have a look at a successful build at https://travis-ci.org/fwalch/TextSecure/builds/24788883.
