### PR TITLE
Add Unicode Stripping for SMS

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -999,6 +999,8 @@
     <string name="preferences__mmsc_password">MMSC Password</string>
     <string name="preferences__sms_delivery_reports">SMS delivery reports</string>
     <string name="preferences__request_a_delivery_report_for_each_sms_message_you_send">Request a delivery report for each SMS message you send</string>
+    <string name="preferences__sms_unicode_stripping">Simple characters only</string>
+    <string name="preferences__strip_all_unicode_characters">Convert special characters in SMS messages you send</string>
     <string name="preferences__automatically_delete_older_messages_once_a_conversation_exceeds_a_specified_length">Automatically delete older messages once a conversation exceeds a specified length</string>
     <string name="preferences__delete_old_messages">Delete old messages</string>
     <string name="preferences__chats">Chats and media</string>

--- a/res/xml/preferences_sms_mms.xml
+++ b/res/xml/preferences_sms_mms.xml
@@ -25,6 +25,12 @@
 
     <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
                         android:defaultValue="false"
+                        android:key="pref_unicode_stripping_sms"
+                        android:summary="@string/preferences__strip_all_unicode_characters"
+                        android:title="@string/preferences__sms_unicode_stripping" />
+
+    <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+                        android:defaultValue="false"
                         android:key="pref_wifi_sms"
                         android:title="@string/preferences__support_wifi_calling"
                         android:summary="@string/preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi"/>

--- a/src/org/thoughtcrime/securesms/jobs/SmsSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/SmsSendJob.java
@@ -23,11 +23,14 @@ import org.thoughtcrime.securesms.service.SmsDeliveryListener;
 import org.thoughtcrime.securesms.transport.UndeliverableMessageException;
 import org.thoughtcrime.securesms.util.NumberUtil;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
+import org.thoughtcrime.securesms.util.UnicodeFilter;
 import org.whispersystems.jobqueue.JobParameters;
 
 import java.util.ArrayList;
 
 public class SmsSendJob extends SendJob {
+
+  private static final long serialVersionUID = 0L;
 
   private static final String TAG = SmsSendJob.class.getSimpleName();
 
@@ -75,6 +78,14 @@ public class SmsSendJob extends SendJob {
     MessageNotifier.notifyMessageDeliveryFailed(context, recipients, threadId);
   }
 
+  private String getMessageBody(String body) {
+    if (TextSecurePreferences.isUnicodeStrippingEnabled(context)) {
+      return UnicodeFilter.filter(body);
+    } else {
+      return body;
+    }
+  }
+
   private void deliver(SmsMessageRecord message)
       throws UndeliverableMessageException
   {
@@ -96,7 +107,7 @@ public class SmsSendJob extends SendJob {
       throw new UndeliverableMessageException("Not a valid SMS destination! " + recipient);
     }
 
-    ArrayList<String> messages                = SmsManager.getDefault().divideMessage(message.getBody().getBody());
+    ArrayList<String> messages                = SmsManager.getDefault().divideMessage(getMessageBody(message.getBody().getBody()));
     ArrayList<PendingIntent> sentIntents      = constructSentIntents(message.getId(), message.getType(), messages, false);
     ArrayList<PendingIntent> deliveredIntents = constructDeliveredIntents(message.getId(), message.getType(), messages);
 

--- a/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -60,6 +60,7 @@ public class TextSecurePreferences {
   private static final String ENTER_SENDS_PREF                 = "pref_enter_sends";
   private static final String ENTER_PRESENT_PREF               = "pref_enter_key";
   private static final String SMS_DELIVERY_REPORT_PREF         = "pref_delivery_report_sms";
+  private static final String SMS_UNICODE_STRIPPING_PREF       = "pref_unicode_stripping_sms";
   public  static final String MMS_USER_AGENT                   = "pref_mms_user_agent";
   private static final String MMS_CUSTOM_USER_AGENT            = "pref_custom_mms_user_agent";
   private static final String THREAD_TRIM_ENABLED              = "pref_trim_threads";
@@ -422,6 +423,10 @@ public class TextSecurePreferences {
 
   public static boolean isSmsDeliveryReportsEnabled(Context context) {
     return getBooleanPreference(context, SMS_DELIVERY_REPORT_PREF, false);
+  }
+
+  public static boolean isUnicodeStrippingEnabled(Context context) {
+    return getBooleanPreference(context, SMS_UNICODE_STRIPPING_PREF, false);
   }
 
   public static boolean hasPromptedPushRegistration(Context context) {

--- a/src/org/thoughtcrime/securesms/util/UnicodeFilter.java
+++ b/src/org/thoughtcrime/securesms/util/UnicodeFilter.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2012-2016 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.thoughtcrime.securesms.util;
+
+import java.text.Normalizer;
+import java.util.regex.Pattern;
+
+/**
+ * Attempts to substitute characters that cannot be encoded in the limited
+ * GSM 03.38 character set. In many cases this will prevent sending a message
+ * containing characters that would switch the message from 7-bit GSM
+ * encoding (160 char limit) to 16-bit Unicode encoding (70 char limit).
+ */
+public class UnicodeFilter {
+    private static final Pattern DIACRITICS_PATTERN =
+            Pattern.compile("\\p{InCombiningDiacriticalMarks}");
+
+    public static String filter(String source) {
+        StringBuilder output = new StringBuilder();
+        final int sourceLength = source.length();
+
+        for (int i = 0; i < sourceLength; i++) {
+            String s = String.valueOf(source.charAt(i));
+
+            // Try normalizing the character into Unicode NFKD form and
+            // stripping out diacritic mark characters.
+            s = Normalizer.normalize(s, Normalizer.Form.NFKD);
+            s = DIACRITICS_PATTERN.matcher(s).replaceAll("");
+
+            // Special case characters that don't get stripped by the
+            // above technique.
+            s = s.replace("Œ", "OE");
+            s = s.replace("œ", "oe");
+            s = s.replace("Ł", "L");
+            s = s.replace("ł", "l");
+            s = s.replace("Đ", "Dj");
+            s = s.replace("đ", "dj");
+            s = s.replace("Α", "A");
+            s = s.replace("Β", "B");
+            s = s.replace("Ε", "E");
+            s = s.replace("Ζ", "Z");
+            s = s.replace("Η", "H");
+            s = s.replace("Ι", "I");
+            s = s.replace("Κ", "K");
+            s = s.replace("Μ", "M");
+            s = s.replace("Ν", "N");
+            s = s.replace("Ο", "O");
+            s = s.replace("Ρ", "P");
+            s = s.replace("Τ", "T");
+            s = s.replace("Υ", "Y");
+            s = s.replace("Χ", "X");
+            s = s.replace("α", "A");
+            s = s.replace("β", "B");
+            s = s.replace("γ", "Γ");
+            s = s.replace("δ", "Δ");
+            s = s.replace("ε", "E");
+            s = s.replace("ζ", "Z");
+            s = s.replace("η", "H");
+            s = s.replace("θ", "Θ");
+            s = s.replace("ι", "I");
+            s = s.replace("κ", "K");
+            s = s.replace("λ", "Λ");
+            s = s.replace("μ", "M");
+            s = s.replace("ν", "N");
+            s = s.replace("ξ", "Ξ");
+            s = s.replace("ο", "O");
+            s = s.replace("π", "Π");
+            s = s.replace("ρ", "P");
+            s = s.replace("σ", "Σ");
+            s = s.replace("τ", "T");
+            s = s.replace("υ", "Y");
+            s = s.replace("φ", "Φ");
+            s = s.replace("χ", "X");
+            s = s.replace("ψ", "Ψ");
+            s = s.replace("ω", "Ω");
+            s = s.replace("ς", "Σ");
+            output.append(s);
+        }
+
+        return output.toString();
+    }
+}


### PR DESCRIPTION
Adds a functionality for stripping unicode characters for unencrypted sms messages only. Signal messages are always intact.
I grabbed UnicodeFilter class from CyanogenMod and modified it a bit and therefore I left their licence as it was.
