### PR TITLE
remove pointless Bitmap allocation for ImageSlides

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -826,7 +826,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
   private void addAttachmentImage(Uri imageUri) {
     try {
-      attachmentManager.setImage(masterSecret, imageUri);
+      attachmentManager.setImage(imageUri);
     } catch (IOException | BitmapDecodingException e) {
       Log.w(TAG, e);
       attachmentManager.clear();

--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -64,8 +64,8 @@ public class AttachmentManager {
     attachmentListener.onAttachmentChanged();
   }
 
-  public void setImage(MasterSecret masterSecret, Uri image) throws IOException, BitmapDecodingException {
-    setMedia(new ImageSlide(context, masterSecret, image), 345, 261);
+  public void setImage(Uri image) throws IOException, BitmapDecodingException {
+    setMedia(new ImageSlide(context, image), 345, 261);
   }
 
   public void setVideo(Uri video) throws IOException, MediaTooLargeException {

--- a/src/org/thoughtcrime/securesms/mms/ImageSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/ImageSlide.java
@@ -62,8 +62,8 @@ public class ImageSlide extends Slide {
     super(context, masterSecret, part);
   }
 
-  public ImageSlide(Context context, MasterSecret masterSecret, Uri uri) throws IOException, BitmapDecodingException {
-    super(context, constructPartFromUri(context, masterSecret, uri));
+  public ImageSlide(Context context, Uri uri) throws IOException, BitmapDecodingException {
+    super(context, constructPartFromUri(uri));
   }
 
   @Override
@@ -190,13 +190,11 @@ public class ImageSlide extends Slide {
     return SmilUtil.createMediaElement("img", document, new String(getPart().getName()));
   }
 
-  private static PduPart constructPartFromUri(Context context, MasterSecret masterSecret, Uri uri)
+  private static PduPart constructPartFromUri(Uri uri)
       throws IOException, BitmapDecodingException
   {
     PduPart part = new PduPart();
-    byte[] data  = BitmapUtil.createScaledBytes(context, masterSecret, uri, 1280, 1280, MAX_MESSAGE_SIZE);
 
-    part.setData(data);
     part.setDataUri(uri);
     part.setContentType(ContentType.IMAGE_JPEG.getBytes());
     part.setContentId((System.currentTimeMillis()+"").getBytes());


### PR DESCRIPTION
The MMS send job sets the data as necessary, so this is unused and causing unnecessary memory contention.
