### PR TITLE
Fix APN permission on android 4.4

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -24,6 +24,7 @@
     <uses-permission android:name="android.permission.READ_SMS"/>
     <uses-permission android:name="android.permission.SEND_SMS"/>
     <uses-permission android:name="android.permission.WRITE_SMS"/>
+    <uses-permission android:name="android.permission.WRITE_APN_SETTINGS" />
     <uses-permission android:name="android.permission.VIBRATE"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />


### PR DESCRIPTION
Phone: Android 4.4.2, Nexus 5.

Added the APN permission to AndroidManifest.xml.

Fixes:

```
E/DatabaseUtils( 1034): Writing exception to parcel
E/DatabaseUtils( 1034): java.lang.SecurityException: No permission to write APN settings: Neither user 10127 nor current process has android.permission.WRITE_APN_SETTINGS.
E/DatabaseUtils( 1034):     at android.app.ContextImpl.enforce(ContextImpl.java:1685)
E/DatabaseUtils( 1034):     at android.app.ContextImpl.enforceCallingOrSelfPermission(ContextImpl.java:1714)
E/DatabaseUtils( 1034):     at com.android.providers.telephony.TelephonyProvider.checkPermission(TelephonyProvider.java:735)
E/DatabaseUtils( 1034):     at com.android.providers.telephony.TelephonyProvider.query(TelephonyProvider.java:462)
E/DatabaseUtils( 1034):     at android.content.ContentProvider.query(ContentProvider.java:857)
E/DatabaseUtils( 1034):     at android.content.ContentProvider$Transport.query(ContentProvider.java:200)
E/DatabaseUtils( 1034):     at android.content.ContentProviderNative.onTransact(ContentProviderNative.java:112)
E/DatabaseUtils( 1034):     at android.os.Binder.execTransact(Binder.java:404)
E/DatabaseUtils( 1034):     at dalvik.system.NativeStart.run(Native Method)
I/MmsCommunication( 5544): Couldn't write APN settings, expected. msg: No permission to write APN settings: Neither user 10127 nor current process has android.permission.WRITE_APN_SETTINGS.
```
