### PR TITLE
Updated import error message for File Not Found

### DIFF
--- a/src/org/thoughtcrime/securesms/ImportExportFragment.java
+++ b/src/org/thoughtcrime/securesms/ImportExportFragment.java
@@ -23,6 +23,7 @@ import org.thoughtcrime.securesms.database.PlaintextBackupImporter;
 import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.service.ApplicationMigrationService;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 
 
@@ -188,6 +189,9 @@ public class ImportExportFragment extends Fragment {
         PlaintextBackupImporter.importPlaintextFromSd(getActivity(), masterSecret);
         return SUCCESS;
       } catch (NoExternalStorageException e) {
+        Log.w("ImportFragment", e);
+        return NO_SD_CARD;
+      } catch (FileNotFoundException e) {
         Log.w("ImportFragment", e);
         return NO_SD_CARD;
       } catch (IOException e) {


### PR DESCRIPTION
When importing the backup file, FileNotFoundException toasts generically "Error importing backup!" (R.string.ImportFragment_error_importing_backup), but it should more specifically toast "No plaintext backup found!" (R.string.ImportFragment_no_plaintext_backup_found).

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X ] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [X ] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X ] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [ X] I have tested my contribution on these devices:
 * Emulator, Android 8.0, API 26 
- [X ] My contribution is fully baked and ready to be merged as is
- [X ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
When importing a backup file and the expected SignalPlaintextBackup.xml is not present in the predefined location, a generic error message is provided: "Error importing backup!".
There is a more specific error message available "No plaintext backup found!".
Code above catches the FileNotFoundException and uses the more specific and already provided/translated error message.

A similar approach without creating a new error message that requires additional translation: https://github.com/WhisperSystems/Signal-Android/pull/6978. Specifically commit: https://github.com/WhisperSystems/Signal-Android/commit/ab3e92ec537e282e58d4b35aa7640c4a16817f03
