### PR TITLE
media preview fixes

### DIFF
--- a/res/layout/media_preview_activity.xml
+++ b/res/layout/media_preview_activity.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:tools="http://schemas.android.com/tools"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:background="@color/gray95">
@@ -10,5 +11,25 @@
                android:layout_height="match_parent"
                android:contentDescription="@string/media_preview_activity__image_content_description"
                android:visibility="gone"/>
+
+    <TextView android:id="@+id/loading_indicator"
+                 android:layout_width="50dp"
+                 android:layout_height="50dp"
+                 android:layout_centerInParent="true"
+                 android:text="···"
+                 android:textSize="30sp"
+                 android:textColor="@color/gray10"
+                 android:visibility="gone"
+                 tools:ignore="HardcodedText" />
+
+    <TextView android:id="@+id/error"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_centerInParent="true"
+              android:background="#ff600000"
+              android:textColor="#ffffffff"
+              android:textSize="15sp"
+              android:padding="10dp"
+              android:visibility="gone" />
 
 </RelativeLayout>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -763,6 +763,7 @@
 
     <!-- MediaPreviewActivity -->
     <string name="MediaPreviewActivity_you">You</string>
+    <string name="MediaPreviewActivity_cant_display">Failed to preview this image</string>
 
     <!-- media_preview -->
     <string name="media_preview__save_title">Save</string>


### PR DESCRIPTION
- Load Bitmaps asynchronously instead of lag on the main thread for sometimes more than a second, oops.
- Never load bitmaps that exceed the device's supported max texture width/height. This stops crashes when previewing images that are received or sent which exceed these device constants.
- Show an error message in place of the image instead of a Toast, giving them chance to hit save before going back.
