### PR TITLE
Make toast after saving attachment translatable

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -689,6 +689,7 @@
 
     <!-- SaveAttachmentTask -->
     <string name="SaveAttachmentTask_open_directory">Open directory</string>
+    <string name="SaveAttachmentTask_saved_to">Saved to %s</string>
 
     <!-- SearchToolbar -->
     <string name="SearchToolbar_search">Search</string>

--- a/src/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
+++ b/src/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
@@ -192,7 +192,10 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
                        Toast.LENGTH_LONG).show();
         break;
       case SUCCESS:
-        Toast.makeText(context, String.format("Saved to %s", result.second()), Toast.LENGTH_LONG).show();
+        Toast.makeText(context,
+                       context.getResources().getString(R.string.SaveAttachmentTask_saved_to,
+                                                        result.second()),
+                       Toast.LENGTH_LONG).show();
         break;
       case WRITE_ACCESS_FAILURE:
         Toast.makeText(context, R.string.ConversationFragment_unable_to_write_to_sd_card_exclamation,


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Nexus 5X, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This PR makes a string translatable, that is shown in a toast after saving an attachment successfully to the phone's storage.
