### PR TITLE
Remove native components from build instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -30,20 +30,6 @@ The following steps should help you (re)build TextSecure from the command line.
 
         ./gradlew build
 
-Re-building native components
------------------------------
-
-Note: This step is optional; native components are contained as binaries (see [libaxolotl/libs](libaxolotl/libs)).
-
-1. Ensure that the Android NDK is installed.
-
-Execute ndk-build:
-
-    cd libaxolotl
-    ndk-build
-
-Afterwards, execute Gradle as above to re-create the APK.
-
 Setting up a development environment
 ------------------------------------
 


### PR DESCRIPTION
Native components were split out into the libaxolotl-android repository in
1833e57, so these instructions are no longer relevant.
