### PR TITLE
Change insecure indicator to red

### DIFF
--- a/res/layout/conversation_item_received.xml
+++ b/res/layout/conversation_item_received.xml
@@ -123,7 +123,7 @@
                            android:contentDescription="@string/conversation_item__secure_message_description"
                            android:visibility="gone"
                            android:alpha=".65"
-                           android:tint="red_400"
+                           android:tint="#f44336"
                            android:tintMode="multiply"
                            tools:visibility="visible"/>
 

--- a/res/layout/conversation_item_received.xml
+++ b/res/layout/conversation_item_received.xml
@@ -123,7 +123,7 @@
                            android:contentDescription="@string/conversation_item__secure_message_description"
                            android:visibility="gone"
                            android:alpha=".65"
-                           android:tint="#f44336"
+                           android:tint=@color/red_400
                            android:tintMode="multiply"
                            tools:visibility="visible"/>
 

--- a/res/layout/conversation_item_received.xml
+++ b/res/layout/conversation_item_received.xml
@@ -123,7 +123,7 @@
                            android:contentDescription="@string/conversation_item__secure_message_description"
                            android:visibility="gone"
                            android:alpha=".65"
-                           android:tint="?conversation_item_received_text_secondary_color"
+                           android:tint="red_400"
                            android:tintMode="multiply"
                            tools:visibility="visible"/>
 

--- a/res/layout/conversation_item_sent.xml
+++ b/res/layout/conversation_item_sent.xml
@@ -167,7 +167,7 @@
                            android:visibility="gone"
                            android:layout_gravity="center_vertical|end"
                            android:alpha=".6"
-                           android:tint="?attr/conversation_item_sent_text_secondary_color"
+                           android:tint="red_400"
                            android:layout_marginLeft="3dp"
                            android:layout_marginStart="3dp"
                            android:tintMode="multiply"

--- a/res/layout/conversation_item_sent.xml
+++ b/res/layout/conversation_item_sent.xml
@@ -167,7 +167,7 @@
                            android:visibility="gone"
                            android:layout_gravity="center_vertical|end"
                            android:alpha=".6"
-                           android:tint="red_400"
+                           android:tint="#f44336"
                            android:layout_marginLeft="3dp"
                            android:layout_marginStart="3dp"
                            android:tintMode="multiply"

--- a/res/layout/conversation_item_sent.xml
+++ b/res/layout/conversation_item_sent.xml
@@ -167,7 +167,7 @@
                            android:visibility="gone"
                            android:layout_gravity="center_vertical|end"
                            android:alpha=".6"
-                           android:tint="#f44336"
+                           android:tint=@color/red_400
                            android:layout_marginLeft="3dp"
                            android:layout_marginStart="3dp"
                            android:tintMode="multiply"


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
  * Virtual device Nexus 5X, Android API 27
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Changes the insecure indicator (open padlock) to red, to draw attention to the message not being encrypted. 
Hopefully should aid users in remembering to switch to insecure SMS after insecure is received.
Should also draw more attention to lack of encryption
-->
