### PR TITLE
move log submission to new library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     compile 'com.astuetz:pagerslidingtabstrip:1.0.1'
     compile 'org.w3c:smil:1.0.0'
     compile 'org.apache.httpcomponents:httpclient-android:4.3.5'
+    compile 'org.whispersystems:libpastelog:1.0.2'
 
     androidTestCompile 'com.squareup:fest-android:1.0.8'
     androidTestCompile 'com.google.dexmaker:dexmaker:1.1'
@@ -54,6 +55,7 @@ dependencyVerification {
             'com.astuetz:pagerslidingtabstrip:f1641396732c7132a7abb837e482e5ee2b0ebb8d10813fc52bbaec2c15c184c2',
             'org.w3c:smil:085dc40f2bb249651578bfa07499fd08b16ad0886dbe2c4078586a408da62f9b',
             'org.apache.httpcomponents:httpclient-android:6f56466a9bd0d42934b90bfbfe9977a8b654c058bf44a12bdc2877c4e1f033f1',
+            'org.whispersystems:libpastelog:9798b3c93a91082c2c68542ce5b5c182e18556aebdcb7c8cebbd89eb48ac4047',
             'com.android.support:support-annotations:1aa96ef0cc4a445bfc2f93ccf762305bc57fa107b12afe9d11f3863ae8a11036',
             'com.google.protobuf:protobuf-java:e0c1c64575c005601725e7c6a02cebf9e1285e888f756b2a1d73ffa8d725cc74',
             'com.madgag:sc-light-jdk15on:931f39d351429fb96c2f749e7ecb1a256a8ebbf5edca7995c9cc085b94d1841d',

--- a/res/layout/log_submit_activity.xml
+++ b/res/layout/log_submit_activity.xml
@@ -1,51 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:id="@+id/fragment_container"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <TextView android:id="@+id/log_submit_confirmation"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:textSize="18sp"
-        android:textStyle="bold"
-        android:text="@string/log_submit_activity__confirmation"
-        android:paddingLeft="15dp"
-        android:paddingRight="15dp"
-        android:paddingTop="10dp"
-        android:paddingBottom="10dp" />
 
-    <ScrollView android:id="@+id/log_preview_container"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
-        android:layout_weight="2">
-        <EditText android:id="@+id/log_preview"
-                  android:layout_width="fill_parent"
-                  android:layout_height="wrap_content"
-                  style="?android:attr/textViewStyle"
-                  android:padding="10dp"
-                  android:background="@null"
-                  android:fontFamily="monospace"
-                  android:hint=""
-                  android:inputType="textImeMultiLine|textNoSuggestions|textMultiLine"
-                  android:textSize="10sp" />
-    </ScrollView>
-
-    <LinearLayout
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-        <Button android:id="@+id/cancel"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/log_submit_activity__button_cancel"
-                android:layout_weight="1"/>
-        <Button android:id="@+id/ok"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/log_submit_activity__button_ok"
-                android:layout_weight="1"/>
-    </LinearLayout>
 
 </LinearLayout>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -495,18 +495,10 @@
 
 
     <!-- log_submit_activity -->
-    <string name="log_submit_activity__confirmation">This log will be posted publicly online for TextSecure contributors to view. Feel free to examine or edit the logs below before hitting submit.</string>
-    <string name="log_submit_activity__button_cancel">Don\'t submit</string>
-    <string name="log_submit_activity__button_ok">Submit</string>
     <string name="log_submit_activity__log_fetch_failed">Could not grab logs from your device. You can still use ADB to get debug logs instead.</string>
-    <string name="log_submit_activity__log_submit_success_title">Success!</string>
-    <string name="log_submit_activity__log_got_it">Got it</string>
-    <string name="log_submit_activity__your_pastebin_url">Please copy this URL and add it to your issue (long press to put in clipboard):\n\n<b>%1$s</b></string>
-    <string name="log_submit_activity__copied_to_clipboard">Copied to clipboard</string>
-    <string name="log_submit_activity__loading_logcat">Loading logcat&#8230;</string>
     <string name="log_submit_activity__thanks">Thanks for your help!</string>
     <string name="log_submit_activity__submitting">Submitting</string>
-    <string name="log_submit_activity__posting_logs">Posting logs to pastebin&#8230;</string>
+    <string name="log_submit_activity__posting_logs">Posting logs to gist&#8230;</string>
 
     <!-- database_migration_activity -->
     <string name="database_migration_activity__would_you_like_to_import_your_existing_text_messages">Would you like to import your existing text messages into TextSecure\'s encrypted database?</string>

--- a/src/org/thoughtcrime/securesms/LogSubmitActivity.java
+++ b/src/org/thoughtcrime/securesms/LogSubmitActivity.java
@@ -1,65 +1,34 @@
 package org.thoughtcrime.securesms;
 
-import android.app.AlertDialog;
-import android.text.ClipboardManager;
-import android.content.DialogInterface;
-import android.os.AsyncTask;
+import android.support.v4.app.FragmentTransaction;
 import android.os.Bundle;
-import android.text.TextUtils;
-import android.util.Log;
-import android.util.TypedValue;
-import android.view.View;
-import android.widget.Button;
-import android.widget.EditText;
-import android.widget.TextView;
 import android.widget.Toast;
 
-import com.actionbarsherlock.app.SherlockActivity;
+import com.actionbarsherlock.app.SherlockFragmentActivity;
 import com.actionbarsherlock.view.MenuItem;
-import com.google.thoughtcrimegson.Gson;
-import com.google.thoughtcrimegson.JsonIOException;
-import com.google.thoughtcrimegson.JsonSyntaxException;
-import com.google.thoughtcrimegson.reflect.TypeToken;
 
-import org.thoughtcrime.securesms.util.ProgressDialogAsyncTask;
-
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.lang.reflect.Type;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.util.Map;
+import org.whispersystems.libpastelog.SubmitLogFragment;
 
 /**
  * Activity for submitting logcat logs to a pastebin service.
  */
-public class LogSubmitActivity extends SherlockActivity {
+public class LogSubmitActivity extends SherlockFragmentActivity implements SubmitLogFragment.OnLogSubmittedListener {
   private static final String TAG = LogSubmitActivity.class.getSimpleName();
-
-  private static final String HASTEBIN_ENDPOINT = "http://hastebin.com/documents";
-  private static final String HASTEBIN_PREFIX   = "http://hastebin.com/";
-
-  private EditText   logPreview;
-  private Button     okButton;
-  private Button     cancelButton;
 
   @Override
   protected void onCreate(Bundle icicle) {
     super.onCreate(icicle);
     setContentView(R.layout.log_submit_activity);
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-    initializeResources();
+    SubmitLogFragment fragment = SubmitLogFragment.newInstance();
+    FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
+    transaction.replace(R.id.fragment_container, fragment);
+    transaction.commit();
   }
 
   @Override
   protected void onResume() {
     super.onResume();
-    new PopulateLogcatAsyncTask().execute();
   }
 
   @Override
@@ -74,161 +43,20 @@ public class LogSubmitActivity extends SherlockActivity {
     return false;
   }
 
-  private void initializeResources() {
-    logPreview =   (EditText) findViewById(R.id.log_preview);
-    okButton =     (Button)   findViewById(R.id.ok);
-    cancelButton = (Button)   findViewById(R.id.cancel);
-
-    okButton.setOnClickListener(new View.OnClickListener() {
-      @Override
-      public void onClick(View view) {
-        new SubmitToPastebinAsyncTask(logPreview.getText().toString()).execute();
-      }
-    });
-
-    cancelButton.setOnClickListener(new View.OnClickListener() {
-      @Override
-      public void onClick(View view) {
-        finish();
-      }
-    });
+  @Override
+  public void onSuccess() {
+    Toast.makeText(getApplicationContext(), R.string.log_submit_activity__thanks, Toast.LENGTH_LONG).show();
+    finish();
   }
 
-  private static String grabLogcat() {
-    try {
-      Process process = Runtime.getRuntime().exec("logcat -d");
-      BufferedReader bufferedReader = new BufferedReader(
-          new InputStreamReader(process.getInputStream()));
-
-      StringBuilder log = new StringBuilder();
-      String separator = System.getProperty("line.separator");
-      String line;
-      while ((line = bufferedReader.readLine()) != null) {
-        log.append(line);
-        log.append(separator);
-      }
-      return log.toString();
-    } catch (IOException ioe) {
-      Log.w(TAG, "IOException when trying to read logcat.", ioe);
-      return null;
-    }
+  @Override
+  public void onFailure() {
+    Toast.makeText(getApplicationContext(), R.string.log_submit_activity__log_fetch_failed, Toast.LENGTH_LONG).show();
+    finish();
   }
 
-  private class PopulateLogcatAsyncTask extends AsyncTask<Void,Void,String> {
-
-    @Override
-    protected String doInBackground(Void... voids) {
-      return grabLogcat();
-    }
-
-    @Override
-    protected void onPreExecute() {
-      super.onPreExecute();
-      logPreview.setText(R.string.log_submit_activity__loading_logcat);
-      okButton.setEnabled(false);
-    }
-
-    @Override
-    protected void onPostExecute(String logcat) {
-      super.onPostExecute(logcat);
-      if (TextUtils.isEmpty(logcat)) {
-        Toast.makeText(getApplicationContext(), R.string.log_submit_activity__log_fetch_failed, Toast.LENGTH_LONG).show();
-        finish();
-        return;
-      }
-      logPreview.setText(logcat);
-      okButton.setEnabled(true);
-    }
-  }
-
-  private class SubmitToPastebinAsyncTask extends ProgressDialogAsyncTask<Void,Void,String> {
-    private final String         paste;
-
-    public SubmitToPastebinAsyncTask(String paste) {
-      super(LogSubmitActivity.this, R.string.log_submit_activity__submitting, R.string.log_submit_activity__posting_logs);
-      this.paste = paste;
-    }
-
-    @Override
-    protected String doInBackground(Void... voids) {
-      HttpURLConnection urlConnection = null;
-      try {
-        URL url = new URL(HASTEBIN_ENDPOINT);
-        urlConnection = (HttpURLConnection) url.openConnection();
-        urlConnection.setDoOutput(true);
-        urlConnection.setReadTimeout(10000);
-        urlConnection.connect();
-
-        OutputStream out = new BufferedOutputStream(urlConnection.getOutputStream());
-        out.write(paste.getBytes());
-        out.flush();
-        InputStream in = new BufferedInputStream(urlConnection.getInputStream());
-
-        Type type = new TypeToken<Map<String, String>>(){}.getType();
-        Map<String, String> responseMap = new Gson().fromJson(new InputStreamReader(in), type);
-
-        if (responseMap.containsKey("key"))
-          return HASTEBIN_PREFIX + responseMap.get("key");
-
-      } catch (IOException ioe) {
-        Log.w(TAG, "Failed to execute POST request to pastebin", ioe);
-      } catch (JsonSyntaxException jpe) {
-        Log.w(TAG, "JSON returned wasn't a valid expected map", jpe);
-      } catch (JsonIOException jioe) {
-        Log.w(TAG, "JSON IOException when trying to read the stream from connection", jioe);
-      } finally {
-        if (urlConnection != null) urlConnection.disconnect();
-      }
-      return null;
-    }
-
-    @Override
-    protected void onPostExecute(final String response) {
-      super.onPostExecute(response);
-
-      if (response != null && !response.startsWith("Bad API request")) {
-        TextView showText = new TextView(LogSubmitActivity.this);
-        showText.setTextSize(TypedValue.COMPLEX_UNIT_SP, 16);
-        showText.setPadding(15, 30, 15, 30);
-        showText.setText(getString(R.string.log_submit_activity__your_pastebin_url, response));
-        showText.setOnLongClickListener(new View.OnLongClickListener() {
-
-          @Override
-          public boolean onLongClick(View v) {
-            // Copy the Text to the clipboard
-            ClipboardManager manager =
-                (ClipboardManager) getSystemService(CLIPBOARD_SERVICE);
-            manager.setText(response);
-            Toast.makeText(getApplicationContext(), R.string.log_submit_activity__copied_to_clipboard,
-                           Toast.LENGTH_SHORT).show();
-            return true;
-          }
-        });
-
-        AlertDialog.Builder builder = new AlertDialog.Builder(LogSubmitActivity.this);
-        builder.setTitle(R.string.log_submit_activity__log_submit_success_title)
-               .setView(showText)
-               .setCancelable(false)
-               .setNeutralButton(R.string.log_submit_activity__log_got_it, new DialogInterface.OnClickListener() {
-                 @Override
-                 public void onClick(DialogInterface dialogInterface, int i) {
-                   dialogInterface.dismiss();
-                   Toast.makeText(getApplicationContext(), R.string.log_submit_activity__thanks, Toast.LENGTH_LONG).show();
-                   LogSubmitActivity.this.setResult(RESULT_OK);
-                   LogSubmitActivity.this.finish();
-                 }
-               });
-        AlertDialog dialog = builder.create();
-        dialog.show();
-      } else {
-        if (response == null) {
-          Log.w(TAG, "Response was null from Pastebin API.");
-        } else {
-          Log.w(TAG, "Response seemed like an error: " + response);
-        }
-        Toast.makeText(getApplicationContext(), R.string.log_submit_activity__log_fetch_failed, Toast.LENGTH_LONG).show();
-        finish();
-      }
-    }
+  @Override
+  public void onCancel() {
+    finish();
   }
 }


### PR DESCRIPTION
### outline
- SubmitLogFragment can be included in any project to report device logs to a hastebin-compatible endpoint as specified by the activity. Activity must implement the proper interface methods to handle success/failure/cancel cases.
- Basic data scrubber to remove potentially sensitive info by default.
### todo
- maven repo and maybe separate git repo? should talk about plan for modularizing code.
- more configuration options as needed, good for now i think.
- work out how translations will work with subprojects
