### PR TITLE
Stop audio playback on deletion

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -52,6 +52,7 @@ import android.widget.Toast;
 
 import org.thoughtcrime.securesms.ConversationAdapter.HeaderViewHolder;
 import org.thoughtcrime.securesms.ConversationAdapter.ItemClickListener;
+import org.thoughtcrime.securesms.audio.AudioSlidePlayer;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.MmsSmsDatabase;
 import org.thoughtcrime.securesms.database.RecipientDatabase;
@@ -325,6 +326,13 @@ public class ConversationFragment extends Fragment
             for (MessageRecord messageRecord : messageRecords) {
               boolean threadDeleted;
 
+              if (messageRecord.isMms()                                       &&
+                  !messageRecord.isMmsNotification()                          &&
+                  ((MediaMmsMessageRecord)messageRecord).containsMediaSlide() &&
+                  AudioSlidePlayer.isPlaying(((MediaMmsMessageRecord) messageRecord).getSlideDeck()
+                                                                                    .getAudioSlide())) {
+                AudioSlidePlayer.stopAll();
+              }
               if (messageRecord.isMms()) {
                 threadDeleted = DatabaseFactory.getMmsDatabase(getActivity()).delete(messageRecord.getId());
               } else {

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -326,12 +326,11 @@ public class ConversationFragment extends Fragment
             for (MessageRecord messageRecord : messageRecords) {
               boolean threadDeleted;
 
-              if (messageRecord.isMms()                                       &&
-                  !messageRecord.isMmsNotification()                          &&
-                  ((MediaMmsMessageRecord)messageRecord).containsMediaSlide() &&
-                  AudioSlidePlayer.isPlaying(((MediaMmsMessageRecord) messageRecord).getSlideDeck()
-                                                                                    .getAudioSlide())) {
-                AudioSlidePlayer.stopAll();
+              if (messageRecord.isMms()              &&
+                  !messageRecord.isMmsNotification() &&
+                  ((MediaMmsMessageRecord)messageRecord).containsMediaSlide()) {
+                AudioSlidePlayer.stopIfIsPlaying(((MediaMmsMessageRecord) messageRecord).getSlideDeck()
+                                                                                        .getAudioSlide());
               }
               if (messageRecord.isMms()) {
                 threadDeleted = DatabaseFactory.getMmsDatabase(getActivity()).delete(messageRecord.getId());

--- a/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
+++ b/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
@@ -197,6 +197,10 @@ public class AudioSlidePlayer implements SensorEventListener {
     }
   }
 
+  public static boolean isPlaying(@Nullable AudioSlide slide) {
+    return playing.isPresent() && playing.get().getAudioSlide().equals(slide);
+  }
+
   public void setListener(@NonNull Listener listener) {
     this.listener = new WeakReference<>(listener);
 

--- a/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
+++ b/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
@@ -175,6 +175,7 @@ public class AudioSlidePlayer implements SensorEventListener {
     Log.w(TAG, "Stop called!");
 
     removePlaying(this);
+    progressEventHandler.removeMessages(0);
 
     if (this.mediaPlayer != null) {
       this.mediaPlayer.stop();

--- a/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
+++ b/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
@@ -197,8 +197,13 @@ public class AudioSlidePlayer implements SensorEventListener {
     }
   }
 
-  public static boolean isPlaying(@Nullable AudioSlide slide) {
-    return playing.isPresent() && playing.get().getAudioSlide().equals(slide);
+  public static boolean stopIfIsPlaying(@Nullable AudioSlide slide) {
+    if (playing.isPresent() && playing.get().getAudioSlide().equals(slide)) {
+      playing.get().stop();
+      return true;
+    } else {
+      return false;
+    }
   }
 
   public void setListener(@NonNull Listener listener) {

--- a/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
+++ b/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
@@ -197,7 +197,7 @@ public class AudioSlidePlayer implements SensorEventListener {
     }
   }
 
-  public static boolean stopIfIsPlaying(@Nullable AudioSlide slide) {
+  public synchronized static boolean stopIfIsPlaying(@Nullable AudioSlide slide) {
     if (playing.isPresent() && playing.get().getAudioSlide().equals(slide)) {
       playing.get().stop();
       return true;


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Xperia U, Android 4.4.4 (CyanogenMod)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
Audio playback will stop if the playing audio attachment gets deleted.

Fixes #4627
// FREEBIE