### PR TITLE
fallback to imprecise scaling if low memory

### DIFF
--- a/src/org/thoughtcrime/securesms/util/FlushedInputStream.java
+++ b/src/org/thoughtcrime/securesms/util/FlushedInputStream.java
@@ -1,0 +1,33 @@
+package org.thoughtcrime.securesms.util;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Memory-friendly workaround found from https://code.google.com/p/android/issues/detail?id=6066#c23
+ * to solve decoding problems in bitmaps from InputStreams that don't skip if no more stream is available.
+ */
+class FlushedInputStream extends FilterInputStream {
+  public FlushedInputStream(InputStream inputStream) {
+    super(inputStream);
+  }
+
+  @Override
+  public long skip(long n) throws IOException {
+    long totalBytesSkipped = 0L;
+    while (totalBytesSkipped < n) {
+      long bytesSkipped = in.skip(n - totalBytesSkipped);
+      if (bytesSkipped == 0L) {
+        int inByte = read();
+        if (inByte < 0) {
+          break;
+        } else {
+          bytesSkipped = 1;
+        }
+      }
+      totalBytesSkipped += bytesSkipped;
+    }
+    return totalBytesSkipped;
+  }
+}


### PR DESCRIPTION
Gracefully falls back to rough scaling to solve the OutOfMemoryErrors that I was able to reproduce on a GB emulator with low RAM. This helps a lot since it doesn't require two large Bitmap objects in memory at the same time.

Also moved away from BufferedInputStream to another workaround to the Android bitmap problems, which will save more memory. On top of that, we weren't closing the streams so that's also fixed.
