### PR TITLE
Support for multi-select in the conversation list.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -118,7 +118,7 @@
     <string name="ConversationFragment_transport_s_sent_received_s">Transport: %1$s\nSent/Received: %2$s</string>
     <string name="ConversationFragment_sender_s_transport_s_sent_s_received_s">Sender: %1$s\nTransport: %2$s\nSent: %3$s\nReceived: %4$s</string>
     <string name="ConversationFragment_confirm_message_delete">Confirm message delete</string>
-    <string name="ConversationFragment_are_you_sure_you_want_to_permanently_delete_this_message">Are you sure that you want to permanently delete this message?</string>
+    <string name="ConversationFragment_are_you_sure_you_want_to_permanently_delete_all_selected_messages">Are you sure that you want to permanently delete all selected messages?</string>
     <string name="ConversationFragment_save_to_sd_card">Save to storage?</string>
     <string name="ConversationFragment_this_media_has_been_stored_in_an_encrypted_database_warning">Saving this media to storage will allow any other apps on your phone to access it.\n\nContinue?</string>
     <string name="ConversationFragment_error_while_saving_attachment_to_sd_card">Error while saving attachment to storage!</string>
@@ -130,6 +130,8 @@
     <string name="ConversationFragment_push">PUSH</string>
     <string name="ConversationFragment_mms">MMS</string>
     <string name="ConversationFragment_sms">SMS</string>
+    <string name="ConversationFragment_deleting">Deleting...</string>
+    <string name="ConversationFragment_deleting_messages">Deleting messages...</string>
 
     <!-- ConversationListFragment -->
     <string name="ConversationListFragment_delete_threads_question">Delete threads?</string>

--- a/src/org/thoughtcrime/securesms/ConversationAdapter.java
+++ b/src/org/thoughtcrime/securesms/ConversationAdapter.java
@@ -35,7 +35,11 @@ import org.thoughtcrime.securesms.util.LRUCache;
 
 import java.lang.ref.SoftReference;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+
+import org.thoughtcrime.securesms.ConversationFragment.SelectionClickListener;
 
 /**
  * A cursor adapter for a conversation thread.  Ultimately
@@ -55,19 +59,23 @@ public class ConversationAdapter extends CursorAdapter implements AbsListView.Re
   public static final int MESSAGE_TYPE_INCOMING = 1;
   public static final int MESSAGE_TYPE_GROUP_ACTION = 2;
 
-  private final Handler failedIconClickHandler;
-  private final Context context;
-  private final MasterSecret masterSecret;
-  private final boolean groupThread;
-  private final boolean pushDestination;
-  private final LayoutInflater inflater;
+  private final Set<MessageRecord> batchSelected = Collections.synchronizedSet(new HashSet<MessageRecord>());
 
-  public ConversationAdapter(Context context, MasterSecret masterSecret,
+  private final SelectionClickListener selectionClickListener;
+  private final Handler                failedIconClickHandler;
+  private final Context                context;
+  private final MasterSecret           masterSecret;
+  private final boolean                groupThread;
+  private final boolean                pushDestination;
+  private final LayoutInflater         inflater;
+
+  public ConversationAdapter(Context context, MasterSecret masterSecret, SelectionClickListener selectionClickListener,
                              Handler failedIconClickHandler, boolean groupThread, boolean pushDestination)
   {
     super(context, null, 0);
     this.context                = context;
     this.masterSecret           = masterSecret;
+    this.selectionClickListener = selectionClickListener;
     this.failedIconClickHandler = failedIconClickHandler;
     this.groupThread            = groupThread;
     this.pushDestination        = pushDestination;
@@ -81,7 +89,8 @@ public class ConversationAdapter extends CursorAdapter implements AbsListView.Re
     String type                 = cursor.getString(cursor.getColumnIndexOrThrow(MmsSmsDatabase.TRANSPORT));
     MessageRecord messageRecord = getMessageRecord(id, cursor, type);
 
-    item.set(masterSecret, messageRecord, failedIconClickHandler, groupThread, pushDestination);
+    item.set(masterSecret, messageRecord, batchSelected, selectionClickListener,
+             failedIconClickHandler, groupThread, pushDestination);
   }
 
   @Override
@@ -156,6 +165,18 @@ public class ConversationAdapter extends CursorAdapter implements AbsListView.Re
 
   public void close() {
     this.getCursor().close();
+  }
+
+  public void toggleBatchSelected(MessageRecord messageRecord) {
+    if (batchSelected.contains(messageRecord)) {
+      batchSelected.remove(messageRecord);
+    } else {
+      batchSelected.add(messageRecord);
+    }
+  }
+
+  public Set<MessageRecord> getBatchSelected() {
+    return batchSelected;
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -25,10 +25,8 @@ import android.content.res.TypedArray;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
-import android.net.Uri;
 import android.os.Handler;
 import android.os.Message;
-import android.provider.Contacts.Intents;
 import android.provider.ContactsContract;
 import android.provider.ContactsContract.QuickContact;
 import android.util.AttributeSet;
@@ -40,9 +38,10 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import org.thoughtcrime.securesms.ConversationFragment.SelectionClickListener;
+import org.thoughtcrime.securesms.contacts.ContactPhotoFactory;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
-import org.thoughtcrime.securesms.contacts.ContactPhotoFactory;
 import org.thoughtcrime.securesms.database.MmsDatabase;
 import org.thoughtcrime.securesms.database.SmsDatabase;
 import org.thoughtcrime.securesms.database.model.MediaMmsMessageRecord;
@@ -60,6 +59,8 @@ import org.thoughtcrime.securesms.util.Dialogs;
 import org.thoughtcrime.securesms.util.Emoji;
 import org.thoughtcrime.securesms.util.FutureTaskListener;
 import org.thoughtcrime.securesms.util.ListenableFutureTask;
+
+import java.util.Set;
 
 /**
  * A view that displays an individual conversation item within a conversation
@@ -81,13 +82,13 @@ public class ConversationItem extends LinearLayout {
                                                       R.attr.conversation_item_sent_push_pending_background,
                                                       R.attr.conversation_item_sent_push_pending_triangle_background};
 
-  private final static int SENT_PUSH = 0;
-  private final static int SENT_PUSH_TRIANGLE = 1;
-  private final static int SENT_SMS = 2;
-  private final static int SENT_SMS_TRIANGLE = 3;
-  private final static int SENT_SMS_PENDING = 4;
-  private final static int SENT_SMS_PENDING_TRIANGLE = 5;
-  private final static int SENT_PUSH_PENDING = 6;
+  private final static int SENT_PUSH                  = 0;
+  private final static int SENT_PUSH_TRIANGLE         = 1;
+  private final static int SENT_SMS                   = 2;
+  private final static int SENT_SMS_TRIANGLE          = 3;
+  private final static int SENT_SMS_PENDING           = 4;
+  private final static int SENT_SMS_PENDING_TRIANGLE  = 5;
+  private final static int SENT_PUSH_PENDING          = 6;
   private final static int SENT_PUSH_PENDING_TRIANGLE = 7;
 
   private Handler       failedIconHandler;
@@ -108,19 +109,21 @@ public class ConversationItem extends LinearLayout {
   private  View      triangleTick;
   private  ImageView pendingIndicator;
 
-  private  View      mmsContainer;
-  private  ImageView mmsThumbnail;
-  private  Button    mmsDownloadButton;
-  private  TextView  mmsDownloadingLabel;
-  private  ListenableFutureTask<SlideDeck> slideDeck;
-  private  FutureTaskListener<SlideDeck> slideDeckListener;
-  private  TypedArray backgroundDrawables;
+  private Set<MessageRecord>              batchSelected;
+  private SelectionClickListener          selectionClickListener;
+  private View                            mmsContainer;
+  private ImageView                       mmsThumbnail;
+  private Button                          mmsDownloadButton;
+  private TextView                        mmsDownloadingLabel;
+  private ListenableFutureTask<SlideDeck> slideDeck;
+  private FutureTaskListener<SlideDeck>   slideDeckListener;
+  private TypedArray                      backgroundDrawables;
 
-  private final FailedIconClickListener failedIconClickListener         = new FailedIconClickListener();
-  private final MmsDownloadClickListener mmsDownloadClickListener       = new MmsDownloadClickListener();
+  private final FailedIconClickListener     failedIconClickListener     = new FailedIconClickListener();
+  private final MmsDownloadClickListener    mmsDownloadClickListener    = new MmsDownloadClickListener();
   private final MmsPreferencesClickListener mmsPreferencesClickListener = new MmsPreferencesClickListener();
-  private final ClickListener clickListener                             = new ClickListener();
-  private final Handler handler                                         = new Handler();
+  private final ClickListener               clickListener               = new ClickListener();
+  private final Handler                     handler                     = new Handler();
   private final Context context;
 
   public ConversationItem(Context context) {
@@ -157,19 +160,23 @@ public class ConversationItem extends LinearLayout {
     setOnClickListener(clickListener);
     if (failedImage != null)       failedImage.setOnClickListener(failedIconClickListener);
     if (mmsDownloadButton != null) mmsDownloadButton.setOnClickListener(mmsDownloadClickListener);
+    if (mmsThumbnail != null)      mmsThumbnail.setOnLongClickListener(new MultiSelectLongClickListener());
   }
 
   public void set(MasterSecret masterSecret, MessageRecord messageRecord,
+                  Set<MessageRecord> batchSelected, SelectionClickListener selectionClickListener,
                   Handler failedIconHandler, boolean groupThread, boolean pushDestination)
   {
+    this.masterSecret           = masterSecret;
+    this.messageRecord          = messageRecord;
+    this.batchSelected          = batchSelected;
+    this.selectionClickListener = selectionClickListener;
+    this.failedIconHandler      = failedIconHandler;
+    this.groupThread            = groupThread;
+    this.pushDestination        = pushDestination;
 
-    this.messageRecord     = messageRecord;
-    this.masterSecret      = masterSecret;
-    this.failedIconHandler = failedIconHandler;
-    this.groupThread       = groupThread;
-    this.pushDestination   = pushDestination;
-
-    setBackgroundDrawables(messageRecord);
+    setConversationBackgroundDrawables(messageRecord);
+    setSelectionBackgroundDrawables(messageRecord);
     setBodyText(messageRecord);
 
     if (!messageRecord.isGroupAction()) {
@@ -211,33 +218,57 @@ public class ConversationItem extends LinearLayout {
 
   /// MessageRecord Attribute Parsers
 
-  private void setBackgroundDrawables(MessageRecord messageRecord) {
+  private void setConversationBackgroundDrawables(MessageRecord messageRecord) {
     if (conversationParent != null && backgroundDrawables != null) {
       if (messageRecord.isOutgoing()) {
         final int background;
         final int triangleBackground;
         if (messageRecord.isPending() && pushDestination && !messageRecord.isForcedSms()) {
-          background = SENT_PUSH_PENDING;
+          background         = SENT_PUSH_PENDING;
           triangleBackground = SENT_PUSH_PENDING_TRIANGLE;
         } else if (messageRecord.isPending() || messageRecord.isPendingSmsFallback()) {
-          background = SENT_SMS_PENDING;
+          background         = SENT_SMS_PENDING;
           triangleBackground = SENT_SMS_PENDING_TRIANGLE;
         } else if (messageRecord.isPush()) {
-          background = SENT_PUSH;
+          background         = SENT_PUSH;
           triangleBackground = SENT_PUSH_TRIANGLE;
         } else {
-          background = SENT_SMS;
+          background         = SENT_SMS;
           triangleBackground = SENT_SMS_TRIANGLE;
         }
+
         setViewBackgroundWithoutResettingPadding(conversationParent, backgroundDrawables.getResourceId(background, -1));
         setViewBackgroundWithoutResettingPadding(triangleTick, backgroundDrawables.getResourceId(triangleBackground, -1));
       }
     }
   }
 
+  private void setSelectionBackgroundDrawables(MessageRecord messageRecord) {
+    int[]      attributes = new int[]{R.attr.conversation_list_item_background_selected,
+                                      R.attr.conversation_item_background};
+
+    TypedArray drawables  = context.obtainStyledAttributes(attributes);
+
+    if (batchSelected.contains(messageRecord)) {
+      setBackgroundDrawable(drawables.getDrawable(0));
+    } else {
+      setBackgroundDrawable(drawables.getDrawable(1));
+    }
+
+    drawables.recycle();
+  }
+
   private void setBodyText(MessageRecord messageRecord) {
-      bodyText.setText(Emoji.getInstance(context).emojify(messageRecord.getDisplayBody(), new Emoji.InvalidatingPageLoadedListener(bodyText)),
-                       TextView.BufferType.SPANNABLE);
+    bodyText.setClickable(false);
+    bodyText.setFocusable(false);
+    bodyText.setText(Emoji.getInstance(context).emojify(messageRecord.getDisplayBody(),
+                                                        new Emoji.InvalidatingPageLoadedListener(bodyText)),
+                     TextView.BufferType.SPANNABLE);
+
+    if (bodyText.isClickable() && bodyText.isFocusable()) {
+      bodyText.setOnLongClickListener(new MultiSelectLongClickListener());
+      bodyText.setOnClickListener(new MultiSelectLongClickListener());
+    }
   }
 
   private void setContactPhoto(MessageRecord messageRecord) {
@@ -365,12 +396,6 @@ public class ConversationItem extends LinearLayout {
               if (slide.hasImage()) {
                 slide.setThumbnailOn(mmsThumbnail);
                 mmsThumbnail.setOnClickListener(new ThumbnailClickListener(slide));
-                mmsThumbnail.setOnLongClickListener(new OnLongClickListener() {
-                  @Override
-                  public boolean onLongClick(View v) {
-                    return false;
-                  }
-                });
                 mmsThumbnail.setVisibility(View.VISIBLE);
                 return;
               }
@@ -474,7 +499,9 @@ public class ConversationItem extends LinearLayout {
     }
 
     public void onClick(View v) {
-      if (MediaPreviewActivity.isContentTypeSupported(slide.getContentType())) {
+      if (!batchSelected.isEmpty()) {
+        selectionClickListener.onItemClick(null, ConversationItem.this, -1, -1);
+      } else if (MediaPreviewActivity.isContentTypeSupported(slide.getContentType())) {
         Intent intent = new Intent(context, MediaPreviewActivity.class);
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         intent.setDataAndType(slide.getUri(), slide.getContentType());
@@ -542,6 +569,19 @@ public class ConversationItem extends LinearLayout {
         handleKeyExchangeClicked();
       else if (messageRecord.isPendingSmsFallback())
         handleMessageApproval();
+    }
+  }
+
+  private class MultiSelectLongClickListener implements OnLongClickListener, OnClickListener {
+    @Override
+    public boolean onLongClick(View view) {
+      selectionClickListener.onItemLongClick(null, ConversationItem.this, -1, -1);
+      return true;
+    }
+
+    @Override
+    public void onClick(View view) {
+      selectionClickListener.onItemClick(null, ConversationItem.this, -1, -1);
     }
   }
 

--- a/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -182,4 +182,15 @@ public abstract class MessageRecord extends DisplayRecord {
 
     return spannable;
   }
+
+  public boolean equals(Object other) {
+    return other != null                              &&
+           other instanceof MessageRecord             &&
+           ((MessageRecord) other).getId() == getId() &&
+           ((MessageRecord) other).isMms() == isMms();
+  }
+
+  public int hashCode() {
+    return (int)getId();
+  }
 }


### PR DESCRIPTION
Unfortunately I'm pretty sure this is the only way to do multi-select on both <> Honeycomb. It'd be nice if we could use the new stuff they were experimenting with in #1601, but I don't think it'll be backwards compatible.
