### PR TITLE
Fix selection for hungarian (magyar)

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -56,7 +56,7 @@
       <item>it</item>
       <item>ja</item>
       <item>kn_IN</item>
-      <item>he</item>
+      <item>hu</item>
       <item>nl</item>
       <item>no</item>
       <item>pl</item>


### PR DESCRIPTION
Hungarian (Magyar) is completely translated, but cause of the typo Hebrew (untranslated) showed up.
