### PR TITLE
Hide message text of blocked contacts

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -574,6 +574,7 @@
 
     <!-- ThreadRecord -->
     <string name="ThreadRecord_group_updated">Group updated</string>
+    <string name="ThreadRecord_blocked">Blocked</string>
     <string name="ThreadRecord_left_the_group">Left the group</string>
     <string name="ThreadRecord_secure_session_reset">Secure session reset.</string>
     <string name="ThreadRecord_draft">Draft:</string>

--- a/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
@@ -72,7 +72,9 @@ public class ThreadRecord extends DisplayRecord {
 
   @Override
   public SpannableString getDisplayBody() {
-    if (SmsDatabase.Types.isDecryptInProgressType(type)) {
+    if (this.getRecipient().isBlocked()) {
+      return emphasisAdded(context.getString(R.string.ThreadRecord_blocked));
+    } else if (SmsDatabase.Types.isDecryptInProgressType(type)) {
       return emphasisAdded(context.getString(R.string.MessageDisplayHelper_decrypting_please_wait));
     } else if (isGroupUpdate()) {
       return emphasisAdded(context.getString(R.string.ThreadRecord_group_updated));


### PR DESCRIPTION
### Contributor checklist

<!-- mark with x between the brackets -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
  - HTC Sensation XE
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the Bithub reward or not by omitting or adding the word `FREEBIE` in my commit message

---
### Description

Fixes #4237
- hide message text, delivery status and thumbnail

**before:**
![blocked_before](https://cloud.githubusercontent.com/assets/3845150/13976987/4568a514-f0c5-11e5-91cc-503632608e50.png)

**after:**
![blocked_after](https://cloud.githubusercontent.com/assets/3845150/13976991/54fcf318-f0c5-11e5-84bf-4b8d17af689e.png)

// FREEBIE
