### PR TITLE
Reset query string when search is collapsed

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -119,7 +119,7 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
       inflater.inflate(R.menu.conversation_list, menu);
       MenuItem menuItem = menu.findItem(R.id.menu_search);
       SearchView searchView = (SearchView) MenuItemCompat.getActionView(menuItem);
-      initializeSearch(searchView);
+      initializeSearch(menuItem);
     } else {
       inflater.inflate(R.menu.conversation_list_empty, menu);
     }
@@ -128,7 +128,8 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     return true;
   }
 
-  private void initializeSearch(SearchView searchView) {
+  private void initializeSearch(MenuItem searchViewItem) {
+    SearchView searchView = (SearchView)MenuItemCompat.getActionView(searchViewItem);
     searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
       @Override
       public boolean onQueryTextSubmit(String query) {
@@ -143,6 +144,19 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
       @Override
       public boolean onQueryTextChange(String newText) {
         return onQueryTextSubmit(newText);
+      }
+    });
+
+    MenuItemCompat.setOnActionExpandListener(searchViewItem, new MenuItemCompat.OnActionExpandListener() {
+      @Override
+      public boolean onMenuItemActionExpand(MenuItem menuItem) {
+        return true;
+      }
+
+      @Override
+      public boolean onMenuItemActionCollapse(MenuItem menuItem) {
+        fragment.resetQueryFilter();
+        return true;
       }
     });
   }


### PR DESCRIPTION
At the moment, when you search in the conversation list, and then tap "back" either on your phone's buttons or in the action bar, the filter stays active. Only way to reset the filter is to search again and input the empty string.
