### PR TITLE
Add share button for attachments and drafts

### DIFF
--- a/res/menu/media_preview.xml
+++ b/res/menu/media_preview.xml
@@ -6,7 +6,7 @@
           android:icon="@drawable/ic_forward_white_24dp"
           app:showAsAction="always"/>
     <item android:id="@+id/share"
-          android:title="Share"
+          android:title="@string/media_preview__share_title"
           android:icon="@drawable/ic_share_white_24dp"
           app:showAsAction="always"/>
     <item android:id="@+id/save"

--- a/res/menu/media_preview.xml
+++ b/res/menu/media_preview.xml
@@ -5,6 +5,10 @@
           android:title="@string/media_preview__forward_title"
           android:icon="@drawable/ic_forward_white_24dp"
           app:showAsAction="always"/>
+    <item android:id="@+id/share"
+          android:title="Share"
+          android:icon="@drawable/ic_share_white_24dp"
+          app:showAsAction="always"/>
     <item android:id="@+id/save"
           android:title="@string/media_preview__save_title"
           android:icon="@drawable/ic_save_white_24dp"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1276,6 +1276,7 @@
     <string name="media_preview__save_title">Save</string>
     <string name="media_preview__forward_title">Forward</string>
     <string name="media_preview__overview_title">All images</string>
+    <string name="media_preview__share_title">Share</string>
 
     <!-- media_overview -->
     <string name="media_overview__save_all">Save all</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1270,6 +1270,7 @@
     <string name="MediaPreviewActivity_you">You</string>
     <string name="MediaPreviewActivity_cant_display">Failed to preview this image</string>
     <string name="MediaPreviewActivity_unssuported_media_type">Unsupported media type</string>
+    <string name="MediaPreviewActivity_share_via">Share via</string>
 
     <!-- media_preview -->
     <string name="media_preview__save_title">Save</string>

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -502,7 +502,8 @@ public class ConversationItem extends LinearLayout
       Log.w(TAG, "Clicked: " + slide.getUri() + " , " + slide.getContentType());
       Intent intent = new Intent(Intent.ACTION_VIEW);
       intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-      intent.setDataAndType(PartAuthority.getAttachmentPublicUri(slide.getUri()), slide.getContentType());
+      intent.setDataAndType(PartAuthority.getAttachmentPublicUri(slide.getUri(), slide.getContentType()),
+                            slide.getContentType());
       try {
         context.startActivity(intent);
       } catch (ActivityNotFoundException anfe) {

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -34,6 +34,7 @@ import android.widget.Toast;
 
 import org.thoughtcrime.securesms.components.ZoomingImageView;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.mms.PartAuthority;
 import org.thoughtcrime.securesms.mms.VideoSlide;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.Recipient.RecipientModifiedListener;
@@ -225,6 +226,15 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     return true;
   }
 
+  private void share() {
+    Intent intent = new Intent(Intent.ACTION_SEND);
+    intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+    intent.setType(mediaType);
+    intent.putExtra(Intent.EXTRA_STREAM, PartAuthority.getAttachmentPublicUri(mediaUri, mediaType));
+
+    startActivity(Intent.createChooser(intent, getString(R.string.MediaPreviewActivity_share_via)));
+  }
+
   @Override
   public boolean onOptionsItemSelected(MenuItem item) {
     super.onOptionsItemSelected(item);
@@ -233,6 +243,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
       case R.id.media_preview__overview: showOverview(); return true;
       case R.id.media_preview__forward:  forward();      return true;
       case R.id.save:                    saveToDisk();   return true;
+      case R.id.share:                   share();        return true;
       case android.R.id.home:            finish();       return true;
     }
 

--- a/src/org/thoughtcrime/securesms/mms/PartAuthority.java
+++ b/src/org/thoughtcrime/securesms/mms/PartAuthority.java
@@ -62,9 +62,18 @@ public class PartAuthority {
     }
   }
 
-  public static Uri getAttachmentPublicUri(Uri uri) {
-    PartUriParser partUri = new PartUriParser(uri);
-    return PartProvider.getContentUri(partUri.getPartId());
+  public static Uri getAttachmentPublicUri(Uri uri, String mimeType) {
+    int match = uriMatcher.match(uri);
+    switch (match) {
+      case PART_ROW:
+      case THUMB_ROW:
+        PartUriParser partUri = new PartUriParser(uri);
+        return PartProvider.getPublicContentUri(partUri.getPartId(), mimeType);
+      case PERSISTENT_ROW:
+        return PartProvider.getPublicContentUri(ContentUris.parseId(uri), mimeType);
+      default:
+        return uri;
+    }
   }
 
   public static Uri getAttachmentDataUri(AttachmentId attachmentId) {

--- a/src/org/thoughtcrime/securesms/mms/PartUriParser.java
+++ b/src/org/thoughtcrime/securesms/mms/PartUriParser.java
@@ -1,6 +1,5 @@
 package org.thoughtcrime.securesms.mms;
 
-import android.content.ContentUris;
 import android.net.Uri;
 
 import org.thoughtcrime.securesms.attachments.AttachmentId;
@@ -18,7 +17,7 @@ public class PartUriParser {
   }
 
   private long getId() {
-    return ContentUris.parseId(uri);
+    return Long.parseLong(uri.getPathSegments().get(2));
   }
 
   private long getUniqueId() {

--- a/src/org/thoughtcrime/securesms/mms/PersistentBlobUriParser.java
+++ b/src/org/thoughtcrime/securesms/mms/PersistentBlobUriParser.java
@@ -1,0 +1,20 @@
+package org.thoughtcrime.securesms.mms;
+
+import android.net.Uri;
+
+public class PersistentBlobUriParser {
+
+  private final Uri uri;
+
+  public PersistentBlobUriParser(Uri uri) {
+    this.uri = uri;
+  }
+
+  public long getId() {
+    return Long.parseLong(uri.getPathSegments().get(3));
+  }
+
+  public long getUniqueId() {
+    return Long.parseLong(uri.getPathSegments().get(2));
+  }
+}

--- a/src/org/thoughtcrime/securesms/providers/PartProvider.java
+++ b/src/org/thoughtcrime/securesms/providers/PartProvider.java
@@ -21,16 +21,23 @@ import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.UriMatcher;
 import android.database.Cursor;
+import android.database.MatrixCursor;
 import android.net.Uri;
 import android.os.ParcelFileDescriptor;
+import android.provider.MediaStore.MediaColumns;
 import android.support.annotation.NonNull;
 import android.util.Log;
+import android.webkit.MimeTypeMap;
 
 import org.thoughtcrime.securesms.attachments.AttachmentId;
+import org.thoughtcrime.securesms.attachments.DatabaseAttachment;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.database.AttachmentDatabase;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.mms.PartUriParser;
+import org.thoughtcrime.securesms.mms.PersistentBlobUriParser;
 import org.thoughtcrime.securesms.service.KeyCachingService;
+import org.thoughtcrime.securesms.util.MediaUtil;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -41,15 +48,19 @@ import java.io.InputStream;
 public class PartProvider extends ContentProvider {
   private static final String TAG = PartProvider.class.getSimpleName();
 
-  private static final String CONTENT_URI_STRING = "content://org.thoughtcrime.provider.securesms/part";
-  private static final Uri    CONTENT_URI        = Uri.parse(CONTENT_URI_STRING);
-  private static final int    SINGLE_ROW         = 1;
+  private static final String PART_URI_STRING       = "content://org.thoughtcrime.provider.securesms/part";
+  private static final String PERSISTENT_URI_STRING = "content://org.thoughtcrime.provider.securesms/capture";
+  private static final Uri    PART_URI              = Uri.parse(PART_URI_STRING);
+  private static final Uri    PERSISTENT_URI        = Uri.parse(PERSISTENT_URI_STRING);
+  private static final int    PART_ROW              = 1;
+  private static final int    PERSISTENT_ROW        = 2;
 
   private static final UriMatcher uriMatcher;
 
   static {
     uriMatcher = new UriMatcher(UriMatcher.NO_MATCH);
-    uriMatcher.addURI("org.thoughtcrime.provider.securesms", "part/*/#", SINGLE_ROW);
+    uriMatcher.addURI("org.thoughtcrime.provider.securesms", "part/*/#/*", PART_ROW);
+    uriMatcher.addURI("org.thoughtcrime.provider.securesms", "capture/*/*/#/*", PERSISTENT_ROW);
   }
 
   @Override
@@ -58,14 +69,27 @@ public class PartProvider extends ContentProvider {
     return true;
   }
 
-  public static Uri getContentUri(AttachmentId attachmentId) {
-    Uri uri = Uri.withAppendedPath(CONTENT_URI, String.valueOf(attachmentId.getUniqueId()));
-    return ContentUris.withAppendedId(uri, attachmentId.getRowId());
+  public static Uri getPublicContentUri(AttachmentId partId, String mimeType) {
+    final Uri uri = Uri.withAppendedPath(PART_URI, String.valueOf(partId.getUniqueId()));
+    return getPublicContentUri(ContentUris.withAppendedId(uri, partId.getRowId()), mimeType);
+  }
+
+  public static Uri getPublicContentUri(long persistentBlobId, String mimeType) {
+    final Uri uri = PERSISTENT_URI.buildUpon()
+                                  .appendPath(mimeType)
+                                  .appendEncodedPath(String.valueOf(System.currentTimeMillis()))
+                                  .build();
+    return getPublicContentUri(ContentUris.withAppendedId(uri, persistentBlobId), mimeType);
+  }
+
+  private static Uri getPublicContentUri(Uri base, String mimeType) {
+    final String extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
+    final String filename  = "attachment." + (extension != null ? extension : "jpg");
+    return base.buildUpon().appendEncodedPath(filename).build();
   }
 
   @SuppressWarnings("ConstantConditions")
-  private File copyPartToTemporaryFile(MasterSecret masterSecret, AttachmentId attachmentId) throws IOException {
-    InputStream in        = DatabaseFactory.getAttachmentDatabase(getContext()).getAttachmentStream(masterSecret, attachmentId);
+  private File copyPartToTemporaryFile(InputStream in) throws IOException {
     File tmpDir           = getContext().getDir("tmp", 0);
     File tmpFile          = File.createTempFile("test", ".jpg", tmpDir);
     FileOutputStream fout = new FileOutputStream(tmpFile);
@@ -91,26 +115,38 @@ public class PartProvider extends ContentProvider {
       return null;
     }
 
-    switch (uriMatcher.match(uri)) {
-    case SINGLE_ROW:
-      Log.w(TAG, "Parting out a single row...");
-      try {
-        PartUriParser        partUri = new PartUriParser(uri);
-        File                 tmpFile = copyPartToTemporaryFile(masterSecret, partUri.getPartId());
-        ParcelFileDescriptor pdf     = ParcelFileDescriptor.open(tmpFile, ParcelFileDescriptor.MODE_READ_ONLY);
-
-        if (!tmpFile.delete()) {
-          Log.w(TAG, "Failed to delete temp file.");
-        }
-
-        return pdf;
-      } catch (IOException ioe) {
-        Log.w(TAG, ioe);
-        throw new FileNotFoundException("Error opening file");
-      }
+    int match = uriMatcher.match(uri);
+    if (match != PART_ROW && match != PERSISTENT_ROW) {
+      throw new FileNotFoundException("Request for bad part.");
     }
 
-    throw new FileNotFoundException("Request for bad part.");
+    try {
+      InputStream in;
+      switch (match) {
+      case PART_ROW:
+        Log.w(TAG, "Parting out a single row...");
+        PartUriParser partUri = new PartUriParser(uri);
+        in = DatabaseFactory.getAttachmentDatabase(getContext())
+                            .getAttachmentStream(masterSecret, partUri.getPartId());
+        break;
+      default:
+        PersistentBlobUriParser blobUri = new PersistentBlobUriParser(uri);
+        in = PersistentBlobProvider.getInstance(getContext()).getStream(masterSecret, blobUri.getId());
+      }
+
+      File                 tmpFile = copyPartToTemporaryFile(in);
+      ParcelFileDescriptor pdf     = ParcelFileDescriptor.open(tmpFile, ParcelFileDescriptor.MODE_READ_ONLY);
+
+      if (!tmpFile.delete()) {
+        Log.w(TAG, "Failed to delete temp file.");
+      }
+
+      return pdf;
+    } catch (IOException ioe) {
+      Log.w(TAG, ioe);
+      throw new FileNotFoundException("Error opening file");
+    }
+
   }
 
   @Override
@@ -119,8 +155,10 @@ public class PartProvider extends ContentProvider {
   }
 
   @Override
-  public String getType(@NonNull Uri arg0) {
-    return null;
+  public String getType(@NonNull Uri uri) {
+    final String extension = MimeTypeMap.getFileExtensionFromUrl(uri.toString());
+    final String mimeType  = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension.toLowerCase());
+    return MediaUtil.getCorrectedMimeType(mimeType);
   }
 
   @Override
@@ -129,8 +167,36 @@ public class PartProvider extends ContentProvider {
   }
 
   @Override
-  public Cursor query(@NonNull Uri arg0, String[] arg1, String arg2, String[] arg3, String arg4) {
-    return null;
+  public Cursor query(@NonNull Uri uri, String[] projection, String selection,
+                      String[] selectionArgs, String sortOrder)
+  {
+    if (projection == null) {
+      projection = new String[] {MediaColumns._ID, MediaColumns.DATA};
+    }
+
+    int match = uriMatcher.match(uri);
+    if (match != PART_ROW && match != PERSISTENT_ROW) {
+      return null;
+    }
+
+    PartUriParser           partUri = new PartUriParser(uri);
+    PersistentBlobUriParser blobUri = new PersistentBlobUriParser(uri);
+    MatrixCursor            cursor  = new MatrixCursor(projection);
+    Object[]                row     = new Object[projection.length];
+
+    for (int i = 0; i < row.length; i++) {
+      switch (projection[i]) {
+      case MediaColumns._ID:
+        row[i] = (match == PART_ROW ? partUri.getPartId().getRowId() : blobUri.getId());
+        break;
+      case MediaColumns.DATA:
+        row[i] = uri.toString();
+        break;
+      }
+    }
+
+    cursor.addRow(row);
+    return cursor;
   }
 
   @Override


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD, Android 6.0
 * MT6589 phone, Android 4.2.2
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description

Fixes #4906, in collaboration with @FeuRenard

This adds a "share" button to the MediaPreviewActivity. Some details:

- This appends a file name with mimetype-specific extension to the PartProvider URI format (required by certain apps)
- I wasn't sure if we want to offer "share" functionality for drafts at all, but ended up implementing it. The additional PersistentBlobProvider-related logic went into PartProvider, though - not really sure if this is appropriate. Alternatively, to turn PersistentBlobProvider into its own ContentProvider, we'd need to change the way it's instantiated (currently there's no public constructor). Would love some opinion / guidance on this!

Tested with images / videos / GIFs attached to messages plus all sorts of drafts from:

- builtin camera
- intent camera (this fails if the target app can't resolve file:// URIs, i.e. when it doesn't have the storage permission)
- attachment drawer -> Image / Video / GIF / "recent photos" thumbnails
- stuff shared to Signal from the Android gallery