### PR TITLE
Inform user that message is too long to be displayed.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -425,6 +425,7 @@
     <string name="MessageRecord_you_marked_your_safety_number_with_s_verified_from_another_device">You marked your safety number with %s verified from another device</string>
     <string name="MessageRecord_you_marked_your_safety_number_with_s_unverified">You marked your safety number with %s unverified</string>
     <string name="MessageRecord_you_marked_your_safety_number_with_s_unverified_from_another_device">You marked your safety number with %s unverified from another device</string>
+    <string name="MessageRecord_message_too_long">Message is too long to be displayed completely.</string>
 
 
     <!-- PassphraseChangeActivity -->
@@ -857,7 +858,7 @@
     </plurals>
 
     <string name="expiration_weeks_abbreviated">%dw</string>
-    
+
     <!-- unverified safety numbers -->
     <string name="IdentityUtil_unverified_banner_one">Your safety number with %s has changed and is no longer verified</string>
     <string name="IdentityUtil_unverified_banner_two">Your safety numbers with %1$s and %2$s are no longer verified</string>

--- a/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -121,7 +121,11 @@ public abstract class MessageRecord extends DisplayRecord {
       if (isOutgoing()) return emphasisAdded(context.getString(R.string.MessageRecord_you_marked_your_safety_number_with_s_unverified, getIndividualRecipient().toShortString()));
       else              return emphasisAdded(context.getString(R.string.MessageRecord_you_marked_your_safety_number_with_s_unverified_from_another_device, getIndividualRecipient().toShortString()));
     } else if (getBody().getBody().length() > MAX_DISPLAY_LENGTH) {
-      return new SpannableString(getBody().getBody().substring(0, MAX_DISPLAY_LENGTH));
+      String trimmedMessage = getBody().getBody().substring(0, MAX_DISPLAY_LENGTH);
+      String messageTooLongSuffix = "\n" + context.getString(R.string.MessageRecord_message_too_long);
+      SpannableString finalMessage = new SpannableString(trimmedMessage + messageTooLongSuffix);
+      setEmphasis(finalMessage, finalMessage.length() - messageTooLongSuffix.length(), finalMessage.length());
+      return finalMessage;
     }
 
     return new SpannableString(getBody().getBody());
@@ -208,10 +212,13 @@ public abstract class MessageRecord extends DisplayRecord {
 
   protected SpannableString emphasisAdded(String sequence) {
     SpannableString spannable = new SpannableString(sequence);
-    spannable.setSpan(new RelativeSizeSpan(0.9f), 0, sequence.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-    spannable.setSpan(new StyleSpan(android.graphics.Typeface.ITALIC), 0, sequence.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-
+    setEmphasis(spannable, 0, spannable.length());
     return spannable;
+  }
+
+  protected void setEmphasis(SpannableString spannable, int start, int end) {
+    spannable.setSpan(new RelativeSizeSpan(0.9f), start, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+    spannable.setSpan(new StyleSpan(android.graphics.Typeface.ITALIC), start, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
   }
 
   public boolean equals(Object other) {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * LG Nexus 5x, Android 7.1.2
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [X] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
Currently text messages are silently cut when they are longer than 2000 characters (as mentioned in issue #5146). It can be really annoying as users may not even notice that part of message is not shown if the message is not cut half-sentence. I had this problem multiple times when my contact copied a longer text to me using Signal Desktop and I tried to read it on Android.

Resolving the issue properly probably requires a lot of work (like adding a way to display full message body or splitting large messages into smaller parts) and I believe it will take some time, especially considering that the issue mentioned is already over a year old. In the meantime I think it would be fair to inform users that part of message is not displayed so that they can resolve it with their contacts somehow (like using another communication channel or splitting the message manually). 

 
