### PR TITLE
Enabled audio and video drafts

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -45,7 +45,7 @@
     <!-- DraftDatabase -->
     <string name="DraftDatabase_Draft_image_snippet">(image)</string>
     <string name="DraftDatabase_Draft_audio_snippet">(audio)</string>
-    <string name="DraftDatabase_Draft_video_snippet">(image)</string>
+    <string name="DraftDatabase_Draft_video_snippet">(video)</string>
 
     <!-- AttchmentManager -->
     <string name="AttachmentManager_cant_open_media_selection">Can\'t find an app to select media.</string>

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -874,9 +874,9 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     }
 
     for (Slide slide : attachmentManager.getSlideDeck().getSlides()) {
-      if      (slide.hasImage()) drafts.add(new Draft(Draft.IMAGE, slide.getUri().toString()));
-      else if (slide.hasAudio()) drafts.add(new Draft(Draft.AUDIO, slide.getUri().toString()));
+      if (slide.hasAudio())      drafts.add(new Draft(Draft.AUDIO, slide.getUri().toString()));
       else if (slide.hasVideo()) drafts.add(new Draft(Draft.VIDEO, slide.getUri().toString()));
+      else if (slide.hasImage()) drafts.add(new Draft(Draft.IMAGE, slide.getUri().toString()));
     }
 
     return drafts;


### PR DESCRIPTION
All slide types do have an "image", therefore we need to switch the check order.
Otherwise `addAttachmentImage` is called and throws `ConversationActivity_sorry_there_was_an_error_setting_your_attachment` as the draftType is marked as IMAGE though there is none. In that case the audio or video draft gets deleted.
