### PR TITLE
Support unread count badge in Nova Launcher + Widgetlocker (using TeslaUnread API)

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -65,6 +65,8 @@ import java.util.List;
 
 public class MessageNotifier {
 
+  private static final String TAG = MessageNotifier.class.getSimpleName();
+
   public static final int NOTIFICATION_ID = 1338;
 
   private volatile static long visibleThread = -1;
@@ -186,7 +188,7 @@ public class MessageNotifier {
       /* Some other error, possibly because the format
          of the ContentValues are incorrect.
          Log but do not crash over this. */
-      ex.printStackTrace();
+      Log.w(TAG, ex);
     }
   }
 
@@ -314,7 +316,7 @@ public class MessageNotifier {
 
       player.start();
     } catch (IOException ioe) {
-      Log.w("MessageNotifier", ioe);
+      Log.w(TAG, ioe);
     }
   }
 
@@ -337,7 +339,7 @@ public class MessageNotifier {
         try {
           recipient = RecipientFactory.getRecipientsFromString(context, message.getSource(), false).getPrimaryRecipient();
         } catch (RecipientFormattingException e) {
-          Log.w("MessageNotifier", e);
+          Log.w(TAG, e);
           recipient = Recipient.getUnknownRecipient(context);
         }
 


### PR DESCRIPTION
This pull request adds support for updating the "unread badge" in Tesla apps (Nova Launcher Prime and WidgetLocker) using the [TeslaUnreadAPI](http://novalauncher.com/teslaunread-api/).

I really like seeing the number of unread messages next to my icons. I'm just a user, I have no affiliation with TeslaCoil Software.

Here's what it looks like (Nova Launcher Prime):
![image](https://cloud.githubusercontent.com/assets/783973/4426361/8744182a-45b2-11e4-92e8-c20d38d02eaf.png)

I've added an option to enable/disable this feature for the paranoid people (and it's off by default), but I don't mind if that doesn't get merged (to avoid adding "yet another option"); all the option-related code is isolated in the 2nd commit.

Judging by what it says on the  [TeslaUnreadAPI](http://novalauncher.com/teslaunread-api/) page about the security of the unread notification count update, it sounds like this API is more secure than broadcast-based alternatives, so maybe it's acceptable to just issue the notification in case the [TeslaUnread app](https://play.google.com/store/apps/details?id=com.teslacoilsw.notifier&hl=en_GB) is there.

I've been using (testing) this for a few weeks now and haven't hit any issues. Technically that's with just the first commit, but the 2nd one just adds the checkbox and an if statement around the main logic, so I think the code is sane! :)
