### PR TITLE
Improve longclick experience for status messages

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationUpdateItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationUpdateItem.java
@@ -94,6 +94,7 @@ public class ConversationUpdateItem extends LinearLayout
     this.locale        = locale;
 
     this.sender.addListener(this);
+    body.setAutoLinkMask(batchSelected.isEmpty() ? Linkify.ALL : 0);
 
     if      (messageRecord.isGroupAction())           setGroupRecord(messageRecord);
     else if (messageRecord.isCallLog())               setCallRecord(messageRecord);

--- a/src/org/thoughtcrime/securesms/ConversationUpdateItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationUpdateItem.java
@@ -7,6 +7,7 @@ import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.text.util.Linkify;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.View;
@@ -61,6 +62,10 @@ public class ConversationUpdateItem extends LinearLayout
     this.icon = (ImageView)findViewById(R.id.conversation_update_icon);
     this.body = (TextView)findViewById(R.id.conversation_update_body);
     this.date = (TextView)findViewById(R.id.conversation_update_date);
+
+    PassthroughClickListener passthroughClickListener = new PassthroughClickListener();
+    body.setOnLongClickListener(passthroughClickListener);
+    body.setOnClickListener(passthroughClickListener);
 
     this.setOnClickListener(new InternalClickListener(null));
   }
@@ -220,4 +225,17 @@ public class ConversationUpdateItem extends LinearLayout
     }
   }
 
+  private class PassthroughClickListener implements View.OnLongClickListener, View.OnClickListener {
+
+    @Override
+    public boolean onLongClick(View v) {
+      performLongClick();
+      return true;
+    }
+
+    @Override
+    public void onClick(View v) {
+      performClick();
+    }
+  }
 }


### PR DESCRIPTION
### Contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
  - Sony Xperia U, Android 4.4.4
  - AVD Nexus 5X, Android 6.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

---
### Description

I applied the same listener as in `ConversationItem` with 68bf5f3 for the body of converation update items. This allows you to reliably select linkified conversation updates with a long click - independent of the spot you tap on.
16e56ec removes the links for conversation updates as soon as you are in selecting mode. This prevents clicking and following a link while selecting conversation items.

As a result the conversation update items behave exactly the same as regular conversation items when you attempt to select them.

Fixes #5691
// FREEBIE
