### PR TITLE
revert content-type generics

### DIFF
--- a/src/org/thoughtcrime/securesms/mms/AudioSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/AudioSlide.java
@@ -38,11 +38,6 @@ public class AudioSlide extends Slide {
     super(context, part);
   }
 
-  @Override
-  public String getContentType() {
-    return "audio/*";
-  }
-
   public AudioSlide(Context context, Uri uri) throws IOException, MediaTooLargeException {
     super(context, constructPartFromUri(context, uri));
   }

--- a/src/org/thoughtcrime/securesms/mms/ImageSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/ImageSlide.java
@@ -60,11 +60,6 @@ public class ImageSlide extends Slide {
     super(context, masterSecret, part);
   }
 
-  @Override
-  public String getContentType() {
-    return "image/*";
-  }
-
   public ImageSlide(Context context, Uri uri) throws IOException, BitmapDecodingException {
     super(context, constructPartFromUri(context, uri));
   }

--- a/src/org/thoughtcrime/securesms/mms/VideoSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/VideoSlide.java
@@ -39,11 +39,6 @@ public class VideoSlide extends Slide {
     super(context, part);
   }
 
-  @Override
-  public String getContentType() {
-    return "video/*";
-  }
-
   public VideoSlide(Context context, Uri uri) throws IOException, MediaTooLargeException {
     super(context, constructPartFromUri(context, uri));
   }


### PR DESCRIPTION
I think we should focus our efforts on viewing the media in-app, and this change seems to do more damage than good. Reverting.
