### PR TITLE
catching failed attachment downloads

### DIFF
--- a/libtextsecure/src/main/java/org/whispersystems/textsecure/internal/push/PushServiceSocket.java
+++ b/libtextsecure/src/main/java/org/whispersystems/textsecure/internal/push/PushServiceSocket.java
@@ -368,6 +368,8 @@ public class PushServiceSocket {
 
       output.close();
       Log.w("PushServiceSocket", "Downloaded: " + url + " to: " + localDestination.getAbsolutePath());
+    } catch (IOException ioe) {
+      throw new PushNetworkException(ioe);
     } finally {
       connection.disconnect();
     }


### PR DESCRIPTION
`AttachmentDownloadJob` is just restarting failed jobs if they fail with `PushNetworkException`.
Should hopefully finally close #1264 

// FREEBIE
