### PR TITLE
remove deferred jobs from persistent DB before they get added again

### DIFF
--- a/jobqueue/src/androidTest/java/org/whispersystems/jobqueue/jobs/PersistentTestJob.java
+++ b/jobqueue/src/androidTest/java/org/whispersystems/jobqueue/jobs/PersistentTestJob.java
@@ -19,7 +19,7 @@ public class PersistentTestJob extends Job {
 
   @Override
   public void onAdded() {
-    PersistentResult.getInstance().onAdded();;
+    PersistentResult.getInstance().onAdded();
   }
 
   @Override

--- a/jobqueue/src/main/java/org/whispersystems/jobqueue/JobConsumer.java
+++ b/jobqueue/src/main/java/org/whispersystems/jobqueue/JobConsumer.java
@@ -42,20 +42,20 @@ public class JobConsumer extends Thread {
 
       JobResult result;
 
-      if ((result = runJob(job)) != JobResult.DEFERRED) {
-        if (result == JobResult.FAILURE) {
-          job.onCanceled();
-        }
-
-        if (job.isPersistent()) {
-          persistentStorage.remove(job.getPersistentId());
-        }
-      } else {
-        jobQueue.add(job);
+      if ((result = runJob(job)) == JobResult.FAILURE) {
+        job.onCanceled();
       }
 
       if (job.getGroupId() != null) {
         jobQueue.setGroupIdAvailable(job.getGroupId());
+      }
+
+      if (job.isPersistent()) {
+        persistentStorage.remove(job.getPersistentId());
+      }
+
+      if (result == JobResult.DEFERRED) {
+        jobQueue.add(job);
       }
     }
   }


### PR DESCRIPTION
I made a mistake in #2033. If a persistent job terminates with `JobResult.DEFERRED` it will be added to the JobManager again. But then it would be twice in the persistent database. 

With this patch it gets deleted first from the DB before adding the Job to the JobManager again. That feels a bit weird, but I didn't found an easy way of re-adding the job to the queue without writing it to the persistent database. Some one has a better solution?

//FREEBIE
