### PR TITLE
Fix user-facing helping term 'insecure' to 'unsecured' 

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -63,7 +63,7 @@
     <string name="ConversationItem_click_to_approve_mms_dialog_title">Fallback to MMS?</string>
     <string name="ConversationItem_click_to_approve_unencrypted_sms_dialog_title">Fallback to unencrypted SMS?</string>
     <string name="ConversationItem_click_to_approve_unencrypted_mms_dialog_title">Fallback to unencrypted MMS?</string>
-    <string name="ConversationItem_click_to_approve_unencrypted_dialog_message">This message will <b>not</b> be encrypted because a secure session could not be established.\n\nSend insecure message?</string>
+    <string name="ConversationItem_click_to_approve_unencrypted_dialog_message">This message will <b>not</b> be encrypted because a secure session could not be established.\n\nSend unsecured message?</string>
 
     <!-- ConversationActivity -->
     <string name="ConversationActivity_initiate_secure_session_question">Initiate secure session?</string>
@@ -446,9 +446,9 @@
     <!-- conversation_activity -->
     <string name="conversation_activity__type_message_push">Send TextSecure message</string>
     <string name="conversation_activity__type_message_sms_secure">Send secure SMS</string>
-    <string name="conversation_activity__type_message_sms_insecure">Send insecure SMS</string>
+    <string name="conversation_activity__type_message_sms_insecure">Send unsecured SMS</string>
     <string name="conversation_activity__type_message_mms_secure">Send secure MMS</string>
-    <string name="conversation_activity__type_message_mms_insecure">Send insecure MMS</string>
+    <string name="conversation_activity__type_message_mms_insecure">Send unsecured MMS</string>
     <string name="conversation_activity__send">Send</string>
     <string name="conversation_activity__remove">Remove</string>
 
@@ -790,9 +790,9 @@
     <!-- conversation_button_context -->
     <string name="conversation_button_context__send_textsecure_message">Send TextSecure message</string>
     <string name="conversation_button_context__send_secure_sms">Send secure SMS</string>
-    <string name="conversation_button_context__send_insecure_sms">Send insecure SMS</string>
+    <string name="conversation_button_context__send_insecure_sms">Send unsecured SMS</string>
     <string name="conversation_button_context__send_secure_mms">Send secure MMS</string>
-    <string name="conversation_button_context__send_insecure_mms">Send insecure MMS</string>
+    <string name="conversation_button_context__send_insecure_mms">Send unsecured MMS</string>
 
     <!-- conversation_callable -->
     <string name="conversation_callable__menu_call">Call</string>


### PR DESCRIPTION
'Insecure' implies an uncertainty of intention or confidence. Unsecured is more specifically addressing the protocol which wraps the message delivered. This struck me immediately while feeling particularly vulnerable and texting someone with whom I experienced real-life drama, and I'm guessing this applies to many 'personal' text messages. Related to #1337 but the term 'unsecured' was never brought up.
