### PR TITLE
Fix everlasting media drafts

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -179,12 +179,12 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
     initializeReceivers();
     initializeResources();
+    initializeDraft();
   }
 
   @Override
   protected void onStart() {
     super.onStart();
-    initializeDraft();
   }
 
   @Override


### PR DESCRIPTION
Due to the changes in #1985 the draft gets recreated right after the attachment dialog returns the new attachment. Therefor the attachment of the draft wont change...
