### PR TITLE
remove workaround for nested PreferenceScreen's

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -17,16 +17,13 @@
 package org.thoughtcrime.securesms;
 
 import android.app.AlertDialog;
-import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
 import android.preference.Preference;
-import android.preference.PreferenceScreen;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;


### PR DESCRIPTION
I know it's some minutes too late, but you always realize another thing when the changes are in... ;)

This workaround was introduced here: https://github.com/WhisperSystems/TextSecure/commit/815613cfaabdc456b86eb6fdccfcb61273d523f6

It fixed some theming issues with nested PreferenceScreen's. But we're not using them anymore (since a long time...), so I guess this is unnecessary.
