### PR TITLE
Added message category to notifications for Android 5 silent mode.

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -172,6 +172,7 @@ public class MessageNotifier {
     builder.setContentIntent(notifications.get(0).getPendingIntent(context));
     builder.setContentInfo(String.valueOf(notificationState.getMessageCount()));
     builder.setNumber(notificationState.getMessageCount());
+    builder.setCategory(Notification.CATEGORY_MESSAGE);
 
     if (masterSecret != null) {
       builder.addAction(R.drawable.check, context.getString(R.string.MessageNotifier_mark_as_read),
@@ -213,9 +214,10 @@ public class MessageNotifier {
     builder.setContentText(String.format(context.getString(R.string.MessageNotifier_most_recent_from_s),
                                          notifications.get(0).getIndividualRecipientName()));
     builder.setContentIntent(PendingIntent.getActivity(context, 0, new Intent(context, RoutingActivity.class), 0));
-    
+
     builder.setContentInfo(String.valueOf(notificationState.getMessageCount()));
     builder.setNumber(notificationState.getMessageCount());
+    builder.setCategory(Notification.CATEGORY_MESSAGE);
 
     if (masterSecret != null) {
       builder.addAction(R.drawable.check, context.getString(R.string.MessageNotifier_mark_all_as_read),


### PR DESCRIPTION
Hi,

I've noticed that textsecure notifications are not treated as messages in Android 5, meaning they won't show up if you configured "silent mode" (see settings -> sounds & notifications -> interruptions). From what I read from the docs, settings the category appropriately should do the trick. That said I currently don't have a build environment setup, but I'd appreciate some feedback on whether this is a good idea or not. If you like it I'll try to test this on my phone first.
