### PR TITLE
Hide copy button for messages without text

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -178,6 +178,7 @@ public class ConversationFragment extends Fragment
   private void setCorrectMenuVisibility(Menu menu) {
     Set<MessageRecord> messageRecords = getListAdapter().getSelectedItems();
     boolean            actionMessage  = false;
+    boolean            emptyBody      = false;
 
     if (actionMode != null && messageRecords.size() == 0) {
       actionMode.finish();
@@ -190,7 +191,10 @@ public class ConversationFragment extends Fragment
           messageRecord.isEndSession() || messageRecord.isIdentityUpdate())
       {
         actionMessage = true;
+        emptyBody     = true;
         break;
+      } else if (!emptyBody) {
+        emptyBody = messageRecord.getDisplayBody().toString().isEmpty();
       }
     }
 
@@ -199,7 +203,7 @@ public class ConversationFragment extends Fragment
       menu.findItem(R.id.menu_context_details).setVisible(false);
       menu.findItem(R.id.menu_context_save_attachment).setVisible(false);
       menu.findItem(R.id.menu_context_resend).setVisible(false);
-      menu.findItem(R.id.menu_context_copy).setVisible(!actionMessage);
+      menu.findItem(R.id.menu_context_copy).setVisible(!actionMessage && !emptyBody);
     } else {
       MessageRecord messageRecord = messageRecords.iterator().next();
 
@@ -211,7 +215,7 @@ public class ConversationFragment extends Fragment
 
       menu.findItem(R.id.menu_context_forward).setVisible(!actionMessage);
       menu.findItem(R.id.menu_context_details).setVisible(!actionMessage);
-      menu.findItem(R.id.menu_context_copy).setVisible(!actionMessage);
+      menu.findItem(R.id.menu_context_copy).setVisible(!actionMessage && !emptyBody);
     }
   }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Xperia U, Android 4.4.4 (CyanogenMod)
 * AVD Nexus 5X, Android 6.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
This PR hides the copy button in a conversation's context menu as soon as a message without text (e.g. image only message) is marked.

Fixes #5802
// FREEBIE

### Screenshots
before
![device-2016-11-14-203304](https://cloud.githubusercontent.com/assets/16167751/20279737/0192e99a-aaaa-11e6-9f65-03a94a6e492f.png)
after
![device-2016-11-14-202924](https://cloud.githubusercontent.com/assets/16167751/20279736/019041fe-aaaa-11e6-8a93-fe427be42f5c.png)