### PR TITLE
Changes filtered conversation thread database query to account for group...

### DIFF
--- a/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -63,6 +63,11 @@ public class ThreadDatabase extends Database {
     "CREATE INDEX IF NOT EXISTS thread_recipient_ids_index ON " + TABLE_NAME + " (" + RECIPIENT_IDS + ");",
   };
 
+  public static final String RECIPIENT_IDS_EQUAL = RECIPIENT_IDS + " = ?";
+  public static final String RECIPIENT_IDS_LIKE = RECIPIENT_IDS + " LIKE ?";
+  public static final String FILTERED_SELECTION_QUERY = RECIPIENT_IDS_EQUAL + " OR "
+          + RECIPIENT_IDS_LIKE + " OR " + RECIPIENT_IDS_LIKE + " OR " + RECIPIENT_IDS_LIKE;
+
   public ThreadDatabase(Context context, SQLiteOpenHelper databaseHelper) {
     super(context, databaseHelper);
   }
@@ -253,14 +258,12 @@ public class ThreadDatabase extends Database {
     if (recipientIds == null || recipientIds.size() == 0)
       return null;
 
-    String selection       = RECIPIENT_IDS + " = ?"  + " OR " + RECIPIENT_IDS + " LIKE ?" + " OR " + RECIPIENT_IDS + " LIKE ?" + " OR " + RECIPIENT_IDS + " LIKE ?";
+    String selection = FILTERED_SELECTION_QUERY;
+
     String[] selectionArgs = new String[recipientIds.size() * 4];
 
     for (int i=0;i<recipientIds.size()-1;i++) {
-        selection += (" OR " + RECIPIENT_IDS + " = ?");
-        selection += (" OR " + RECIPIENT_IDS + " LIKE ?");
-        selection += (" OR " + RECIPIENT_IDS + " LIKE ?");
-        selection += (" OR " + RECIPIENT_IDS + " LIKE ?");
+        selection += (" OR " +  FILTERED_SELECTION_QUERY);
     }
 
     int i= 0;


### PR DESCRIPTION
...s

Fixes #1954

I go into discussion on this fix (and an alternative) in some depth in the issues ticket: 
https://github.com/WhisperSystems/TextSecure/issues/1954

I've tested this fix on Motorola Atrix 2 running 4.0.4, verified first that searching doesn't show groups, and then that after this fix they show up in a search. 

The crux of this is bug is that the thread db search uses an equals operator to query and individual recipientIds are a substring in the case of a group recipientId, for which equals does not match.
