### PR TITLE
Fixed leek of personal information (phone number) to Android Logcat.

### DIFF
--- a/src/org/thoughtcrime/securesms/database/EarlyReceiptCache.java
+++ b/src/org/thoughtcrime/securesms/database/EarlyReceiptCache.java
@@ -4,6 +4,7 @@ import android.support.annotation.NonNull;
 import android.util.Log;
 
 import org.thoughtcrime.securesms.util.LRUCache;
+import org.thoughtcrime.securesms.util.NumberUtil;
 
 public class EarlyReceiptCache {
 
@@ -13,7 +14,7 @@ public class EarlyReceiptCache {
 
   public synchronized void increment(long timestamp, String address) {
     Log.w(TAG, this+"");
-    Log.w(TAG, String.format("Early receipt: %d,%s", timestamp, address));
+    Log.w(TAG, String.format("Early receipt: %d,%s", timestamp, NumberUtil.anonymizePhoneNumber(address)));
     Placeholder tuple = new Placeholder(timestamp, address);
     Long        count = cache.get(tuple);
 
@@ -27,7 +28,7 @@ public class EarlyReceiptCache {
   public synchronized long remove(long timestamp, String address) {
     Long count = cache.remove(new Placeholder(timestamp, address));
     Log.w(TAG, this+"");
-    Log.w(TAG, String.format("Checking early receipts (%d, %s): %d", timestamp, address, count));
+    Log.w(TAG, String.format("Checking early receipts (%d, %s): %d", timestamp, NumberUtil.anonymizePhoneNumber(address), count));
     return count != null ? count : 0;
   }
 

--- a/src/org/thoughtcrime/securesms/database/TextSecureDirectory.java
+++ b/src/org/thoughtcrime/securesms/database/TextSecureDirectory.java
@@ -10,6 +10,7 @@ import android.provider.ContactsContract.CommonDataKinds.Phone;
 import android.text.TextUtils;
 import android.util.Log;
 
+import org.thoughtcrime.securesms.util.NumberUtil;
 import org.whispersystems.signalservice.api.push.ContactTokenDetails;
 import org.whispersystems.signalservice.api.util.InvalidNumberException;
 import org.whispersystems.signalservice.api.util.PhoneNumberFormatter;
@@ -151,7 +152,7 @@ public class TextSecureDirectory {
 
     try {
       for (ContactTokenDetails token : activeTokens) {
-        Log.w("Directory", "Adding active token: " + token.getNumber() + ", " + token.getToken());
+        Log.w("Directory", "Adding active token: " + NumberUtil.anonymizePhoneNumber(token.getNumber()) + ", " + token.getToken());
         ContentValues values = new ContentValues();
         values.put(NUMBER, token.getNumber());
         values.put(REGISTERED, 1);

--- a/src/org/thoughtcrime/securesms/service/MessageRetrievalService.java
+++ b/src/org/thoughtcrime/securesms/service/MessageRetrievalService.java
@@ -7,10 +7,14 @@ import android.os.IBinder;
 import android.support.annotation.Nullable;
 import android.util.Log;
 
+import com.google.i18n.phonenumbers.PhoneNumberUtil;
+import com.google.zxing.common.StringUtils;
+
 import org.thoughtcrime.securesms.ApplicationContext;
 import org.thoughtcrime.securesms.dependencies.InjectableType;
 import org.thoughtcrime.securesms.gcm.GcmBroadcastReceiver;
 import org.thoughtcrime.securesms.jobs.PushContentReceiveJob;
+import org.thoughtcrime.securesms.util.NumberUtil;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.whispersystems.jobqueue.requirements.NetworkRequirement;
 import org.whispersystems.jobqueue.requirements.NetworkRequirementProvider;
@@ -20,6 +24,7 @@ import org.whispersystems.signalservice.api.SignalServiceMessagePipe;
 import org.whispersystems.signalservice.api.SignalServiceMessageReceiver;
 import org.whispersystems.signalservice.api.messages.SignalServiceEnvelope;
 
+import java.security.MessageDigest;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -86,7 +91,7 @@ public class MessageRetrievalService extends Service implements Runnable, Inject
                       new SignalServiceMessagePipe.MessagePipeCallback() {
                         @Override
                         public void onMessage(SignalServiceEnvelope envelope) {
-                          Log.w(TAG, "Retrieved envelope! " + envelope.getSource());
+                          Log.w(TAG, "Retrieved envelope! " + NumberUtil.anonymizePhoneNumber(envelope.getSource()));
 
                           PushContentReceiveJob receiveJob = new PushContentReceiveJob(MessageRetrievalService.this);
                           receiveJob.handle(envelope, false);

--- a/src/org/thoughtcrime/securesms/util/NumberUtil.java
+++ b/src/org/thoughtcrime/securesms/util/NumberUtil.java
@@ -40,6 +40,23 @@ public class NumberUtil {
         GroupUtil.isEncodedGroup(number);
   }
 
+  /**
+   * Anonymizes given phone number for a use in logs. It parses a number to get correct country code.
+   * For a number "+48123456789" it will return "+*********89".
+   *
+   * @param phoneNumber The phone number to be anonymized
+   * @return Anonymized phone number
+   */
+  public static String anonymizePhoneNumber(String phoneNumber) {
+    StringBuilder sb = new StringBuilder(phoneNumber.length());
+    sb.append(phoneNumber.substring(0, 1));
+    for (int i=1; i<phoneNumber.length()-2; i++) {
+      sb.append("*");
+    }
+    sb.append(phoneNumber.substring(phoneNumber.length()-2, phoneNumber.length()));
+    return sb.toString();
+  }
+
   public static String filterNumber(String number) {
     if (number == null) return null;
 

--- a/test/unitTest/java/org/thoughtcrime/securesms/util/NumberUtilTest.java
+++ b/test/unitTest/java/org/thoughtcrime/securesms/util/NumberUtilTest.java
@@ -1,0 +1,32 @@
+package org.thoughtcrime.securesms.util;
+
+import com.google.i18n.phonenumbers.NumberParseException;
+import com.google.i18n.phonenumbers.PhoneNumberUtil;
+
+import org.junit.Test;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.thoughtcrime.securesms.BaseUnitTest;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@PrepareForTest({ PhoneNumberUtil.class })
+public class NumberUtilTest extends BaseUnitTest {
+  private String[][] numbersToTest = new String[][] {
+    { "+15555555555", "+*********55" },
+    { "+41446681800", "+*********00" },
+    { "+442079460018", "+**********18" },
+    { "+4930123456", "+********56" },
+    { "+49171123456", "+*********56" },
+    { "+358041234567", "+**********67" } // Finnish mobile number
+  };
+
+  @Test public void testAnonymizePhoneNumber() throws Exception {
+    for (String[] numbers : numbersToTest) {
+        assertEquals(numbers[1], NumberUtil.anonymizePhoneNumber(numbers[0]));
+    }
+  }
+}


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy Nexus, Android 4.3
 * LG Nexus 5, Android 6.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
PII informations are stripped prior to writing them into logcat. This prevents other apps to access them (on older or rooted devices). Stripping is done the same way as in libpastelog - "+" and two last digits of the phone number is left, the rest is changed to "*". 