### PR TITLE
MMS M-NotifyResp-Ind added if MMSC requires it

### DIFF
--- a/src/org/thoughtcrime/securesms/mms/IncomingLollipopMmsConnection.java
+++ b/src/org/thoughtcrime/securesms/mms/IncomingLollipopMmsConnection.java
@@ -26,10 +26,15 @@ import android.support.annotation.Nullable;
 import android.telephony.SmsManager;
 import android.util.Log;
 
+import com.google.android.mms.InvalidHeaderValueException;
+import com.google.android.mms.pdu_alt.NotifyRespInd;
+import com.google.android.mms.pdu_alt.PduComposer;
+import com.google.android.mms.pdu_alt.PduHeaders;
 import com.google.android.mms.pdu_alt.PduParser;
 import com.google.android.mms.pdu_alt.RetrieveConf;
 
 import org.thoughtcrime.securesms.providers.MmsBodyProvider;
+import org.thoughtcrime.securesms.transport.UndeliverableMessageException;
 import org.thoughtcrime.securesms.util.Util;
 
 import java.io.ByteArrayOutputStream;
@@ -89,12 +94,25 @@ public class IncomingLollipopMmsConnection extends LollipopMmsConnection impleme
 
       Log.w(TAG, baos.size() + "-byte response: ");// + Hex.dump(baos.toByteArray()));
 
-      return (RetrieveConf) new PduParser(baos.toByteArray()).parse();
+      RetrieveConf retrieved = (RetrieveConf) new PduParser(baos.toByteArray()).parse();
+      sendRetrievedAcknowledgement(transactionId, retrieved.getMmsVersion(), subscriptionId);
+      return retrieved;
     } catch (IOException | TimeoutException e) {
       Log.w(TAG, e);
       throw new MmsException(e);
     } finally {
       endTransaction();
+    }
+  }
+
+  private void sendRetrievedAcknowledgement(byte[] transactionId, int mmsVersion, int subscriptionId) {
+    try {
+      NotifyRespInd retrieveResponse = new NotifyRespInd(mmsVersion, transactionId, PduHeaders.STATUS_RETRIEVED);
+      new OutgoingLollipopMmsConnection(getContext()).send(new PduComposer(getContext(), retrieveResponse).make(), subscriptionId);
+    } catch (UndeliverableMessageException e) {
+      Log.w(TAG, e);
+    } catch (InvalidHeaderValueException e) {
+      Log.w(TAG, e);
     }
   }
 }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 5x, Android 7.1.2
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description

This is proposal fix for #5177, #5396, #6808, #3149, #2207 and possibly others

I've started solving this based on https://github.com/WhisperSystems/Signal-Android/issues/5177#issuecomment-321786318

Also the proposal is based on OSS Android sms-mms sources, such as this:
[Android SMSMMS RetrieveTransaction.java#L287](https://github.com/klinker41/android-smsmms/blob/master/library/src/main/java/com/android/mms/transaction/RetrieveTransaction.java#L287)
