### PR TITLE
prevent another cursor leak

### DIFF
--- a/src/org/thoughtcrime/securesms/database/ApnDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/ApnDatabase.java
@@ -108,6 +108,7 @@ public class ApnDatabase {
       }
 
       if (cursor == null || !cursor.moveToFirst()) {
+        if (cursor != null) cursor.close();
         Log.w(TAG, "Querying table for MCC+MNC " + mccmnc + " without APN name");
         cursor = db.query(TABLE_NAME, null,
                           BASE_SELECTION,


### PR DESCRIPTION
if two queries happen because the first failed to find one with the apn discriminator, one cursor is leaked
