### PR TITLE
Automatic dark mode based on ambient light

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -99,11 +99,13 @@
   <string-array name="pref_theme_entries">
       <item>@string/preferences__light_theme</item>
       <item>@string/preferences__dark_theme</item>
+      <item>@string/preferences__auto_dark__theme</item>
   </string-array>
 
   <string-array name="pref_theme_values" translatable="false">
       <item>light</item>
       <item>dark</item>
+      <item>auto_dark</item>
   </string-array>
 
   <string-array name="pref_led_color_entries">
@@ -304,5 +306,4 @@
         <item>1</item>
         <item>2</item>
     </string-array>
-
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1203,6 +1203,7 @@
     <string name="preferences__linked_devices">Linked devices</string>
     <string name="preferences__light_theme">Light</string>
     <string name="preferences__dark_theme">Dark</string>
+    <string name="preferences__auto_dark__theme">Automatic dark</string>
     <string name="preferences__appearance">Appearance</string>
     <string name="preferences__theme">Theme</string>
     <string name="preferences__default">Default</string>

--- a/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -94,6 +94,12 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
   }
 
   @Override
+  protected void onPause() {
+    super.onPause();
+    dynamicTheme.onPause(this);
+  }
+
+  @Override
   protected void onActivityResult(int requestCode, int resultCode, Intent data)
   {
     super.onActivityResult(requestCode, resultCode, data);

--- a/src/org/thoughtcrime/securesms/BlockedContactsActivity.java
+++ b/src/org/thoughtcrime/securesms/BlockedContactsActivity.java
@@ -51,6 +51,12 @@ public class BlockedContactsActivity extends PassphraseRequiredActionBarActivity
   }
 
   @Override
+  protected void onPause() {
+    super.onPause();
+    dynamicTheme.onPause(this);
+  }
+
+  @Override
   public boolean onOptionsItemSelected(MenuItem item) {
     switch (item.getItemId()) {
       case android.R.id.home: finish(); return true;

--- a/src/org/thoughtcrime/securesms/ContactSelectionActivity.java
+++ b/src/org/thoughtcrime/securesms/ContactSelectionActivity.java
@@ -86,6 +86,12 @@ public abstract class ContactSelectionActivity extends PassphraseRequiredActionB
     dynamicLanguage.onResume(this);
   }
 
+  @Override
+  protected void onPause() {
+    super.onPause();
+    dynamicTheme.onPause(this);
+  }
+
   protected ContactFilterToolbar getToolbar() {
     return toolbar;
   }

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -347,6 +347,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     markLastSeen();
     AudioSlidePlayer.stopAll();
     EventBus.getDefault().unregister(this);
+    dynamicTheme.onPause(this);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -84,6 +84,12 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
   }
 
   @Override
+  protected void onPause() {
+    super.onPause();
+    dynamicTheme.onPause(this);
+  }
+
+  @Override
   public void onDestroy() {
     if (observer != null) getContentResolver().unregisterContentObserver(observer);
     super.onDestroy();

--- a/src/org/thoughtcrime/securesms/ConversationListArchiveActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListArchiveActivity.java
@@ -43,6 +43,12 @@ public class ConversationListArchiveActivity extends PassphraseRequiredActionBar
   }
 
   @Override
+  protected void onPause() {
+    super.onPause();
+    dynamicTheme.onPause(this);
+  }
+
+  @Override
   public boolean onOptionsItemSelected(MenuItem item) {
     super.onOptionsItemSelected(item);
 

--- a/src/org/thoughtcrime/securesms/DeviceActivity.java
+++ b/src/org/thoughtcrime/securesms/DeviceActivity.java
@@ -79,6 +79,12 @@ public class DeviceActivity extends PassphraseRequiredActionBarActivity
   }
 
   @Override
+  protected void onPause() {
+    super.onPause();
+    dynamicTheme.onPause(this);
+  }
+
+  @Override
   public boolean onOptionsItemSelected(MenuItem item) {
     switch (item.getItemId()) {
       case android.R.id.home: finish(); return true;

--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -138,6 +138,12 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
     updateViewState();
   }
 
+  @Override
+  protected void onPause() {
+    super.onPause();
+    dynamicTheme.onPause(this);
+  }
+
   private boolean isSignalGroup() {
     return TextSecurePreferences.isPushRegistered(this) && !getAdapter().hasNonPushMembers();
   }

--- a/src/org/thoughtcrime/securesms/ImportExportActivity.java
+++ b/src/org/thoughtcrime/securesms/ImportExportActivity.java
@@ -33,6 +33,12 @@ public class ImportExportActivity extends PassphraseRequiredActionBarActivity {
   }
 
   @Override
+  protected void onPause() {
+    super.onPause();
+    dynamicTheme.onPause(this);
+  }
+
+  @Override
   public boolean onOptionsItemSelected(MenuItem item) {
     super.onOptionsItemSelected(item);
 

--- a/src/org/thoughtcrime/securesms/LogSubmitActivity.java
+++ b/src/org/thoughtcrime/securesms/LogSubmitActivity.java
@@ -39,6 +39,12 @@ public class LogSubmitActivity extends BaseActionBarActivity implements SubmitLo
   }
 
   @Override
+  protected void onPause() {
+    super.onPause();
+    dynamicTheme.onPause(this);
+  }
+
+  @Override
   public boolean onOptionsItemSelected(MenuItem item) {
     super.onOptionsItemSelected(item);
     switch (item.getItemId()) {

--- a/src/org/thoughtcrime/securesms/MessageDetailsActivity.java
+++ b/src/org/thoughtcrime/securesms/MessageDetailsActivity.java
@@ -127,6 +127,7 @@ public class MessageDetailsActivity extends PassphraseRequiredActionBarActivity 
   protected void onPause() {
     super.onPause();
     MessageNotifier.setVisibleThread(-1L);
+    dynamicTheme.onPause(this);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/PassphraseChangeActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphraseChangeActivity.java
@@ -68,6 +68,12 @@ public class PassphraseChangeActivity extends PassphraseActivity {
     dynamicLanguage.onResume(this);
   }
 
+  @Override
+  protected void onPause() {
+    super.onPause();
+    dynamicTheme.onPause(this);
+  }
+
   private void initializeResources() {
     this.originalPassphrase      = (EditText) findViewById(R.id.old_passphrase      );
     this.newPassphrase           = (EditText) findViewById(R.id.new_passphrase      );

--- a/src/org/thoughtcrime/securesms/PassphrasePromptActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphrasePromptActivity.java
@@ -76,6 +76,12 @@ public class PassphrasePromptActivity extends PassphraseActivity {
   }
 
   @Override
+  protected void onPause() {
+    super.onPause();
+    dynamicTheme.onPause(this);
+  }
+
+  @Override
   protected void onNewIntent(Intent intent) {
     super.onNewIntent(intent);
     setIntent(intent);

--- a/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
+++ b/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
@@ -107,6 +107,12 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
   }
 
   @Override
+  protected void onPause() {
+    super.onPause();
+    dynamicTheme.onPause(this);
+  }
+
+  @Override
   public void onDestroy() {
     super.onDestroy();
     unregisterReceiver(staleReceiver);

--- a/src/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/org/thoughtcrime/securesms/ShareActivity.java
@@ -109,6 +109,7 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity
   @Override
   public void onPause() {
     super.onPause();
+    dynamicTheme.onPause(this);
     if (!isPassingAlongMedia && resolvedExtra != null) {
       PersistentBlobProvider.getInstance(this).delete(resolvedExtra);
     }

--- a/src/org/thoughtcrime/securesms/preferences/MmsPreferencesActivity.java
+++ b/src/org/thoughtcrime/securesms/preferences/MmsPreferencesActivity.java
@@ -59,6 +59,12 @@ public class MmsPreferencesActivity extends PassphraseRequiredActionBarActivity 
   }
 
   @Override
+  protected void onPause() {
+    super.onPause();
+    dynamicTheme.onPause(this);
+  }
+
+  @Override
   public boolean onOptionsItemSelected(MenuItem item) {
     switch (item.getItemId()) {
       case android.R.id.home:

--- a/src/org/thoughtcrime/securesms/util/ActivityUtil.java
+++ b/src/org/thoughtcrime/securesms/util/ActivityUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2017 Fernando Garcia Alvarez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thoughtcrime.securesms.util;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Build;
+
+/**
+ * Class used to perform actions
+ * on Activities in a compatible way
+ *
+ * @author fercarcedo
+ */
+public class ActivityUtil {
+  public static void recreateActivity(Activity activity) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+      recreateHoneycomb(activity);
+    } else {
+      recreatePreHoneycomb(activity);
+    }
+  }
+
+  @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+  private static void recreateHoneycomb(Activity activity) {
+    activity.recreate();
+  }
+
+  private static void recreatePreHoneycomb(Activity activity) {
+    Intent intent = activity.getIntent();
+    intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+    activity.finish();
+    activity.overridePendingTransition(0, 0);
+    activity.startActivity(intent);
+    activity.overridePendingTransition(0, 0);
+  }
+}

--- a/src/org/thoughtcrime/securesms/util/ActivityUtil.java
+++ b/src/org/thoughtcrime/securesms/util/ActivityUtil.java
@@ -13,24 +13,13 @@ import android.os.Build;
  */
 public class ActivityUtil {
   public static void recreateActivity(Activity activity) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-      recreateHoneycomb(activity);
-    } else {
-      recreatePreHoneycomb(activity);
+    if (activity != null) {
+      Intent intent = activity.getIntent();
+      intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+      activity.finish();
+      activity.overridePendingTransition(0, 0);
+      activity.startActivity(intent);
+      activity.overridePendingTransition(0, 0);
     }
-  }
-
-  @TargetApi(Build.VERSION_CODES.HONEYCOMB)
-  private static void recreateHoneycomb(Activity activity) {
-    activity.recreate();
-  }
-
-  private static void recreatePreHoneycomb(Activity activity) {
-    Intent intent = activity.getIntent();
-    intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
-    activity.finish();
-    activity.overridePendingTransition(0, 0);
-    activity.startActivity(intent);
-    activity.overridePendingTransition(0, 0);
   }
 }

--- a/src/org/thoughtcrime/securesms/util/ActivityUtil.java
+++ b/src/org/thoughtcrime/securesms/util/ActivityUtil.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2017 Fernando Garcia Alvarez
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.thoughtcrime.securesms.util;
 
 import android.annotation.TargetApi;

--- a/src/org/thoughtcrime/securesms/util/AutoDarkModeManager.java
+++ b/src/org/thoughtcrime/securesms/util/AutoDarkModeManager.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2017 Fernando Garcia Alvarez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thoughtcrime.securesms.util;
+
+import android.app.Activity;
+import android.content.Context;
+import android.hardware.Sensor;
+import android.hardware.SensorEvent;
+import android.hardware.SensorEventListener;
+import android.hardware.SensorManager;
+
+/**
+ * Class used to manage the automatic
+ * dark mode based on ambient light
+ *
+ * @author fercarcedo
+ */
+public class AutoDarkModeManager implements SensorEventListener {
+  private static final float MAX_LUX_FOR_DARK_THEME = 10;
+  private static boolean showDarkTheme;
+  private static String lastActivityName;
+
+  private Activity activity;
+
+  public AutoDarkModeManager(Activity activity) {
+    this.activity = activity;
+  }
+
+  public static boolean shouldShowDarkTheme() {
+    return showDarkTheme;
+  }
+
+  public void listenForCurrentActivityIfNecessary() {
+    if (!activity.getClass().getSimpleName().equals(lastActivityName)) {
+      startListening();
+    }
+  }
+
+  private void startListening() {
+    SensorManager sensorManager = (SensorManager) activity.getSystemService(Context.SENSOR_SERVICE);
+    Sensor sensor = sensorManager.getDefaultSensor(Sensor.TYPE_LIGHT);
+
+    if (sensor != null) {
+      sensorManager.registerListener(this, sensor, SensorManager.SENSOR_DELAY_UI);
+    }
+  }
+
+  private void stopListening() {
+    SensorManager sensorManager = (SensorManager) activity.getSystemService(Context.SENSOR_SERVICE);
+    sensorManager.unregisterListener(this);
+  }
+
+  @Override
+  public void onSensorChanged(SensorEvent event) {
+    lastActivityName = activity.getClass().getSimpleName();
+
+    float lux = event.values[0];
+    boolean previousShowDarkTheme = showDarkTheme;
+    showDarkTheme = lux <= MAX_LUX_FOR_DARK_THEME;
+    if (previousShowDarkTheme != showDarkTheme)
+      ActivityUtil.recreateActivity(activity);
+    stopListening();
+  }
+
+  @Override
+  public void onAccuracyChanged(Sensor sensor, int accuracy) {
+
+  }
+}

--- a/src/org/thoughtcrime/securesms/util/AutoDarkModeManager.java
+++ b/src/org/thoughtcrime/securesms/util/AutoDarkModeManager.java
@@ -18,55 +18,57 @@ import java.lang.ref.WeakReference;
 public class AutoDarkModeManager implements SensorEventListener {
   private static final float MAX_LUX_FOR_DARK_THEME = 10;
   private static boolean showDarkTheme;
-  private static Class<?> lastActivityClass;
-  private static SensorManager sensorManager;
-  private static boolean luxValueFound;
-  private WeakReference<Activity> activity;
+  private SensorValueReader sensorValueReader;
+  private WeakReference<Activity> activityReference;
+
+  public AutoDarkModeManager(Activity activity) {
+    activityReference = new WeakReference<>(activity);
+    sensorValueReader = new SensorValueReader(activity, Sensor.TYPE_LIGHT, this);
+  }
 
   public static boolean shouldShowDarkTheme() {
     return showDarkTheme;
   }
 
-  public static void listenForCurrentActivityIfNecessary(Activity activity) {
-    if (activity.getClass() != lastActivityClass || !luxValueFound) {
-      luxValueFound = false;
-      new AutoDarkModeManager().startListening(activity);
-    }
+  public void startListening() {
+    sensorValueReader.readSingleValue();
   }
 
-  private void startListening(Activity activity) {
-    this.activity = new WeakReference<>(activity);
-    lastActivityClass = activity.getClass();
-    sensorManager = (SensorManager) activity.getSystemService(Context.SENSOR_SERVICE);
-    Sensor sensor = sensorManager.getDefaultSensor(Sensor.TYPE_LIGHT);
-
-    if (sensor != null) {
-      sensorManager.registerListener(this, sensor, SensorManager.SENSOR_DELAY_UI);
-    }
-  }
-
-  private void stopListening() {
-    sensorManager.unregisterListener(this);
+  public void stopListening() {
+    sensorValueReader.stopListening();
   }
 
   @Override
   public void onSensorChanged(SensorEvent event) {
-    parseAmbientLightValue(event);
+    float ambientLightInLux = event.values[0];
+
+    if (shouldChangeTheme(ambientLightInLux)) {
+      changeTheme(ambientLightInLux);
+      recreateActivity();
+    }
+  }
+
+  private boolean shouldChangeTheme(float ambientLightInLux) {
+    return (lowLight(ambientLightInLux) && !showDarkTheme) || (!lowLight(ambientLightInLux) && showDarkTheme);
+  }
+
+  private boolean lowLight(float ambientLightInLux) {
+    return ambientLightInLux <= MAX_LUX_FOR_DARK_THEME;
+  }
+
+  private void changeTheme(float ambientLightInLux) {
+    showDarkTheme = lowLight(ambientLightInLux);
+  }
+
+  private void recreateActivity() {
+    Activity activity = activityReference.get();
+
+    if (activity != null)
+      ActivityUtil.recreateActivity(activity);
   }
 
   @Override
   public void onAccuracyChanged(Sensor sensor, int accuracy) {
 
-  }
-
-  private synchronized void parseAmbientLightValue(SensorEvent event) {
-    luxValueFound = true;
-    float lux = event.values[0];
-    boolean previousShowDarkTheme = showDarkTheme;
-    showDarkTheme = lux <= MAX_LUX_FOR_DARK_THEME;
-    Activity currentActivity = activity.get();
-    if (previousShowDarkTheme != showDarkTheme && currentActivity != null)
-      ActivityUtil.recreateActivity(currentActivity);
-    stopListening();
   }
 }

--- a/src/org/thoughtcrime/securesms/util/DynamicTheme.java
+++ b/src/org/thoughtcrime/securesms/util/DynamicTheme.java
@@ -6,7 +6,7 @@ import android.content.Intent;
 import org.thoughtcrime.securesms.R;
 
 public class DynamicTheme {
-
+  public static final String AUTO_DARK = "auto_dark";
   public static final String DARK  = "dark";
   public static final String LIGHT = "light";
 
@@ -25,12 +25,19 @@ public class DynamicTheme {
       activity.startActivity(intent);
       OverridePendingTransition.invoke(activity);
     }
+
+    String theme = TextSecurePreferences.getTheme(activity);
+    if (theme.equals(AUTO_DARK))
+      new AutoDarkModeManager(activity).listenForCurrentActivityIfNecessary();
   }
 
   protected int getSelectedTheme(Activity activity) {
     String theme = TextSecurePreferences.getTheme(activity);
 
     if (theme.equals(DARK)) return R.style.TextSecure_DarkTheme;
+
+    if (theme.equals(AUTO_DARK) && AutoDarkModeManager.shouldShowDarkTheme())
+      return R.style.TextSecure_DarkTheme;
 
     return R.style.TextSecure_LightTheme;
   }

--- a/src/org/thoughtcrime/securesms/util/DynamicTheme.java
+++ b/src/org/thoughtcrime/securesms/util/DynamicTheme.java
@@ -28,7 +28,7 @@ public class DynamicTheme {
 
     String theme = TextSecurePreferences.getTheme(activity);
     if (theme.equals(AUTO_DARK))
-      new AutoDarkModeManager(activity).listenForCurrentActivityIfNecessary();
+      AutoDarkModeManager.listenForCurrentActivityIfNecessary(activity);
   }
 
   protected int getSelectedTheme(Activity activity) {

--- a/src/org/thoughtcrime/securesms/util/SensorValueReader.java
+++ b/src/org/thoughtcrime/securesms/util/SensorValueReader.java
@@ -1,0 +1,61 @@
+package org.thoughtcrime.securesms.util;
+
+import android.content.Context;
+import android.hardware.Sensor;
+import android.hardware.SensorEvent;
+import android.hardware.SensorEventListener;
+import android.hardware.SensorManager;
+
+/**
+ * Class used to simplify reading values
+ * from sensors
+ *
+ * @author fercarcedo
+ */
+public class SensorValueReader implements SensorEventListener {
+
+  private SensorEventListener listener;
+  private SensorManager sensorManager;
+  private int sensorCode;
+
+  public SensorValueReader(Context context, int sensorCode, SensorEventListener listener) {
+    this.listener = listener;
+    this.sensorManager = getSensorManager(context);
+    this.sensorCode = sensorCode;
+  }
+
+  public void readSingleValue() {
+    registerSingleValueListener();
+  }
+
+  private void registerSingleValueListener() {
+    Sensor sensor = sensorManager.getDefaultSensor(sensorCode);
+
+    if (sensor != null) {
+      sensorManager.registerListener(this, sensor, SensorManager.SENSOR_DELAY_UI);
+    }
+  }
+
+  private SensorManager getSensorManager(Context context) {
+    return (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
+  }
+
+  public void stopListening() {
+    stopListening(this);
+  }
+
+  private void stopListening(SensorEventListener listener) {
+    sensorManager.unregisterListener(listener);
+  }
+
+  @Override
+  public void onSensorChanged(SensorEvent event) {
+    listener.onSensorChanged(event);
+    stopListening(this);
+  }
+
+  @Override
+  public void onAccuracyChanged(Sensor sensor, int accuracy) {
+    listener.onAccuracyChanged(sensor, accuracy);
+  }
+}


### PR DESCRIPTION
// FREEBIE

### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 5, Android 7.1.2
 * Virtual device Pixel, Android 7.0.0
 * Virtual device Pixel XL, Android O
 * Virtual device Nexus 5X, Android 4.2
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
This pull request enables Signal to automatically change to dark theme based on the current ambient light condition, like many other apps do.
I have tested this pull request in both emulators (setting manually the number of lux), as well as on my Nexus 5, going from outdoors to a dark room indoors, and in the night outside.
