### PR TITLE
fixes #1407, sharing contact from the Contacts app

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -71,6 +71,7 @@
                 <data android:mimeType="image/*" />
                 <data android:mimeType="text/plain" />
                 <data android:mimeType="video/*" />
+                <data android:mimeType="text/x-vcard"/> <!-- Share button in Contacts -->
             </intent-filter>
 
         </activity>

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -19,6 +19,7 @@ package org.thoughtcrime.securesms;
 import android.app.AlertDialog;
 import android.content.ActivityNotFoundException;
 import android.content.BroadcastReceiver;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -53,6 +54,7 @@ import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.TextView;
 import android.widget.Toast;
+import android.database.Cursor;
 
 import com.actionbarsherlock.view.Menu;
 import com.actionbarsherlock.view.MenuInflater;
@@ -140,6 +142,7 @@ public class ConversationActivity extends PassphraseRequiredSherlockFragmentActi
   public static final String DRAFT_IMAGE_EXTRA       = "draft_image";
   public static final String DRAFT_AUDIO_EXTRA       = "draft_audio";
   public static final String DRAFT_VIDEO_EXTRA       = "draft_video";
+  public static final String DRAFT_VCARD_EXTRA       = "draft_vcard";
   public static final String DISTRIBUTION_TYPE_EXTRA = "distribution_type";
 
   private static final int PICK_IMAGE        = 1;
@@ -638,15 +641,35 @@ public class ConversationActivity extends PassphraseRequiredSherlockFragmentActi
     Uri    draftImage = getIntent().getParcelableExtra(DRAFT_IMAGE_EXTRA);
     Uri    draftAudio = getIntent().getParcelableExtra(DRAFT_AUDIO_EXTRA);
     Uri    draftVideo = getIntent().getParcelableExtra(DRAFT_VIDEO_EXTRA);
+    Uri    draftVCard = getIntent().getParcelableExtra(DRAFT_VCARD_EXTRA);
 
     if (draftText != null)  composeText.setText(draftText);
     if (draftImage != null) addAttachmentImage(draftImage);
     if (draftAudio != null) addAttachmentAudio(draftAudio);
     if (draftVideo != null) addAttachmentVideo(draftVideo);
+    if (draftVCard != null) addVCard(draftVCard);
 
-    if (draftText == null && draftImage == null && draftAudio == null && draftVideo == null) {
+    if (draftText == null && draftImage == null && draftAudio == null && draftVideo == null && draftVCard == null) {
       initializeDraftFromDatabase();
     }
+  }
+
+  private void addVCard(Uri uri) {
+    ContentResolver resolver = getContentResolver();
+    Cursor cursor;
+    try {
+        // zxing is seeing about six reports a week of this exception although I don't understand why.
+        // https://github.com/zxing/zxing/blob/dfd6fe71c2075cf404d9d039935bbe8e60dfcf32/android/src/com/google/zxing/client/android/share/ShareActivity.java#L181
+        cursor = resolver.query(uri, null, null, null, null);
+    } catch (IllegalArgumentException ignored) {
+        return;
+    }
+    if (cursor == null || !cursor.moveToFirst()) {
+        return;
+    }
+    ContactAccessor accessor        = ContactAccessor.getInstance();
+    ContactData     contactData     = accessor.getContactData(this, cursor);
+    addContactInfo(contactData);
   }
 
   private void initializeEnabledCheck() {
@@ -895,7 +918,10 @@ public class ConversationActivity extends PassphraseRequiredSherlockFragmentActi
   private void addContactInfo(Uri contactUri) {
     ContactAccessor contactDataList = ContactAccessor.getInstance();
     ContactData contactData = contactDataList.getContactData(this, contactUri);
+    addContactInfo(contactData);
+  }
 
+  private void addContactInfo(ContactData contactData) {
     if      (contactData.numbers.size() == 1) composeText.append(contactData.numbers.get(0).number);
     else if (contactData.numbers.size() > 1)  selectContactInfo(contactData);
   }

--- a/src/org/thoughtcrime/securesms/NewConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/NewConversationActivity.java
@@ -159,6 +159,7 @@ public class NewConversationActivity extends PassphraseRequiredSherlockFragmentA
       intent.putExtra(ConversationActivity.DRAFT_AUDIO_EXTRA, getIntent().getParcelableExtra(ConversationActivity.DRAFT_AUDIO_EXTRA));
       intent.putExtra(ConversationActivity.DRAFT_VIDEO_EXTRA, getIntent().getParcelableExtra(ConversationActivity.DRAFT_VIDEO_EXTRA));
       intent.putExtra(ConversationActivity.DRAFT_IMAGE_EXTRA, getIntent().getParcelableExtra(ConversationActivity.DRAFT_IMAGE_EXTRA));
+      intent.putExtra(ConversationActivity.DRAFT_VCARD_EXTRA, getIntent().getParcelableExtra(ConversationActivity.DRAFT_VCARD_EXTRA));
       long existingThread = DatabaseFactory.getThreadDatabase(this).getThreadIdIfExistsFor(recipients);
       intent.putExtra(ConversationActivity.THREAD_ID_EXTRA, existingThread);
       intent.putExtra(ConversationActivity.DISTRIBUTION_TYPE_EXTRA, ThreadDatabase.DistributionTypes.DEFAULT);

--- a/src/org/thoughtcrime/securesms/RoutingActivity.java
+++ b/src/org/thoughtcrime/securesms/RoutingActivity.java
@@ -163,6 +163,7 @@ public class RoutingActivity extends PassphraseRequiredSherlockActivity {
       intent.putExtra(ConversationActivity.DRAFT_IMAGE_EXTRA, parameters.draftImage);
       intent.putExtra(ConversationActivity.DRAFT_AUDIO_EXTRA, parameters.draftAudio);
       intent.putExtra(ConversationActivity.DRAFT_VIDEO_EXTRA, parameters.draftVideo);
+      intent.putExtra(ConversationActivity.DRAFT_VCARD_EXTRA, parameters.draftVCard);
     }
 
     return intent;
@@ -223,7 +224,7 @@ public class RoutingActivity extends PassphraseRequiredSherlockActivity {
       recipients = null;
     }
 
-    return new ConversationParameters(threadId, recipients, null, null, null, null);
+    return new ConversationParameters(threadId, recipients, null, null, null, null, null);
   }
 
   private ConversationParameters getConversationParametersForShareAction() {
@@ -232,6 +233,7 @@ public class RoutingActivity extends PassphraseRequiredSherlockActivity {
     Uri draftImage   = null;
     Uri draftAudio   = null;
     Uri draftVideo   = null;
+    Uri draftVCard   = null;
 
     Uri streamExtra = getIntent().getParcelableExtra(Intent.EXTRA_STREAM);
 
@@ -245,9 +247,11 @@ public class RoutingActivity extends PassphraseRequiredSherlockActivity {
       draftAudio = streamExtra;
     } else if (type != null && type.startsWith("video/")) {
       draftVideo = streamExtra;
+    } else if (type != null && type.equals("text/x-vcard")) {
+      draftVCard = streamExtra;
     }
 
-    return new ConversationParameters(-1, null, draftText, draftImage, draftAudio, draftVideo);
+    return new ConversationParameters(-1, null, draftText, draftImage, draftAudio, draftVideo, draftVCard);
   }
 
   private String getMimeType(Uri uri) {
@@ -265,7 +269,7 @@ public class RoutingActivity extends PassphraseRequiredSherlockActivity {
     long threadId         = getIntent().getLongExtra("thread_id", -1);
     Recipients recipients = getIntent().getParcelableExtra("recipients");
 
-    return new ConversationParameters(threadId, recipients, null, null, null, null);
+    return new ConversationParameters(threadId, recipients, null, null, null, null, null);
   }
 
   private boolean isShareAction() {
@@ -283,9 +287,11 @@ public class RoutingActivity extends PassphraseRequiredSherlockActivity {
     public final Uri        draftImage;
     public final Uri        draftAudio;
     public final Uri        draftVideo;
+    public final Uri        draftVCard;
 
     public ConversationParameters(long thread, Recipients recipients,
-                                  String draftText, Uri draftImage, Uri draftAudio, Uri draftVideo)
+                                  String draftText, Uri draftImage, Uri draftAudio, Uri draftVideo,
+                                  Uri draftVCard)
     {
      this.thread     = thread;
      this.recipients = recipients;
@@ -293,6 +299,7 @@ public class RoutingActivity extends PassphraseRequiredSherlockActivity {
      this.draftImage = draftImage;
      this.draftAudio = draftAudio;
      this.draftVideo = draftVideo;
+     this.draftVCard = draftVCard;
     }
   }
 

--- a/src/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/org/thoughtcrime/securesms/ShareActivity.java
@@ -147,11 +147,13 @@ public class ShareActivity extends PassphraseRequiredSherlockFragmentActivity
     final Uri    draftImage = originalIntent.getParcelableExtra(ConversationActivity.DRAFT_IMAGE_EXTRA);
     final Uri    draftAudio = originalIntent.getParcelableExtra(ConversationActivity.DRAFT_AUDIO_EXTRA);
     final Uri    draftVideo = originalIntent.getParcelableExtra(ConversationActivity.DRAFT_VIDEO_EXTRA);
+    final Uri    draftVCard = originalIntent.getParcelableExtra(ConversationActivity.DRAFT_VCARD_EXTRA);
 
     intent.putExtra(ConversationActivity.DRAFT_TEXT_EXTRA, draftText);
     intent.putExtra(ConversationActivity.DRAFT_IMAGE_EXTRA, draftImage);
     intent.putExtra(ConversationActivity.DRAFT_AUDIO_EXTRA, draftAudio);
     intent.putExtra(ConversationActivity.DRAFT_VIDEO_EXTRA, draftVideo);
+    intent.putExtra(ConversationActivity.DRAFT_VCARD_EXTRA, draftVCard);
     intent.putExtra(NewConversationActivity.MASTER_SECRET_EXTRA, masterSecret);
 
     return intent;


### PR DESCRIPTION
- closes #1407
- TextSecure is listed when you share a contact via Contacts app
- lets you choose a phone number, if there are multiple
- copies just the phone number into a new message
- new message is empty, if there is no phone number
