### PR TITLE
[UX] Open Keyboard When NewConversationActivity opened

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -144,7 +144,7 @@
 
     <activity android:name=".NewConversationActivity"
               android:label="@string/AndroidManifest__select_contacts"
-              android:windowSoftInputMode="stateHidden"
+              android:windowSoftInputMode="stateVisible"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
     <activity android:name=".PushContactSelectionActivity"


### PR DESCRIPTION
This is a very small PR which fixes a minor UX issue that was annoying me.

In short it opens the on-screen keyboard automatically when you hit the "New Message" button at the top of the screen.

I feel that this is advantageous, as it removes some friction with the UX for those who are wanting to send a message to someone not already near the top of their conversation list. You no longer have to press the text field at the top of the screen to activate the keyboard (but can still hide it).

Thoughts?
