### PR TITLE
Clear attachments on reselection

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -835,7 +835,7 @@ public class ConversationActivity extends PassphraseRequiredSherlockFragmentActi
 
   private void addAttachment(int type) {
     Log.w("ComposeMessageActivity", "Selected: " + type);
-    attachmentManager.clear();
+    attachmentManager.clear(); 
     switch (type) {
     case AttachmentTypeSelectorAdapter.ADD_IMAGE:
       AttachmentManager.selectImage(this, PICK_IMAGE); break;


### PR DESCRIPTION
- as we only show the FIRST attachment per message, we also should only send one attachment
  (not sure about sending, but code looks as if all attachments gets sent)
- changing for example a video to an image or an audio was also not working, as the first attachment persists
- avoid sending wrong attachments. reproduce like this:

Add text: "He mom thats me on holiday"
Add attachment: "Me_on_Holly.jpg"
_OMG, wrong attachment. Better change..._ (ignoring the delete button)
Add attachment: "Me_on_holiday.jpg"
_puh, that was close!_
send
😳_OMG²_ 😲 

---

I would not implement a "Do you want to change the attachment" button, to keep the UX. Also **I** never felt that more than one attachment is going out at once.

Works with drafts.
Tested KK, but should also work on GB...
