### PR TITLE
Prevent multiple instances of several activities

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -365,6 +365,7 @@
 
     <activity android:name=".RecipientPreferenceActivity"
               android:theme="@style/TextSecure.LightNoActionBar"
+              android:launchMode="singleTop"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
     <activity android:name=".BlockedContactsActivity"

--- a/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
@@ -35,6 +35,8 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
         .setOnPreferenceChangeListener(new ListSummaryListener());
     this.findPreference(TextSecurePreferences.RINGTONE_PREF)
         .setOnPreferenceChangeListener(new RingtoneSummaryListener());
+    this.findPreference(TextSecurePreferences.RINGTONE_PREF)
+        .setOnPreferenceClickListener(new RingtoneSummaryListener());
     this.findPreference(TextSecurePreferences.REPEAT_ALERTS_PREF)
         .setOnPreferenceChangeListener(new ListSummaryListener());
     this.findPreference(TextSecurePreferences.NOTIFICATION_PRIVACY_PREF)
@@ -51,9 +53,11 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
   public void onResume() {
     super.onResume();
     ((ApplicationPreferencesActivity) getActivity()).getSupportActionBar().setTitle(R.string.preferences__notifications);
+    findPreference(TextSecurePreferences.RINGTONE_PREF).setEnabled(true);
   }
 
-  private class RingtoneSummaryListener implements Preference.OnPreferenceChangeListener {
+  private class RingtoneSummaryListener implements Preference.OnPreferenceChangeListener,
+          Preference.OnPreferenceClickListener {
     @Override
     public boolean onPreferenceChange(Preference preference, Object newValue) {
       String value = (String) newValue;
@@ -66,6 +70,15 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
           preference.setSummary(tone.getTitle(getActivity()));
         }
       }
+
+      preference.setEnabled(true);
+
+      return true;
+    }
+
+    @Override
+    public boolean onPreferenceClick(final Preference preference) {
+      preference.setEnabled(false);
 
       return true;
     }

--- a/src/org/thoughtcrime/securesms/preferences/SmsMmsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/SmsMmsPreferenceFragment.java
@@ -48,6 +48,9 @@ public class SmsMmsPreferenceFragment extends PreferenceFragment {
     Preference       allMmsPreference    = findPreference(TextSecurePreferences.ALL_MMS_PREF);
     Preference       manualMmsPreference = findPreference(MMS_PREF);
 
+    defaultPreference.setEnabled(true);
+    defaultPreference.setOnPreferenceClickListener(new SmsPreferenceListener());
+
     if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
       if (allSmsPreference != null) preferenceScreen.removePreference(allSmsPreference);
       if (allMmsPreference != null) preferenceScreen.removePreference(allMmsPreference);
@@ -84,6 +87,15 @@ public class SmsMmsPreferenceFragment extends PreferenceFragment {
       fragmentTransaction.commit();
 
       return true;
+    }
+  }
+
+  private class SmsPreferenceListener implements Preference.OnPreferenceClickListener {
+    @Override
+    public boolean onPreferenceClick(Preference preference) {
+      preference.setEnabled(false);
+
+      return false;
     }
   }
 


### PR DESCRIPTION
This PR is to address several places where it was possible to launch more than one instance of an activity by tapping multiple times in quick succession.

The contact name in the conversation view could launch multiple `RecipientPreferenceActivity` instances.
The Notification Sound preference could launch multiple instances of the Ringtone selector.
The default SMS app preference could launch multiple Android Settings instances.

The `RecipientPreferenceActivity` is fixed by altering the [launchMode](https://developer.android.com/guide/topics/manifest/activity-element.html#lmode) in the manifest.
The two preferences are fixed by disabling the preferences in their `onPreferenceClick()` methods and enabling them again in the activity's `onResume()` method.

Fixes #6065

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * LG Nexus 4, Android 5.0.2
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
This change prevents multiple instances of various activities from being created by double-tapping in various places in the app, detailed in the commit message.

I discovered the places by double-tapping multiple places in the app. I verified the fixes by double-tapping the same places after my code change.

I verified that pressing `Cancel` on the ringtone selector still results in the preference being re-enabled. This logic has to go in the `onResume()` method because the `onPreferenceChange()` method is not called if the preference doesn't actually change.