### PR TITLE
use wildcard media types, don't crash on preview fail

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -64,6 +64,7 @@
     <string name="ConversationItem_click_to_approve_unencrypted_sms_dialog_title">Fallback to unencrypted SMS?</string>
     <string name="ConversationItem_click_to_approve_unencrypted_mms_dialog_title">Fallback to unencrypted MMS?</string>
     <string name="ConversationItem_click_to_approve_unencrypted_dialog_message">This message will <b>not</b> be encrypted because a secure session could not be established.\n\nSend insecure message?</string>
+    <string name="ConversationItem_unable_to_open_media">Can\'t find an app able to open this media.</string>
 
     <!-- ConversationActivity -->
     <string name="ConversationActivity_initiate_secure_session_question">Initiate secure session?</string>

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -17,6 +17,7 @@
 package org.thoughtcrime.securesms;
 
 import android.app.AlertDialog;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -36,6 +37,7 @@ import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.MmsDatabase;
@@ -446,7 +448,12 @@ public class ConversationItem extends LinearLayout {
       Intent intent = new Intent(Intent.ACTION_VIEW);
       intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
       intent.setDataAndType(slide.getUri(), slide.getContentType());
-      context.startActivity(intent);
+      try {
+        context.startActivity(intent);
+      } catch (ActivityNotFoundException anfe) {
+        Log.w(TAG, "No activity existed to view the media.");
+        Toast.makeText(context, R.string.ConversationItem_unable_to_open_media, Toast.LENGTH_LONG).show();
+      }
     }
 
     public void onClick(View v) {

--- a/src/org/thoughtcrime/securesms/mms/AudioSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/AudioSlide.java
@@ -38,6 +38,11 @@ public class AudioSlide extends Slide {
     super(context, part);
   }
 
+  @Override
+  public String getContentType() {
+    return "audio/*";
+  }
+
   public AudioSlide(Context context, Uri uri) throws IOException, MediaTooLargeException {
     super(context, constructPartFromUri(context, uri));
   }

--- a/src/org/thoughtcrime/securesms/mms/ImageSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/ImageSlide.java
@@ -60,6 +60,11 @@ public class ImageSlide extends Slide {
     super(context, masterSecret, part);
   }
 
+  @Override
+  public String getContentType() {
+    return "image/*";
+  }
+
   public ImageSlide(Context context, Uri uri) throws IOException, BitmapDecodingException {
     super(context, constructPartFromUri(context, uri));
   }

--- a/src/org/thoughtcrime/securesms/mms/VideoSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/VideoSlide.java
@@ -39,6 +39,11 @@ public class VideoSlide extends Slide {
     super(context, part);
   }
 
+  @Override
+  public String getContentType() {
+    return "video/*";
+  }
+
   public VideoSlide(Context context, Uri uri) throws IOException, MediaTooLargeException {
     super(context, constructPartFromUri(context, uri));
   }


### PR DESCRIPTION
Checked some snippets and this seems to be the recommended approach (`image/*` instead of `image/jpeg` for example). Also catching ActivityNotFoundExceptions as recommended, showing toast instead of crashing.

Should resolve #1365
