### PR TITLE
Set hint before input type to display correctly in fullscreen IME

### DIFF
--- a/src/org/thoughtcrime/securesms/components/ComposeText.java
+++ b/src/org/thoughtcrime/securesms/components/ComposeText.java
@@ -113,11 +113,11 @@ public class ComposeText extends EmojiEditText {
                ? imeOptions & ~EditorInfo.IME_FLAG_NO_ENTER_ACTION
                : imeOptions | EditorInfo.IME_FLAG_NO_ENTER_ACTION;
 
-    setInputType(inputType);
     setImeOptions(imeOptions);
     setHint(transport.getComposeHint(),
             transport.getSimName().isPresent()
                 ? getContext().getString(R.string.conversation_activity__from_sim_name, transport.getSimName().get())
                 : null);
+    setInputType(inputType);
   }
 }


### PR DESCRIPTION
### Contributor checklist

<!-- mark with x between the brackets -->
- [X] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
  - Nexus 5, Android 6.0.1
- [X] My contribution is fully baked and ready to be merged as is
- [X] I have made the choice whether I want the Bithub reward or not by omitting or adding the word `FREEBIE` in my commit message

---
### Description

Fixes #5294
// FREEBIE

Strange framework bug results in landscape fullscreen IME's displaying previous hint text rather than the current hint text. Calling `setHint(CharSequence)` before `setInputType(int)` seems to work around the bug with no ill effects.

Related
https://code.google.com/p/android/issues/detail?id=170596
