### PR TITLE
Fix some potential integer overflows for expiration time

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -594,7 +594,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
         @Override
         protected Void doInBackground(Void... params) {
           DatabaseFactory.getRecipientDatabase(ConversationActivity.this).setExpireMessages(recipient, expirationTime);
-          OutgoingExpirationUpdateMessage outgoingMessage = new OutgoingExpirationUpdateMessage(getRecipient(), System.currentTimeMillis(), expirationTime * 1000);
+          OutgoingExpirationUpdateMessage outgoingMessage = new OutgoingExpirationUpdateMessage(getRecipient(), System.currentTimeMillis(), expirationTime * 1000L);
           MessageSender.send(ConversationActivity.this, masterSecret, outgoingMessage, threadId, false, null);
 
           return null;
@@ -1635,7 +1635,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
       boolean    forceSms       = sendButton.isManualSelection() && sendButton.getSelectedTransport().isSms();
       int        subscriptionId = sendButton.getSelectedTransport().getSimSubscriptionId().or(-1);
-      long       expiresIn      = recipient.getExpireMessages() * 1000;
+      long       expiresIn      = recipient.getExpireMessages() * 1000L;
       boolean    initiating     = threadId == -1;
 
       Log.w(TAG, "isManual Selection: " + sendButton.isManualSelection());
@@ -1850,7 +1850,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       public void onSuccess(final @NonNull Pair<Uri, Long> result) {
         boolean    forceSms       = sendButton.isManualSelection() && sendButton.getSelectedTransport().isSms();
         int        subscriptionId = sendButton.getSelectedTransport().getSimSubscriptionId().or(-1);
-        long       expiresIn      = recipient.getExpireMessages() * 1000;
+        long       expiresIn      = recipient.getExpireMessages() * 1000L;
         boolean    initiating     = threadId == -1;
         AudioSlide audioSlide     = new AudioSlide(ConversationActivity.this, result.first, result.second, MediaUtil.AUDIO_AAC, true);
         SlideDeck  slideDeck      = new SlideDeck();

--- a/src/org/thoughtcrime/securesms/jobs/PushDecryptJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushDecryptJob.java
@@ -392,7 +392,7 @@ public class PushDecryptJob extends ContextJob {
     IncomingMediaMessage mediaMessage = new IncomingMediaMessage(masterSecret,
                                                                  Address.fromExternal(context, envelope.getSource()),
                                                                  message.getTimestamp(), -1,
-                                                                 message.getExpiresInSeconds() * 1000, true,
+                                                                 message.getExpiresInSeconds() * 1000L, true,
                                                                  Optional.fromNullable(envelope.getRelay()),
                                                                  Optional.<String>absent(), message.getGroupInfo(),
                                                                  Optional.<List<SignalServiceAttachment>>absent());
@@ -524,7 +524,7 @@ public class PushDecryptJob extends ContextJob {
     IncomingMediaMessage mediaMessage = new IncomingMediaMessage(masterSecret,
                                                                  Address.fromExternal(context, envelope.getSource()),
                                                                  message.getTimestamp(), -1,
-                                                                 message.getExpiresInSeconds() * 1000, false,
+                                                                 message.getExpiresInSeconds() * 1000L, false,
                                                                  Optional.fromNullable(envelope.getRelay()),
                                                                  message.getBody(),
                                                                  message.getGroupInfo(),
@@ -568,7 +568,7 @@ public class PushDecryptJob extends ContextJob {
 
     OutgoingExpirationUpdateMessage expirationUpdateMessage = new OutgoingExpirationUpdateMessage(recipient,
                                                                                                   message.getTimestamp(),
-                                                                                                  message.getMessage().getExpiresInSeconds() * 1000);
+                                                                                                  message.getMessage().getExpiresInSeconds() * 1000L);
 
     long threadId  = DatabaseFactory.getThreadDatabase(context).getThreadIdFor(recipient);
     long messageId = database.insertMessageOutbox(masterSecret, expirationUpdateMessage, threadId, false, null);
@@ -589,7 +589,7 @@ public class PushDecryptJob extends ContextJob {
     OutgoingMediaMessage  mediaMessage = new OutgoingMediaMessage(recipients, message.getMessage().getBody().orNull(),
                                                                   PointerAttachment.forPointers(masterSecret, message.getMessage().getAttachments()),
                                                                   message.getTimestamp(), -1,
-                                                                  message.getMessage().getExpiresInSeconds() * 1000,
+                                                                  message.getMessage().getExpiresInSeconds() * 1000L,
                                                                   ThreadDatabase.DistributionTypes.DEFAULT);
 
     mediaMessage = new OutgoingSecureMediaMessage(mediaMessage);
@@ -615,7 +615,7 @@ public class PushDecryptJob extends ContextJob {
                         .getExpiringMessageManager()
                         .scheduleDeletion(messageId, true,
                                           message.getExpirationStartTimestamp(),
-                                          message.getMessage().getExpiresInSeconds() * 1000);
+                                          message.getMessage().getExpiresInSeconds() * 1000L);
     }
 
     return threadId;
@@ -644,7 +644,7 @@ public class PushDecryptJob extends ContextJob {
                                                                 envelope.getSourceDevice(),
                                                                 message.getTimestamp(), body,
                                                                 message.getGroupInfo(),
-                                                                message.getExpiresInSeconds() * 1000);
+                                                                message.getExpiresInSeconds() * 1000L);
 
       textMessage = new IncomingEncryptedMessage(textMessage, body);
       Optional<InsertResult> insertResult = database.insertMessageInbox(masterSecret, textMessage);
@@ -667,7 +667,7 @@ public class PushDecryptJob extends ContextJob {
 
     Recipient recipient       = getSyncMessageDestination(message);
     String    body            = message.getMessage().getBody().or("");
-    long      expiresInMillis = message.getMessage().getExpiresInSeconds() * 1000;
+    long      expiresInMillis = message.getMessage().getExpiresInSeconds() * 1000L;
 
     if (recipient.getExpireMessages() != message.getMessage().getExpiresInSeconds()) {
       handleSynchronizeSentExpirationUpdate(masterSecret, message);

--- a/src/org/thoughtcrime/securesms/notifications/AndroidAutoReplyReceiver.java
+++ b/src/org/thoughtcrime/securesms/notifications/AndroidAutoReplyReceiver.java
@@ -74,7 +74,7 @@ public class AndroidAutoReplyReceiver extends MasterSecretBroadcastReceiver {
           long replyThreadId;
 
           int  subscriptionId = recipient.getDefaultSubscriptionId().or(-1);
-          long expiresIn      = recipient.getExpireMessages() * 1000;
+          long expiresIn      = recipient.getExpireMessages() * 1000L;
 
           if (recipient.isGroupRecipient()) {
             Log.w("AndroidAutoReplyReceiver", "GroupRecipient, Sending media message");

--- a/src/org/thoughtcrime/securesms/notifications/RemoteReplyReceiver.java
+++ b/src/org/thoughtcrime/securesms/notifications/RemoteReplyReceiver.java
@@ -69,7 +69,7 @@ public class RemoteReplyReceiver extends MasterSecretBroadcastReceiver {
 
           Recipient recipient = Recipient.from(context, address, false);
           int  subscriptionId = recipient.getDefaultSubscriptionId().or(-1);
-          long expiresIn      = recipient.getExpireMessages() * 1000;
+          long expiresIn      = recipient.getExpireMessages() * 1000L;
 
           if (recipient.isGroupRecipient()) {
             OutgoingMediaMessage reply = new OutgoingMediaMessage(recipient, responseText.toString(), new LinkedList<Attachment>(), System.currentTimeMillis(), subscriptionId, expiresIn, 0);

--- a/src/org/thoughtcrime/securesms/service/QuickResponseService.java
+++ b/src/org/thoughtcrime/securesms/service/QuickResponseService.java
@@ -54,7 +54,7 @@ public class QuickResponseService extends MasterSecretIntentService {
       Address   address        = Address.fromExternal(this, number);
       Recipient recipient      = Recipient.from(this, address, false);
       int       subscriptionId = recipient.getDefaultSubscriptionId().or(-1);
-      long      expiresIn      = recipient.getExpireMessages() * 1000;
+      long      expiresIn      = recipient.getExpireMessages() * 1000L;
 
       if (!TextUtils.isEmpty(content)) {
         MessageSender.send(this, masterSecret, new OutgoingTextMessage(recipient, content, expiresIn, subscriptionId), -1, false, null);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device: Pixel, Android 8.0 Oreo
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
In a number of locations in the code, there were conversions of message
expiration times from seconds to milliseconds, and then assigned to `long`
contexts. However these conversions were being done as integer multiplication
rather than long multiplication, meaning that there was a potential for
overflows.

Specifically, the maximum value that could be represented before overflowing
was `(2^31 / 1000 / 60 / 60 / 24)` days = `24.8` days (< 1 month). Luckily the
current allowed timeouts are all less than that value, but this fix would
remove the artificial restriction, effectively allowing values of 1000x greater
(68 years), at least for android.

Related: #5775

----------

Full Disclosure: I initially found these problems [on lgtm.com](https://lgtm.com/projects/g/WhisperSystems/Signal-Android/alerts/?mode=tree&severity=warning&rule=7900075), which is a product that I work on. There are a [bunch more alerts / findings](https://lgtm.com/projects/g/WhisperSystems/Signal-Android/alerts/?mode=tree&severity=error) that it is probably a good idea to look at.
