### PR TITLE
Show Drafts in ConversationList

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -355,6 +355,7 @@
     <string name="MessageDisplayHelper_bad_encrypted_message">Bad encrypted message...</string>
     <string name="MessageDisplayHelper_decrypting_please_wait">Decrypting, please wait...</string>
     <string name="MessageDisplayHelper_message_encrypted_for_non_existing_session">Message encrypted for non-existing session...</string>
+    <string name="MessageDisplayHelper_message_draft">Draft</string>
 
     <!-- MmsDatabase -->
     <string name="MmsDatabase_connecting_to_mms_server">Connecting to MMS server...</string>

--- a/src/org/thoughtcrime/securesms/database/MmsSmsColumns.java
+++ b/src/org/thoughtcrime/securesms/database/MmsSmsColumns.java
@@ -33,6 +33,7 @@ public interface MmsSmsColumns {
     // Message attributes
     protected static final long MESSAGE_ATTRIBUTE_MASK = 0xE0;
     protected static final long MESSAGE_FORCE_SMS_BIT  = 0x40;
+    protected static final long MESSAGE_DRAFT_BIT      = 0x80;
 
     // Key Exchange Information
     protected static final long KEY_EXCHANGE_BIT                 = 0x8000;
@@ -170,6 +171,10 @@ public interface MmsSmsColumns {
 
     public static boolean isNoRemoteSessionType(long type) {
       return (type & ENCRYPTION_REMOTE_NO_SESSION_BIT) != 0;
+    }
+
+    public static boolean isDraftType(long type) {
+      return (type & MESSAGE_DRAFT_BIT) != 0;
     }
 
     public static boolean isLegacyType(long type) {

--- a/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -379,13 +379,17 @@ public class ThreadDatabase extends Database {
     MmsSmsDatabase.Reader reader = null;
 
     try {
-      reader               = mmsSmsDatabase.readerFor(mmsSmsDatabase.getConversationSnippet(threadId));
-      MessageRecord record = null;
-
-      if (reader != null && (record = reader.getNext()) != null) {
-        updateThread(threadId, count, record.getBody().getBody(), record.getDateReceived(), record.getType());
+      if (draftCount > 0) {
+        updateThread(threadId, count, "", System.currentTimeMillis(), MmsSmsColumns.Types.MESSAGE_DRAFT_BIT);
       } else {
-        deleteThread(threadId);
+        reader = mmsSmsDatabase.readerFor(mmsSmsDatabase.getConversationSnippet(threadId));
+        MessageRecord record = null;
+
+        if (reader != null && (record = reader.getNext()) != null) {
+          updateThread(threadId, count, record.getBody().getBody(), record.getDateReceived(), record.getType());
+        } else {
+          deleteThread(threadId);
+        }
       }
     } finally {
       if (reader != null)

--- a/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
@@ -66,6 +66,8 @@ public class ThreadRecord extends DisplayRecord {
       return emphasisAdded(context.getString(R.string.MessageDisplayHelper_bad_encrypted_message));
     } else if (SmsDatabase.Types.isNoRemoteSessionType(type)) {
       return emphasisAdded(context.getString(R.string.MessageDisplayHelper_message_encrypted_for_non_existing_session));
+    } else if (SmsDatabase.Types.isDraftType(type)) {
+      return emphasisAdded(context.getString(R.string.MessageDisplayHelper_message_draft));
     } else if (!getBody().isPlaintext()) {
       return emphasisAdded(context.getString(R.string.MessageNotifier_encrypted_message));
     } else if (SmsDatabase.Types.isEndSessionType(type)) {


### PR DESCRIPTION
I modified ThreadDatabase.update() to show an italic "Draft" in the ConversationList, when a draft exists. This way threads with drafts are shown on the top (sorted by date) and drafts for new recipients don't show the default "(No subject)" text. I'm not sure if I implemented this the correct way. I added a new constant MESSAGE_DRAFT_BIT in MmsSmsColumns.Types to indicate the conversation contains a draft.
