### PR TITLE
add notification for key change event, fixes #1460

### DIFF
--- a/src/org/thoughtcrime/securesms/service/PushReceiver.java
+++ b/src/org/thoughtcrime/securesms/service/PushReceiver.java
@@ -112,8 +112,8 @@ public class PushReceiver {
     }
 
     try {
-      Recipient              recipient       = RecipientFactory.getRecipientsFromString(context, message.getSource(), false).getPrimaryRecipient();
-      Recipients             recipients      = RecipientFactory.getRecipientsFromMessage(context, message, false);
+      Recipients             recipients      = RecipientFactory.getRecipientsFromString(context, message.getSource(), false);
+      Recipient              recipient       = recipients.getPrimaryRecipient();
       RecipientDevice        recipientDevice = new RecipientDevice(recipient.getRecipientId(), message.getSourceDevice());
       KeyExchangeProcessorV2 processor       = new KeyExchangeProcessorV2(context, masterSecret, recipientDevice);
       PreKeyWhisperMessage   preKeyExchange  = new PreKeyWhisperMessage(message.getBody());


### PR DESCRIPTION
This adds a notification when a message is received but the key has changed. Until now, you didn't got a notification and had to open TextSecure to notice the message.

This fixes #1460
