### PR TITLE
use https maven central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,8 @@
 buildscript {
     repositories {
-        mavenCentral()
+        maven {
+            url "https://repo1.maven.org/maven2"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:0.12.2'
@@ -12,7 +14,9 @@ apply plugin: 'com.android.application'
 apply plugin: 'witness'
 
 repositories {
-    mavenCentral()
+    maven {
+        url "https://repo1.maven.org/maven2"
+    }
     maven {
         url "https://raw.github.com/whispersystems/maven/master/gcm-client/releases/"
     }


### PR DESCRIPTION
Apparently it's been available since August.

http://central.sonatype.org/articles/2014/Aug/03/https-support-launching-now/
http://central.sonatype.org/pages/consumers.html#gradle
