### PR TITLE
Show date and year for ancient (> 1 year old) messages

### DIFF
--- a/src/org/thoughtcrime/securesms/util/DateUtils.java
+++ b/src/org/thoughtcrime/securesms/util/DateUtils.java
@@ -43,7 +43,7 @@ public class DateUtils extends android.text.format.DateUtils {
       } else if (isWithinYear(millis)) {
         formatFlags |= DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_NO_YEAR | DateUtils.FORMAT_ABBREV_ALL;
       } else {
-        formatFlags |= DateUtils.FORMAT_NUMERIC_DATE;
+        formatFlags |= DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_ABBREV_ALL;
       }
     }
     return DateUtils.formatDateTime(c, millis, formatFlags);


### PR DESCRIPTION
The timestamp shown for very old messages only includes the time without a date at all. Fix it. FREEBIE.
