### PR TITLE
fix EmojiLRU concurrency exception

### DIFF
--- a/src/org/thoughtcrime/securesms/util/Emoji.java
+++ b/src/org/thoughtcrime/securesms/util/Emoji.java
@@ -332,11 +332,12 @@ public class Emoji {
         iterator.remove();
       }
 
+      final LinkedHashSet<String> latestRecentlyUsed = new LinkedHashSet<String>(recentlyUsed);
       new AsyncTask<Void, Void, Void>() {
 
         @Override
         protected Void doInBackground(Void... params) {
-          String serialized = new Gson().toJson(recentlyUsed);
+          String serialized = new Gson().toJson(latestRecentlyUsed);
           prefs.edit()
               .putString(EMOJI_LRU_PREFERENCE, serialized)
               .apply();


### PR DESCRIPTION
Clone the cache before persisting it to avoid writes occurring during serialization, causing a ConcurrentModificationException.
