### PR TITLE
Improve TransportOption strings, landscape message composition

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -131,8 +131,8 @@
     <string name="ConversationActivity_this_device_does_not_appear_to_support_dial_actions">This device does not appear to support dial actions.</string>
     <string name="ConversationActivity_leave_group">Leave group?</string>
     <string name="ConversationActivity_are_you_sure_you_want_to_leave_this_group">Are you sure you want to leave this group?</string>
-    <string name="ConversationActivity_transport_insecure_sms">Insecure SMS</string>
-    <string name="ConversationActivity_transport_insecure_mms">Insecure MMS</string>
+    <string name="ConversationActivity_transport_unsecured_sms">Unsecured SMS</string>
+    <string name="ConversationActivity_transport_unsecured_mms">Unsecured MMS</string>
     <string name="ConversationActivity_transport_signal">Signal</string>
     <string name="ConversationActivity_lets_switch_to_signal">Let\'s switch to Signal %1$s</string>
     <string name="ConversationActivity_lets_use_this_to_chat">Let\'s use this to chat: %1$s</string>
@@ -661,9 +661,12 @@
     <string name="conversation_title_view__conversation_muted">Conversation muted</string>
 
     <!-- conversation_activity -->
-    <string name="conversation_activity__type_message_push">Send Signal message</string>
-    <string name="conversation_activity__type_message_sms_insecure">Send unsecured SMS</string>
-    <string name="conversation_activity__type_message_mms_insecure">Send unsecured MMS</string>
+    <string name="conversation_activity__enter_signal_message">Enter Signal message</string>
+    <string name="conversation_activity__enter_unsecured_sms">Enter unsecured SMS</string>
+    <string name="conversation_activity__enter_unsecured_mms">Enter unsecured MMS</string>
+    <string name="conversation_activity__send_signal_message">Send\nSignal\nmessage</string>
+    <string name="conversation_activity__send_unsecured_sms">Send\nunsecured\nSMS</string>
+    <string name="conversation_activity__send_unsecured_mms">Send\nunsecured\nMMS</string>
     <string name="conversation_activity__from_sim_name">From %1$s</string>
     <string name="conversation_activity__send">Send</string>
     <string name="conversation_activity__remove">Remove</string>

--- a/src/org/thoughtcrime/securesms/TransportOption.java
+++ b/src/org/thoughtcrime/securesms/TransportOption.java
@@ -19,6 +19,7 @@ public class TransportOption {
   private final @NonNull String                 text;
   private final @NonNull Type                   type;
   private final @NonNull String                 composeHint;
+  private final @NonNull String                 imeActionLabel;
   private final @NonNull CharacterCalculator    characterCalculator;
   private final @NonNull Optional<CharSequence> simName;
   private final @NonNull Optional<Integer>      simSubscriptionId;
@@ -28,9 +29,10 @@ public class TransportOption {
                          int backgroundColor,
                          @NonNull String text,
                          @NonNull String composeHint,
+                         @NonNull String imeActionLabel,
                          @NonNull CharacterCalculator characterCalculator)
   {
-    this(type, drawable, backgroundColor, text, composeHint, characterCalculator,
+    this(type, drawable, backgroundColor, text, composeHint, imeActionLabel, characterCalculator,
          Optional.<CharSequence>absent(), Optional.<Integer>absent());
   }
 
@@ -39,6 +41,7 @@ public class TransportOption {
                          int backgroundColor,
                          @NonNull String text,
                          @NonNull String composeHint,
+                         @NonNull String imeActionLabel,
                          @NonNull CharacterCalculator characterCalculator,
                          @NonNull Optional<CharSequence> simName,
                          @NonNull Optional<Integer> simSubscriptionId)
@@ -48,6 +51,7 @@ public class TransportOption {
     this.backgroundColor     = backgroundColor;
     this.text                = text;
     this.composeHint         = composeHint;
+    this.imeActionLabel      = imeActionLabel;
     this.characterCalculator = characterCalculator;
     this.simName             = simName;
     this.simSubscriptionId   = simSubscriptionId;
@@ -80,6 +84,10 @@ public class TransportOption {
 
   public @NonNull String getComposeHint() {
     return composeHint;
+  }
+
+  public @NonNull String getImeActionLabel() {
+    return imeActionLabel;
   }
 
   public @NonNull String getDescription() {

--- a/src/org/thoughtcrime/securesms/TransportOptions.java
+++ b/src/org/thoughtcrime/securesms/TransportOptions.java
@@ -121,19 +121,22 @@ public class TransportOptions {
     List<TransportOption> results = new LinkedList<>();
 
     if (isMediaMessage) {
-      results.addAll(getTransportOptionsForSimCards(context.getString(R.string.ConversationActivity_transport_insecure_mms),
-                                                    context.getString(R.string.conversation_activity__type_message_mms_insecure),
+      results.addAll(getTransportOptionsForSimCards(context.getString(R.string.ConversationActivity_transport_unsecured_mms),
+                                                    context.getString(R.string.conversation_activity__enter_unsecured_mms),
+                                                    context.getString(R.string.conversation_activity__send_unsecured_mms),
                                                     new MmsCharacterCalculator()));
     } else {
-      results.addAll(getTransportOptionsForSimCards(context.getString(R.string.ConversationActivity_transport_insecure_sms),
-                                                    context.getString(R.string.conversation_activity__type_message_sms_insecure),
+      results.addAll(getTransportOptionsForSimCards(context.getString(R.string.ConversationActivity_transport_unsecured_sms),
+                                                    context.getString(R.string.conversation_activity__enter_unsecured_sms),
+                                                    context.getString(R.string.conversation_activity__send_unsecured_sms),
                                                     new SmsCharacterCalculator()));
     }
 
     results.add(new TransportOption(Type.TEXTSECURE, R.drawable.ic_send_push_white_24dp,
                                     context.getResources().getColor(R.color.textsecure_primary),
                                     context.getString(R.string.ConversationActivity_transport_signal),
-                                    context.getString(R.string.conversation_activity__type_message_push),
+                                    context.getString(R.string.conversation_activity__enter_signal_message),
+                                    context.getString(R.string.conversation_activity__send_signal_message),
                                     new PushCharacterCalculator()));
 
     return results;
@@ -141,6 +144,7 @@ public class TransportOptions {
 
   private @NonNull List<TransportOption> getTransportOptionsForSimCards(@NonNull String text,
                                                                         @NonNull String composeHint,
+                                                                        @NonNull String imeActionLabel,
                                                                         @NonNull CharacterCalculator characterCalculator)
   {
     List<TransportOption>        results             = new LinkedList<>();
@@ -150,12 +154,12 @@ public class TransportOptions {
     if (subscriptions.size() < 2) {
       results.add(new TransportOption(Type.SMS, R.drawable.ic_send_sms_white_24dp,
                                       context.getResources().getColor(R.color.grey_600),
-                                      text, composeHint, characterCalculator));
+                                      text, composeHint, imeActionLabel, characterCalculator));
     } else {
       for (SubscriptionInfoCompat subscriptionInfo : subscriptions) {
         results.add(new TransportOption(Type.SMS, R.drawable.ic_send_sms_white_24dp,
                                         context.getResources().getColor(R.color.grey_600),
-                                        text, composeHint, characterCalculator,
+                                        text, composeHint, imeActionLabel, characterCalculator,
                                         Optional.of(subscriptionInfo.getDisplayName()),
                                         Optional.of(subscriptionInfo.getSubscriptionId())));
       }

--- a/src/org/thoughtcrime/securesms/components/ComposeText.java
+++ b/src/org/thoughtcrime/securesms/components/ComposeText.java
@@ -98,7 +98,7 @@ public class ComposeText extends EmojiEditText {
     int imeOptions = (getImeOptions() & ~EditorInfo.IME_MASK_ACTION) | EditorInfo.IME_ACTION_SEND;
     int inputType  = getInputType();
 
-    if (isLandscape()) setImeActionLabel(transport.getComposeHint(), EditorInfo.IME_ACTION_SEND);
+    if (isLandscape()) setImeActionLabel(transport.getImeActionLabel(), EditorInfo.IME_ACTION_SEND);
     else               setImeActionLabel(null, 0);
 
     if (useSystemEmoji) {


### PR DESCRIPTION
Fixes #4786 

**Before:**
![before](https://cloud.githubusercontent.com/assets/11031903/12300735/2696c346-ba60-11e5-9bb3-edb6cc633794.png)

**After:**
![after](https://cloud.githubusercontent.com/assets/11031903/12300741/2c1ef6da-ba60-11e5-9ae9-17b9cfe27bc6.png)

Used "enter" instead of "type" to accommodate alternate input methods (speech-to-text, etc.), as in other apps.  @RiseT, please let me know what you think.

Also made TransportOption strings more consistent with other strings by replacing "insecure" with "unsecured".
