### PR TITLE
Use "sms_body" extra from "smsto:" Intent

### DIFF
--- a/src/org/thoughtcrime/securesms/RoutingActivity.java
+++ b/src/org/thoughtcrime/securesms/RoutingActivity.java
@@ -196,17 +196,19 @@ public class RoutingActivity extends PassphraseRequiredActionBarActivity {
 
   private ConversationParameters getConversationParametersForSendAction() {
     Recipients recipients;
+    String body = null;
     long       threadId = getIntent().getLongExtra("thread_id", -1);
 
     try {
       String data = getIntent().getData().getSchemeSpecificPart();
       recipients = RecipientFactory.getRecipientsFromString(this, data, false);
       threadId   = DatabaseFactory.getThreadDatabase(this).getThreadIdIfExistsFor(recipients);
+      body = getIntent().getStringExtra("sms_body");
     } catch (RecipientFormattingException rfe) {
       recipients = null;
     }
 
-    return new ConversationParameters(threadId, recipients, null, null, null, null);
+    return new ConversationParameters(threadId, recipients, body, null, null, null);
   }
 
   private ConversationParameters getConversationParametersForShareAction() {


### PR DESCRIPTION
When processing a SENDTO intent, the stock SMS app also populates the text of the draft from the `sms_body` extra (if present), while TextSecure does not.

The fix is trivial and should pose no risks, and it brings TextSecure's behaviour more in line with the stock app.

`Intent.getStringExtra` is documented to return `null` in case there's no extra of the requested name, so no error checking is necessary.
