### PR TITLE
stringifying messages in Trimmer.java

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -657,6 +657,11 @@
     <string name="verify_keys_activity__they_read_this">They read this:</string>
     <string name="verify_keys_activity__you_read_this">You read this:</string>
 
+    <!-- Trimming old messages -->
+    <string name="Trimmer__deleting_old_messages_title">Deleting&#8230;</string>
+    <string name="Trimmer__deleting_old_messages_message">Deleting old messages&#8230;</string>
+    <string name="Trimmer__old_messages_successfully_deleted_toast">Old messages successfully deleted!</string>
+
     <!-- AndroidManifest.xml -->
     <string name="AndroidManifest__create_passphrase">Create passphrase</string>
     <string name="AndroidManifest__enter_passphrase">Enter passphrase</string>

--- a/src/org/thoughtcrime/securesms/util/Trimmer.java
+++ b/src/org/thoughtcrime/securesms/util/Trimmer.java
@@ -7,6 +7,7 @@ import android.widget.Toast;
 
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.ThreadDatabase;
+import org.thoughtcrime.securesms.R;
 
 public class Trimmer {
 
@@ -44,8 +45,8 @@ public class Trimmer {
       progressDialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
       progressDialog.setCancelable(false);
       progressDialog.setIndeterminate(false);
-      progressDialog.setTitle("Deleting...");
-      progressDialog.setMessage("Deleting old messages...");
+      progressDialog.setTitle(context.getString(R.string.Trimmer__deleting_old_messages_title));
+      progressDialog.setMessage(context.getString(R.string.Trimmer__deleting_old_messages_message));
       progressDialog.setMax(100);
       progressDialog.show();
     }
@@ -68,7 +69,7 @@ public class Trimmer {
     protected void onPostExecute(Void result) {
       progressDialog.dismiss();
       Toast.makeText(context,
-                     "Old messages successfully deleted!",
+                     context.getString(R.string.Trimmer__old_messages_successfully_deleted_toast),
                      Toast.LENGTH_LONG).show();
     }
 


### PR DESCRIPTION
- enabling l10n/i18n of "Delete old messages..." messages

@moxie:
I found that it was previously not possible to translate these "trimming" messages, here's my patch which enables this.
