### PR TITLE
Added l10n for message details

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -99,6 +99,10 @@
     <string name="ConversationFragment_unable_to_write_to_sd_card_exclamation">Unable to write to storage!</string>
     <string name="ConversationFragment_saving_attachment">Saving attachment</string>
     <string name="ConversationFragment_saving_attachment_to_sd_card">Saving attachment to storage...</string>
+    <string name="ConversationFragment_pending">PENDING</string>
+    <string name="ConversationFragment_push">PUSH</string>
+    <string name="ConversationFragment_mms">MMS</string>
+    <string name="ConversationFragment_sms">SMS</string>
 
     <!-- ConversationListFragment -->
     <string name="ConversationListFragment_delete_threads_question">Delete threads?</string>

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -198,10 +198,10 @@ public class ConversationFragment extends ListFragment
 
     String transport;
 
-    if      (message.isPending()) transport = "pending";
-    else if (message.isPush())    transport = "push";
-    else if (message.isMms())     transport = "mms";
-    else                          transport = "sms";
+    if      (message.isPending()) transport = getString(R.string.ConversationFragment_pending);
+    else if (message.isPush())    transport = getString(R.string.ConversationFragment_push);
+    else if (message.isMms())     transport = getString(R.string.ConversationFragment_mms);
+    else                          transport = getString(R.string.ConversationFragment_sms);
 
     SimpleDateFormat dateFormatter = new SimpleDateFormat("EEE MMM d, yyyy 'at' hh:mm:ss a zzz");
     AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
@@ -212,13 +212,13 @@ public class ConversationFragment extends ListFragment
     if (dateReceived == dateSent || message.isOutgoing()) {
       builder.setMessage(String.format(getActivity()
                                        .getString(R.string.ConversationFragment_transport_s_sent_received_s),
-                                       transport.toUpperCase(),
+                                       transport,
                                        dateFormatter.format(new Date(dateSent))));
     } else {
       builder.setMessage(String.format(getActivity()
                                        .getString(R.string.ConversationFragment_sender_s_transport_s_sent_s_received_s),
                                        message.getIndividualRecipient().getNumber(),
-                                       transport.toUpperCase(),
+                                       transport,
                                        dateFormatter.format(new Date(dateSent)),
                                        dateFormatter.format(new Date(dateReceived))));
     }


### PR DESCRIPTION
This was already in PR #1309 that was closed by the author.

Added the 4 missing strings for translation. There are indeed languages that don't use the words SMS and MMS...
Removed `toUpperCase()` to leave this up to the translators.

I tended to move SMS, MMS and PUSH at top of `strings.xml` as these are some main strings, but ConversationFragment is the only place they are used standing alone.
