### PR TITLE
Fix launchMode of MediaPreviewActivity

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -308,7 +308,7 @@
     <activity android:name=".MediaPreviewActivity"
               android:label="@string/AndroidManifest__media_preview"
               android:windowSoftInputMode="stateHidden"
-              android:launchMode="singleTask"
+              android:launchMode="singleTop"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
     <activity android:name=".MediaOverviewActivity"

--- a/src/org/thoughtcrime/securesms/ImageMediaAdapter.java
+++ b/src/org/thoughtcrime/securesms/ImageMediaAdapter.java
@@ -91,6 +91,7 @@ public class ImageMediaAdapter extends CursorRecyclerViewAdapter<ViewHolder> {
         Intent intent = new Intent(getContext(), MediaPreviewActivity.class);
         intent.putExtra(MediaPreviewActivity.DATE_EXTRA, imageRecord.getDate());
         intent.putExtra(MediaPreviewActivity.THREAD_ID_EXTRA, threadId);
+        intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
 
         if (!TextUtils.isEmpty(imageRecord.getAddress())) {
           Recipients recipients = RecipientFactory.getRecipientsFromString(getContext(),


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung GT-I8160, Android 4.4.4 (CyanogenMod)
 * Wileyfox Swift, Android 6.0.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixes https://github.com/WhisperSystems/Signal-Android/issues/5940

Changed launchMode of MediaPreviewActivity to SingleTop to prevent issues like in https://github.com/WhisperSystems/Signal-Android/issues/6065
Added Intent.FLAG_ACTIVITY_REORDER_TO_FRONT to MediaPreviewActivity Intent to prevent multiple Media Previews

//FREEBIE