### PR TITLE
don't try to load recipients for each filter text

### DIFF
--- a/src/org/thoughtcrime/securesms/contacts/ContactSelectionListAdapter.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactSelectionListAdapter.java
@@ -185,7 +185,7 @@ public class ContactSelectionListAdapter extends    CursorAdapter
       holder.number.setText(numberLabelSpan);
     }
     holder.contactPhoto.setImageBitmap(defaultCroppedPhoto);
-    loadBitmap(contactData.number, holder.contactPhoto);
+    if (contactData.id > -1) loadBitmap(contactData.number, holder.contactPhoto);
   }
 
   @Override


### PR DESCRIPTION
Stops all the entries coming up in the canonical address id and saves CPU time.
