### PR TITLE
Make register button text translatable

### DIFF
--- a/res/layout/registration_activity.xml
+++ b/res/layout/registration_activity.xml
@@ -104,7 +104,7 @@
 
             <com.dd.CircularProgressButton
                     android:id="@+id/registerButton"
-                    app:cpb_textIdle="Register"
+                    app:cpb_textIdle="@string/registration_activity__register"
                     app:cpb_selectorIdle="@drawable/progress_button_state"
                     app:cpb_colorIndicator="@color/white"
                     app:cpb_colorProgress="@color/textsecure_primary"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -974,6 +974,7 @@
     <string name="registration_activity__registration_will_transmit_some_contact_information_to_the_server_temporariliy">Signal makes it easy to communicate by using your existing phone number and address book. Friends and contacts who already know how to contact you by phone will be able to easily get in touch by Signal.\n\nRegistration transmits some contact information to the server. It is not stored.</string>
     <string name="registration_activity__verify_your_number">Verify Your Number</string>
     <string name="registration_activity__please_enter_your_mobile_number_to_receive_a_verification_code_carrier_rates_may_apply">Please enter your mobile number to receive a verification code. Carrier rates may apply.</string>
+    <string name="registration_activity__register">Register</string>
 
     <!-- registration_problems -->
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Nexus 5X, Android 5.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Makes the string displayed in the register button translatable. This issue was noted [here](https://github.com/signalapp/Signal-Android/commit/90ff0e58b0206ac2b047c3db70980f29a533b9d9#r27045519).