### PR TITLE
Catch issues with bad MMSC URIs, add validation

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -502,6 +502,9 @@
     <string name="MmsPreferencesFragment__manual_mms_settings_are_required">Manual MMS settings are required for your phone.</string>
     <string name="MmsPreferencesFragment__enabled">Enabled</string>
     <string name="MmsPreferencesFragment__disabled">Disabled</string>
+    <string name="MmsPreferencesFragment__not_set">Not set</string>
+    <string name="MmsPreferencesFragment__invalid_uri">The text entered was not a valid URI</string>
+    <string name="MmsPreferencesFragment__invalid_host">The text entered was not a valid host</string>
 
     <!-- prompt_passphrase_activity -->
     <string name="prompt_passphrase_activity__unlock">Unlock</string>

--- a/src/org/thoughtcrime/securesms/MmsPreferencesFragment.java
+++ b/src/org/thoughtcrime/securesms/MmsPreferencesFragment.java
@@ -20,11 +20,16 @@ import android.content.Context;
 import android.os.Bundle;
 import android.preference.EditTextPreference;
 import android.preference.Preference;
+import android.preference.Preference.OnPreferenceChangeListener;
 import android.support.v4.preference.PreferenceFragment;
+import android.text.TextUtils;
 import android.widget.Toast;
 
 import org.thoughtcrime.securesms.mms.OutgoingMmsConnection;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 
 
 public class MmsPreferencesFragment extends PreferenceFragment {
@@ -47,22 +52,15 @@ public class MmsPreferencesFragment extends PreferenceFragment {
     } else {
       addPreferencesFromResource(R.xml.preferences_manual_mms);
     }
+    this.findPreference(TextSecurePreferences.MMSC_HOST_PREF).setOnPreferenceChangeListener(new ValidUriVerificationListener());
+    this.findPreference(TextSecurePreferences.MMSC_PROXY_HOST_PREF).setOnPreferenceChangeListener(new ValidHostnameVerificationListener());
+    this.findPreference(TextSecurePreferences.MMSC_PROXY_PORT_PREF).setOnPreferenceChangeListener(new EditTextVerificationListener());
+    this.findPreference(TextSecurePreferences.MMSC_USERNAME_PREF).setOnPreferenceChangeListener(new EditTextVerificationListener());
+    this.findPreference(TextSecurePreferences.MMSC_PASSWORD_PREF).setOnPreferenceChangeListener(new EditTextVerificationListener());
   }
 
   private void initializeEditTextSummary(final EditTextPreference preference) {
-    if (preference.getText() == null) {
-      preference.setSummary("Not set");
-    } else {
-      preference.setSummary(preference.getText());
-    }
-
-    preference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-      @Override
-      public boolean onPreferenceChange(Preference pref, Object newValue) {
-        preference.setSummary(newValue == null ? "Not set" : ((String) newValue));
-        return true;
-      }
-    });
+    preference.setSummary(TextUtils.isEmpty(preference.getText()) ? getString(R.string.MmsPreferencesFragment__not_set) : preference.getText());
   }
 
   private void initializeEditTextSummaries() {
@@ -88,5 +86,58 @@ public class MmsPreferencesFragment extends PreferenceFragment {
     final int disabledResId = R.string.MmsPreferencesFragment__disabled;
 
     return context.getString(TextSecurePreferences.isUseLocalApnsEnabled(context) ? enabledResId : disabledResId);
+  }
+
+  private class EditTextVerificationListener implements OnPreferenceChangeListener {
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+      String newString = (String)newValue;
+      if (isValid(newString)) {
+        preference.setSummary(TextUtils.isEmpty(newString) ? getString(R.string.MmsPreferencesFragment__not_set) : newString);
+        return true;
+      } else {
+        Toast.makeText(getActivity(), getErrorMessage(), Toast.LENGTH_LONG).show();
+        return false;
+      }
+    }
+
+    protected boolean isValid(String newString) { return true; }
+    protected int getErrorMessage() { return 0; }
+  }
+
+  private class ValidUriVerificationListener extends EditTextVerificationListener {
+    @Override
+    protected boolean isValid(String newString) {
+      if (TextUtils.isEmpty(newString)) return true;
+      try {
+        new URI(newString);
+        return true;
+      } catch (URISyntaxException mue) {
+        return false;
+      }
+    }
+
+    @Override
+    protected int getErrorMessage() {
+      return R.string.MmsPreferencesFragment__invalid_uri;
+    }
+  }
+
+  private class ValidHostnameVerificationListener extends EditTextVerificationListener {
+    @Override
+    protected boolean isValid(String newString) {
+      if (TextUtils.isEmpty(newString)) return true;
+      try {
+        URI uri = new URI(null, newString, null, null);
+        return true;
+      } catch (URISyntaxException mue) {
+        return false;
+      }
+    }
+
+    @Override
+    protected int getErrorMessage() {
+      return R.string.MmsPreferencesFragment__invalid_host;
+    }
   }
 }

--- a/src/org/thoughtcrime/securesms/mms/OutgoingMmsConnection.java
+++ b/src/org/thoughtcrime/securesms/mms/OutgoingMmsConnection.java
@@ -47,16 +47,20 @@ public class OutgoingMmsConnection extends MmsConnection {
   protected HttpUriRequest constructRequest(boolean useProxy)
       throws IOException
   {
-    HttpPostHC4 request = new HttpPostHC4(apn.getMmsc());
-    request.addHeader("Accept", "*/*, application/vnd.wap.mms-message, application/vnd.wap.sic");
-    request.addHeader("x-wap-profile", "http://www.google.com/oha/rdf/ua-profile-kila.xml");
-    request.addHeader("Content-Type", "application/vnd.wap.mms-message");
-    request.setEntity(new ByteArrayEntityHC4(mms));
-    if (useProxy) {
-      HttpHost proxy = new HttpHost(apn.getProxy(), apn.getPort());
-      request.setConfig(RequestConfig.custom().setProxy(proxy).build());
+    try {
+      HttpPostHC4 request = new HttpPostHC4(apn.getMmsc());
+      request.addHeader("Accept", "*/*, application/vnd.wap.mms-message, application/vnd.wap.sic");
+      request.addHeader("x-wap-profile", "http://www.google.com/oha/rdf/ua-profile-kila.xml");
+      request.addHeader("Content-Type", "application/vnd.wap.mms-message");
+      request.setEntity(new ByteArrayEntityHC4(mms));
+      if (useProxy) {
+        HttpHost proxy = new HttpHost(apn.getProxy(), apn.getPort());
+        request.setConfig(RequestConfig.custom().setProxy(proxy).build());
+      }
+      return request;
+    } catch (IllegalArgumentException iae) {
+      throw new IOException(iae);
     }
-    return request;
   }
 
   public void sendNotificationReceived(boolean usingMmsRadio, boolean useProxyIfAvailable)


### PR DESCRIPTION
Bad arguments into HttpClient constructors are caught and wrapped in an IOException, preventing crashes. Also added validators to the manual MMS preferences to stop these kinds of issues from coming up in the future.
