### PR TITLE
sane fallback for media selection on exception

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -37,6 +37,9 @@
     <string name="ApplicationPreferencesActivity_sms_disabled">Incoming SMS Disabled</string>
     <string name="ApplicationPreferencesActivity_touch_to_make_textsecure_your_default_sms_app">Touch to make TextSecure your default SMS app</string>
 
+    <!-- AttchmentManager -->
+    <string name="AttachmentManager_cant_open_media_selection">Can\'t find an app to select media.</string>
+
     <!-- AttachmentTypeSelectorAdapter -->
 
     <string name="AttachmentTypeSelectorAdapter_picture">Picture</string>

--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -17,13 +17,16 @@
 package org.thoughtcrime.securesms.mms;
 
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
+import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
+import android.widget.Toast;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.util.BitmapDecodingException;
@@ -31,6 +34,7 @@ import org.thoughtcrime.securesms.util.BitmapDecodingException;
 import java.io.IOException;
 
 public class AttachmentManager {
+  private final static String TAG = AttachmentManager.class.getSimpleName();
 
   private final Context context;
   private final View attachmentView;
@@ -101,16 +105,26 @@ public class AttachmentManager {
   }
 
   private static void selectMediaType(Activity activity, String type, int requestCode) {
-    final Intent intent;
+    final Intent intent = new Intent();
+    intent.setType(type);
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-      intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
-    } else {
-      intent = new Intent(Intent.ACTION_GET_CONTENT);
+      intent.setAction(Intent.ACTION_OPEN_DOCUMENT);
+      try {
+        activity.startActivityForResult(intent, requestCode);
+        return;
+      } catch (ActivityNotFoundException anfe) {
+        Log.w(TAG, "couldn't complete ACTION_OPEN_DOCUMENT, no activity found. falling back.");
+      }
     }
 
-    intent.setType(type);
-    activity.startActivityForResult(intent, requestCode);
+    intent.setAction(Intent.ACTION_GET_CONTENT);
+    try {
+      activity.startActivityForResult(intent, requestCode);
+    } catch (ActivityNotFoundException anfe) {
+      Log.w(TAG, "couldn't complete ACTION_GET_CONTENT intent, no activity found. falling back.");
+      Toast.makeText(activity, R.string.AttachmentManager_cant_open_media_selection, Toast.LENGTH_LONG).show();
+    }
   }
 
   private class RemoveButtonListener implements View.OnClickListener {


### PR DESCRIPTION
Apparently some KitKat users can't handle the OPEN_DOCUMENT intent, so we can fallback to the older GET_CONTENT one and finally fail much more nicely if neither work.
