### PR TITLE
Add number of messages to the notification number attribute

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -172,6 +172,7 @@ public class MessageNotifier {
     builder.setContentText(notifications.get(0).getText());
     builder.setContentIntent(notifications.get(0).getPendingIntent(context));
     builder.setContentInfo(String.valueOf(notificationState.getMessageCount()));
+    builder.setNumber(notificationState.getMessageCount());
 
     if (masterSecret != null) {
       builder.addAction(R.drawable.check, context.getString(R.string.MessageNotifier_mark_as_read),
@@ -215,6 +216,7 @@ public class MessageNotifier {
     builder.setContentIntent(PendingIntent.getActivity(context, 0, new Intent(context, RoutingActivity.class), 0));
     
     builder.setContentInfo(String.valueOf(notificationState.getMessageCount()));
+    builder.setNumber(notificationState.getMessageCount());
 
     if (masterSecret != null) {
       builder.addAction(R.drawable.check, context.getString(R.string.MessageNotifier_mark_all_as_read),


### PR DESCRIPTION
Although not used by stock Android, many custom ROM's (and possibly OEM
versions?) have a setting to display the "number" count of a notification
overlayed on the status bar icon. Add support for this.
