### PR TITLE
prevent MMS notification NPE

### DIFF
--- a/androidTest/org/thoughtcrime/securesms/service/MmsReceiverTest.java
+++ b/androidTest/org/thoughtcrime/securesms/service/MmsReceiverTest.java
@@ -1,0 +1,28 @@
+package org.thoughtcrime.securesms.service;
+
+import android.content.Intent;
+import android.test.InstrumentationTestCase;
+
+import static org.fest.assertions.api.Assertions.*;
+
+public class MmsReceiverTest extends InstrumentationTestCase {
+
+  private MmsReceiver mmsReceiver;
+
+  public void setUp() throws Exception {
+    super.setUp();
+    mmsReceiver = new MmsReceiver(getInstrumentation().getContext());
+  }
+
+  public void tearDown() throws Exception {
+
+  }
+
+  public void testProcessMalformedData() throws Exception {
+    Intent intent = new Intent();
+    intent.setAction(SendReceiveService.RECEIVE_MMS_ACTION);
+    intent.putExtra("data", new byte[]{0x00});
+    mmsReceiver.process(null, intent);
+  }
+
+}

--- a/src/org/thoughtcrime/securesms/service/MmsReceiver.java
+++ b/src/org/thoughtcrime/securesms/service/MmsReceiver.java
@@ -58,7 +58,7 @@ public class MmsReceiver {
     PduParser parser = new PduParser(mmsData);
     GenericPdu pdu   = parser.parse();
 
-    if (pdu.getMessageType() == PduHeaders.MESSAGE_TYPE_NOTIFICATION_IND) {
+    if (pdu != null && pdu.getMessageType() == PduHeaders.MESSAGE_TYPE_NOTIFICATION_IND) {
       MmsDatabase database                = DatabaseFactory.getMmsDatabase(context);
       Pair<Long, Long> messageAndThreadId = database.insertMessageInbox((NotificationInd)pdu);
 


### PR DESCRIPTION
Unparseable MMS's were causing NPEs. Added quick test.
