### PR TITLE
Fix a couple of fast scroller glitches

### DIFF
--- a/src/org/thoughtcrime/securesms/components/RecyclerViewFastScroller.java
+++ b/src/org/thoughtcrime/securesms/components/RecyclerViewFastScroller.java
@@ -54,7 +54,7 @@ public class RecyclerViewFastScroller extends LinearLayout {
     @Override
     public void onScrolled(final RecyclerView recyclerView, final int dx, final int dy) {
       if (handle.isSelected()) return;
-      computeBubbleAndHandlePosition();
+      setBubbleAndHandlePosition(computeBubbleAndHandlePosition(recyclerView));
     }
   };
 
@@ -80,7 +80,9 @@ public class RecyclerViewFastScroller extends LinearLayout {
   protected void onSizeChanged(int w, int h, int oldw, int oldh) {
     super.onSizeChanged(w, h, oldw, oldh);
     height = h;
-    computeBubbleAndHandlePosition();
+    if (recyclerView != null) {
+      setBubbleAndHandlePosition(computeBubbleAndHandlePosition(recyclerView));
+    }
   }
 
   @Override
@@ -172,14 +174,12 @@ public class RecyclerViewFastScroller extends LinearLayout {
                                      height - bubbleHeight));
   }
 
-  private void computeBubbleAndHandlePosition() {
-    if (recyclerView != null) {
-      final int offset      = recyclerView.computeVerticalScrollOffset();
-      final int range       = recyclerView.computeVerticalScrollRange();
-      final int extent      = recyclerView.computeVerticalScrollExtent();
-      final int offsetRange = Math.max(range - extent, 1);
-      setBubbleAndHandlePosition((float) Util.clamp(offset, 0, offsetRange) / offsetRange);
-    }
+  private float computeBubbleAndHandlePosition(@NonNull RecyclerView recyclerView) {
+    int offset      = recyclerView.computeVerticalScrollOffset();
+    int range       = recyclerView.computeVerticalScrollRange();
+    int extent      = recyclerView.computeVerticalScrollExtent();
+    int offsetRange = Math.max(range - extent, 1);
+    return (float) Util.clamp(offset, 0, offsetRange) / offsetRange;
   }
 
   @TargetApi(11)

--- a/src/org/thoughtcrime/securesms/components/RecyclerViewFastScroller.java
+++ b/src/org/thoughtcrime/securesms/components/RecyclerViewFastScroller.java
@@ -79,9 +79,11 @@ public class RecyclerViewFastScroller extends LinearLayout {
   @Override
   protected void onSizeChanged(int w, int h, int oldw, int oldh) {
     super.onSizeChanged(w, h, oldw, oldh);
-    height = h;
-    if (recyclerView != null) {
-      setBubbleAndHandlePosition(computeBubbleAndHandlePosition(recyclerView));
+    if (height != h) {
+      height = h;
+      if (recyclerView != null) {
+        setBubbleAndHandlePosition(computeBubbleAndHandlePosition(recyclerView));
+      }
     }
   }
 

--- a/src/org/thoughtcrime/securesms/components/RecyclerViewFastScroller.java
+++ b/src/org/thoughtcrime/securesms/components/RecyclerViewFastScroller.java
@@ -129,10 +129,7 @@ public class RecyclerViewFastScroller extends LinearLayout {
       public boolean onPreDraw() {
         recyclerView.getViewTreeObserver().removeOnPreDrawListener(this);
         if (handle.isSelected()) return true;
-        final int verticalScrollOffset = recyclerView.computeVerticalScrollOffset();
-        final int verticalScrollRange = recyclerView.computeVerticalScrollRange();
-        float proportion = (float)verticalScrollOffset / ((float)verticalScrollRange - height);
-        setBubbleAndHandlePosition(height * proportion);
+        setBubbleAndHandlePosition(computeBubbleAndHandlePosition(recyclerView));
         return true;
       }
     });

--- a/src/org/thoughtcrime/securesms/components/RecyclerViewFastScroller.java
+++ b/src/org/thoughtcrime/securesms/components/RecyclerViewFastScroller.java
@@ -54,11 +54,7 @@ public class RecyclerViewFastScroller extends LinearLayout {
     @Override
     public void onScrolled(final RecyclerView recyclerView, final int dx, final int dy) {
       if (handle.isSelected()) return;
-      final int   offset      = recyclerView.computeVerticalScrollOffset();
-      final int   range       = recyclerView.computeVerticalScrollRange();
-      final int   extent      = recyclerView.computeVerticalScrollExtent();
-      final int   offsetRange = Math.max(range - extent, 1);
-      setBubbleAndHandlePosition((float) Util.clamp(offset, 0, offsetRange) / offsetRange);
+      computeBubbleAndHandlePosition();
     }
   };
 
@@ -84,6 +80,7 @@ public class RecyclerViewFastScroller extends LinearLayout {
   protected void onSizeChanged(int w, int h, int oldw, int oldh) {
     super.onSizeChanged(w, h, oldw, oldh);
     height = h;
+    computeBubbleAndHandlePosition();
   }
 
   @Override
@@ -173,6 +170,16 @@ public class RecyclerViewFastScroller extends LinearLayout {
     ViewUtil.setY(bubble, Util.clamp(handleY - bubbleHeight - bubble.getPaddingBottom() + handleHeight,
                                      0,
                                      height - bubbleHeight));
+  }
+
+  private void computeBubbleAndHandlePosition() {
+    if (recyclerView != null) {
+      final int offset      = recyclerView.computeVerticalScrollOffset();
+      final int range       = recyclerView.computeVerticalScrollRange();
+      final int extent      = recyclerView.computeVerticalScrollExtent();
+      final int offsetRange = Math.max(range - extent, 1);
+      setBubbleAndHandlePosition((float) Util.clamp(offset, 0, offsetRange) / offsetRange);
+    }
   }
 
   @TargetApi(11)


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Android 7.1.1 emulator
 * Android 4.2.2 phone
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description

Redraw the fast scroller handle on height change, e.g. when opening / closing the keyboard or rotating the phone.

// FREEBIE

Extracting this from my other PR #6105 since it fixes an actual glitch happening with the current version of Signal.

### Repro steps

- Open contact selection list (leave the keyboard open)
- Scroll all the way down
- Close the keyboard

**Expected result:** Handle jumps to the bottom of the screen
**Actual result:** Handle stays where it is