### PR TITLE
Fix some Javadoc typos

### DIFF
--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -32,7 +32,7 @@ import org.thoughtcrime.securesms.util.Util;
 import org.whispersystems.signalservice.api.util.PhoneNumberFormatter;
 
 /**
- * The register account activity.  Prompts ths user for their registration information
+ * The register account activity.  Prompts the user for their registration information
  * and begins the account registration process.
  *
  * @author Moxie Marlinspike

--- a/src/org/thoughtcrime/securesms/components/multiwaveview/TargetDrawable.java
+++ b/src/org/thoughtcrime/securesms/components/multiwaveview/TargetDrawable.java
@@ -128,7 +128,7 @@ public class TargetDrawable {
 
     /**
      * Makes drawables in a StateListDrawable all the same dimensions.
-     * If not a StateListDrawable, then justs sets the bounds to the intrinsic size of the
+     * If not a StateListDrawable, then just sets the bounds to the intrinsic size of the
      * drawable.
      */
 

--- a/src/org/thoughtcrime/securesms/contacts/ContactAccessor.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactAccessor.java
@@ -41,7 +41,7 @@ import static org.thoughtcrime.securesms.database.GroupDatabase.GroupRecord;
 
 /**
  * This class was originally a layer of indirection between
- * ContactAccessorNewApi and ContactAccesorOldApi, which corresponded
+ * ContactAccessorNewApi and ContactAccessorOldApi, which corresponded
  * to the API changes between 1.x and 2.x.
  *
  * Now that we no longer support 1.x, this class mostly serves as a place

--- a/src/org/thoughtcrime/securesms/crypto/AsymmetricMasterCipher.java
+++ b/src/org/thoughtcrime/securesms/crypto/AsymmetricMasterCipher.java
@@ -34,7 +34,7 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
 /**
- * This class is used to asymmetricly encrypt local data.  This is used in the case
+ * This class is used to asymmetrically encrypt local data.  This is used in the case
  * where TextSecure receives an SMS, but the user's local encryption passphrase is
  * not cached (either because of a timeout, or because it hasn't yet been entered).
  * 

--- a/src/org/thoughtcrime/securesms/dom/smil/TimeImpl.java
+++ b/src/org/thoughtcrime/securesms/dom/smil/TimeImpl.java
@@ -64,7 +64,7 @@ public class TimeImpl implements Time {
      * @return  A TimeImpl instance representing
      * @exception java.lang.IllegalArgumentException if the timeValue input
      *          parameter does not comply with the defined syntax
-     * @exception java.lang.NullPointerException if the timekValue string is
+     * @exception java.lang.NullPointerException if the timeValue string is
      *          <code>null</code>
      */
     TimeImpl(String timeValue, int constraints) {

--- a/src/org/thoughtcrime/securesms/util/Base64.java
+++ b/src/org/thoughtcrime/securesms/util/Base64.java
@@ -65,7 +65,7 @@ package org.thoughtcrime.securesms.util;
  *      <a href="http://www.faqs.org/rfcs/rfc3548.html">RFC3548</a>.</li>
  *    <li><em>Throws exceptions instead of returning null values.</em> Because some operations
  *      (especially those that may permit the GZIP option) use IO streams, there
- *      is a possiblity of an java.io.IOException being thrown. After some discussion and
+ *      is a possibility of an java.io.IOException being thrown. After some discussion and
  *      thought, I've changed the behavior of the methods to throw java.io.IOExceptions
  *      rather than return null if ever there's an error. I think this is more
  *      appropriate, though it will require some changes to your code. Sorry,
@@ -479,7 +479,7 @@ public class Base64
      * anywhere along their length by specifying 
      * <var>srcOffset</var> and <var>destOffset</var>.
      * This method does not check to make sure your arrays
-     * are large enough to accomodate <var>srcOffset</var> + 3 for
+     * are large enough to accommodate <var>srcOffset</var> + 3 for
      * the <var>source</var> array or <var>destOffset</var> + 4 for
      * the <var>destination</var> array.
      * The actual number of significant bytes in your array is
@@ -1027,7 +1027,7 @@ public class Base64
      * anywhere along their length by specifying 
      * <var>srcOffset</var> and <var>destOffset</var>.
      * This method does not check to make sure your arrays
-     * are large enough to accomodate <var>srcOffset</var> + 4 for
+     * are large enough to accommodate <var>srcOffset</var> + 4 for
      * the <var>source</var> array or <var>destOffset</var> + 3 for
      * the <var>destination</var> array.
      * This method returns the actual number of bytes that 

--- a/src/org/thoughtcrime/securesms/util/MathUtils.java
+++ b/src/org/thoughtcrime/securesms/util/MathUtils.java
@@ -30,7 +30,7 @@ public class MathUtils {
      *
      * @param a beginning of 2 vectors
      * @param b end of vector 1
-     * @param c enf of vector 2
+     * @param c end of vector 2
      * @return cross product AB * AC
      */
     private static float crossProduct(@NonNull PointF a, @NonNull PointF b, @NonNull PointF c) {

--- a/src/ws/com/google/android/mms/pdu/AcknowledgeInd.java
+++ b/src/ws/com/google/android/mms/pdu/AcknowledgeInd.java
@@ -26,7 +26,7 @@ public class AcknowledgeInd extends GenericPdu {
     /**
      * Constructor, used when composing a M-Acknowledge.ind pdu.
      *
-     * @param mmsVersion current viersion of mms
+     * @param mmsVersion current version of mms
      * @param transactionId the transaction-id value
      * @throws InvalidHeaderValueException if parameters are invalid.
      *         NullPointerException if transactionId is null.

--- a/src/ws/com/google/android/mms/pdu/Base64.java
+++ b/src/ws/com/google/android/mms/pdu/Base64.java
@@ -56,7 +56,7 @@ public class Base64 {
     }
 
     /**
-     * Decodes Base64 data into octects
+     * Decodes Base64 data into octets
      *
      * @param base64Data Byte array containing Base64 data
      * @return Array containing decoded data.
@@ -124,10 +124,10 @@ public class Base64 {
     }
 
     /**
-     * Check octect wheter it is a base64 encoding.
+     * Check octet whether it is a base64 encoding.
      *
      * @param octect to be checked byte
-     * @return ture if it is base64 encoding, false otherwise.
+     * @return true if it is base64 encoding, false otherwise.
      */
     private static boolean isBase64(byte octect) {
         if (octect == PAD) {

--- a/src/ws/com/google/android/mms/pdu/EncodedStringValue.java
+++ b/src/ws/com/google/android/mms/pdu/EncodedStringValue.java
@@ -158,7 +158,7 @@ public class EncodedStringValue implements Cloneable {
      *
      * @param textString the textString to append
      * @throws NullPointerException if the text String is null
-     *                      or an IOException occured.
+     *                      or an IOException occurred.
      */
     public void appendTextString(byte[] textString) {
         if(null == textString) {

--- a/src/ws/com/google/android/mms/pdu/PduBody.java
+++ b/src/ws/com/google/android/mms/pdu/PduBody.java
@@ -160,7 +160,7 @@ public class PduBody {
 
     /**
      * Get pdu part by Content-Location. Content-Location of part is
-     * the same as filename and name(param of content-type).
+     * the same as filename and name (param of content-type).
      *
      * @param fileName the value of filename.
      * @return the pdu part.

--- a/src/ws/com/google/android/mms/pdu/PduComposer.java
+++ b/src/ws/com/google/android/mms/pdu/PduComposer.java
@@ -145,7 +145,7 @@ public class PduComposer {
      * Make the message. No need to check whether mandatory fields are set,
      * because the constructors of outgoing pdus are taking care of this.
      *
-     * @return OutputStream of maked message. Return null if
+     * @return OutputStream of made message. Return null if
      *         the PDU is invalid.
      */
     public byte[] make() {
@@ -1023,7 +1023,7 @@ public class PduComposer {
     }
 
     /**
-     *  Record current message informations.
+     *  Record current message information.
      */
     static private class LengthRecordNode {
         ByteArrayOutputStream currentMessage = null;
@@ -1033,7 +1033,7 @@ public class PduComposer {
     }
 
     /**
-     * Mark current message position and stact size.
+     * Mark current message position and stack size.
      */
     private class PositionMarker {
         private int c_pos;   // Current position

--- a/src/ws/com/google/android/mms/pdu/PduParser.java
+++ b/src/ws/com/google/android/mms/pdu/PduParser.java
@@ -1489,7 +1489,7 @@ public class PduParser {
      * Parse part's headers.
      *
      * @param pduDataStream pdu data input stream
-     * @param part to store the header informations of the part
+     * @param part to store the header information of the part
      * @param length length of the headers
      * @return true if parse successfully, false otherwise
      */

--- a/src/ws/com/google/android/mms/pdu/ReadRecInd.java
+++ b/src/ws/com/google/android/mms/pdu/ReadRecInd.java
@@ -25,7 +25,7 @@ public class ReadRecInd extends GenericPdu {
      *
      * @param from the from value
      * @param messageId the message ID value
-     * @param mmsVersion current viersion of mms
+     * @param mmsVersion current version of mms
      * @param readStatus the read status value
      * @param to the to value
      * @throws InvalidHeaderValueException if parameters are invalid.

--- a/src/ws/com/google/android/mms/pdu/SendReq.java
+++ b/src/ws/com/google/android/mms/pdu/SendReq.java
@@ -52,7 +52,7 @@ public class SendReq extends MultimediaMessagePdu {
      *
      * @param contentType the content type value
      * @param from the from value
-     * @param mmsVersion current viersion of mms
+     * @param mmsVersion current version of mms
      * @param transactionId the transaction-id value
      * @throws InvalidHeaderValueException if parameters are invalid.
      *         NullPointerException if contentType, form or transactionId is null.


### PR DESCRIPTION
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 No functional changes, only Javadoc changed, can't break anything
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
I checked the Javadocs for spelling mistakes and fixed them
