### PR TITLE
Only notify 'in-thread' when notifications are actually enabled

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -241,7 +241,7 @@ public class MessageNotifier {
 
   private static void sendInThreadNotification(Context context) {
     try {
-      if (!TextSecurePreferences.isInThreadNotifications(context)) {
+      if (!TextSecurePreferences.isInThreadNotifications(context) || !TextSecurePreferences.isNotificationsEnabled(context)) {
         return;
       }
 


### PR DESCRIPTION
This should fix #1371 by only notifying when actually enabled.
