### PR TITLE
Avoid multiple drafts when creating a draft from an intent

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -616,6 +616,9 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     if (draftText == null && draftImage == null && draftAudio == null && draftVideo == null) {
       initializeDraftFromDatabase();
     }
+    else {
+      clearDraftsFromDatabase();
+    }
   }
 
   private void initializeEnabledCheck() {
@@ -664,6 +667,19 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
         }
       }
     }.execute();
+  }
+
+  private void clearDraftsFromDatabase() {
+    if (threadId != -1) {
+      new AsyncTask<Void, Void, Void>() {
+        @Override
+        protected Void doInBackground(Void... params) {
+          DraftDatabase draftDatabase = DatabaseFactory.getDraftDatabase(ConversationActivity.this);
+          draftDatabase.clearDrafts(threadId);
+          return null;
+        }
+      }.execute();
+    }
   }
 
   private void initializeSecurity() {


### PR DESCRIPTION
If a draft is created through an intent any existing draft for the thread needs to be cleared.
Otherwise the old drafts pops up after sending the new one, or when deleting the new one and leaving the thread 'draftless'
