### PR TITLE
Show drafts emojified when Android version is below KitKat

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -34,6 +34,7 @@ import android.provider.ContactsContract;
 import android.telephony.PhoneNumberUtils;
 import android.text.Editable;
 import android.text.InputType;
+import android.text.SpannableString;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.Log;
@@ -94,6 +95,7 @@ import org.thoughtcrime.securesms.util.Dialogs;
 import org.thoughtcrime.securesms.util.DirectoryHelper;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicTheme;
+import org.thoughtcrime.securesms.util.Emoji;
 import org.thoughtcrime.securesms.util.EncryptedCharacterCalculator;
 import org.thoughtcrime.securesms.util.GroupUtil;
 import org.thoughtcrime.securesms.util.MemoryCleaner;
@@ -617,7 +619,7 @@ public class ConversationActivity extends PassphraseRequiredSherlockFragmentActi
     if (draftVideo != null) addAttachmentVideo(draftVideo);
 
     if (draftText == null && draftImage == null && draftAudio == null && draftVideo == null) {
-      initializeDraftFromDatabase();
+      initializeDraftFromDatabase(this);
     }
   }
 
@@ -632,7 +634,7 @@ public class ConversationActivity extends PassphraseRequiredSherlockFragmentActi
         (TextSecurePreferences.isPushRegistered(this) && !TextSecurePreferences.isSmsFallbackEnabled(this)));
   }
 
-  private void initializeDraftFromDatabase() {
+  private void initializeDraftFromDatabase(final Context context) {
     new AsyncTask<Void, Void, List<Draft>>() {
       @Override
       protected List<Draft> doInBackground(Void... params) {
@@ -647,11 +649,23 @@ public class ConversationActivity extends PassphraseRequiredSherlockFragmentActi
 
       @Override
       protected void onPostExecute(List<Draft> drafts) {
+        SpannableString draftText;
         for (Draft draft : drafts) {
-          if      (draft.getType().equals(Draft.TEXT))  composeText.setText(draft.getValue());
-          else if (draft.getType().equals(Draft.IMAGE)) addAttachmentImage(Uri.parse(draft.getValue()));
-          else if (draft.getType().equals(Draft.AUDIO)) addAttachmentAudio(Uri.parse(draft.getValue()));
-          else if (draft.getType().equals(Draft.VIDEO)) addAttachmentVideo(Uri.parse(draft.getValue()));
+          if (draft.getType().equals(Draft.TEXT)) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
+              Emoji emoji = Emoji.getInstance(context);
+              draftText   = emoji.emojify(draft.getValue());
+            } else {
+              draftText   = SpannableString.valueOf(draft.getValue());
+            }
+            composeText.setText(draftText, TextView.BufferType.SPANNABLE);
+          } else if (draft.getType().equals(Draft.IMAGE)) {
+            addAttachmentImage(Uri.parse(draft.getValue()));
+          } else if (draft.getType().equals(Draft.AUDIO)) {
+            addAttachmentAudio(Uri.parse(draft.getValue()));
+          } else if (draft.getType().equals(Draft.VIDEO)) {
+            addAttachmentVideo(Uri.parse(draft.getValue()));
+          }
         }
       }
     }.execute();


### PR DESCRIPTION
Fixes the issue that drafts with emojis (added from the TS emoji drawer) are shown 
- as rectangles on GB  
- as font letter emojis on JB and ICS

when opening a conversation that has a draft.

The only thing I'm not completely sure about is the `getBaseContext()`.

GB
![unbenannt3](https://cloud.githubusercontent.com/assets/5326916/3060200/233b46c6-e1f5-11e3-861e-28fa0d3c2529.png)
![unbenannt4](https://cloud.githubusercontent.com/assets/5326916/3060203/27076668-e1f5-11e3-9015-dce744b0e006.png)

ICS
![unbenannt2](https://cloud.githubusercontent.com/assets/5326916/3060205/2bd63d54-e1f5-11e3-9e97-5c84df874f8f.png)
![unbenannt1](https://cloud.githubusercontent.com/assets/5326916/3060209/2eb38c66-e1f5-11e3-9070-5ca780cb6ba7.png)
