### PR TITLE
don't crash if we can't get an mccmnc

### DIFF
--- a/src/org/thoughtcrime/securesms/database/ApnDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/ApnDatabase.java
@@ -95,7 +95,10 @@ public class ApnDatabase {
                                                                              final String apn)
   {
 
-    if (mccmnc == null) throw new InvalidParameterException("mccmnc must not be null");
+    if (mccmnc == null) {
+      Log.w(TAG, "mccmnc was null, returning null");
+      return null;
+    }
 
     Cursor cursor = null;
 


### PR DESCRIPTION
I shouldn't be throwing an uncaught exception when we can't work out a phone's MCC/MNC, we should just be going up the normal logic chain of not being able to find a matching APN.

Fixes #1916
