### PR TITLE
Adding task affinity to the share activity. Fixes #7312.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -155,6 +155,7 @@
               android:theme="@style/TextSecure.LightNoActionBar"
               android:excludeFromRecents="true"
               android:launchMode="singleTask"
+              android:taskAffinity=""
               android:noHistory="true"
               android:windowSoftInputMode="stateHidden"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize">


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * LG-M322, Android 7.0
 * Moto X, Android 6.0
 * Virtual device Pixel XL, API 25
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
I think by setting the task affinity in the manifest file, the ShareActivity will be spawned in different task stack with the Signal app itself. The step for me to test it locally:
* Open signal app.
* Open imgur app.
* Share something from imgur app.
* Press the overview button and you will see the original signal app in the back of the imgur app in the stack, and then a separate ShareActivity from signal app on the top of the overview stack.
* Pressing back now will bring back imgur app.
