### PR TITLE
Include group titles in search

### DIFF
--- a/src/org/thoughtcrime/securesms/database/GroupDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/GroupDatabase.java
@@ -79,6 +79,14 @@ public class GroupDatabase extends Database {
     return record;
   }
 
+  public Reader getGroupsFilteredByTitle(String constraint) {
+    Cursor cursor = databaseHelper.getReadableDatabase().query(TABLE_NAME, null, TITLE + " LIKE ?",
+                                                               new String[]{"%" + constraint + "%"},
+                                                               null, null, null);
+
+    return new Reader(cursor);
+  }
+
   public Recipients getGroupMembers(byte[] groupId, boolean includeSelf) {
     String          localNumber = TextSecurePreferences.getLocalNumber(context);
     List<String>    members     = getCurrentMembers(groupId);
@@ -294,6 +302,10 @@ public class GroupDatabase extends Database {
       } catch (IOException ioe) {
         throw new AssertionError(ioe);
       }
+    }
+
+    public String getEncodedId() {
+      return id;
     }
 
     public String getTitle() {

--- a/src/org/thoughtcrime/securesms/database/loaders/ConversationListLoader.java
+++ b/src/org/thoughtcrime/securesms/database/loaders/ConversationListLoader.java
@@ -22,7 +22,7 @@ public class ConversationListLoader extends AbstractCursorLoader {
   public Cursor getCursor() {
     if (filter != null && filter.trim().length() != 0) {
       List<String> numbers = ContactAccessor.getInstance()
-          .getNumbersForThreadSearchFilter(filter, context.getContentResolver());
+          .getNumbersForThreadSearchFilter(filter, context);
 
       return DatabaseFactory.getThreadDatabase(context).getFilteredConversationList(numbers);
     } else {


### PR DESCRIPTION
When searching for messages only simple threads matching the contact
names are returned as search results. With this commit also group
converstations where the group title matches the search term are
displayed in the result. This makes search results more consistent with the
conversation list as now all conversation titles (i.e. contact names and
group titles) are searched through.

Fixes #1954
