### PR TITLE
fix for ringtone selection with android-support-v4-preferencefragment

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -119,6 +119,14 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
   }
 
   @Override
+  protected void onActivityResult(int requestCode, int resultCode, Intent data)
+  {
+    super.onActivityResult(requestCode, resultCode, data);
+    Fragment fragment = getSupportFragmentManager().findFragmentById(android.R.id.content);
+    fragment.onActivityResult(requestCode, resultCode, data);
+  }
+
+  @Override
   public void onDestroy() {
     MemoryCleaner.clean((MasterSecret) getIntent().getParcelableExtra("master_secret"));
     super.onDestroy();


### PR DESCRIPTION
as mentioned in #1635 the ringtone selection is not working with `android-support-v4-preferencefragment`. This workaround from https://github.com/kolavar/android-support-v4-preferencefragment/issues/1 fixes this issue...

//FREEBIE
