### PR TITLE
Color new conversation button lighter

### DIFF
--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -109,9 +109,9 @@
         <item name="actionBarTabBarStyle">@style/TextSecure.LightActionBar.TabBar</item>
         <item name="colorPrimary">@color/textsecure_primary</item>
         <item name="colorPrimaryDark">@color/textsecure_primary_dark</item>
-        <item name="colorAccent">@color/textsecure_primary_dark</item>
+        <item name="colorAccent">@color/signal_primary</item>
         <item name="colorControlActivated">@color/signal_primary</item>
-        <item name="colorControlHighlight">@color/signal_primary</item>
+        <item name="colorControlHighlight">@color/signal_primary_dark</item>
         <item name="android:windowBackground">@color/white</item>
         <item name="alertDialogTheme">@style/AppCompatAlertDialogStyleLight</item>
         <item name="android:alertDialogTheme">@style/AppCompatDialogStyleLight</item>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -235,7 +235,7 @@
         <item name="actionBarPopupTheme">@style/ThemeOverlay.AppCompat.Dark</item>
         <item name="android:textColor">@color/text_color_dark_theme</item>
         <item name="android:textColorSecondary">@color/text_color_secondary_dark_theme</item>
-        <item name="colorAccent">@color/textsecure_primary_dark</item>
+        <item name="colorAccent">@color/signal_primary</item>
         <item name="colorControlActivated">@color/signal_primary_dark</item>
         <item name="colorControlHighlight">@color/signal_primary_dark</item>
         <item name="android:windowBackground">@color/black</item>


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
  - Sony Xperia U, Android 4.4.4 (screenshots)
  - AVD: Nexus 5, Android 6.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

---
### Description

Fixes #5034 

It's a design decision I made, that the button in dark theme is light, too. I thought, it would be nice to have this animation when pressed. Without the dark coloring there would be no animation.
### Screenshots

before
![before_dark-button](https://cloud.githubusercontent.com/assets/16167751/14227543/ae8a2fc0-f900-11e5-8970-51df8080070d.gif) ![before_light-button](https://cloud.githubusercontent.com/assets/16167751/14227545/b53ac2f8-f900-11e5-967f-92519992e27c.gif)
after
![after_dark-button](https://cloud.githubusercontent.com/assets/16167751/14227548/c191617e-f900-11e5-8129-7f8b36de9eeb.gif) ![after_light-button](https://cloud.githubusercontent.com/assets/16167751/14227549/c4320adc-f900-11e5-9634-295a4f31399c.gif)

EDIT:
side effects:
- buttons when pressed show darker blue (not all Android Versions, 4.4 here)
  ![invite](https://cloud.githubusercontent.com/assets/16167751/14227794/992c699a-f905-11e5-89c0-3079999e8593.gif)
- ripples in settings are darker (thanks for testing, @agrajaghh)
