### PR TITLE
allow url client to follow redirects before checking response code

### DIFF
--- a/src/org/thoughtcrime/securesms/mms/MmsCommunication.java
+++ b/src/org/thoughtcrime/securesms/mms/MmsCommunication.java
@@ -180,6 +180,7 @@ public class MmsCommunication {
       urlConnection = (HttpURLConnection) url.openConnection();
     }
 
+    urlConnection.setInstanceFollowRedirects(true);
     urlConnection.setConnectTimeout(20*1000);
     urlConnection.setReadTimeout(20*1000);
     urlConnection.setUseCaches(false);

--- a/src/org/thoughtcrime/securesms/mms/MmsDownloadHelper.java
+++ b/src/org/thoughtcrime/securesms/mms/MmsDownloadHelper.java
@@ -21,6 +21,7 @@ import android.net.Uri;
 import android.util.Log;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 
 import ws.com.google.android.mms.pdu.PduParser;
@@ -44,7 +45,8 @@ public class MmsDownloadHelper extends MmsCommunication {
       Log.w(TAG, "Connecting to " + url);
       client.connect();
 
-      int responseCode = client.getResponseCode();
+      final InputStream is           = client.getInputStream();
+      final int         responseCode = client.getResponseCode();
 
       Log.w(TAG, "Response code: " + responseCode + "/" + client.getResponseMessage());
 
@@ -52,7 +54,7 @@ public class MmsDownloadHelper extends MmsCommunication {
         throw new IOException("non-200 response");
       }
 
-      return parseResponse(client.getInputStream());
+      return parseResponse(is);
     } finally {
       if (client != null) client.disconnect();
     }

--- a/src/org/thoughtcrime/securesms/mms/MmsSendHelper.java
+++ b/src/org/thoughtcrime/securesms/mms/MmsSendHelper.java
@@ -66,7 +66,8 @@ public class MmsSendHelper extends MmsCommunication {
 
       Log.w(TAG, "Payload sent");
 
-      int responseCode = client.getResponseCode();
+      final InputStream is           = client.getInputStream();
+      final int         responseCode = client.getResponseCode();
 
       Log.w(TAG, "Response code: " + responseCode + "/" + client.getResponseMessage());
 
@@ -74,7 +75,7 @@ public class MmsSendHelper extends MmsCommunication {
         throw new IOException("non-200 response");
       }
 
-      return parseResponse(client.getInputStream());
+      return parseResponse(is);
     } finally {
       if (client != null) client.disconnect();
     }


### PR DESCRIPTION
getInputStream is the method that follows redirects, so we need to call that first to get to the final URL before checking the status code.

evidence: http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/7u40-b43/sun/net/www/protocol/http/HttpURLConnection.java/
