### PR TITLE
Remove magic number in GCM register

### DIFF
--- a/src/org/thoughtcrime/securesms/service/RegistrationService.java
+++ b/src/org/thoughtcrime/securesms/service/RegistrationService.java
@@ -233,7 +233,7 @@ public class RegistrationService extends Service {
 
     setState(new RegistrationState(RegistrationState.STATE_GCM_REGISTERING, number));
 
-    String gcmRegistrationId = GoogleCloudMessaging.getInstance(this).register("312334754206");
+    String gcmRegistrationId = GoogleCloudMessaging.getInstance(this).register(GcmRegistrationService.REGISTRATION_ID);
     TextSecurePreferences.setGcmRegistrationId(this, gcmRegistrationId);
     socket.registerGcmId(gcmRegistrationId);
 


### PR DESCRIPTION
In the RegistrationService the sender id of the TextSecure server was hard-coded, although present as a constant in the GcmRegistrationService.
