### PR TITLE
actually fallback when mms local params unset

### DIFF
--- a/src/org/thoughtcrime/securesms/database/ApnDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/ApnDatabase.java
@@ -20,6 +20,7 @@ import android.content.Context;
 import android.content.res.AssetManager;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
+import android.text.TextUtils;
 import android.util.Log;
 
 import org.thoughtcrime.securesms.mms.ApnUnavailableException;
@@ -94,9 +95,8 @@ public class ApnDatabase {
   }
   protected Apn getLocallyConfiguredMmsConnectionParameters() throws ApnUnavailableException {
     if (TextSecurePreferences.isUseLocalApnsEnabled(context)) {
-      String mmsc = TextSecurePreferences.getMmscUrl(context);
-
-      if (mmsc == null)
+      String mmsc = TextSecurePreferences.getMmscUrl(context).trim();
+      if (TextUtils.isEmpty(mmsc))
         throw new ApnUnavailableException("Malformed locally configured MMSC.");
 
       if (!mmsc.startsWith("http"))


### PR DESCRIPTION
preferences was returning "" instead of null when unset, so things broke when you had manual MMS override checked but didn't set the MMSC.
