### PR TITLE
opportunistically use Android's E164 cached numbers

### DIFF
--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -170,7 +170,7 @@ public class GroupCreateActivity extends PassphraseRequiredSherlockFragmentActiv
 
   private static boolean isActiveInDirectory(Context context, Recipient recipient) {
     try {
-      if (!Directory.getInstance(context).isActiveNumber(Util.canonicalizeNumber(context, recipient.getNumber()))) {
+      if (!Directory.getInstance(context).isActiveNumber(Util.canonicalizeNumber(context, recipient))) {
         return false;
       }
     } catch (NotInDirectoryException e) {
@@ -491,7 +491,7 @@ public class GroupCreateActivity extends PassphraseRequiredSherlockFragmentActiv
     Set<String> results = new HashSet<String>();
 
     for (Recipient recipient : recipients) {
-      results.add(Util.canonicalizeNumber(this, recipient.getNumber()));
+      results.add(Util.canonicalizeNumber(this, recipient));
     }
 
     return results;

--- a/src/org/thoughtcrime/securesms/ReceiveKeyActivity.java
+++ b/src/org/thoughtcrime/securesms/ReceiveKeyActivity.java
@@ -246,7 +246,7 @@ public class ReceiveKeyActivity extends Activity {
               CiphertextMessage bundledMessage = keyExchangeMessageBundle.getWhisperMessage();
 
               if (getIntent().getBooleanExtra("is_push", false)) {
-                String source = Util.canonicalizeNumber(ReceiveKeyActivity.this, recipient.getNumber());
+                String source = Util.canonicalizeNumber(ReceiveKeyActivity.this, recipient);
                 IncomingPushMessage incoming = new IncomingPushMessage(Type.CIPHERTEXT_VALUE, source, recipientDeviceId, bundledMessage.serialize(), System.currentTimeMillis());
 
                 DatabaseFactory.getEncryptingSmsDatabase(ReceiveKeyActivity.this)

--- a/src/org/thoughtcrime/securesms/recipients/Recipient.java
+++ b/src/org/thoughtcrime/securesms/recipients/Recipient.java
@@ -52,6 +52,7 @@ public class Recipient implements Parcelable, CanonicalRecipient {
   private final long recipientId;
 
   private String number;
+  private String canonicalNumber;
   private String name;
 
   private Bitmap contactPhoto;
@@ -76,6 +77,7 @@ public class Recipient implements Parcelable, CanonicalRecipient {
           synchronized (Recipient.this) {
             Recipient.this.name                      = result.name;
             Recipient.this.number                    = result.number;
+            Recipient.this.canonicalNumber           = result.canonicalNumber;
             Recipient.this.contactUri                = result.contactUri;
             Recipient.this.contactPhoto              = result.avatar;
             Recipient.this.circleCroppedContactPhoto = result.croppedAvatar;
@@ -135,6 +137,10 @@ public class Recipient implements Parcelable, CanonicalRecipient {
 
   public String getNumber() {
     return number;
+  }
+
+  public String getCanonicalNumber() {
+    return canonicalNumber;
   }
 
   public int describeContents() {

--- a/src/org/thoughtcrime/securesms/transport/PushTransport.java
+++ b/src/org/thoughtcrime/securesms/transport/PushTransport.java
@@ -197,7 +197,7 @@ public class PushTransport extends BaseTransport {
       throws InvalidNumberException, IOException, UntrustedIdentityException
   {
     try {
-      String e164number = Util.canonicalizeNumber(context, recipient.getNumber());
+      String e164number = Util.canonicalizeNumber(context, recipient);
       long   recipientId = recipient.getRecipientId();
 
       for (int extraDeviceId : mismatchedDevices.getExtraDevices()) {
@@ -226,7 +226,7 @@ public class PushTransport extends BaseTransport {
   {
     try {
       long   recipientId = recipient.getRecipientId();
-      String e164number  = Util.canonicalizeNumber(context, recipient.getNumber());
+      String e164number  = Util.canonicalizeNumber(context, recipient);
 
       for (int staleDeviceId : staleDevices.getStaleDevices()) {
         PushAddress address = PushAddress.create(context, recipientId, e164number, staleDeviceId);
@@ -305,7 +305,7 @@ public class PushTransport extends BaseTransport {
                                                        Recipient recipient, byte[] plaintext)
       throws IOException, InvalidNumberException, UntrustedIdentityException
   {
-    String      e164number   = Util.canonicalizeNumber(context, recipient.getNumber());
+    String      e164number   = Util.canonicalizeNumber(context, recipient);
     long        recipientId  = recipient.getRecipientId();
     PushAddress masterDevice = PushAddress.create(context, recipientId, e164number, 1);
     PushBody    masterBody   = getEncryptedMessage(socket, threadId, masterDevice, plaintext);

--- a/src/org/thoughtcrime/securesms/transport/UniversalTransport.java
+++ b/src/org/thoughtcrime/securesms/transport/UniversalTransport.java
@@ -78,7 +78,7 @@ public class UniversalTransport {
 
     try {
       Recipient recipient = message.getIndividualRecipient();
-      String    number    = Util.canonicalizeNumber(context, recipient.getNumber());
+      String    number    = Util.canonicalizeNumber(context, recipient);
 
       if (isPushTransport(number) && !message.isKeyExchange()) {
         boolean isSmsFallbackSupported = isSmsFallbackSupported(number);

--- a/src/org/thoughtcrime/securesms/util/DirectoryHelper.java
+++ b/src/org/thoughtcrime/securesms/util/DirectoryHelper.java
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms.util;
 
 import android.content.Context;
+import android.text.TextUtils;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -96,13 +97,11 @@ public class DirectoryHelper {
         return true;
       }
 
-      final String number = recipients.getPrimaryRecipient().getNumber();
-
-      if (number == null) {
+      if (recipients.getPrimaryRecipient().getNumber() == null) {
         return false;
       }
 
-      final String e164number = Util.canonicalizeNumber(context, number);
+      String e164number = Util.canonicalizeNumber(context, recipients.getPrimaryRecipient());
 
       return Directory.getInstance(context).isActiveNumber(e164number);
     } catch (InvalidNumberException e) {

--- a/src/org/thoughtcrime/securesms/util/Util.java
+++ b/src/org/thoughtcrime/securesms/util/Util.java
@@ -24,9 +24,11 @@ import android.os.Build;
 import android.provider.Telephony;
 import android.text.Spannable;
 import android.text.SpannableString;
+import android.text.TextUtils;
 import android.text.style.StyleSpan;
 import android.util.Log;
 
+import org.thoughtcrime.securesms.recipients.Recipient;
 import org.whispersystems.textsecure.util.InvalidNumberException;
 import org.whispersystems.textsecure.util.PhoneNumberFormatter;
 
@@ -125,6 +127,12 @@ public class Util {
     } catch (InterruptedException ie) {
       throw new AssertionError(ie);
     }
+  }
+
+  public static String canonicalizeNumber(Context context, Recipient recipient) throws InvalidNumberException {
+    final String canonicalNumber = recipient.getCanonicalNumber();
+    return TextUtils.isEmpty(canonicalNumber) ? canonicalizeNumber(context, recipient.getNumber())
+                                              : canonicalNumber;
   }
 
   public static String canonicalizeNumber(Context context, String number)


### PR DESCRIPTION
The first call (and any calls if libphonenumber decides to clear out its memory cache) to canonicalizeNumber takes 700-950ms on my Nexus 5 due to the amount of metadata being read from disk. This leads to a pretty noticeable delay when opening a conversation sometimes.

This is a proposal that benefits devices on Jelly Bean or higher. Since API 16, Android provides E164 normalized numbers for any contact that has a number specified, and we can take advantage of that.
