### PR TITLE
move FLAG_SECURE to PassphraseRequiredMixin

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -203,7 +203,6 @@ public class ConversationActivity extends PassphraseRequiredSherlockFragmentActi
     dynamicLanguage.onResume(this);
 
     initializeSecurity();
-    initializeScreenshotSecurity();
     initializeTitleBar();
     initializeEnabledCheck();
     initializeMmsEnabledCheck();
@@ -731,15 +730,6 @@ public class ConversationActivity extends PassphraseRequiredSherlockFragmentActi
     calculateCharactersRemaining();
   }
 
-  private void initializeScreenshotSecurity() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-      if (TextSecurePreferences.isScreenSecurityEnabled(this)) {
-        getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
-      } else {
-        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
-      }
-    }
-  }
 
   private void initializeMmsEnabledCheck() {
     new AsyncTask<Void, Void, Boolean>() {

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -86,7 +86,6 @@ public class ConversationListActivity extends PassphraseRequiredSherlockFragment
     dynamicLanguage.onResume(this);
 
     initializeDefaultMessengerCheck();
-    initializeSecurity();
   }
 
   @Override
@@ -296,16 +295,6 @@ public class ConversationListActivity extends PassphraseRequiredSherlockFragment
       Intent intent = new Intent(Telephony.Sms.Intents.ACTION_CHANGE_DEFAULT);
       intent.putExtra(Telephony.Sms.Intents.EXTRA_PACKAGE_NAME, getPackageName());
       startActivity(intent);
-    }
-  }
-
-  private void initializeSecurity() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-      if (TextSecurePreferences.isScreenSecurityEnabled(this)) {
-        getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
-      } else {
-        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
-      }
     }
   }
 

--- a/src/org/thoughtcrime/securesms/PassphraseRequiredSherlockActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphraseRequiredSherlockActivity.java
@@ -13,25 +13,25 @@ public class PassphraseRequiredSherlockActivity extends SherlockActivity impleme
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    delegate.onCreate(this, this);
+    delegate.onCreate(this);
   }
 
   @Override
   protected void onResume() {
     super.onResume();
-    delegate.onResume(this, this);
+    delegate.onResume(this);
   }
 
   @Override
   protected void onPause() {
     super.onPause();
-    delegate.onPause(this, this);
+    delegate.onPause(this);
   }
 
   @Override
   protected void onDestroy() {
     super.onDestroy();
-    delegate.onDestroy(this, this);
+    delegate.onDestroy(this);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/PassphraseRequiredSherlockFragmentActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphraseRequiredSherlockFragmentActivity.java
@@ -13,25 +13,25 @@ public class PassphraseRequiredSherlockFragmentActivity extends SherlockFragment
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    delegate.onCreate(this, this);
+    delegate.onCreate(this);
   }
 
   @Override
   protected void onResume() {
     super.onResume();
-    delegate.onResume(this, this);
+    delegate.onResume(this);
   }
 
   @Override
   protected void onPause() {
     super.onPause();
-    delegate.onPause(this, this);
+    delegate.onPause(this);
   }
 
   @Override
   protected void onDestroy() {
     super.onDestroy();
-    delegate.onDestroy(this, this);
+    delegate.onDestroy(this);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/PassphraseRequiredSherlockListActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphraseRequiredSherlockListActivity.java
@@ -13,25 +13,25 @@ public class PassphraseRequiredSherlockListActivity extends SherlockListActivity
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    delegate.onCreate(this, this);
+    delegate.onCreate(this);
   }
 
   @Override
   protected void onResume() {
     super.onResume();
-    delegate.onResume(this, this);
+    delegate.onResume(this);
   }
 
   @Override
   protected void onPause() {
     super.onPause();
-    delegate.onPause(this, this);
+    delegate.onPause(this);
   }
 
   @Override
   protected void onDestroy() {
     super.onDestroy();
-    delegate.onDestroy(this, this);
+    delegate.onDestroy(this);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/PassphraseRequiredSherlockPreferenceActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphraseRequiredSherlockPreferenceActivity.java
@@ -16,25 +16,25 @@ public abstract class PassphraseRequiredSherlockPreferenceActivity
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    delegate.onCreate(this, this);
+    delegate.onCreate(this);
   }
 
   @Override
   protected void onResume() {
     super.onResume();
-    delegate.onResume(this, this);
+    delegate.onResume(this);
   }
 
   @Override
   protected void onPause() {
     super.onPause();
-    delegate.onPause(this, this);
+    delegate.onPause(this);
   }
 
   @Override
   protected void onDestroy() {
     super.onDestroy();
-    delegate.onDestroy(this, this);
+    delegate.onDestroy(this);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/org/thoughtcrime/securesms/ShareActivity.java
@@ -72,7 +72,6 @@ public class ShareActivity extends PassphraseRequiredSherlockFragmentActivity
     dynamicTheme.onResume(this);
     dynamicLanguage.onResume(this);
     getSupportActionBar().setTitle(R.string.ShareActivity_share_with);
-    initializeSecurity();
   }
 
   @Override
@@ -139,16 +138,6 @@ public class ShareActivity extends PassphraseRequiredSherlockFragmentActivity
         .findFragmentById(R.id.fragment_content);
 
     this.fragment.setMasterSecret(masterSecret);
-  }
-
-  private void initializeSecurity() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-      if (TextSecurePreferences.isScreenSecurityEnabled(this)) {
-        getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
-      } else {
-        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
-      }
-    }
   }
 
   private Intent getBaseShareIntent(final Class<?> target) {


### PR DESCRIPTION
This change applies the presumption that Activities which require a passphrase should also be protected with FLAG_SECURE if the user has that option enabled.

Also takes better advantage of java generics to save an argument. Tested on Android 2.3 and 4.4.
