### PR TITLE
Show play overlay for video thumbnail placeholder

### DIFF
--- a/res/layout/thumbnail_view.xml
+++ b/res/layout/thumbnail_view.xml
@@ -18,7 +18,7 @@
                android:clickable="false"
                android:longClickable="false"
                android:src="@drawable/ic_play_circle_outline_white_48dp"
-               android:tint="#77ffffff"
+               android:tint="?thumbnail_play_overlay_tint"
                android:tintMode="src_in"
                android:visibility="gone"/>
 

--- a/res/layout/thumbnail_view.xml
+++ b/res/layout/thumbnail_view.xml
@@ -18,7 +18,7 @@
                android:clickable="false"
                android:longClickable="false"
                android:src="@drawable/ic_play_circle_outline_white_48dp"
-               android:tint="?thumbnail_play_overlay_tint"
+               android:tint="?attr/placeholder_play_overlay_tint"
                android:tintMode="src_in"
                android:visibility="gone"/>
 

--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -148,6 +148,7 @@
 
     <declare-styleable name="ThumbnailView">
         <attr name="backgroundColorHint" format="color" />
+        <attr name="thumbnail_play_overlay_tint" format="color" />
     </declare-styleable>
 
     <declare-styleable name="DeliveryStatusView">

--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -119,7 +119,7 @@
 
     <attr name="app_protect_timeout_picker_color" format="reference"/>
 
-    <attr name="thumbnail_play_overlay_tint" format="reference|color" />
+    <attr name="placeholder_play_overlay_tint" format="reference|color" />
 
     <declare-styleable name="CustomDefaultPreference">
         <attr name="custom_pref_toggle" format="string"/>

--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -119,6 +119,8 @@
 
     <attr name="app_protect_timeout_picker_color" format="reference"/>
 
+    <attr name="thumbnail_play_overlay_tint" format="reference|color" />
+
     <declare-styleable name="CustomDefaultPreference">
         <attr name="custom_pref_toggle" format="string"/>
     </declare-styleable>
@@ -148,7 +150,6 @@
 
     <declare-styleable name="ThumbnailView">
         <attr name="backgroundColorHint" format="color" />
-        <attr name="thumbnail_play_overlay_tint" format="color" />
     </declare-styleable>
 
     <declare-styleable name="DeliveryStatusView">

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -55,4 +55,6 @@
 
     <color name="sticker_selected_color">#8cf437</color>
     <color name="transparent">#00FFFFFF</color>
+
+    <color name="thumbnail_play_overlay_tint">#77ffffff</color>
 </resources>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -235,7 +235,7 @@
         <item name="group_members_dialog_icon">@drawable/ic_group_grey600_24dp</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.Fix</item>
 
-        <item name="thumbnail_play_overlay_tint">#77ffffff</item>
+        <item name="placeholder_play_overlay_tint">#77ffffff</item>
     </style>
 
     <style name="TextSecure.DarkTheme" parent="@style/Theme.AppCompat">
@@ -361,6 +361,6 @@
         <item name="group_members_dialog_icon">@drawable/ic_group_white_24dp</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.Fix</item>
 
-        <item name="thumbnail_play_overlay_tint">#77000000</item>
+        <item name="placeholder_play_overlay_tint">#77000000</item>
     </style>
 </resources>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -21,6 +21,7 @@
         <item name="dialog_background_color">@color/background_material_light</item>
         <item name="pref_divider">@drawable/preference_divider_light</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.Fix</item>
+        <item name="placeholder_play_overlay_tint">#77ffffff</item>
 
         <item name="media_overview_toolbar_background">@color/white</item>
         <item name="media_overview_toolbar_foreground">@color/gray70</item>
@@ -49,6 +50,7 @@
         <item name="dialog_background_color">@color/background_material_dark</item>
         <item name="pref_divider">@drawable/preference_divider_dark</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.Fix</item>
+        <item name="placeholder_play_overlay_tint">#77000000</item>
 
         <item name="media_overview_toolbar_background">@color/black</item>
         <item name="media_overview_toolbar_foreground">@color/white</item>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -234,6 +234,8 @@
 
         <item name="group_members_dialog_icon">@drawable/ic_group_grey600_24dp</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.Fix</item>
+
+        <item name="thumbnail_play_overlay_tint">#77ffffff</item>
     </style>
 
     <style name="TextSecure.DarkTheme" parent="@style/Theme.AppCompat">
@@ -358,5 +360,7 @@
 
         <item name="group_members_dialog_icon">@drawable/ic_group_white_24dp</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.Fix</item>
+
+        <item name="thumbnail_play_overlay_tint">#77000000</item>
     </style>
 </resources>

--- a/src/org/thoughtcrime/securesms/components/ThumbnailView.java
+++ b/src/org/thoughtcrime/securesms/components/ThumbnailView.java
@@ -107,9 +107,9 @@ public class ThumbnailView extends FrameLayout {
       getTransferControls().setVisibility(View.GONE);
     }
 
-    if (slide.getThumbnailUri() != null && slide.hasPlayOverlay() &&
-        (slide.getTransferState() == AttachmentDatabase.TRANSFER_PROGRESS_DONE || isPreview))
-    {
+    if ((slide.getThumbnailUri() != null || slide.hasPlaceholder()) &&
+        slide.hasPlayOverlay()                                      &&
+        (slide.getTransferState() == AttachmentDatabase.TRANSFER_PROGRESS_DONE || isPreview)) {
       this.playOverlay.setVisibility(View.VISIBLE);
     } else {
       this.playOverlay.setVisibility(View.GONE);

--- a/src/org/thoughtcrime/securesms/components/ThumbnailView.java
+++ b/src/org/thoughtcrime/securesms/components/ThumbnailView.java
@@ -9,6 +9,8 @@ import android.net.Uri;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.support.annotation.NonNull;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.graphics.drawable.DrawableCompat;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.View;
@@ -110,6 +112,11 @@ public class ThumbnailView extends FrameLayout {
     if ((slide.getThumbnailUri() != null || slide.hasPlaceholder()) &&
         slide.hasPlayOverlay()                                      &&
         (slide.getTransferState() == AttachmentDatabase.TRANSFER_PROGRESS_DONE || isPreview)) {
+      if (slide.getThumbnailUri() != null) {
+        DrawableCompat.setTint(this.playOverlay.getDrawable(),
+                               ContextCompat.getColor(getContext(),
+                                                      R.color.thumbnail_play_overlay_tint));
+      }
       this.playOverlay.setVisibility(View.VISIBLE);
     } else {
       this.playOverlay.setVisibility(View.GONE);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Xperia U, Android 4.4.4 (CyanogenMod)
 * AVD Nexus 5X, Android 7.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
Showing the play overlay above the video thumbnail placeholder should highlight, that the video can be played by clicking it.

### Screenshots
Android 4.4.4 KitKat
![device-2017-05-13-152730](https://cloud.githubusercontent.com/assets/16167751/26026039/9f188634-37f4-11e7-844e-c9f85100e17b.png)
![device-2017-05-13-152820](https://cloud.githubusercontent.com/assets/16167751/26026040/a1440a00-37f4-11e7-8cd1-49f1ccf85ac8.png)
![device-2017-05-13-155931](https://cloud.githubusercontent.com/assets/16167751/26026119/fb009206-37f5-11e7-9e58-bf73d01cbe97.png)

Android 7.1.1 Nougat
![bildschirmfoto von 2017-05-13 15-44-33](https://cloud.githubusercontent.com/assets/16167751/26026041/a4a9e9da-37f4-11e7-8bea-5f3febfe1cef.png)
![bildschirmfoto von 2017-05-13 15-45-03](https://cloud.githubusercontent.com/assets/16167751/26026043/a6e814e2-37f4-11e7-989a-bf44629a6b8a.png)
