### PR TITLE
The Google Repository is needed to build TextSecure

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -46,13 +46,14 @@ Setting up a development environment
 [Android Studio](https://developer.android.com/sdk/installing/studio.html) is the recommended development environment.
 
 1. Install Android Studio.
-2. Make sure the "Android Support Repository" is installed in the Android Studio SDK.
-3. Make sure the latest "Android SDK build-tools" is installed in the Android Studio SDK.
-4. Create a new Android Studio project. from the Quickstart pannel (use File > Close Project to see it), choose "Checkout from Version Control" then "git".
-5. Paste the URL for the TextSecure project when prompted (https://github.com/WhisperSystems/TextSecure.git).
-6. Android studio should detect the presence of a project file and ask you whether to open it. Click "yes".
-7. Default config options should be good enough.
-8. Project initialisation and build should proceed.
+2. Make sure the "Google Repository" is installed in the Android Studio SDK.
+3. Make sure the "Android Support Repository" is installed in the Android Studio SDK.
+4. Make sure the latest "Android SDK build-tools" is installed in the Android Studio SDK.
+5. Create a new Android Studio project. from the Quickstart pannel (use File > Close Project to see it), choose "Checkout from Version Control" then "git".
+6. Paste the URL for the TextSecure project when prompted (https://github.com/WhisperSystems/TextSecure.git).
+7. Android studio should detect the presence of a project file and ask you whether to open it. Click "yes".
+8. Default config options should be good enough.
+9. Project initialisation and build should proceed.
 
 Contributing code
 -----------------


### PR DESCRIPTION
If the Google Repository is not installed, Gradle will complain that com.google.android.gms:play-services:6.1.71 is missing. Installing Google Play Services (counter intuitively) does not solve the issue. Solution found via: http://stackoverflow.com/a/25313527/1975217
