### PR TITLE
Allow deleting attachments from media overview

### DIFF
--- a/res/drawable/media_overview_item_foreground.xml
+++ b/res/drawable/media_overview_item_foreground.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/textsecure_primary_alpha33" android:state_selected="true" />
+</selector>

--- a/res/layout/media_overview_item.xml
+++ b/res/layout/media_overview_item.xml
@@ -8,6 +8,7 @@
             android:id="@+id/image"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:contentDescription="@string/media_preview_activity__media_content_description" />
+            android:contentDescription="@string/media_preview_activity__media_content_description"
+            android:foreground="@drawable/media_overview_item_foreground" />
 
 </org.thoughtcrime.securesms.components.SquareFrameLayout>

--- a/res/menu/media_overview_context.xml
+++ b/res/menu/media_overview_context.xml
@@ -4,4 +4,9 @@
           android:id="@+id/menu_context_delete_attachments"
           android:icon="?menu_trash_icon"
           app:showAsAction="always" />
+
+    <item android:title="@string/media_overview_context__menu_select_all"
+          android:id="@+id/menu_context_select_all"
+          android:icon="?menu_selectall_icon"
+          app:showAsAction="always" />
 </menu>

--- a/res/menu/media_overview_context.xml
+++ b/res/menu/media_overview_context.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item android:title="@string/media_overview_context__menu_delete_attachments"
+          android:id="@+id/menu_context_delete_attachments"
+          android:icon="?menu_trash_icon"
+          app:showAsAction="always" />
+</menu>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1452,6 +1452,7 @@
 
     <!-- media_overview_context -->
     <string name="media_overview_context__menu_delete_attachments">Delete attachments</string>
+    <string name="media_overview_context__menu_select_all">Select all</string>
 
     <!-- media_preview_activity -->
     <string name="media_preview_activity__media_content_description">Media preview</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -954,6 +954,18 @@
     <!-- load_more_header -->
     <string name="load_more_header__see_full_conversation">See full conversation</string>
 
+    <!-- MediaOverviewActivity -->
+    <plurals name="MediaOverviewActivity_delete_selected_attachments">
+        <item quantity="one">Delete selected attachment?</item>
+        <item quantity="other">Delete selected attachments?</item>
+    </plurals>
+    <plurals name="MediaOverviewActivity_this_will_permanently_delete_all_n_selected_attachments">
+        <item quantity="one">This will permanently delete the selected attachment.</item>
+        <item quantity="other">This will permanently delete all %1$d selected attachments.</item>
+    </plurals>
+    <string name="MediaOverviewActivity_deleting">Deleting</string>
+    <string name="MediaOverviewActivity_deleting_messages">Deleting attachments...</string>
+
     <!-- media_overview_activity -->
     <string name="media_overview_activity__no_media">No media</string>
 
@@ -1437,6 +1449,9 @@
 
     <!-- media_overview -->
     <string name="media_overview__save_all">Save all</string>
+
+    <!-- media_overview_context -->
+    <string name="media_overview_context__menu_delete_attachments">Delete attachments</string>
 
     <!-- media_preview_activity -->
     <string name="media_preview_activity__media_content_description">Media preview</string>

--- a/src/org/thoughtcrime/securesms/MediaAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaAdapter.java
@@ -102,6 +102,13 @@ public class MediaAdapter extends CursorRecyclerViewAdapter<ViewHolder> {
     this.notifyDataSetChanged();
   }
 
+  public void selectAllMedia() {
+    for (int i = 0; i < getItemCount(); i++) {
+      batchSelected.add(MediaRecord.from(getContext(), masterSecret, getCursorAtPositionOrThrow(i)));
+    }
+    this.notifyDataSetChanged();
+  }
+
   public void clearSelection() {
     batchSelected.clear();
     this.notifyDataSetChanged();

--- a/src/org/thoughtcrime/securesms/MediaAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaAdapter.java
@@ -24,6 +24,7 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
+import android.view.View.OnLongClickListener;
 import android.view.ViewGroup;
 
 import org.thoughtcrime.securesms.MediaAdapter.ViewHolder;
@@ -34,11 +35,18 @@ import org.thoughtcrime.securesms.database.MediaDatabase.MediaRecord;
 import org.thoughtcrime.securesms.mms.Slide;
 import org.thoughtcrime.securesms.util.MediaUtil;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 public class MediaAdapter extends CursorRecyclerViewAdapter<ViewHolder> {
   private static final String TAG = MediaAdapter.class.getSimpleName();
 
-  private final MasterSecret masterSecret;
-  private final long         threadId;
+  private final Set<MediaRecord> batchSelected = Collections.synchronizedSet(new HashSet<MediaRecord>());
+
+  private final MasterSecret      masterSecret;
+  private final ItemClickListener clickListener;
+  private final long              threadId;
 
   public static class ViewHolder extends RecyclerView.ViewHolder {
     public ThumbnailView imageView;
@@ -49,10 +57,18 @@ public class MediaAdapter extends CursorRecyclerViewAdapter<ViewHolder> {
     }
   }
 
-  public MediaAdapter(Context context, MasterSecret masterSecret, Cursor c, long threadId) {
+  public interface ItemClickListener {
+    void onItemClick(MediaRecord item);
+    void onItemLongClick(MediaRecord item);
+  }
+
+  public MediaAdapter(Context context, MasterSecret masterSecret, ItemClickListener clickListener,
+                      Cursor c, long threadId)
+  {
     super(context, c);
-    this.masterSecret = masterSecret;
-    this.threadId     = threadId;
+    this.masterSecret  = masterSecret;
+    this.clickListener = clickListener;
+    this.threadId      = threadId;
   }
 
   @Override
@@ -63,8 +79,9 @@ public class MediaAdapter extends CursorRecyclerViewAdapter<ViewHolder> {
 
   @Override
   public void onBindItemViewHolder(final ViewHolder viewHolder, final @NonNull Cursor cursor) {
-    final ThumbnailView imageView   = viewHolder.imageView;
-    final MediaRecord   mediaRecord = MediaRecord.from(getContext(), masterSecret, cursor);
+    final ThumbnailView        imageView   = viewHolder.imageView;
+    final MediaRecord          mediaRecord = MediaRecord.from(getContext(), masterSecret, cursor);
+    final OnMediaClickListener listener    = new OnMediaClickListener(mediaRecord);
 
     Slide slide = MediaUtil.getSlideForAttachment(getContext(), mediaRecord.getAttachment());
 
@@ -72,10 +89,29 @@ public class MediaAdapter extends CursorRecyclerViewAdapter<ViewHolder> {
       imageView.setImageResource(masterSecret, slide, false, false);
     }
 
-    imageView.setOnClickListener(new OnMediaClickListener(mediaRecord));
+    imageView.setSelected(batchSelected.contains(mediaRecord));
+
+    imageView.setOnClickListener(listener);
+    imageView.setOnLongClickListener(listener);
   }
 
-  private class OnMediaClickListener implements OnClickListener {
+  public void toggleSelection(MediaRecord mediaRecord) {
+    if (!batchSelected.remove(mediaRecord)) {
+      batchSelected.add(mediaRecord);
+    }
+    this.notifyDataSetChanged();
+  }
+
+  public void clearSelection() {
+    batchSelected.clear();
+    this.notifyDataSetChanged();
+  }
+
+  public Set<MediaRecord> getSelectedItems() {
+    return Collections.unmodifiableSet(new HashSet<>(batchSelected));
+  }
+
+  private class OnMediaClickListener implements OnClickListener, OnLongClickListener {
     private final MediaRecord mediaRecord;
 
     private OnMediaClickListener(MediaRecord mediaRecord) {
@@ -84,7 +120,9 @@ public class MediaAdapter extends CursorRecyclerViewAdapter<ViewHolder> {
 
     @Override
     public void onClick(View v) {
-      if (mediaRecord.getAttachment().getDataUri() != null) {
+      if (!batchSelected.isEmpty()) {
+        clickListener.onItemClick(mediaRecord);
+      } else if (mediaRecord.getAttachment().getDataUri() != null) {
         Intent intent = new Intent(getContext(), MediaPreviewActivity.class);
         intent.putExtra(MediaPreviewActivity.DATE_EXTRA, mediaRecord.getDate());
         intent.putExtra(MediaPreviewActivity.SIZE_EXTRA, mediaRecord.getAttachment().getSize());
@@ -97,6 +135,12 @@ public class MediaAdapter extends CursorRecyclerViewAdapter<ViewHolder> {
         intent.setDataAndType(mediaRecord.getAttachment().getDataUri(), mediaRecord.getContentType());
         getContext().startActivity(intent);
       }
+    }
+
+    @Override
+    public boolean onLongClick(View v) {
+      clickListener.onItemLongClick(mediaRecord);
+      return true;
     }
   }
 }

--- a/src/org/thoughtcrime/securesms/MediaOverviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaOverviewActivity.java
@@ -234,6 +234,10 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity i
     builder.show();
   }
 
+  private void handleSelectAllMedia() {
+    getListAdapter().selectAllMedia();
+  }
+
   private MediaAdapter getListAdapter() {
     return (MediaAdapter) gridView.getAdapter();
   }
@@ -354,6 +358,9 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity i
         case R.id.menu_context_delete_attachments:
           handleDeleteAttachments(getListAdapter().getSelectedItems());
           actionMode.finish();
+          return true;
+        case R.id.menu_context_select_all:
+          handleSelectAllMedia();
           return true;
       }
 

--- a/src/org/thoughtcrime/securesms/database/AttachmentDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/AttachmentDatabase.java
@@ -243,6 +243,7 @@ public class AttachmentDatabase extends Database {
     }
 
     database.delete(TABLE_NAME, MMS_ID + " = ?", new String[] {mmsId + ""});
+    notifyConversationListeners(DatabaseFactory.getMmsDatabase(context).getThreadIdForMessage(mmsId));
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored")

--- a/src/org/thoughtcrime/securesms/database/MediaDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MediaDatabase.java
@@ -103,6 +103,18 @@ public class MediaDatabase extends Database {
       return date;
     }
 
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      return attachment.equals(((MediaRecord) o).attachment);
+    }
+
+    @Override
+    public int hashCode() {
+      return attachment.hashCode();
+    }
   }
 
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
* Android 6 and 7.1 emulators
* Android 4.2.2 phone
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description

Batch-select and delete attachments.

<img src="https://cloud.githubusercontent.com/assets/264472/22621573/2b7bee4c-eb27-11e6-8924-2859f9e92b5f.png" height="480">

The message itself is currently not deleted (even if it's empty); only the attachment is removed.

Fixes #4242
Fixes #6111