### PR TITLE
Use ACTION_GET_CONTENT for attachment picking on all platforms

### DIFF
--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -23,7 +23,6 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.provider.ContactsContract;
 import android.provider.MediaStore;
 import android.support.annotation.NonNull;
@@ -55,6 +54,7 @@ import org.thoughtcrime.securesms.util.concurrent.ListenableFuture.Listener;
 import org.whispersystems.libsignal.util.guava.Optional;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -174,12 +174,73 @@ public class AttachmentManager {
                        @NonNull final MediaType mediaType,
                        @NonNull final MediaConstraints constraints)
   {
-    new AsyncTask<Void, Void, Slide>() {
+    if (MediaUtil.isPersistent(uri)) setMediaWithPersistentUri(masterSecret, uri, mediaType, constraints, true);
+    else                             setMediaWithNonPersistentUri(masterSecret, uri, mediaType, constraints);
+  }
+
+  private void setMediaWithNonPersistentUri(@NonNull final MasterSecret masterSecret,
+                                            @NonNull final Uri uri,
+                                            @NonNull final MediaType mediaType,
+                                            @NonNull final MediaConstraints constraints)
+  {
+    new AsyncTask<Void, Void, InputStream>() {
       @Override
       protected void onPreExecute() {
         thumbnail.clear();
         thumbnail.showProgressSpinner();
         attachmentView.setVisibility(View.VISIBLE);
+      }
+
+      @Override
+      protected InputStream doInBackground(Void... params) {
+        try {
+          return context.getContentResolver().openInputStream(uri);
+        } catch (IOException ioe) {
+          Log.w(TAG, ioe);
+          return null;
+        }
+      }
+
+      @Override
+      protected void onPostExecute(InputStream result) {
+        final String mimeType = MediaUtil.getMimeType(context, uri);
+        if (result == null || mimeType == null) {
+          abortAttachment(context.getString(R.string.ConversationActivity_sorry_there_was_an_error_setting_your_attachment));
+          return;
+        }
+
+        ListenableFuture<Uri> future = PersistentBlobProvider.getInstance(context)
+                                                             .create(masterSecret, result, mimeType);
+
+        future.addListener(new ListenableFuture.Listener<Uri>() {
+          @Override
+          public void onSuccess(Uri result) {
+            setMediaWithPersistentUri(masterSecret, result, mediaType, constraints, false);
+          }
+
+          @Override
+          public void onFailure(ExecutionException e) {
+            abortAttachment(context.getString(R.string.ConversationActivity_sorry_there_was_an_error_setting_your_attachment));
+          }
+        });
+      }
+    }.execute();
+  }
+
+  private void setMediaWithPersistentUri(@NonNull final MasterSecret masterSecret,
+                                         @NonNull final Uri uri,
+                                         @NonNull final MediaType mediaType,
+                                         @NonNull final MediaConstraints constraints,
+                                                  final boolean initThumbnail)
+  {
+    new AsyncTask<Void, Void, Slide>() {
+      @Override
+      protected void onPreExecute() {
+        if (initThumbnail) {
+          thumbnail.clear();
+          thumbnail.showProgressSpinner();
+          attachmentView.setVisibility(View.VISIBLE);
+        }
       }
 
       @Override
@@ -199,15 +260,9 @@ public class AttachmentManager {
       @Override
       protected void onPostExecute(@Nullable final Slide slide) {
         if (slide == null) {
-          attachmentView.setVisibility(View.GONE);
-          Toast.makeText(context,
-                         R.string.ConversationActivity_sorry_there_was_an_error_setting_your_attachment,
-                         Toast.LENGTH_SHORT).show();
+          abortAttachment(context.getString(R.string.ConversationActivity_sorry_there_was_an_error_setting_your_attachment));
         } else if (!areConstraintsSatisfied(context, masterSecret, slide, constraints)) {
-          attachmentView.setVisibility(View.GONE);
-          Toast.makeText(context,
-                         R.string.ConversationActivity_attachment_exceeds_size_limits,
-                         Toast.LENGTH_SHORT).show();
+          abortAttachment(context.getString(R.string.ConversationActivity_attachment_exceeds_size_limits));
         } else {
           setSlide(slide);
           attachmentView.setVisibility(View.VISIBLE);
@@ -224,6 +279,11 @@ public class AttachmentManager {
         }
       }
     }.execute();
+  }
+
+  private void abortAttachment(String message) {
+    attachmentView.setVisibility(View.GONE);
+    Toast.makeText(context, message, Toast.LENGTH_SHORT).show();
   }
 
   public boolean isAttachmentPresent() {
@@ -289,17 +349,6 @@ public class AttachmentManager {
   private static void selectMediaType(Activity activity, String type, int requestCode) {
     final Intent intent = new Intent();
     intent.setType(type);
-
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-      intent.setAction(Intent.ACTION_OPEN_DOCUMENT);
-      try {
-        activity.startActivityForResult(intent, requestCode);
-        return;
-      } catch (ActivityNotFoundException anfe) {
-        Log.w(TAG, "couldn't complete ACTION_OPEN_DOCUMENT, no activity found. falling back.");
-      }
-    }
-
     intent.setAction(Intent.ACTION_GET_CONTENT);
     try {
       activity.startActivityForResult(intent, requestCode);

--- a/src/org/thoughtcrime/securesms/util/MediaUtil.java
+++ b/src/org/thoughtcrime/securesms/util/MediaUtil.java
@@ -1,8 +1,10 @@
 package org.thoughtcrime.securesms.util;
 
+import android.content.ContentResolver;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.net.Uri;
+import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
@@ -23,7 +25,6 @@ import org.thoughtcrime.securesms.providers.PersistentBlobProvider;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.concurrent.ExecutionException;
 
 import ws.com.google.android.mms.ContentType;
 
@@ -133,6 +134,12 @@ public class MediaUtil {
 
   public static boolean isVideo(Attachment attachment) {
     return ContentType.isVideoType(attachment.getContentType());
+  }
+
+  public static boolean isPersistent(@NonNull final Uri uri) {
+    return MediaStore.AUTHORITY            .equals(uri.getAuthority()) ||
+           PersistentBlobProvider.AUTHORITY.equals(uri.getAuthority()) ||
+           ContentResolver.SCHEME_FILE     .equals(uri.getScheme());
   }
 
   public static @Nullable String getDiscreteMimeType(@NonNull String mimeType) {

--- a/src/org/thoughtcrime/securesms/util/Util.java
+++ b/src/org/thoughtcrime/securesms/util/Util.java
@@ -196,15 +196,7 @@ public class Util {
 
   public static byte[] readFully(InputStream in) throws IOException {
     ByteArrayOutputStream bout = new ByteArrayOutputStream();
-    byte[] buffer              = new byte[4096];
-    int read;
-
-    while ((read = in.read(buffer)) != -1) {
-      bout.write(buffer, 0, read);
-    }
-
-    in.close();
-
+    copy(in, bout);
     return bout.toByteArray();
   }
 


### PR DESCRIPTION
@unrulygnu This is more what I had in mind for #3154 when I was asking for a single public method that returns a future.  It seems like we should always return a future when the input is a stream, since the Uri shouldn't be usable until the persistence task is complete.

It's been a while since I looked at the mechanisms of all this, so I could be wrong, but let me know if this meets your needs.  Thanks!
