### PR TITLE
replace unlocalized 'at' in message details date

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -207,9 +207,9 @@ public class ConversationFragment extends ListFragment
     String dateFormatPattern;
 
     if (DateFormat.is24HourFormat(getActivity().getApplicationContext())) {
-      dateFormatPattern = "EEE MMM d, yyyy 'at' HH:mm:ss zzz";
+      dateFormatPattern = "EEE MMM d, yyyy '-' HH:mm:ss zzz";
     } else {
-      dateFormatPattern = "EEE MMM d, yyyy 'at' hh:mm:ss a zzz";
+      dateFormatPattern = "EEE MMM d, yyyy '-' hh:mm:ss a zzz";
     }
 
     SimpleDateFormat    dateFormatter = new SimpleDateFormat(dateFormatPattern);


### PR DESCRIPTION
...with a dash

Making this a string resource has the potential for crashes.
Leaving it out completely is a little confusing.
The dash is the perfect solution - until a better date formatter is used.
