### PR TITLE
Pass recipient references instead of their parceled objects

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -246,7 +246,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       addAttachmentContactInfo(data.getData());
       break;
     case GROUP_EDIT:
-      this.recipients = data.getParcelableExtra(GroupCreateActivity.GROUP_RECIPIENT_EXTRA);
+      this.recipients = RecipientFactory.getRecipientsForIds(this, data.getLongArrayExtra(GroupCreateActivity.GROUP_RECIPIENT_EXTRA), true);
       initializeTitleBar();
       break;
     }
@@ -349,7 +349,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
   private void handleVerifyIdentity() {
     Intent verifyIdentityIntent = new Intent(this, VerifyIdentityActivity.class);
-    verifyIdentityIntent.putExtra("recipient", getRecipients().getPrimaryRecipient());
+    verifyIdentityIntent.putExtra("recipient", getRecipients().getPrimaryRecipient().getRecipientId());
     verifyIdentityIntent.putExtra("master_secret", masterSecret);
     startActivity(verifyIdentityIntent);
   }
@@ -458,7 +458,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private void handleEditPushGroup() {
     Intent intent = new Intent(ConversationActivity.this, GroupCreateActivity.class);
     intent.putExtra(GroupCreateActivity.MASTER_SECRET_EXTRA, masterSecret);
-    intent.putExtra(GroupCreateActivity.GROUP_RECIPIENT_EXTRA, recipients);
+    intent.putExtra(GroupCreateActivity.GROUP_RECIPIENT_EXTRA, recipients.getIds());
     startActivityForResult(intent, GROUP_EDIT);
   }
 
@@ -719,7 +719,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void initializeResources() {
-    recipients          = RecipientFactory.getRecipientsForIds(this, getIntent().getStringExtra(RECIPIENTS_EXTRA), true);
+    recipients          = RecipientFactory.getRecipientsForIds(this, getIntent().getLongArrayExtra(RECIPIENTS_EXTRA), true);
     threadId            = getIntent().getLongExtra(THREAD_ID_EXTRA, -1);
     distributionType    = getIntent().getIntExtra(DISTRIBUTION_TYPE_EXTRA,
                                                   ThreadDatabase.DistributionTypes.DEFAULT);
@@ -779,7 +779,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       public void onReceive(Context context, Intent intent) {
         Log.w("ConversationActivity", "Group update received...");
         if (recipients != null) {
-          String ids = recipients.toIdString();
+          long[] ids = recipients.getIds();
           Log.w("ConversationActivity", "Looking up new recipients...");
           recipients = RecipientFactory.getRecipientsForIds(context, ids, false);
           initializeTitleBar();

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -79,10 +79,8 @@ public class ConversationFragment extends ListFragment
   }
 
   private void initializeResources() {
-    String recipientIds = this.getActivity().getIntent().getStringExtra("recipients");
-
     this.masterSecret = this.getActivity().getIntent().getParcelableExtra("master_secret");
-    this.recipients   = RecipientFactory.getRecipientsForIds(getActivity(), recipientIds, true);
+    this.recipients   = RecipientFactory.getRecipientsForIds(getActivity(), getActivity().getIntent().getLongArrayExtra("recipients"), true);
     this.threadId     = this.getActivity().getIntent().getLongExtra("thread_id", -1);
   }
 

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -400,7 +400,7 @@ public class ConversationItem extends LinearLayout {
       intent.setClass(context, AutoInitiateActivity.class);
       intent.putExtra("threadId", threadId);
       intent.putExtra("masterSecret", masterSecret);
-      intent.putExtra("recipient", recipient);
+      intent.putExtra("recipient", recipient.getRecipientId());
 
       context.startActivity(intent);
     }
@@ -440,7 +440,7 @@ public class ConversationItem extends LinearLayout {
 
   private void handleKeyExchangeClicked() {
     Intent intent = new Intent(context, ReceiveKeyActivity.class);
-    intent.putExtra("recipient", messageRecord.getIndividualRecipient());
+    intent.putExtra("recipient", messageRecord.getIndividualRecipient().getRecipientId());
     intent.putExtra("recipient_device_id", messageRecord.getRecipientDeviceId());
     intent.putExtra("body", messageRecord.getBody().getBody());
     intent.putExtra("thread_id", messageRecord.getThreadId());
@@ -479,7 +479,7 @@ public class ConversationItem extends LinearLayout {
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         intent.setDataAndType(slide.getUri(), slide.getContentType());
         intent.putExtra(MediaPreviewActivity.MASTER_SECRET_EXTRA, masterSecret);
-        if (!messageRecord.isOutgoing()) intent.putExtra(MediaPreviewActivity.RECIPIENT_EXTRA, messageRecord.getIndividualRecipient());
+        if (!messageRecord.isOutgoing()) intent.putExtra(MediaPreviewActivity.RECIPIENT_EXTRA, messageRecord.getIndividualRecipient().getRecipientId());
         intent.putExtra(MediaPreviewActivity.DATE_EXTRA, messageRecord.getDateReceived());
         context.startActivity(intent);
       } else {

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -22,21 +22,11 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.provider.ContactsContract;
 import android.util.Log;
-import android.provider.Telephony;
-import android.support.v4.app.ActionBarDrawerToggle;
-import android.support.v4.view.GravityCompat;
 import android.support.v4.view.MenuItemCompat;
-import android.support.v4.widget.DrawerLayout;
 import android.support.v7.widget.SearchView;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-import android.view.View;
-import android.view.WindowManager;
-import android.widget.AdapterView;
-import android.widget.ListView;
-import android.widget.SimpleAdapter;
 
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
@@ -197,7 +187,7 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
 
   private void createConversation(long threadId, Recipients recipients, int distributionType) {
     Intent intent = new Intent(this, ConversationActivity.class);
-    intent.putExtra(ConversationActivity.RECIPIENTS_EXTRA, recipients.toIdString());
+    intent.putExtra(ConversationActivity.RECIPIENTS_EXTRA, recipients.getIds());
     intent.putExtra(ConversationActivity.THREAD_ID_EXTRA, threadId);
     intent.putExtra(ConversationActivity.MASTER_SECRET_EXTRA, masterSecret);
     intent.putExtra(ConversationActivity.DISTRIBUTION_TYPE_EXTRA, distributionType);

--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -18,7 +18,6 @@
 package org.thoughtcrime.securesms;
 
 import android.app.Activity;
-import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
@@ -70,7 +69,6 @@ import org.whispersystems.textsecure.api.util.InvalidNumberException;
 
 import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
-import java.io.InputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -94,8 +92,8 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity {
   private final static String TAG = GroupCreateActivity.class.getSimpleName();
 
   public static final String GROUP_RECIPIENT_EXTRA = "group_recipient";
-  public static final String GROUP_THREAD_EXTRA = "group_thread";
-  public static final String MASTER_SECRET_EXTRA    = "master_secret";
+  public static final String GROUP_THREAD_EXTRA    = "group_thread";
+  public static final String MASTER_SECRET_EXTRA   = "master_secret";
 
   private final DynamicTheme    dynamicTheme    = new DynamicTheme();
   private final DynamicLanguage dynamicLanguage = new DynamicLanguage();
@@ -110,7 +108,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity {
   private ImageView           avatar;
   private TextView            creatingText;
 
-  private Recipients     groupRecipient    = null;
+  private Recipient      groupRecipient    = null;
   private long           groupThread       = -1;
   private byte[]         groupId           = null;
   private Set<Recipient> existingContacts  = null;
@@ -217,10 +215,10 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity {
   }
 
   private void initializeResources() {
-    groupRecipient = getIntent().getParcelableExtra(GROUP_RECIPIENT_EXTRA);
+    groupRecipient = RecipientFactory.getRecipientForId(this, getIntent().getLongExtra(GROUP_RECIPIENT_EXTRA, -1), true);
     groupThread = getIntent().getLongExtra(GROUP_THREAD_EXTRA, -1);
     if (groupRecipient != null) {
-      final String encodedGroupId = groupRecipient.getPrimaryRecipient().getNumber();
+      final String encodedGroupId = groupRecipient.getNumber();
       if (encodedGroupId != null) {
         try {
           groupId = GroupUtil.getDecodedId(encodedGroupId);
@@ -543,7 +541,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity {
         intent.putExtra(ConversationActivity.DISTRIBUTION_TYPE_EXTRA, ThreadDatabase.DistributionTypes.DEFAULT);
 
         ArrayList<Recipient> selectedContactsList = setToArrayList(selectedContacts);
-        intent.putExtra(ConversationActivity.RECIPIENTS_EXTRA, new Recipients(selectedContactsList).toIdString());
+        intent.putExtra(ConversationActivity.RECIPIENTS_EXTRA, new Recipients(selectedContactsList).getIds());
         startActivity(intent);
         finish();
       } else {
@@ -594,7 +592,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity {
       if (threadId > -1) {
         Intent intent = getIntent();
         intent.putExtra(GROUP_THREAD_EXTRA, threadId);
-        intent.putExtra(GROUP_RECIPIENT_EXTRA, recipients);
+        intent.putExtra(GROUP_RECIPIENT_EXTRA, recipients.getIds());
         setResult(RESULT_OK, intent);
         finish();
       } else if (threadId == RES_BAD_NUMBER) {
@@ -642,7 +640,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity {
         intent.putExtra(ConversationActivity.MASTER_SECRET_EXTRA, masterSecret);
         intent.putExtra(ConversationActivity.THREAD_ID_EXTRA, threadId);
         intent.putExtra(ConversationActivity.DISTRIBUTION_TYPE_EXTRA, ThreadDatabase.DistributionTypes.DEFAULT);
-        intent.putExtra(ConversationActivity.RECIPIENTS_EXTRA, recipients.toIdString());
+        intent.putExtra(ConversationActivity.RECIPIENTS_EXTRA, recipients.getIds());
         startActivity(intent);
         finish();
       } else if (threadId == RES_BAD_NUMBER) {

--- a/src/org/thoughtcrime/securesms/NewConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/NewConversationActivity.java
@@ -152,7 +152,7 @@ public class NewConversationActivity extends PassphraseRequiredActionBarActivity
   private void openNewConversation(Recipients recipients) {
     if (recipients != null) {
       Intent intent = new Intent(this, ConversationActivity.class);
-      intent.putExtra(ConversationActivity.RECIPIENTS_EXTRA, recipients.toIdString());
+      intent.putExtra(ConversationActivity.RECIPIENTS_EXTRA, recipients.getIds());
       intent.putExtra(ConversationActivity.MASTER_SECRET_EXTRA, masterSecret);
       intent.putExtra(ConversationActivity.DRAFT_TEXT_EXTRA, getIntent().getStringExtra(ConversationActivity.DRAFT_TEXT_EXTRA));
       intent.putExtra(ConversationActivity.DRAFT_AUDIO_EXTRA, getIntent().getParcelableExtra(ConversationActivity.DRAFT_AUDIO_EXTRA));

--- a/src/org/thoughtcrime/securesms/ReceiveKeyActivity.java
+++ b/src/org/thoughtcrime/securesms/ReceiveKeyActivity.java
@@ -41,6 +41,7 @@ import org.thoughtcrime.securesms.database.PushDatabase;
 import org.thoughtcrime.securesms.jobs.PushDecryptJob;
 import org.thoughtcrime.securesms.jobs.SmsDecryptJob;
 import org.thoughtcrime.securesms.recipients.Recipient;
+import org.thoughtcrime.securesms.recipients.RecipientFactory;
 import org.thoughtcrime.securesms.sms.IncomingIdentityUpdateMessage;
 import org.thoughtcrime.securesms.sms.IncomingKeyExchangeMessage;
 import org.thoughtcrime.securesms.sms.IncomingPreKeyBundleMessage;
@@ -123,7 +124,7 @@ public class ReceiveKeyActivity extends Activity {
       @Override
       public void onClick(View widget) {
         Intent intent = new Intent(ReceiveKeyActivity.this, VerifyIdentityActivity.class);
-        intent.putExtra("recipient", recipient);
+        intent.putExtra("recipient", recipient.getRecipientId());
         intent.putExtra("master_secret", masterSecret);
         intent.putExtra("remote_identity", new IdentityKeyParcelable(identityKey));
         startActivity(intent);
@@ -167,7 +168,7 @@ public class ReceiveKeyActivity extends Activity {
     this.descriptionText      = (TextView) findViewById(R.id.description_text);
     this.confirmButton        = (Button)   findViewById(R.id.ok_button);
     this.cancelButton         = (Button)   findViewById(R.id.cancel_button);
-    this.recipient            = getIntent().getParcelableExtra("recipient");
+    this.recipient            = RecipientFactory.getRecipientForId(this, getIntent().getLongExtra("recipient", -1), true);
     this.recipientDeviceId    = getIntent().getIntExtra("recipient_device_id", -1);
     this.messageId            = getIntent().getLongExtra("message_id", -1);
     this.masterSecret         = getIntent().getParcelableExtra("master_secret");

--- a/src/org/thoughtcrime/securesms/RoutingActivity.java
+++ b/src/org/thoughtcrime/securesms/RoutingActivity.java
@@ -129,7 +129,7 @@ public class RoutingActivity extends PassphraseRequiredActionBarActivity {
 
   private Intent getConversationIntent(ConversationParameters parameters) {
     Intent intent = new Intent(this, ConversationActivity.class);
-    intent.putExtra(ConversationActivity.RECIPIENTS_EXTRA, parameters.recipients != null ? parameters.recipients.toIdString() : "");
+    intent.putExtra(ConversationActivity.RECIPIENTS_EXTRA, parameters.recipients != null ? parameters.recipients.getIds() : new long[]{});
     intent.putExtra(ConversationActivity.THREAD_ID_EXTRA, parameters.thread);
     intent.putExtra(ConversationActivity.MASTER_SECRET_EXTRA, masterSecret);
     intent.putExtra(ConversationActivity.DRAFT_TEXT_EXTRA, parameters.draftText);
@@ -246,8 +246,9 @@ public class RoutingActivity extends PassphraseRequiredActionBarActivity {
   }
 
   private ConversationParameters getConversationParametersForInternalAction() {
-    long threadId         = getIntent().getLongExtra("thread_id", -1);
-    Recipients recipients = getIntent().getParcelableExtra("recipients");
+    long   threadId       = getIntent().getLongExtra("thread_id", -1);
+    long[] recipientIds   = getIntent().getLongArrayExtra("recipients");
+    Recipients recipients = recipientIds == null ? null : RecipientFactory.getRecipientsForIds(this, recipientIds, true);
 
     return new ConversationParameters(threadId, recipients, null, null, null, null);
   }

--- a/src/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/org/thoughtcrime/securesms/ShareActivity.java
@@ -120,7 +120,7 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity
 
   private void createConversation(long threadId, Recipients recipients, int distributionType) {
     final Intent intent = getBaseShareIntent(ConversationActivity.class);
-    intent.putExtra(ConversationActivity.RECIPIENTS_EXTRA, recipients.toIdString());
+    intent.putExtra(ConversationActivity.RECIPIENTS_EXTRA, recipients.getIds());
     intent.putExtra(ConversationActivity.THREAD_ID_EXTRA, threadId);
     intent.putExtra(ConversationActivity.DISTRIBUTION_TYPE_EXTRA, distributionType);
 

--- a/src/org/thoughtcrime/securesms/database/IdentityDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/IdentityDatabase.java
@@ -143,8 +143,8 @@ public class IdentityDatabase extends Database {
     }
 
     public Identity getCurrent() {
-      long recipientId      = cursor.getLong(cursor.getColumnIndexOrThrow(RECIPIENT));
-      Recipients recipients = RecipientFactory.getRecipientsForIds(context, recipientId + "", true);
+      long       recipientId = cursor.getLong(cursor.getColumnIndexOrThrow(RECIPIENT));
+      Recipients recipients  = RecipientFactory.getRecipientsForIds(context, new long[]{recipientId}, true);
 
       try {
         String identityKeyString = cursor.getString(cursor.getColumnIndexOrThrow(IDENTITY_KEY));

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -86,7 +86,7 @@ public class MessageNotifier {
     } else {
       Intent intent = new Intent(context, RoutingActivity.class);
       intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-      intent.putExtra("recipients", recipients);
+      intent.putExtra("recipients", recipients.getIds());
       intent.putExtra("thread_id", threadId);
       intent.setData((Uri.parse("custom://"+System.currentTimeMillis())));
 

--- a/src/org/thoughtcrime/securesms/notifications/NotificationItem.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationItem.java
@@ -74,8 +74,8 @@ public class NotificationItem {
     intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
 
     if (recipients != null || threadRecipients != null) {
-      if (threadRecipients != null) intent.putExtra("recipients", threadRecipients);
-      else                          intent.putExtra("recipients", recipients);
+      if (threadRecipients != null) intent.putExtra("recipients", threadRecipients.getIds());
+      else                          intent.putExtra("recipients", recipients.getIds());
 
       intent.putExtra("thread_id", threadId);
     }

--- a/src/org/thoughtcrime/securesms/push/SecurityEventListener.java
+++ b/src/org/thoughtcrime/securesms/push/SecurityEventListener.java
@@ -20,10 +20,9 @@ public class SecurityEventListener implements TextSecureMessageSender.EventListe
 
   @Override
   public void onSecurityEvent(long recipientId) {
-    Recipients recipients = RecipientFactory.getRecipientsForIds(context, String.valueOf(recipientId), false);
+    Recipients recipients = RecipientFactory.getRecipientsForIds(context, new long[]{recipientId}, false);
     long       threadId   = DatabaseFactory.getThreadDatabase(context).getThreadIdFor(recipients);
 
     SecurityEvent.broadcastSecurityUpdateEvent(context, threadId);
   }
-
 }

--- a/src/org/thoughtcrime/securesms/recipients/Recipient.java
+++ b/src/org/thoughtcrime/securesms/recipients/Recipient.java
@@ -19,8 +19,6 @@ package org.thoughtcrime.securesms.recipients;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.net.Uri;
-import android.os.Parcel;
-import android.os.Parcelable;
 import android.util.Log;
 
 import org.thoughtcrime.securesms.contacts.ContactPhotoFactory;
@@ -31,19 +29,9 @@ import org.thoughtcrime.securesms.util.ListenableFutureTask;
 
 import java.util.HashSet;
 
-public class Recipient implements Parcelable {
+public class Recipient {
 
   private final static String TAG = Recipient.class.getSimpleName();
-
-  public static final Parcelable.Creator<Recipient> CREATOR = new Parcelable.Creator<Recipient>() {
-    public Recipient createFromParcel(Parcel in) {
-      return new Recipient(in);
-    }
-
-    public Recipient[] newArray(int size) {
-      return new Recipient[size];
-    }
-  };
 
   private final HashSet<RecipientModifiedListener> listeners = new HashSet<RecipientModifiedListener>();
 
@@ -107,14 +95,6 @@ public class Recipient implements Parcelable {
     this.circleCroppedContactPhoto  = circleCroppedContactPhoto;
   }
 
-  public Recipient(Parcel in) {
-    this.number       = in.readString();
-    this.name         = in.readString();
-    this.recipientId  = in.readLong();
-    this.contactUri   = in.readParcelable(null);
-    this.contactPhoto = in.readParcelable(null);
-  }
-
   public synchronized Uri getContactUri() {
     return this.contactUri;
   }
@@ -135,10 +115,6 @@ public class Recipient implements Parcelable {
 
   public String getNumber() {
     return number;
-  }
-
-  public int describeContents() {
-    return 0;
   }
 
   public long getRecipientId() {
@@ -167,14 +143,6 @@ public class Recipient implements Parcelable {
     for (RecipientModifiedListener listener : localListeners) {
       listener.onModified(this);
     }
-  }
-
-  public synchronized void writeToParcel(Parcel dest, int flags) {
-    dest.writeString(number);
-    dest.writeString(name);
-    dest.writeLong(recipientId);
-    dest.writeParcelable(contactUri, 0);
-    dest.writeParcelable(contactPhoto, 0);
   }
 
   public synchronized String toShortString() {

--- a/src/org/thoughtcrime/securesms/recipients/RecipientFactory.java
+++ b/src/org/thoughtcrime/securesms/recipients/RecipientFactory.java
@@ -23,6 +23,7 @@ import android.util.Log;
 import org.thoughtcrime.securesms.contacts.ContactPhotoFactory;
 import org.thoughtcrime.securesms.database.CanonicalAddressDatabase;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.StringTokenizer;
@@ -35,16 +36,29 @@ public class RecipientFactory {
     if (TextUtils.isEmpty(recipientIds))
       return new Recipients(new LinkedList<Recipient>());
 
-    List<Recipient> results   = new LinkedList<Recipient>();
+    List<Recipient> results   = new LinkedList<>();
     StringTokenizer tokenizer = new StringTokenizer(recipientIds.trim(), " ");
 
     while (tokenizer.hasMoreTokens()) {
       String recipientId  = tokenizer.nextToken();
-      Recipient recipient = getRecipientFromProviderId(context, recipientId, asynchronous);
+      Recipient recipient = getRecipientFromProviderId(context, Long.parseLong(recipientId), asynchronous);
 
       results.add(recipient);
     }
 
+    return new Recipients(results);
+  }
+
+  public static Recipient getRecipientForId(Context context, long recipientId, boolean asynchronous) {
+    return getRecipientFromProviderId(context, recipientId, asynchronous);
+  }
+
+  public static Recipients getRecipientsForIds(Context context, long[] recipientIds, boolean asynchronous) {
+    List<Recipient> results = new LinkedList<>();
+    if (recipientIds == null) return new Recipients(results);
+    for (long recipientId : recipientIds) {
+      results.add(getRecipientFromProviderId(context, recipientId, asynchronous));
+    }
     return new Recipients(results);
   }
 
@@ -72,9 +86,9 @@ public class RecipientFactory {
     return new Recipients(results);
   }
 
-  private static Recipient getRecipientFromProviderId(Context context, String recipientId, boolean asynchronous) {
+  private static Recipient getRecipientFromProviderId(Context context, long recipientId, boolean asynchronous) {
     try {
-      return provider.getRecipient(context, Long.parseLong(recipientId), asynchronous);
+      return provider.getRecipient(context, recipientId, asynchronous);
     } catch (NumberFormatException e) {
       Log.w("RecipientFactory", e);
       return Recipient.getUnknownRecipient(context);

--- a/src/org/thoughtcrime/securesms/recipients/Recipients.java
+++ b/src/org/thoughtcrime/securesms/recipients/Recipients.java
@@ -16,8 +16,6 @@
  */
 package org.thoughtcrime.securesms.recipients;
 
-import android.os.Parcel;
-import android.os.Parcelable;
 import android.util.Patterns;
 
 import org.thoughtcrime.securesms.recipients.Recipient.RecipientModifiedListener;
@@ -30,18 +28,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
-public class Recipients implements Parcelable {
-
-  public static final Parcelable.Creator<Recipients> CREATOR = new Parcelable.Creator<Recipients>() {
-    public Recipients createFromParcel(Parcel in) {
-      return new Recipients(in);
-    }
-
-    public Recipients[] newArray(int size) {
-      return new Recipients[size];
-    }
-  };
-
+public class Recipients {
 
   private List<Recipient> recipients;
 
@@ -53,11 +40,6 @@ public class Recipients implements Parcelable {
     this.recipients = new LinkedList<Recipient>() {{
       add(recipient);
     }};
-  }
-
-  public Recipients(Parcel in) {
-    this.recipients = new ArrayList<Recipient>();
-    in.readTypedList(recipients, Recipient.CREATOR);
   }
 
   public void append(Recipients recipients) {
@@ -138,14 +120,12 @@ public class Recipients implements Parcelable {
     return this.recipients;
   }
 
-  public String toIdString() {
-    List<String> ids = new LinkedList<String>();
-
-    for (Recipient recipient : recipients) {
-      ids.add(String.valueOf(recipient.getRecipientId()));
+  public long[] getIds() {
+    long[] ids = new long[recipients.size()];
+    for (int i=0; i<recipients.size(); i++) {
+      ids[i] = recipients.get(i).getRecipientId();
     }
-
-    return Util.join(ids, " ");
+    return ids;
   }
 
   public String[] toNumberStringArray(boolean scrub) {
@@ -184,9 +164,5 @@ public class Recipients implements Parcelable {
 
   public int describeContents() {
     return 0;
-  }
-
-  public void writeToParcel(Parcel dest, int flags) {
-    dest.writeTypedList(recipients);
   }
 }


### PR DESCRIPTION
Also move toward passing recipient ids as the longs they were born as instead of going back and forth from Strings.

This could also tangentially solve most of the issues with recipients not updating properly since they were cloned and marshalled into a Parcel. And, most importantly, this is a net :small_red_triangle_down: diff.

Fixes #2233, as recipient objects including their photos are no longer put into a parcel.
