### PR TITLE
add PushDownloaderJob

### DIFF
--- a/src/org/thoughtcrime/securesms/RoutingActivity.java
+++ b/src/org/thoughtcrime/securesms/RoutingActivity.java
@@ -9,7 +9,10 @@ import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.recipients.RecipientFactory;
 import org.thoughtcrime.securesms.recipients.RecipientFormattingException;
 import org.thoughtcrime.securesms.recipients.Recipients;
+import org.thoughtcrime.securesms.util.ParcelUtil;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
+import org.whispersystems.jobqueue.EncryptionKeys;
+import org.whispersystems.jobqueue.JobManager;
 import org.whispersystems.textsecure.crypto.MasterSecret;
 
 public class RoutingActivity extends PassphraseRequiredSherlockActivity {
@@ -58,6 +61,9 @@ public class RoutingActivity extends PassphraseRequiredSherlockActivity {
     if (isVisible) {
       routeApplicationState();
     }
+
+    JobManager jobManager = ApplicationContext.getInstance(this).getJobManager();
+    jobManager.setEncryptionKeys(new EncryptionKeys(ParcelUtil.serialize(masterSecret)));
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/jobs/PushDownloadJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushDownloadJob.java
@@ -1,0 +1,67 @@
+package org.thoughtcrime.securesms.jobs;
+
+import android.content.Context;
+import android.util.Log;
+
+import org.thoughtcrime.securesms.service.PushDownloader;
+import org.thoughtcrime.securesms.util.ParcelUtil;
+import org.whispersystems.jobqueue.EncryptionKeys;
+import org.whispersystems.jobqueue.JobParameters;
+import org.whispersystems.jobqueue.requirements.NetworkRequirement;
+import org.whispersystems.textsecure.crypto.MasterSecret;
+
+import java.io.IOException;
+
+public class PushDownloadJob extends ContextJob {
+  private static final String TAG = PushDownloadJob.class.getSimpleName();
+
+  private long messageId;
+
+  public PushDownloadJob(Context context, MasterSecret masterSecret, long messageId) {
+    super(context, JobParameters.newBuilder()
+      .withRequirement(new NetworkRequirement(context))
+      .withRetryCount(20)
+      .withPersistence()
+      .withEncryption(new EncryptionKeys(ParcelUtil.serialize(masterSecret)))
+      .create());
+
+    this.messageId = messageId;
+  }
+
+  @Override
+  public void onAdded() {}
+
+  @Override
+  public void onRun() throws Exception {
+    MasterSecret masterSecret = ParcelUtil.deserialize(getEncryptionKeys().getEncoded(), MasterSecret.CREATOR);
+
+    PushDownloader pushDownloader = new PushDownloader(this.context);
+    pushDownloader.process(masterSecret, this.messageId);
+  }
+
+  @Override
+  public void onCanceled() {
+    Log.w(TAG, "PushDownloadJob canceled");
+  }
+
+  @Override
+  public boolean onShouldRetry(Throwable throwable) {
+    Log.w(TAG, throwable.getMessage());
+
+    if (throwable instanceof IOException) {
+      return true;
+    }
+
+    return false;
+  }
+
+  @Override
+  public void setEncryptionKeys(EncryptionKeys keys) {
+    super.setEncryptionKeys(keys);
+  }
+
+  @Override
+  public EncryptionKeys getEncryptionKeys() {
+    return super.getEncryptionKeys();
+  }
+}

--- a/src/org/thoughtcrime/securesms/service/PushDownloader.java
+++ b/src/org/thoughtcrime/securesms/service/PushDownloader.java
@@ -35,11 +35,7 @@ public class PushDownloader {
     this.context = context.getApplicationContext();
   }
 
-  public void process(MasterSecret masterSecret, Intent intent) {
-    if (!SendReceiveService.DOWNLOAD_PUSH_ACTION.equals(intent.getAction()))
-      return;
-
-    long         messageId = intent.getLongExtra("message_id", -1);
+  public void process(MasterSecret masterSecret, long messageId) throws IOException {
     PartDatabase database  = DatabaseFactory.getEncryptingPartDatabase(context, masterSecret);
 
     Log.w("PushDownloader", "Downloading push parts for: " + messageId);
@@ -61,7 +57,7 @@ public class PushDownloader {
     }
   }
 
-  private void retrievePart(MasterSecret masterSecret, PduPart part, long messageId, long partId) {
+  private void retrievePart(MasterSecret masterSecret, PduPart part, long messageId, long partId) throws IOException {
     EncryptingPartDatabase database       = DatabaseFactory.getEncryptingPartDatabase(context, masterSecret);
     File                   attachmentFile = null;
 
@@ -100,9 +96,6 @@ public class PushDownloader {
       } catch (MmsException mme) {
         Log.w("PushDownloader", mme);
       }
-    } catch (IOException e) {
-      Log.w("PushDownloader", e);
-      /// XXX schedule some kind of soft failure retry action
     } finally {
       if (attachmentFile != null)
         attachmentFile.delete();


### PR DESCRIPTION
This fixes #1264 

If a pending attachment download is interrupted, it will be resumed as soon as the network connection is established again. The job is persistent, so the download will be resumed after an app restart as well.

Until now `JobManager.setEncryptionKeys()` was never called, so encrypted jobs were never loaded to the JobQueue from the database. I put the call to `setEncryptionKeys()` in `RoutingActivity.onNewMasterSecret()`, I'm not sure if this is the best place for it?
