### PR TITLE
add encrypted full backup functionality

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -120,6 +120,10 @@
     <activity android:name=".CountrySelectionActivity"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
+    <activity android:name=".EnterPassphraseActivity"
+              android:label="@string/AndroidManifest__enter_passphrase"
+              android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize" />
+
     <activity android:name=".ImportExportActivity"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 

--- a/res/layout/enter_passphrase_activity.xml
+++ b/res/layout/enter_passphrase_activity.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:fillViewport="true">
+
+    <FrameLayout android:layout_width="fill_parent"
+                 android:layout_height="wrap_content"
+                 android:gravity="center">
+
+        <LinearLayout android:paddingRight="16dip"
+                      android:paddingLeft="16dip"
+                      android:paddingTop="10dip"
+                      android:layout_width="fill_parent"
+                      android:layout_height="wrap_content"
+                      android:layout_gravity="center"
+                      android:visibility="visible"
+                      android:orientation="vertical">
+
+            <android.support.design.widget.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <EditText android:id="@+id/passphrase"
+                          android:layout_width="match_parent"
+                          android:layout_height="wrap_content"
+                          android:inputType="textPassword"
+                          android:layout_marginBottom="10dip"
+                          android:hint="@string/enter_passphrase_activity__passphrase"
+                          android:singleLine="true"/>
+
+            </android.support.design.widget.TextInputLayout>
+
+            <android.support.design.widget.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <EditText android:id="@+id/repeat_passphrase"
+                          android:layout_width="fill_parent"
+                          android:layout_height="wrap_content"
+                          android:inputType="textPassword"
+                          android:hint="@string/enter_passphrase_activity__repeat_passphrase"
+                          android:singleLine="true" />
+
+            </android.support.design.widget.TextInputLayout>
+
+            <LinearLayout android:orientation="horizontal"
+                          android:layout_width="fill_parent"
+                          android:layout_height="wrap_content"
+                          android:layout_marginTop="30dip">
+
+                <Button android:id="@+id/cancel_button"
+                        android:text="@android:string/cancel"
+                        android:layout_weight="1"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginRight="7dip"
+                        android:textAppearance="?android:attr/textAppearanceMedium"/>
+
+                <Button android:id="@+id/ok_button"
+                        android:text="@android:string/ok"
+                        android:layout_weight="1"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:textAppearance="?android:attr/textAppearanceMedium"/>
+            </LinearLayout>
+        </LinearLayout>
+    </FrameLayout>
+</ScrollView>

--- a/res/layout/import_export_fragment.xml
+++ b/res/layout/import_export_fragment.xml
@@ -124,45 +124,90 @@
         android:textColor="@color/signal_primary_dark"/>
 
     <LinearLayout android:layout_width="wrap_content"
-                  android:layout_height="wrap_content"
-                  android:orientation="vertical">
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
         <LinearLayout android:id="@+id/export_plaintext_backup"
-                      android:clickable="true"
-                      android:orientation="horizontal"
-                      android:layout_width="wrap_content"
-                      android:layout_height="wrap_content"
-                      android:paddingTop="12dp"
-                      android:paddingBottom="12dp"
-                      android:gravity="center_vertical"
-                      android:background="?selectableItemBackground">
+            android:clickable="true"
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingTop="12dp"
+            android:paddingBottom="12dp"
+            android:gravity="center_vertical"
+            android:background="?selectableItemBackground">
 
             <ImageView android:layout_width="wrap_content"
-                       android:layout_height="wrap_content"
-                       android:layout_marginLeft="16dp"
-                       android:layout_marginStart="16dp"
-                       android:layout_marginRight="32dp"
-                       android:layout_marginEnd="32dp"
-                       android:src="@drawable/ic_content_copy_white_24dp"
-                       android:tint="?attr/pref_icon_tint"/>
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="16dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginRight="32dp"
+                android:layout_marginEnd="32dp"
+                android:src="@drawable/ic_content_copy_white_24dp"
+                android:tint="?attr/pref_icon_tint"/>
 
             <LinearLayout android:orientation="vertical"
-                          android:layout_width="wrap_content"
-                          android:layout_height="wrap_content"
-                          android:layout_marginRight="16dp"
-                          android:layout_marginEnd="16dp">
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="16dp"
+                android:layout_marginEnd="16dp">
 
                 <TextView android:layout_width="match_parent"
-                          android:layout_height="wrap_content"
-                          android:gravity="start"
-                          style="@style/Registration.Description"
-                          android:text="@string/export_fragment__export_plaintext_backup"/>
+                    android:layout_height="wrap_content"
+                    android:gravity="start"
+                    style="@style/Registration.Description"
+                    android:text="@string/export_fragment__export_plaintext_backup"/>
 
                 <TextView android:layout_width="match_parent"
-                          android:layout_height="wrap_content"
-                          android:gravity="start"
-                          android:textAppearance="?android:attr/textAppearanceSmall"
-                          android:text="@string/export_fragment__export_a_plaintext_backup_compatible_with"/>
+                    android:layout_height="wrap_content"
+                    android:gravity="start"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:text="@string/export_fragment__export_a_plaintext_backup_compatible_with"/>
+            </LinearLayout>
+        </LinearLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="?android:attr/listDivider"/>
+
+
+        <LinearLayout android:id="@+id/export_encrypted_backup"
+            android:clickable="true"
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingTop="12dp"
+            android:paddingBottom="12dp"
+            android:gravity="center_vertical"
+            android:background="?selectableItemBackground">
+
+            <ImageView android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="16dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginRight="32dp"
+                android:layout_marginEnd="32dp"
+                android:src="@drawable/ic_content_copy_white_24dp"
+                android:tint="?attr/pref_icon_tint"/>
+
+            <LinearLayout android:orientation="vertical"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="16dp"
+                android:layout_marginEnd="16dp">
+
+                <TextView android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="start"
+                    style="@style/Registration.Description"
+                    android:text="@string/export_fragment__export_encrypted_backup"/>
+
+                <TextView android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="start"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:text="@string/export_fragment__export_an_encrypted_backup"/>
             </LinearLayout>
         </LinearLayout>
 

--- a/res/layout/registration_activity.xml
+++ b/res/layout/registration_activity.xml
@@ -37,7 +37,6 @@
                       android:textColor="@color/white"
                       android:text="@string/registration_activity__please_enter_your_mobile_number_to_receive_a_verification_code_carrier_rates_may_apply"
                       android:gravity="center"/>
-
         </LinearLayout>
 
         <android.support.design.widget.FloatingActionButton
@@ -117,6 +116,48 @@
                     android:layout_marginRight="16dp"
                     android:layout_marginTop="20dp"
                     android:layout_gravity="center_horizontal"/>
+
+            <LinearLayout
+                android:layout_marginTop="10dp"
+                android:layout_width="match_parent"
+                android:layout_height="36dp"
+                android:layout_marginLeft="32dp"
+                android:layout_marginRight="32dp"
+                android:gravity="center">
+                <View
+                    android:layout_weight="1"
+                    android:layout_height="1dp"
+                    android:layout_width="20dp"
+                    android:background="@color/grey_600" />
+                <TextView
+                    android:layout_weight="0"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="8dp"
+                    android:paddingRight="8dp"
+                    android:text="@string/registration_activity__or_import_full_backup" />
+                <View
+                    android:layout_weight="1"
+                    android:layout_height="1dp"
+                    android:layout_width="20dp"
+                    android:background="@color/grey_600"/>
+            </LinearLayout>
+
+            <com.dd.CircularProgressButton
+                android:id="@+id/import_button"
+                app:cpb_textIdle="Import"
+                app:cpb_selectorIdle="@drawable/progress_button_state"
+                app:cpb_colorIndicator="@color/white"
+                app:cpb_colorProgress="@color/textsecure_primary"
+                app:cpb_cornerRadius="50dp"
+                android:background="@color/signal_primary"
+                android:textColor="@color/white"
+                android:layout_width="match_parent"
+                android:layout_height="50dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:layout_marginTop="10dp"
+                android:layout_gravity="center_horizontal"/>
 
             <TextView android:id="@+id/skip_button"
                       android:layout_gravity="center_horizontal"
@@ -199,5 +240,4 @@
 
         </RelativeLayout>
     </RelativeLayout>
-
 </ScrollView>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -293,6 +293,7 @@
     <string name="ExportFragment_exporting">Exporting</string>
     <string name="ExportFragment_exporting_plaintext_to_storage">Exporting plaintext to storage...</string>
     <string name="ExportFragment_error_unable_to_write_to_storage">Error, unable to write to storage.</string>
+    <string name="ExportFragment_error_no_passphrase_given">Unable to export without passphrase</string>
     <string name="ExportFragment_error_while_writing_to_storage">Error while writing to storage.</string>
     <string name="ExportFragment_export_successful">Export successful.</string>
 
@@ -439,6 +440,10 @@
     <string name="PassphraseChangeActivity_passphrases_dont_match_exclamation">Passphrases don\'t match!</string>
     <string name="PassphraseChangeActivity_incorrect_old_passphrase_exclamation">Incorrect old passphrase!</string>
     <string name="PassphraseChangeActivity_enter_new_passphrase_exclamation">Enter new passphrase!</string>
+
+    <!-- EnterPassphraseActivity -->
+    <string name="EnterPassphraseActivity_passphrases_dont_match_exclamation">Passphrases don\'t match!</string>
+    <string name="EnterPassphraseActivity_enter_passphrase_exclamation">Enter passphrase!</string>
 
     <!-- DeviceProvisioningActivity -->
     <string name="DeviceProvisioningActivity_link_this_device">Link this device?</string>
@@ -820,6 +825,10 @@
     <string name="device_list_fragment__no_devices_linked">No devices linked</string>
     <string name="device_list_fragment__link_new_device">Link new device</string>
 
+    <!-- enter_passphrase_activity -->
+    <string name="enter_passphrase_activity__passphrase">Passphrase</string>
+    <string name="enter_passphrase_activity__repeat_passphrase">Repeat passphrase</string>
+
     <!-- experience_upgrade_activity -->
     <string name="experience_upgrade_activity__continue">continue</string>
 
@@ -912,6 +921,8 @@
 
     <string name="export_fragment__export_plaintext_backup">Export plaintext backup</string>
     <string name="export_fragment__export_a_plaintext_backup_compatible_with">Export a plaintext backup compatible with \'SMS Backup &amp; Restore\' to storage</string>
+    <string name="export_fragment__export_encrypted_backup">Export encrypted backup</string>
+    <string name="export_fragment__export_an_encrypted_backup">Export an encrypted backup which can be used to restore your app data on another device</string>
     <string name="import_fragment__import_system_sms_database">Import system SMS database</string>
     <string name="import_fragment__import_the_database_from_the_default_system">Import the database from the default system messenger app</string>
     <string name="import_fragment__import_plaintext_backup">Import plaintext backup</string>
@@ -1309,6 +1320,8 @@
 
     <!-- transport_selection_list_item -->
     <string name="transport_selection_list_item__transport_icon">Transport icon</string>
+
+    <string name="registration_activity__or_import_full_backup">Or import full backup</string>
     <string name="ConversationListFragment_loading">Loading...</string>
     <string name="CallNotificationBuilder_connecting">Connecting...</string>
     <string name="Permissions_permission_required">Permission required</string>

--- a/src/org/thoughtcrime/securesms/EnterPassphraseActivity.java
+++ b/src/org/thoughtcrime/securesms/EnterPassphraseActivity.java
@@ -1,0 +1,91 @@
+package org.thoughtcrime.securesms;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.Editable;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+
+import org.thoughtcrime.securesms.util.DynamicLanguage;
+import org.thoughtcrime.securesms.util.DynamicTheme;
+
+public class EnterPassphraseActivity extends BaseActionBarActivity {
+
+  private DynamicTheme dynamicTheme = new DynamicTheme();
+  private DynamicLanguage dynamicLanguage = new DynamicLanguage();
+
+  private EditText passphraseView;
+  private EditText repeatPassphraseView;
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    dynamicTheme.onCreate(this);
+    dynamicLanguage.onCreate(this);
+    super.onCreate(savedInstanceState);
+
+    setContentView(R.layout.enter_passphrase_activity);
+
+    initializeResources();
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    dynamicTheme.onResume(this);
+    dynamicLanguage.onResume(this);
+  }
+
+  private void initializeResources() {
+    this.passphraseView = (EditText) findViewById(R.id.passphrase);
+    this.repeatPassphraseView = (EditText) findViewById(R.id.repeat_passphrase);
+
+    Button okButton = (Button) findViewById(R.id.ok_button);
+    Button cancelButton = (Button) findViewById(R.id.cancel_button);
+
+    okButton.setOnClickListener(new EnterPassphraseActivity.OkButtonClickListener());
+    cancelButton.setOnClickListener(new EnterPassphraseActivity.CancelButtonClickListener());
+  }
+
+  private class CancelButtonClickListener implements View.OnClickListener {
+    public void onClick(View v) {
+      cleanup();
+      finish();
+    }
+  }
+
+  private class OkButtonClickListener implements View.OnClickListener {
+    public void onClick(View v) {
+      Editable passphraseText = passphraseView.getText();
+      Editable repeatPassphraseText = repeatPassphraseView.getText();
+
+      String passphrase = passphraseText == null ? "" : passphraseText.toString();
+      String repeatPassphrase = repeatPassphraseText == null ? "" : repeatPassphraseText.toString();
+
+      if (!passphrase.equals(repeatPassphrase)) {
+        passphraseView.setText("");
+        repeatPassphraseView.setText("");
+        passphraseView.setError(getString(R.string.EnterPassphraseActivity_passphrases_dont_match_exclamation));
+        passphraseView.requestFocus();
+      } else if ("".equals(passphrase)) {
+        passphraseView.setText("");
+        repeatPassphraseView.setText("");
+        passphraseView.setError(getString(R.string.EnterPassphraseActivity_enter_passphrase_exclamation));
+        passphraseView.requestFocus();
+      } else {
+        Intent result = getIntent();
+        result.putExtra("passphrase", passphrase);
+        setResult(RESULT_OK, result);
+        cleanup();
+        finish();
+      }
+    }
+  }
+
+  protected void cleanup() {
+    this.passphraseView = null;
+    this.repeatPassphraseView = null;
+    System.gc();
+  }
+
+}

--- a/src/org/thoughtcrime/securesms/ExportEncryptedBackupDialog.java
+++ b/src/org/thoughtcrime/securesms/ExportEncryptedBackupDialog.java
@@ -1,0 +1,21 @@
+package org.thoughtcrime.securesms;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+
+class ExportEncryptedBackupDialog extends AlertDialog {
+    ExportEncryptedBackupDialog(Context context, OnClickListener positiveListener) {
+        super(context);
+        setTitle("encrypted Backup information");
+        setMessage("Please note that this backup can only be imported at registration time. It will only be useful for transferring your data to another phone or in case you lost your phone.");
+        setButton(AlertDialog.BUTTON_POSITIVE, "OK", positiveListener);
+        setButton(AlertDialog.BUTTON_NEGATIVE, "Cancel", new NegativeListener());
+    }
+
+    private class NegativeListener implements OnClickListener {
+        @Override
+        public void onClick(DialogInterface dialogInterface, int i) {
+        }
+    }
+}

--- a/src/org/thoughtcrime/securesms/ImportExportActivity.java
+++ b/src/org/thoughtcrime/securesms/ImportExportActivity.java
@@ -1,15 +1,35 @@
 package org.thoughtcrime.securesms;
 
+import android.content.Context;
+import android.content.Intent;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.util.Log;
 import android.view.MenuItem;
+import android.widget.Toast;
 
+import org.thoughtcrime.securesms.backup.Exporter;
+import org.thoughtcrime.securesms.backup.ImportExportResult;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.database.NoExternalStorageException;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicTheme;
 
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
+import static org.thoughtcrime.securesms.backup.ImportExportResult.ERROR_IO;
+import static org.thoughtcrime.securesms.backup.ImportExportResult.INTERNAL_ERROR;
+import static org.thoughtcrime.securesms.backup.ImportExportResult.NO_SD_CARD;
+import static org.thoughtcrime.securesms.backup.ImportExportResult.PASSPHRASE_REQUIRED;
+import static org.thoughtcrime.securesms.backup.ImportExportResult.SUCCESS;
+
 
 public class ImportExportActivity extends PassphraseRequiredActionBarActivity {
+
+  private static final int ENTER_PASSPHRASE = 1;
 
   private DynamicTheme    dynamicTheme    = new DynamicTheme();
   private DynamicLanguage dynamicLanguage = new DynamicLanguage();
@@ -24,6 +44,69 @@ public class ImportExportActivity extends PassphraseRequiredActionBarActivity {
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     initFragment(android.R.id.content, new ImportExportFragment(),
                  masterSecret, dynamicLanguage.getCurrentLocale());
+  }
+
+  protected void handleExportEncryptedBackup() {
+    Intent intent = new Intent(ImportExportActivity.this, EnterPassphraseActivity.class);
+    startActivityForResult(intent, ENTER_PASSPHRASE);
+  }
+
+  @Override
+  protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    if ((requestCode == ENTER_PASSPHRASE) && (data != null)) {
+      String passphrase = data.getStringExtra("passphrase");
+      new ExportEncryptedBackupTask().execute(passphrase);
+    }
+  }
+
+  private class ExportEncryptedBackupTask extends AsyncTask<String, Void, ImportExportResult> {
+    @Override
+    protected ImportExportResult doInBackground(String... params) {
+      if ((params == null) || (params.length != 1)) {
+        return PASSPHRASE_REQUIRED;
+      }
+      try {
+        String passphrase = params[0];
+        Exporter.exportEncrypted(ImportExportActivity.this, passphrase);
+        return SUCCESS;
+      } catch (NoExternalStorageException e) {
+        Log.w("ImportExportActivity", e);
+        return NO_SD_CARD;
+      } catch (IOException e) {
+        Log.w("ImportExportActivity", e);
+        return ERROR_IO;
+      } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+        Log.w("ImportExportActivity", e);
+        return INTERNAL_ERROR;
+      }
+    }
+
+    @Override
+    protected void onPostExecute(ImportExportResult result) {
+      Context context = ImportExportActivity.this;
+      switch (result) {
+        case PASSPHRASE_REQUIRED:
+          Toast.makeText(context,
+                  context.getString(R.string.ExportFragment_error_no_passphrase_given),
+                  Toast.LENGTH_LONG).show();
+          break;
+        case NO_SD_CARD:
+          Toast.makeText(context,
+                  context.getString(R.string.ExportFragment_error_unable_to_write_to_storage),
+                  Toast.LENGTH_LONG).show();
+          break;
+        case ERROR_IO:
+          Toast.makeText(context,
+                  context.getString(R.string.ExportFragment_error_while_writing_to_storage),
+                  Toast.LENGTH_LONG).show();
+          break;
+        case SUCCESS:
+          Toast.makeText(context,
+                  context.getString(R.string.ExportFragment_export_successful),
+                  Toast.LENGTH_LONG).show();
+          break;
+      }
+    }
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/ImportExportFragment.java
+++ b/src/org/thoughtcrime/securesms/ImportExportFragment.java
@@ -4,6 +4,7 @@ import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -28,12 +29,12 @@ import java.io.IOException;
 
 public class ImportExportFragment extends Fragment {
 
-  @SuppressWarnings("unused")
-  private static final String TAG = ImportExportFragment.class.getSimpleName();
-
   private static final int SUCCESS    = 0;
   private static final int NO_SD_CARD = 1;
   private static final int ERROR_IO   = 2;
+
+  @SuppressWarnings("unused")
+  private static final String TAG = ImportExportFragment.class.getSimpleName();
 
   private MasterSecret   masterSecret;
   private ProgressDialog progressDialog;
@@ -50,10 +51,20 @@ public class ImportExportFragment extends Fragment {
     View importSmsView       = layout.findViewById(R.id.import_sms             );
     View importPlaintextView = layout.findViewById(R.id.import_plaintext_backup);
     View exportPlaintextView = layout.findViewById(R.id.export_plaintext_backup);
+    View exportEncryptedView = layout.findViewById(R.id.export_encrypted_backup);
 
     importSmsView.setOnClickListener(v -> handleImportSms());
     importPlaintextView.setOnClickListener(v -> handleImportPlaintextBackup());
     exportPlaintextView.setOnClickListener(v -> handleExportPlaintextBackup());
+
+    exportEncryptedView.setOnClickListener(v -> {
+      DialogInterface.OnClickListener positiveListener = (dialogInterface, i) -> {
+        ImportExportActivity activity = (ImportExportActivity) getActivity();
+        activity.handleExportEncryptedBackup();
+      };
+      ExportEncryptedBackupDialog dialog = new ExportEncryptedBackupDialog(getContext(), positiveListener);
+      dialog.show();
+    });
 
     return layout;
   }

--- a/src/org/thoughtcrime/securesms/backup/AttachmentMapping.java
+++ b/src/org/thoughtcrime/securesms/backup/AttachmentMapping.java
@@ -1,0 +1,60 @@
+package org.thoughtcrime.securesms.backup;
+
+import static android.database.Cursor.FIELD_TYPE_BLOB;
+import static android.database.Cursor.FIELD_TYPE_FLOAT;
+import static android.database.Cursor.FIELD_TYPE_INTEGER;
+import static android.database.Cursor.FIELD_TYPE_STRING;
+
+public enum AttachmentMapping implements Exporter.Mapping {
+
+  ID("_id", "id", FIELD_TYPE_INTEGER),
+  MMS_ID("mid", "mid", FIELD_TYPE_INTEGER),
+  SEQ("seq", "seq", FIELD_TYPE_INTEGER),
+  CONTENT_TYPE("ct", "ct", FIELD_TYPE_STRING),
+  NAME("name", "name", FIELD_TYPE_STRING),
+  CONTENT_DISPOSITION("cd", "cd", FIELD_TYPE_STRING),
+  FN("fn", "fn", FIELD_TYPE_STRING),
+  CID("cid", "cid", FIELD_TYPE_STRING),
+  CONTENT_LOCATION("cl", "cl", FIELD_TYPE_STRING),
+  CTT_S("ctt_s", "ctt_s", FIELD_TYPE_INTEGER),
+  CTT_T("ctt_t", "ctt_t", FIELD_TYPE_STRING),
+  ENCRYPTED("encrypted", "encrypted", FIELD_TYPE_INTEGER),
+  TRANSFER_STATE("pending_push", "pending_push", FIELD_TYPE_INTEGER),
+  DATA("_data", "data", FIELD_TYPE_STRING),
+  SIZE("data_size", "data_size", FIELD_TYPE_INTEGER),
+  FILE_NAME("file_name", "file_name", FIELD_TYPE_STRING),
+  THUMBNAIL("thumbnail", "thumbnail", FIELD_TYPE_STRING),
+  THUMBNAIL_ASPECT_RATIO("aspect_ratio", "aspect_ratio", FIELD_TYPE_FLOAT),
+  UNIQUE_ID("unique_id", "unique_id", FIELD_TYPE_INTEGER),
+  DIGEST("digest", "digest", FIELD_TYPE_BLOB),
+  FAST_PREFLIGHT_ID("fast_preflight_id", "fast_preflight_id", FIELD_TYPE_STRING),
+  VOICE_NOTE("voice_note", "voice_note", FIELD_TYPE_INTEGER);
+
+  public static final String TAG_ATTACHMENT_ROW = "SignalAttachmentRow";
+  public static final String TABLE_NAME_ATTACHMENT_ROW = "part";
+
+  private String sqliteColumnName;
+  private String xmlAttributeName;
+  private int type;
+
+  AttachmentMapping(String sqliteColumnName, String xmlAttributeName, int type) {
+    this.sqliteColumnName = sqliteColumnName;
+    this.xmlAttributeName = xmlAttributeName;
+    this.type = type;
+  }
+
+  @Override
+  public String sqliteColumnName() {
+    return this.sqliteColumnName;
+  }
+
+  @Override
+  public String xmlAttributeName() {
+    return this.xmlAttributeName;
+  }
+
+  @Override
+  public int type() {
+    return this.type;
+  }
+}

--- a/src/org/thoughtcrime/securesms/backup/DecodeBase64Writer.java
+++ b/src/org/thoughtcrime/securesms/backup/DecodeBase64Writer.java
@@ -1,0 +1,133 @@
+package org.thoughtcrime.securesms.backup;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+class DecodeBase64Writer {
+
+  private final static byte OFF_0 = 0;
+  private final static byte OFF_6 = 1;
+  private final static byte OFF_4 = 2;
+  private final static byte OFF_2 = 3;
+  private final static byte EQ_OFF_2 = 4;
+  private final static byte F = 5;
+
+  private static final byte IGNORE_CHARACTER = -1;
+  private static final byte EQUAL_SIGN_READ = -2;
+
+  private byte buffer;
+  private byte state;
+  private OutputStream outputStream;
+
+  DecodeBase64Writer(OutputStream outputStream) {
+    this.buffer = 0;
+    this.state = OFF_0;
+    this.outputStream = outputStream;
+  }
+
+  public void write(char[] chars)
+          throws IOException {
+    write(chars, 0, chars.length);
+  }
+
+  public void write(char[] chars, int offset, int length)
+          throws IOException {
+    for (int i = 0; i < length; ++i) {
+      write(chars[offset + i]);
+    }
+  }
+
+  public void write(char c)
+          throws IOException {
+    byte b = charToNum(c);
+
+    if ((b == IGNORE_CHARACTER) && (state != F)) {
+      return;
+    }
+
+    switch (state) {
+      case OFF_0:
+        if (b == EQUAL_SIGN_READ) {
+          throw new RuntimeException("unexpected =");
+        }
+        buffer = (byte) (b << 2);
+        state = OFF_6;
+        break;
+      case OFF_6:
+        if (b == EQUAL_SIGN_READ) {
+          throw new RuntimeException("unexpected =");
+        }
+        outputStream.write(buffer | (b >>> 4));
+        buffer = (byte) ((b & 15) << 4);
+        state = OFF_4;
+        break;
+      case OFF_4:
+        if (b == EQUAL_SIGN_READ) {
+          state = EQ_OFF_2;
+        } else {
+          outputStream.write(buffer | (b >>> 2));
+          buffer = (byte) ((b & 3) << 6);
+          state = OFF_2;
+        }
+        break;
+      case OFF_2:
+        if (b == EQUAL_SIGN_READ) {
+          state = F;
+        } else {
+          outputStream.write(buffer | b);
+          buffer = 0;
+          state = OFF_0;
+        }
+        break;
+      case EQ_OFF_2:
+        if (b == EQUAL_SIGN_READ) {
+          state = F;
+        } else {
+          throw new RuntimeException("expected =, but got " + c);
+        }
+        break;
+      default:
+        throw new RuntimeException("unreachable statement");
+    }
+  }
+
+  private byte charToNum(char c) {
+    if ((c < 0) || (c > 127)) {
+      throw new RuntimeException("no valid char");
+    }
+    if ((c >= 'A') && (c <= 'Z')) {
+      return (byte) (c - 'A');
+    }
+    if ((c >= 'a') && (c <= 'z')) {
+      return (byte) (c - 'a' + 26);
+    }
+    if ((c >= '0') && (c <= '9')) {
+      return (byte) (c - '0' + 52);
+    }
+    if (c == '+') {
+      return 62;
+    }
+    if (c == '/') {
+      return 63;
+    }
+    if (c == '=') {
+      return EQUAL_SIGN_READ;
+    }
+    // else return special value "please ignore"
+    return IGNORE_CHARACTER;
+  }
+
+  public void close()
+          throws IOException {
+    if (outputStream != null) {
+      try {
+        outputStream.close();
+      } catch (IOException e) {
+        outputStream = null;
+        throw e;
+      }
+    }
+    outputStream = null;
+  }
+
+}

--- a/src/org/thoughtcrime/securesms/backup/DraftsMapping.java
+++ b/src/org/thoughtcrime/securesms/backup/DraftsMapping.java
@@ -1,0 +1,40 @@
+package org.thoughtcrime.securesms.backup;
+
+import static android.database.Cursor.FIELD_TYPE_INTEGER;
+import static android.database.Cursor.FIELD_TYPE_STRING;
+
+public enum DraftsMapping implements Exporter.Mapping {
+
+  ID("_id", "id", FIELD_TYPE_INTEGER),
+  THREAD_ID("thread_id", "thread_id", FIELD_TYPE_INTEGER),
+  DRAFT_TYPE("type", "type", FIELD_TYPE_STRING),
+  DRAFT_VALUE("value", "value", FIELD_TYPE_STRING);
+
+  public static final String TAG_DRAFTS = "SignalDrafts";
+  public static final String TABLE_NAME_DRAFTS = "drafts";
+
+  private String sqliteColumnName;
+  private String xmlAttributeName;
+  private int type;
+
+  DraftsMapping(String sqliteColumnName, String xmlAttributeName, int type) {
+    this.sqliteColumnName = sqliteColumnName;
+    this.xmlAttributeName = xmlAttributeName;
+    this.type = type;
+  }
+
+  @Override
+  public String sqliteColumnName() {
+    return this.sqliteColumnName;
+  }
+
+  @Override
+  public String xmlAttributeName() {
+    return this.xmlAttributeName;
+  }
+
+  @Override
+  public int type() {
+    return this.type;
+  }
+}

--- a/src/org/thoughtcrime/securesms/backup/Exporter.java
+++ b/src/org/thoughtcrime/securesms/backup/Exporter.java
@@ -1,0 +1,259 @@
+package org.thoughtcrime.securesms.backup;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.preference.PreferenceManager;
+import android.util.Base64;
+import android.util.Xml;
+
+import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.database.DatabaseFactory;
+import org.thoughtcrime.securesms.database.NoExternalStorageException;
+import org.thoughtcrime.securesms.database.RawDatabase;
+import org.xmlpull.v1.XmlSerializer;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Writer;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Map;
+import java.util.Stack;
+
+import static android.database.Cursor.FIELD_TYPE_BLOB;
+import static org.thoughtcrime.securesms.backup.AttachmentMapping.TABLE_NAME_ATTACHMENT_ROW;
+import static org.thoughtcrime.securesms.backup.AttachmentMapping.TAG_ATTACHMENT_ROW;
+import static org.thoughtcrime.securesms.backup.DraftsMapping.TABLE_NAME_DRAFTS;
+import static org.thoughtcrime.securesms.backup.DraftsMapping.TAG_DRAFTS;
+import static org.thoughtcrime.securesms.backup.GroupsMapping.TABLE_NAME_GROUPS;
+import static org.thoughtcrime.securesms.backup.GroupsMapping.TAG_GROUPS;
+import static org.thoughtcrime.securesms.backup.IdentitiesMapping.TABLE_NAME_IDENTITIES;
+import static org.thoughtcrime.securesms.backup.IdentitiesMapping.TAG_IDENTITIES;
+import static org.thoughtcrime.securesms.backup.MmsMapping.TABLE_NAME_MMS;
+import static org.thoughtcrime.securesms.backup.MmsMapping.TAG_MMS;
+import static org.thoughtcrime.securesms.backup.PushMapping.TABLE_NAME_PUSH;
+import static org.thoughtcrime.securesms.backup.PushMapping.TAG_PUSH;
+import static org.thoughtcrime.securesms.backup.RecipientPreferencesMapping.TABLE_NAME_RECIPIENT_PREFERENCES;
+import static org.thoughtcrime.securesms.backup.RecipientPreferencesMapping.TAG_RECIPIENT_PREFERENCES;
+import static org.thoughtcrime.securesms.backup.SmsMapping.TABLE_NAME_SMS;
+import static org.thoughtcrime.securesms.backup.SmsMapping.TAG_SMS;
+import static org.thoughtcrime.securesms.backup.ThreadMapping.TABLE_NAME_THREAD;
+import static org.thoughtcrime.securesms.backup.ThreadMapping.TAG_THREAD;
+import static org.thoughtcrime.securesms.util.Base64.ENCODE;
+
+public class Exporter {
+
+  public interface Mapping {
+    String sqliteColumnName();
+
+    String xmlAttributeName();
+
+    int type();
+  }
+
+  static class ExportParams {
+    final String tableName;
+    final String tagName;
+    final String idColumn;
+    final Mapping[] mappingValues;
+
+    ExportParams(String tableName, String tagName, String idColumn, Mapping[] mappingValues) {
+      this.tableName = tableName;
+      this.tagName = tagName;
+      this.idColumn = idColumn;
+      this.mappingValues = mappingValues;
+    }
+  }
+
+  public static void exportEncrypted(Context context, String passphrase)
+          throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, NoExternalStorageException {
+    Writer writer = Utils.createEncryptingExportWriter(passphrase);
+    try {
+      exportWithWriter(context, writer);
+    } finally {
+      writer.close();
+    }
+  }
+
+  private static void exportWithWriter(Context context, Writer writer)
+          throws IOException {
+    XmlSerializer xmlSerializer = Xml.newSerializer();
+    xmlSerializer.setOutput(writer);
+    xmlSerializer.startTag("", "SignalBackup");
+
+    RawDatabase rawDatabase = DatabaseFactory.getRawDatabase(context);
+    SQLiteDatabase db = rawDatabase.getWritableDatabase();
+
+
+    ExportParams[] exportParams = {
+            new ExportParams(TABLE_NAME_DRAFTS, TAG_DRAFTS,
+                    DraftsMapping.ID.sqliteColumnName(), DraftsMapping.values()),
+            new ExportParams(TABLE_NAME_GROUPS, TAG_GROUPS,
+                    GroupsMapping.ID.sqliteColumnName(), GroupsMapping.values()),
+            new ExportParams(TABLE_NAME_IDENTITIES, TAG_IDENTITIES,
+                    IdentitiesMapping.ID.sqliteColumnName(), IdentitiesMapping.values()),
+            new ExportParams(TABLE_NAME_MMS, TAG_MMS,
+                    MmsMapping.ID.sqliteColumnName(), MmsMapping.values()),
+            new ExportParams(TABLE_NAME_PUSH, TAG_PUSH,
+                    PushMapping.ID.sqliteColumnName(), PushMapping.values()),
+            new ExportParams(TABLE_NAME_RECIPIENT_PREFERENCES, TAG_RECIPIENT_PREFERENCES,
+                    RecipientPreferencesMapping.ID.sqliteColumnName(),
+                    RecipientPreferencesMapping.values()),
+            new ExportParams(TABLE_NAME_SMS, TAG_SMS,
+                    SmsMapping.ID.sqliteColumnName(), SmsMapping.values()),
+            new ExportParams(TABLE_NAME_THREAD, TAG_THREAD,
+                    ThreadMapping.ID.sqliteColumnName(), ThreadMapping.values()),
+            new ExportParams(TABLE_NAME_ATTACHMENT_ROW, TAG_ATTACHMENT_ROW,
+                    AttachmentMapping.ID.sqliteColumnName(), AttachmentMapping.values())
+    };
+
+    for (ExportParams ep : exportParams) {
+      exportTable(db, xmlSerializer, ep.tableName, ep.idColumn,
+              ep.tagName, ep.mappingValues);
+    }
+
+    exportAttachments(context, xmlSerializer);
+    exportFilesDirectory(context, xmlSerializer);
+    exportSharedPreferences(context, xmlSerializer);
+    xmlSerializer.endTag("", "SignalBackup");
+    xmlSerializer.flush();
+  }
+
+  private static void exportSharedPreferences(Context context,
+                                              XmlSerializer xmlSerializer) throws IOException {
+    exportSharedPreferencesFile(context, xmlSerializer, "SecureSMS-Preferences");
+    SharedPreferences defaultSharedPrefs = PreferenceManager.getDefaultSharedPreferences(context);
+    exportSharedPreferences(context, xmlSerializer, null, defaultSharedPrefs);
+  }
+
+  private static void exportSharedPreferencesFile(Context context,
+                                                  XmlSerializer xmlSerializer,
+                                                  String sharedPrefsName) throws IOException {
+    SharedPreferences sharedPrefs = context.getSharedPreferences(sharedPrefsName, 0);
+    exportSharedPreferences(context, xmlSerializer, sharedPrefsName, sharedPrefs);
+  }
+
+  private static void exportSharedPreferences(Context context,
+                                              XmlSerializer xmlSerializer,
+                                              String sharedPrefsName,
+                                              SharedPreferences sharedPrefs) throws IOException {
+    Map<String, ?> allPrefs = sharedPrefs.getAll();
+    for (String key : allPrefs.keySet()) {
+      xmlSerializer.startTag("", "SignalSharedPreference");
+      if (sharedPrefsName != null) {
+        xmlSerializer.attribute("", "sharedPreferencesFileName", sharedPrefsName);
+      }
+      xmlSerializer.attribute("", "key", key);
+      xmlSerializer.attribute("", "value", allPrefs.get(key).toString());
+      xmlSerializer.attribute("", "type", allPrefs.get(key).getClass().toString());
+      xmlSerializer.endTag("", "SignalSharedPreference");
+      xmlSerializer.flush();
+    }
+  }
+
+  private static void exportAttachments(Context context,
+                                        XmlSerializer xmlSerializer) throws IOException {
+    String tagName = "SignalAttachment";
+    File dir = context.getDir("parts", Context.MODE_PRIVATE);
+    exportDirectory(xmlSerializer, tagName, dir);
+  }
+
+  private static void exportFilesDirectory(Context context,
+                                           XmlSerializer xmlSerializer) throws IOException {
+    String tagName = "SignalFile";
+    File dir = context.getFilesDir();
+    exportDirectory(xmlSerializer, tagName, dir);
+  }
+
+  private static void exportDirectory(XmlSerializer xmlSerializer,
+                                      String tagName,
+                                      File dir) throws IOException {
+    Stack<File> stack = new Stack<>();
+    stack.push(dir);
+    String parentPath = dir.getPath() + File.separator;
+    while (!stack.empty()) {
+      File d = stack.pop();
+      File[] files = d.listFiles();
+      for (File f : files) {
+        if (f.isDirectory()) {
+          stack.push(f);
+        } else {
+          String relativePath = f.getPath();
+          relativePath = relativePath.substring(parentPath.length());
+          xmlSerializer.startTag("", tagName);
+          xmlSerializer.attribute("", "relativePath", relativePath);
+          writeBlob(xmlSerializer, f);
+          xmlSerializer.endTag("", tagName);
+          xmlSerializer.flush();
+        }
+      }
+    }
+  }
+
+  private static void writeBlob(XmlSerializer xmlSerializer, File f) throws IOException {
+    FileInputStream rawInput = null;
+    try {
+      rawInput = new FileInputStream(f);
+      InputStream encodedInput = new org.thoughtcrime.securesms.util.Base64.InputStream(rawInput, ENCODE);
+      try {
+        while (true) {
+          int read = encodedInput.read();
+          if (read == -1) {
+            break;
+          } else {
+            xmlSerializer.text("" + ((char) read));
+          }
+        }
+      } finally {
+        encodedInput.close();
+      }
+    } finally {
+      if (rawInput != null) {
+        rawInput.close();
+      }
+    }
+  }
+
+  private static void exportTable(SQLiteDatabase db,
+                                  XmlSerializer xmlSerializer,
+                                  String tableName,
+                                  String keyColumnName,
+                                  String tagName,
+                                  Mapping[] mappings)
+          throws IOException {
+    String[] columns = new String[mappings.length];
+    for (int i = 0; i < columns.length; ++i) {
+      columns[i] = mappings[i].sqliteColumnName();
+    }
+    Cursor cursor = db.query(tableName, columns, null, null, null, null, keyColumnName, null);
+    if (cursor.getCount() > 0) {
+      while (cursor.moveToNext()) {
+        xmlSerializer.startTag("", tagName);
+        for (int i = 0; i < columns.length; ++i) {
+          Mapping m = mappings[i];
+          String xmlKey = m.xmlAttributeName();
+          String xmlValue = null;
+          if (m.type() == FIELD_TYPE_BLOB) {
+            byte[] blob = cursor.getBlob(i);
+            if (blob != null) {
+              xmlValue = Base64.encodeToString(blob, Base64.NO_WRAP);
+            }
+          } else {
+            xmlValue = cursor.getString(i);
+          }
+          if (xmlValue != null) {
+            xmlSerializer.attribute("", xmlKey, xmlValue);
+          }
+        }
+        xmlSerializer.endTag("", tagName);
+        xmlSerializer.flush();
+      }
+      cursor.close();
+    }
+  }
+
+}

--- a/src/org/thoughtcrime/securesms/backup/FullBackupImporter.java
+++ b/src/org/thoughtcrime/securesms/backup/FullBackupImporter.java
@@ -1,0 +1,94 @@
+package org.thoughtcrime.securesms.backup;
+
+import android.content.Context;
+
+import org.thoughtcrime.securesms.crypto.DecryptingPartInputStream;
+import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.crypto.MasterSecretFromPassphraseSpec;
+import org.thoughtcrime.securesms.database.NoExternalStorageException;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Arrays;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import static org.thoughtcrime.securesms.crypto.MasterSecretFromPassphraseSpec.ITERATION_LENGTH;
+import static org.thoughtcrime.securesms.crypto.MasterSecretFromPassphraseSpec.SALT_LENGTH;
+
+public class FullBackupImporter {
+
+  // forbid instantiation
+  private FullBackupImporter() {
+
+  }
+
+  public static void importXml(Context context, String passphrase)
+          throws ParserConfigurationException, NoExternalStorageException, SAXException,
+          IOException, InvalidKeySpecException, NoSuchAlgorithmException {
+    importEncrypted(context, passphrase);
+  }
+
+  private static void importEncrypted(Context context, String passphrase)
+          throws IOException, ParserConfigurationException, SAXException, InvalidKeySpecException,
+          NoSuchAlgorithmException, NoExternalStorageException {
+    String encryptedBackupPath = Utils.getEncryptedBackupPath();
+    File encryptedBackupFile = new File(encryptedBackupPath);
+
+    byte[] saltAndIterationBytes = read(encryptedBackupFile, SALT_LENGTH + ITERATION_LENGTH);
+    byte[] salt = Arrays.copyOfRange(saltAndIterationBytes, 0, SALT_LENGTH);
+    byte[] iterations = Arrays.copyOfRange(saltAndIterationBytes, SALT_LENGTH, saltAndIterationBytes.length);
+    MasterSecretFromPassphraseSpec spec = new MasterSecretFromPassphraseSpec(passphrase, salt, iterations);
+    MasterSecret masterSecret = spec.deriveMasterSecret();
+
+    InputStream inputStream = DecryptingPartInputStream.createFor(masterSecret, encryptedBackupFile, saltAndIterationBytes.length);
+    try {
+      importWithInputStream(context, inputStream);
+    } finally {
+      inputStream.close();
+    }
+  }
+
+  private static byte[] read(File file, int numberOfBytes) throws IOException {
+    if (file.length() <= numberOfBytes) {
+      throw new IOException("File too short");
+    }
+
+    FileInputStream stream = new FileInputStream(file);
+    try {
+      return readFully(stream, numberOfBytes);
+    } finally {
+      stream.close();
+    }
+  }
+
+  private static byte[] readFully(FileInputStream stream, int numberOfBytes) throws IOException {
+    byte[] result = new byte[numberOfBytes];
+    int read;
+    for (int i = 0; i < numberOfBytes; ++i) {
+      read = stream.read();
+      if (read == -1) {
+        throw new IOException("unexpected end of file");
+      }
+      result[i] = (byte) read;
+    }
+    return result;
+  }
+
+  private static void importWithInputStream(Context context, InputStream inputStream)
+          throws ParserConfigurationException, SAXException, IOException {
+    InputSource is = new InputSource(inputStream);
+    DefaultHandler handler = new XmlImportHandler(context);
+    SAXParser parser = SAXParserFactory.newInstance().newSAXParser();
+    parser.parse(is, handler);
+  }
+}

--- a/src/org/thoughtcrime/securesms/backup/GroupsMapping.java
+++ b/src/org/thoughtcrime/securesms/backup/GroupsMapping.java
@@ -1,0 +1,49 @@
+package org.thoughtcrime.securesms.backup;
+
+import static android.database.Cursor.FIELD_TYPE_BLOB;
+import static android.database.Cursor.FIELD_TYPE_INTEGER;
+import static android.database.Cursor.FIELD_TYPE_STRING;
+
+public enum GroupsMapping implements Exporter.Mapping {
+
+  ID("_id", "id", FIELD_TYPE_INTEGER),
+  GROUP_ID("group_id", "group_id", FIELD_TYPE_STRING),
+  TITLE("title", "title", FIELD_TYPE_STRING),
+  MEMBERS("members", "members", FIELD_TYPE_STRING),
+  AVATAR("avatar", "avatar", FIELD_TYPE_BLOB),
+  AVATAR_ID("avatar_id", "avatar_id", FIELD_TYPE_INTEGER),
+  AVATAR_KEY("avatar_key", "avatar_key", FIELD_TYPE_BLOB),
+  AVATAR_CONTENT_TYPE("avatar_content_type", "avatar_content_type", FIELD_TYPE_STRING),
+  AVATAR_RELAY("avatar_relay", "avatar_relay", FIELD_TYPE_STRING),
+  AVATAR_DIGEST("avatar_digest", "avatar_digest", FIELD_TYPE_BLOB),
+  TIMESTAMP("timestamp", "timestamp", FIELD_TYPE_INTEGER),
+  ACTIVE("active", "active", FIELD_TYPE_INTEGER);
+
+  public static final String TAG_GROUPS = "SignalGroups";
+  public static final String TABLE_NAME_GROUPS = "groups";
+
+  private String sqliteColumnName;
+  private String xmlAttributeName;
+  private int type;
+
+  GroupsMapping(String sqliteColumnName, String xmlAttributeName, int type) {
+    this.sqliteColumnName = sqliteColumnName;
+    this.xmlAttributeName = xmlAttributeName;
+    this.type = type;
+  }
+
+  @Override
+  public String sqliteColumnName() {
+    return this.sqliteColumnName;
+  }
+
+  @Override
+  public String xmlAttributeName() {
+    return this.xmlAttributeName;
+  }
+
+  @Override
+  public int type() {
+    return this.type;
+  }
+}

--- a/src/org/thoughtcrime/securesms/backup/IdentitiesMapping.java
+++ b/src/org/thoughtcrime/securesms/backup/IdentitiesMapping.java
@@ -1,0 +1,43 @@
+package org.thoughtcrime.securesms.backup;
+
+import static android.database.Cursor.FIELD_TYPE_INTEGER;
+import static android.database.Cursor.FIELD_TYPE_STRING;
+
+public enum IdentitiesMapping implements Exporter.Mapping {
+
+  ID("_id", "id", FIELD_TYPE_INTEGER),
+  ADDRESS("address", "address", FIELD_TYPE_STRING),
+  IDENTITY_KEY("key", "key", FIELD_TYPE_STRING),
+  TIMESTAMP("timestamp", "timestamp", FIELD_TYPE_INTEGER),
+  FIRST_USE("first_use", "first_use", FIELD_TYPE_INTEGER),
+  NONBLOCKING_APPROVAL("nonblocking_approval", "nonblocking_approval", FIELD_TYPE_INTEGER),
+  VERIFIED("verified", "verified", FIELD_TYPE_INTEGER);
+
+  public static final String TAG_IDENTITIES = "SignalIdentities";
+  public static final String TABLE_NAME_IDENTITIES = "identities";
+
+  private String sqliteColumnName;
+  private String xmlAttributeName;
+  private int type;
+
+  IdentitiesMapping(String sqliteColumnName, String xmlAttributeName, int type) {
+    this.sqliteColumnName = sqliteColumnName;
+    this.xmlAttributeName = xmlAttributeName;
+    this.type = type;
+  }
+
+  @Override
+  public String sqliteColumnName() {
+    return this.sqliteColumnName;
+  }
+
+  @Override
+  public String xmlAttributeName() {
+    return this.xmlAttributeName;
+  }
+
+  @Override
+  public int type() {
+    return this.type;
+  }
+}

--- a/src/org/thoughtcrime/securesms/backup/ImportException.java
+++ b/src/org/thoughtcrime/securesms/backup/ImportException.java
@@ -1,0 +1,7 @@
+package org.thoughtcrime.securesms.backup;
+
+public class ImportException extends Exception {
+  public ImportException(String message) {
+    super(message);
+  }
+}

--- a/src/org/thoughtcrime/securesms/backup/ImportExportResult.java
+++ b/src/org/thoughtcrime/securesms/backup/ImportExportResult.java
@@ -1,0 +1,6 @@
+package org.thoughtcrime.securesms.backup;
+
+public enum ImportExportResult {
+  SUCCESS, PASSPHRASE_REQUIRED, NO_SD_CARD, ERROR_IO, ERROR_PARSER_CONFIGURATION, ERROR_PARSE,
+  INTERNAL_ERROR;
+}

--- a/src/org/thoughtcrime/securesms/backup/MmsMapping.java
+++ b/src/org/thoughtcrime/securesms/backup/MmsMapping.java
@@ -1,0 +1,77 @@
+package org.thoughtcrime.securesms.backup;
+
+import static android.database.Cursor.FIELD_TYPE_INTEGER;
+import static android.database.Cursor.FIELD_TYPE_STRING;
+
+public enum MmsMapping implements Exporter.Mapping {
+
+  ID("_id", "id", FIELD_TYPE_INTEGER),
+  THREAD_ID("thread_id", "thread_id", FIELD_TYPE_INTEGER),
+  DATE_SENT("date", "date", FIELD_TYPE_INTEGER),
+  DATE_RECEIVED("date_received", "date_received", FIELD_TYPE_INTEGER),
+  MESSAGE_BOX("msg_box", "msg_box", FIELD_TYPE_INTEGER),
+  READ("read", "read", FIELD_TYPE_INTEGER),
+  M_ID("m_id", "m_id", FIELD_TYPE_STRING),
+  SUB("sub", "sub", FIELD_TYPE_STRING),
+  SUB_CS("sub_cs", "sub_cs", FIELD_TYPE_INTEGER),
+  BODY("body", "body", FIELD_TYPE_STRING),
+  PART_COUNT("part_count", "part_count", FIELD_TYPE_INTEGER),
+  CT_T("ct_t", "ct_t", FIELD_TYPE_STRING),
+  CONTENT_LOCATION("ct_l", "ct_l", FIELD_TYPE_STRING),
+  ADDRESS("address", "address", FIELD_TYPE_STRING),
+  ADDRESS_DEVICE_ID("address_device_id", "address_device_id", FIELD_TYPE_INTEGER),
+  EXPIRY("exp", "exp", FIELD_TYPE_INTEGER),
+  M_CLS("m_cls", "m_cls", FIELD_TYPE_STRING),
+  MESSAGE_TYPE("m_type", "m_type", FIELD_TYPE_INTEGER),
+  V("v", "v", FIELD_TYPE_INTEGER),
+  MESSAGE_SIZE("m_size", "m_size", FIELD_TYPE_INTEGER),
+  PRI("pri", "pri", FIELD_TYPE_INTEGER),
+  RR("rr", "rr", FIELD_TYPE_INTEGER),
+  RPT_A("rpt_a", "rpt_a", FIELD_TYPE_INTEGER),
+  RESP_ST("resp_st", "resp_st", FIELD_TYPE_INTEGER),
+  STATUS("st", "st", FIELD_TYPE_INTEGER),
+  TRANSACTION_ID("tr_id", "tr_id", FIELD_TYPE_STRING),
+  RETR_ST("retr_st", "retr_st", FIELD_TYPE_INTEGER),
+  RETR_TXT("retr_txt", "retr_txt", FIELD_TYPE_STRING),
+  RETR_TXT_CS("retr_txt_cs", "retr_txt_cs", FIELD_TYPE_INTEGER),
+  READ_STATUS("read_status", "read_status", FIELD_TYPE_INTEGER),
+  CT_CLS("ct_cls", "ct_cls", FIELD_TYPE_INTEGER),
+  RESP_TXT("resp_txt", "resp_txt", FIELD_TYPE_STRING),
+  D_TM("d_tm", "d_tm", FIELD_TYPE_INTEGER),
+  RECEIPT_COUNT("delivery_receipt_count", "delivery_receipt_count", FIELD_TYPE_INTEGER),
+  MISMATCHED_IDENTITIES("mismatched_identities", "mismatched_identities", FIELD_TYPE_STRING),
+  NETWORK_FAILURE("network_failures", "network_failures", FIELD_TYPE_STRING),
+  D_RPT("d_rpt", "d_rpt", FIELD_TYPE_INTEGER),
+  SUBSCRIPTION_ID("subscription_id", "subscription_id", FIELD_TYPE_INTEGER),
+  EXPIRES_IN("expires_in", "expires_in", FIELD_TYPE_INTEGER),
+  EXPIRE_STARTED("expire_started", "expire_started", FIELD_TYPE_INTEGER),
+  NOTIFIED("notified", "notified", FIELD_TYPE_INTEGER);
+
+  public static final String TAG_MMS = "SignalMms";
+  public static final String TABLE_NAME_MMS = "mms";
+
+  private String sqliteColumnName;
+  private String xmlAttributeName;
+  private int type;
+
+  MmsMapping(String sqliteColumnName, String xmlAttributeName, int type) {
+    this.sqliteColumnName = sqliteColumnName;
+    this.xmlAttributeName = xmlAttributeName;
+    this.type = type;
+  }
+
+  @Override
+  public String sqliteColumnName() {
+    return this.sqliteColumnName;
+  }
+
+  @Override
+  public String xmlAttributeName() {
+    return this.xmlAttributeName;
+  }
+
+  @Override
+  public int type() {
+    return this.type;
+  }
+}

--- a/src/org/thoughtcrime/securesms/backup/PushMapping.java
+++ b/src/org/thoughtcrime/securesms/backup/PushMapping.java
@@ -1,0 +1,43 @@
+package org.thoughtcrime.securesms.backup;
+
+import static android.database.Cursor.FIELD_TYPE_INTEGER;
+import static android.database.Cursor.FIELD_TYPE_STRING;
+
+public enum PushMapping implements Exporter.Mapping {
+
+  ID("_id", "id", FIELD_TYPE_INTEGER),
+  TYPE("type", "type", FIELD_TYPE_INTEGER),
+  SOURCE("source", "source", FIELD_TYPE_STRING),
+  DEVICE_ID("device_id", "device_id", FIELD_TYPE_INTEGER),
+  LEGACY_MSG("body", "body", FIELD_TYPE_STRING),
+  CONTENT("content", "content", FIELD_TYPE_STRING),
+  TIMESTAMP("timestamp", "timestamp", FIELD_TYPE_INTEGER);
+
+  public static final String TAG_PUSH = "SignalPush";
+  public static final String TABLE_NAME_PUSH = "push";
+
+  private String sqliteColumnName;
+  private String xmlAttributeName;
+  private int type;
+
+  PushMapping(String sqliteColumnName, String xmlAttributeName, int type) {
+    this.sqliteColumnName = sqliteColumnName;
+    this.xmlAttributeName = xmlAttributeName;
+    this.type = type;
+  }
+
+  @Override
+  public String sqliteColumnName() {
+    return this.sqliteColumnName;
+  }
+
+  @Override
+  public String xmlAttributeName() {
+    return this.xmlAttributeName;
+  }
+
+  @Override
+  public int type() {
+    return this.type;
+  }
+}

--- a/src/org/thoughtcrime/securesms/backup/RecipientPreferencesMapping.java
+++ b/src/org/thoughtcrime/securesms/backup/RecipientPreferencesMapping.java
@@ -1,0 +1,46 @@
+package org.thoughtcrime.securesms.backup;
+
+import static android.database.Cursor.FIELD_TYPE_INTEGER;
+import static android.database.Cursor.FIELD_TYPE_STRING;
+
+public enum RecipientPreferencesMapping implements Exporter.Mapping {
+
+  ID("_id", "id", FIELD_TYPE_INTEGER),
+  ADDRESSES("recipient_ids", "recipient_ids", FIELD_TYPE_STRING),
+  BLOCK("block", "block", FIELD_TYPE_INTEGER),
+  NOTIFICATION("notification", "notification", FIELD_TYPE_STRING),
+  VIBRATE("vibrate", "vibrate", FIELD_TYPE_INTEGER),
+  MUTE_UNTIL("mute_until", "mute_until", FIELD_TYPE_INTEGER),
+  COLOR("color", "color", FIELD_TYPE_STRING),
+  SEEN_INVITE_REMINDER("seen_invite_reminder", "seen_invite_reminder", FIELD_TYPE_INTEGER),
+  DEFAULT_SUBSCRIPTION_ID("default_subscription_id", "default_subscription_id", FIELD_TYPE_INTEGER),
+  EXPIRE_MESSAGES("expire_messages", "expire_messages", FIELD_TYPE_INTEGER);
+
+  public static final String TAG_RECIPIENT_PREFERENCES = "SignalRecipientPreferences";
+  public static final String TABLE_NAME_RECIPIENT_PREFERENCES = "recipient_preferences";
+
+  private String sqliteColumnName;
+  private String xmlAttributeName;
+  private int type;
+
+  RecipientPreferencesMapping(String sqliteColumnName, String xmlAttributeName, int type) {
+    this.sqliteColumnName = sqliteColumnName;
+    this.xmlAttributeName = xmlAttributeName;
+    this.type = type;
+  }
+
+  @Override
+  public String sqliteColumnName() {
+    return this.sqliteColumnName;
+  }
+
+  @Override
+  public String xmlAttributeName() {
+    return this.xmlAttributeName;
+  }
+
+  @Override
+  public int type() {
+    return this.type;
+  }
+}

--- a/src/org/thoughtcrime/securesms/backup/SmsMapping.java
+++ b/src/org/thoughtcrime/securesms/backup/SmsMapping.java
@@ -1,0 +1,56 @@
+package org.thoughtcrime.securesms.backup;
+
+import static android.database.Cursor.FIELD_TYPE_INTEGER;
+import static android.database.Cursor.FIELD_TYPE_STRING;
+
+public enum SmsMapping implements Exporter.Mapping {
+
+  ID("_id", "id", FIELD_TYPE_INTEGER),
+  THREAD_ID("thread_id", "thread_id", FIELD_TYPE_INTEGER),
+  ADDRESS("address", "address", FIELD_TYPE_STRING),
+  ADDRESS_DEVICE_ID("address_device_id", "address_device_id", FIELD_TYPE_INTEGER),
+  PERSON("person", "person", FIELD_TYPE_INTEGER),
+  DATE_RECEIVED("date", "date_received", FIELD_TYPE_INTEGER),
+  DATE_SENT("date_sent", "date_sent", FIELD_TYPE_INTEGER),
+  PROTOCOL("protocol", "protocol", FIELD_TYPE_INTEGER),
+  READ("read", "read", FIELD_TYPE_INTEGER),
+  STATUS("status", "status", FIELD_TYPE_INTEGER),
+  TYPE("type", "type", FIELD_TYPE_INTEGER),
+  REPLY_PATH_PRESENT("reply_path_present", "reply_path_present", FIELD_TYPE_INTEGER),
+  RECEIPT_COUNT("delivery_receipt_count", "delivery_receipt_count", FIELD_TYPE_INTEGER),
+  SUBJECT("subject", "subject", FIELD_TYPE_STRING),
+  BODY("body", "body", FIELD_TYPE_STRING),
+  MISMATCHED_IDENTITIES("mismatched_identities", "mismatched_identities", FIELD_TYPE_STRING),
+  SERVICE_CENTER("service_center", "service_center", FIELD_TYPE_STRING),
+  SUBSCRIPTION_ID("subscription_id", "subscription_id", FIELD_TYPE_INTEGER),
+  EXPIRES_IN("expires_in", "expires_in", FIELD_TYPE_INTEGER),
+  EXPIRE_STARTED("expire_started", "expire_started", FIELD_TYPE_INTEGER);
+
+  public static final String TAG_SMS = "SignalSms";
+  public static final String TABLE_NAME_SMS = "sms";
+
+  private String sqliteColumnName;
+  private String xmlAttributeName;
+  private int type;
+
+  SmsMapping(String sqliteColumnName, String xmlAttributeName, int type) {
+    this.sqliteColumnName = sqliteColumnName;
+    this.xmlAttributeName = xmlAttributeName;
+    this.type = type;
+  }
+
+  @Override
+  public String sqliteColumnName() {
+    return this.sqliteColumnName;
+  }
+
+  @Override
+  public String xmlAttributeName() {
+    return this.xmlAttributeName;
+  }
+
+  @Override
+  public int type() {
+    return this.type;
+  }
+}

--- a/src/org/thoughtcrime/securesms/backup/ThreadMapping.java
+++ b/src/org/thoughtcrime/securesms/backup/ThreadMapping.java
@@ -1,0 +1,52 @@
+package org.thoughtcrime.securesms.backup;
+
+import static android.database.Cursor.FIELD_TYPE_INTEGER;
+import static android.database.Cursor.FIELD_TYPE_STRING;
+
+public enum ThreadMapping implements Exporter.Mapping {
+
+  ID("_id", "id", FIELD_TYPE_INTEGER),
+  DATE("date", "date", FIELD_TYPE_INTEGER),
+  MESSAGE_COUNT("message_count", "message_count", FIELD_TYPE_INTEGER),
+  ADDRESSES("recipient_ids", "recipient_ids", FIELD_TYPE_STRING),
+  SNIPPET("snippet", "snippet", FIELD_TYPE_STRING),
+  SNIPPET_CHARSET("snippet_cs", "snippet_cs", FIELD_TYPE_INTEGER),
+  READ("read", "read", FIELD_TYPE_INTEGER),
+  TYPE("type", "type", FIELD_TYPE_INTEGER),
+  ERROR("error", "error", FIELD_TYPE_INTEGER),
+  SNIPPET_TYPE("snippet_type", "snippet_type", FIELD_TYPE_INTEGER),
+  SNIPPET_URI("snippet_uri", "snippet_uri", FIELD_TYPE_STRING),
+  ARCHIVED("archived", "archived", FIELD_TYPE_INTEGER),
+  STATUS("status", "status", FIELD_TYPE_INTEGER),
+  RECEIPT_COUNT("delivery_receipt_count", "delivery_receipt_count", FIELD_TYPE_INTEGER),
+  EXPIRES_IN("expires_in", "expires_in", FIELD_TYPE_INTEGER),
+  LAST_SEEN("last_seen", "last_seen", FIELD_TYPE_INTEGER);
+
+  public static final String TAG_THREAD = "SignalThread";
+  public static final String TABLE_NAME_THREAD = "thread";
+
+  private String sqliteColumnName;
+  private String xmlAttributeName;
+  private int type;
+
+  ThreadMapping(String sqliteColumnName, String xmlAttributeName, int type) {
+    this.sqliteColumnName = sqliteColumnName;
+    this.xmlAttributeName = xmlAttributeName;
+    this.type = type;
+  }
+
+  @Override
+  public String sqliteColumnName() {
+    return this.sqliteColumnName;
+  }
+
+  @Override
+  public String xmlAttributeName() {
+    return this.xmlAttributeName;
+  }
+
+  @Override
+  public int type() {
+    return this.type;
+  }
+}

--- a/src/org/thoughtcrime/securesms/backup/Utils.java
+++ b/src/org/thoughtcrime/securesms/backup/Utils.java
@@ -1,0 +1,41 @@
+package org.thoughtcrime.securesms.backup;
+
+import org.thoughtcrime.securesms.crypto.EncryptingPartOutputStream;
+import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.crypto.MasterSecretFromPassphraseSpec;
+import org.thoughtcrime.securesms.database.NoExternalStorageException;
+import org.thoughtcrime.securesms.util.StorageUtil;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
+class Utils {
+
+  private static final String ENCRYPTED_BACKUP_FILENAME = "EncryptedFullSignalBackup";
+
+  static String getEncryptedBackupPath() throws NoExternalStorageException {
+    return (new File(StorageUtil.getBackupDir(), ENCRYPTED_BACKUP_FILENAME)).getAbsolutePath();
+  }
+
+  static Writer createEncryptingExportWriter(String passphrase)
+          throws NoSuchAlgorithmException, NoExternalStorageException, InvalidKeySpecException,
+          FileNotFoundException {
+    String path = getEncryptedBackupPath();
+    File file = new File(path);
+    MasterSecretFromPassphraseSpec spec = new MasterSecretFromPassphraseSpec(passphrase);
+    MasterSecret masterSecret = spec.deriveMasterSecret();
+
+    OutputStream outputStream =
+            new EncryptingPartOutputStream(file, masterSecret, spec.saltAndIterationBytes());
+    return new OutputStreamWriter(outputStream);
+  }
+
+}

--- a/src/org/thoughtcrime/securesms/backup/XmlImportHandler.java
+++ b/src/org/thoughtcrime/securesms/backup/XmlImportHandler.java
@@ -1,0 +1,307 @@
+package org.thoughtcrime.securesms.backup;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.database.sqlite.SQLiteDatabase;
+import android.preference.PreferenceManager;
+import android.util.Base64;
+
+import org.thoughtcrime.securesms.database.DatabaseFactory;
+import org.thoughtcrime.securesms.database.RawDatabase;
+import org.xml.sax.Attributes;
+import org.xml.sax.helpers.DefaultHandler;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Hashtable;
+
+import static android.database.Cursor.FIELD_TYPE_BLOB;
+import static android.database.Cursor.FIELD_TYPE_FLOAT;
+import static android.database.Cursor.FIELD_TYPE_INTEGER;
+import static android.database.Cursor.FIELD_TYPE_STRING;
+import static org.thoughtcrime.securesms.backup.AttachmentMapping.TABLE_NAME_ATTACHMENT_ROW;
+import static org.thoughtcrime.securesms.backup.AttachmentMapping.TAG_ATTACHMENT_ROW;
+import static org.thoughtcrime.securesms.backup.DraftsMapping.TABLE_NAME_DRAFTS;
+import static org.thoughtcrime.securesms.backup.DraftsMapping.TAG_DRAFTS;
+import static org.thoughtcrime.securesms.backup.GroupsMapping.TABLE_NAME_GROUPS;
+import static org.thoughtcrime.securesms.backup.GroupsMapping.TAG_GROUPS;
+import static org.thoughtcrime.securesms.backup.IdentitiesMapping.TABLE_NAME_IDENTITIES;
+import static org.thoughtcrime.securesms.backup.IdentitiesMapping.TAG_IDENTITIES;
+import static org.thoughtcrime.securesms.backup.MmsMapping.TABLE_NAME_MMS;
+import static org.thoughtcrime.securesms.backup.MmsMapping.TAG_MMS;
+import static org.thoughtcrime.securesms.backup.PushMapping.TABLE_NAME_PUSH;
+import static org.thoughtcrime.securesms.backup.PushMapping.TAG_PUSH;
+import static org.thoughtcrime.securesms.backup.RecipientPreferencesMapping.TABLE_NAME_RECIPIENT_PREFERENCES;
+import static org.thoughtcrime.securesms.backup.RecipientPreferencesMapping.TAG_RECIPIENT_PREFERENCES;
+import static org.thoughtcrime.securesms.backup.SmsMapping.TABLE_NAME_SMS;
+import static org.thoughtcrime.securesms.backup.SmsMapping.TAG_SMS;
+import static org.thoughtcrime.securesms.backup.ThreadMapping.TABLE_NAME_THREAD;
+import static org.thoughtcrime.securesms.backup.ThreadMapping.TAG_THREAD;
+
+public class XmlImportHandler extends DefaultHandler {
+
+  private DecodeBase64Writer writer;
+  private Context context = null;
+  private SQLiteDatabase db;
+  private Hashtable<String, Exporter.Mapping> draftsMappingHt;
+  private Hashtable<String, Exporter.Mapping> groupsMappingHt;
+  private Hashtable<String, Exporter.Mapping> identitiesMappingHt;
+  private Hashtable<String, Exporter.Mapping> mmsMappingHt;
+  private Hashtable<String, Exporter.Mapping> pushMappingHt;
+  private Hashtable<String, Exporter.Mapping> recipientPreferencesMappingHt;
+  private Hashtable<String, Exporter.Mapping> smsMappingHt;
+  private Hashtable<String, Exporter.Mapping> threadsMappingHt;
+  private Hashtable<String, Exporter.Mapping> attachmentMappingHt;
+
+  XmlImportHandler(Context context) {
+    super();
+
+    RawDatabase rawDatabase = DatabaseFactory.getRawDatabase(context);
+    this.context = context;
+    this.db = rawDatabase.getWritableDatabase();
+
+    cleanDatabase(db);
+
+    this.draftsMappingHt = generateXmlToMappingHT(DraftsMapping.values());
+    this.groupsMappingHt = generateXmlToMappingHT(GroupsMapping.values());
+    this.identitiesMappingHt = generateXmlToMappingHT(IdentitiesMapping.values());
+    this.mmsMappingHt = generateXmlToMappingHT(MmsMapping.values());
+    this.pushMappingHt = generateXmlToMappingHT(PushMapping.values());
+    this.recipientPreferencesMappingHt = generateXmlToMappingHT(RecipientPreferencesMapping.values());
+    this.smsMappingHt = generateXmlToMappingHT(SmsMapping.values());
+    this.threadsMappingHt = generateXmlToMappingHT(ThreadMapping.values());
+    this.attachmentMappingHt = generateXmlToMappingHT(AttachmentMapping.values());
+  }
+
+  private static void cleanDatabase(SQLiteDatabase db) {
+    db.delete(TABLE_NAME_DRAFTS, null, null);
+    db.delete(TABLE_NAME_GROUPS, null, null);
+    db.delete(TABLE_NAME_IDENTITIES, null, null);
+    db.delete(TABLE_NAME_MMS, null, null);
+    db.delete(TABLE_NAME_PUSH, null, null);
+    db.delete(TABLE_NAME_RECIPIENT_PREFERENCES, null, null);
+    db.delete(TABLE_NAME_SMS, null, null);
+    db.delete(TABLE_NAME_THREAD, null, null);
+  }
+
+  @Override
+  public void startElement(String uri, String localName,
+                           String qName, Attributes attributes) {
+    closeWriter();
+
+    if (localName.equals(TAG_IDENTITIES)) {
+      importTableRow(db, attributes, TABLE_NAME_IDENTITIES, identitiesMappingHt);
+    } else if (localName.equals(TAG_SMS)) {
+      importTableRow(db, attributes, TABLE_NAME_SMS, smsMappingHt);
+    } else if (localName.equals(TAG_MMS)) {
+      importTableRow(db, attributes, TABLE_NAME_MMS, mmsMappingHt);
+    } else if (localName.equals(TAG_GROUPS)) {
+      importTableRow(db, attributes, TABLE_NAME_GROUPS, groupsMappingHt);
+    } else if (localName.equals(TAG_DRAFTS)) {
+      importTableRow(db, attributes, TABLE_NAME_DRAFTS, draftsMappingHt);
+    } else if (localName.equals(TAG_PUSH)) {
+      importTableRow(db, attributes, TABLE_NAME_PUSH, pushMappingHt);
+    } else if (localName.equals(TAG_RECIPIENT_PREFERENCES)) {
+      importTableRow(db, attributes, TABLE_NAME_RECIPIENT_PREFERENCES, recipientPreferencesMappingHt);
+    } else if (localName.equals(TAG_THREAD)) {
+      importTableRow(db, attributes, TABLE_NAME_THREAD, threadsMappingHt);
+    } else if (localName.equals(TAG_ATTACHMENT_ROW)) {
+      importTableRow(db, attributes, TABLE_NAME_ATTACHMENT_ROW, attachmentMappingHt);
+    } else if (localName.equals("SignalSharedPreference")) {
+      importSharedPreference(context, attributes);
+    } else if (localName.equals("SignalAttachment")) {
+      createAttachmentStreams(context, attributes);
+    } else if (localName.equals("SignalFile")) {
+      createFileStreams(context, attributes);
+    }
+  }
+
+  @Override
+  public void endElement(String uri, String localName,
+                         String qName) {
+    closeWriter();
+  }
+
+  @Override
+  public void characters(char[] ch, int start, int length) {
+    if (this.writer != null) {
+      try {
+        this.writer.write(ch, start, length);
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  @Override
+  public void endDocument() {
+    closeWriter();
+    db.close();
+    db = null;
+    context = null;
+  }
+
+  private void createAttachmentStreams(Context context, Attributes attributes) {
+    String dirname = "parts";
+    String filename = null;
+    if (attributes.getLength() < 1) {
+      throw new RuntimeException("must have a filename");
+    }
+    filename = attributes.getValue(0);
+    File outdir = context.getDir(dirname, Context.MODE_PRIVATE);
+    File rawOutputFile = new File(outdir, filename);
+    try {
+      makeParentDirs(rawOutputFile);
+    } catch (IOException e) {
+      e.printStackTrace();
+    } catch (ImportException e) {
+      e.printStackTrace();
+    }
+    this.writer = createWriter(rawOutputFile);
+  }
+
+  private void createFileStreams(Context context, Attributes attributes) {
+    String relativePath = null;
+    for (int i = 0; i < attributes.getLength(); ++i) {
+      if ("relativePath".equals(attributes.getLocalName(i))) {
+        relativePath = attributes.getValue(i);
+      }
+    }
+    if (relativePath == null) {
+      throw new RuntimeException("must have a relativePath");
+    }
+    File filesDir = context.getFilesDir();
+    File outfile = new File(filesDir, relativePath);
+    try {
+      makeParentDirs(outfile);
+    } catch (ImportException e) {
+      e.printStackTrace();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    this.writer = createWriter(outfile);
+  }
+
+  private DecodeBase64Writer createWriter(File file) {
+    FileOutputStream rawStream = null;
+    try {
+      rawStream = new FileOutputStream(file);
+    } catch (FileNotFoundException e) {
+      e.printStackTrace();
+    }
+    if (rawStream != null) {
+      return new DecodeBase64Writer(rawStream);
+    } else {
+      return null;
+    }
+  }
+
+  private static void makeParentDirs(File f) throws IOException, ImportException {
+    File parentDir = f.getParentFile();
+    if (parentDir != null) {
+      parentDir.mkdirs();
+    }
+  }
+
+  private void closeWriter() {
+    if (this.writer != null) {
+      try {
+        this.writer.close();
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+    this.writer = null;
+  }
+
+  private static Hashtable<String, Exporter.Mapping> generateXmlToMappingHT(Exporter.Mapping[] mappings) {
+    Hashtable<String, Exporter.Mapping> ht = new Hashtable<>();
+    for (Exporter.Mapping m : mappings) {
+      ht.put(m.xmlAttributeName(), m);
+    }
+    return ht;
+  }
+
+  private static void importTableRow(SQLiteDatabase db,
+                                     Attributes attributes,
+                                     String tableName,
+                                     Hashtable<String, Exporter.Mapping> xmlNameToMappingHt) {
+    int attributeCount = attributes.getLength();
+    if (attributeCount <= 0) {
+      return;
+    }
+    ContentValues contentValues = new ContentValues();
+    for (int i = 0; i < attributeCount; ++i) {
+      String key = attributes.getLocalName(i);
+      String value = attributes.getValue(i);
+      Exporter.Mapping mapping = xmlNameToMappingHt.get(key);
+      if (mapping != null) {
+        String sqliteName = mapping.sqliteColumnName();
+        switch (mapping.type()) {
+          case FIELD_TYPE_INTEGER:
+            long t = Long.parseLong(value);
+            contentValues.put(sqliteName, t);
+            break;
+          case FIELD_TYPE_STRING:
+            contentValues.put(sqliteName, value);
+            break;
+          case FIELD_TYPE_BLOB:
+            byte[] blob = Base64.decode(value, Base64.NO_WRAP);
+            contentValues.put(sqliteName, blob);
+            break;
+          case FIELD_TYPE_FLOAT:
+            float f = Float.parseFloat(value);
+            contentValues.put(sqliteName, f);
+            break;
+        }
+      }
+    }
+    db.insert(tableName, null, contentValues);
+  }
+
+
+  private static void importSharedPreference(Context context, Attributes attributes) {
+    String sharedPreferenceFilename = null;
+    String key = null;
+    String value = null;
+    String type = null;
+    for (int i = 0; i < attributes.getLength(); ++i) {
+      String k = attributes.getLocalName(i);
+      String v = attributes.getValue(i);
+      if (k.equals("sharedPreferencesFileName")) {
+        sharedPreferenceFilename = v;
+      } else if (k.equals("key")) {
+        key = v;
+      } else if (k.equals("value")) {
+        value = v;
+      } else if (k.equals("type")) {
+        type = v;
+      }
+    }
+    if ((key == null) || (value == null) || (type == null)) {
+      return;
+    }
+
+    SharedPreferences sharedPrefs;
+    if (sharedPreferenceFilename != null) {
+      sharedPrefs = context.getSharedPreferences(sharedPreferenceFilename, 0);
+    } else {
+      sharedPrefs = PreferenceManager.getDefaultSharedPreferences(context);
+    }
+    if ("class java.lang.String".equals(type)) {
+      sharedPrefs.edit().putString(key, value).commit();
+    } else if ("class java.lang.Boolean".equals(type)) {
+      Boolean parsedValue = Boolean.parseBoolean(value);
+      sharedPrefs.edit().putBoolean(key, parsedValue).commit();
+    } else if ("class java.lang.Integer".equals(type)) {
+      Integer parsedValue = Integer.parseInt(value);
+      sharedPrefs.edit().putInt(key, parsedValue).commit();
+    } else if ("class java.lang.Long".equals(type)) {
+      Long parsedValue = Long.parseLong(value);
+      sharedPrefs.edit().putLong(key, parsedValue).commit();
+    }
+  }
+}

--- a/src/org/thoughtcrime/securesms/crypto/EncryptingPartOutputStream.java
+++ b/src/org/thoughtcrime/securesms/crypto/EncryptingPartOutputStream.java
@@ -44,10 +44,13 @@ public class EncryptingPartOutputStream extends FileOutputStream {
   private Mac mac;
   private boolean closed;
 
-  public EncryptingPartOutputStream(File file, MasterSecret masterSecret) throws FileNotFoundException {
+  public EncryptingPartOutputStream(File file, MasterSecret masterSecret, byte[] unencryptedStartBytes) throws FileNotFoundException {
     super(file);
 
     try {
+      if (unencryptedStartBytes != null) {
+        super.write(unencryptedStartBytes, 0, unencryptedStartBytes.length);
+      }
       mac    = initializeMac(masterSecret.getMacKey());
       cipher = initializeCipher(mac, masterSecret.getEncryptionKey());
       closed = false;
@@ -61,6 +64,10 @@ public class EncryptingPartOutputStream extends FileOutputStream {
     } catch (NoSuchPaddingException e) {
       throw new AssertionError(e);
     }
+  }
+
+  public EncryptingPartOutputStream(File file, MasterSecret masterSecret) throws FileNotFoundException {
+    this(file, masterSecret, null);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/crypto/MasterSecretFromPassphraseSpec.java
+++ b/src/org/thoughtcrime/securesms/crypto/MasterSecretFromPassphraseSpec.java
@@ -1,0 +1,84 @@
+package org.thoughtcrime.securesms.crypto;
+
+import org.thoughtcrime.securesms.util.Util;
+
+import java.nio.ByteBuffer;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Arrays;
+
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+
+public class MasterSecretFromPassphraseSpec {
+
+  public static final int ENCRYPTION_KEY_LENGTH = 128; // bits
+  public static final int MAC_KEY_LENGTH = 128; // bits
+  public static final int SALT_LENGTH = 16; // bytes
+  public static final int ITERATION_LENGTH = 4; // bytes
+
+  private String passphrase;
+  private byte[] salt;
+  private int iterations;
+
+  public MasterSecretFromPassphraseSpec(String passphrase) throws NoSuchAlgorithmException {
+    this.passphrase = passphrase;
+    this.salt = MasterSecretUtil.generateSalt();
+    this.iterations = MasterSecretUtil.generateIterationCount(passphrase, salt);
+  }
+
+  public MasterSecretFromPassphraseSpec(String passphrase,
+                                        byte[] salt,
+                                        byte[] iterations) {
+    this.passphrase = passphrase;
+    this.salt = salt;
+    this.iterations = convertIterations(iterations);
+  }
+
+  public String passphrase() {
+    return passphrase;
+  }
+
+  public byte[] salt() {
+    return salt;
+  }
+
+  public int iterations() {
+    return this.iterations;
+  }
+
+  public byte[] saltAndIterationBytes() {
+    return Util.combine(
+            salt,
+            convertIterations(iterations()));
+  }
+
+  public static byte[] convertIterations(int iterations) {
+    return new byte[]{
+            (byte) (iterations >>> 24),
+            (byte) (iterations >>> 16),
+            (byte) (iterations >>> 8),
+            (byte) iterations
+    };
+  }
+
+  public static int convertIterations(byte[] iterations) {
+    if (iterations.length != 4) {
+      throw new AssertionError();
+    }
+    return ByteBuffer.wrap(iterations).getInt();
+  }
+
+  public MasterSecret deriveMasterSecret() throws InvalidKeySpecException, NoSuchAlgorithmException {
+    int combinedKeyLength = ENCRYPTION_KEY_LENGTH + MAC_KEY_LENGTH;
+    PBEKeySpec keySpec = new PBEKeySpec(passphrase.toCharArray(), salt, iterations, combinedKeyLength);
+    SecretKeyFactory keyFactory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1");
+    byte[] combinedKey = keyFactory.generateSecret(keySpec).getEncoded();
+    byte[] encryptionKey = Arrays.copyOfRange(combinedKey, 0, ENCRYPTION_KEY_LENGTH / 8);
+    byte[] macKey = Arrays.copyOfRange(combinedKey, ENCRYPTION_KEY_LENGTH / 8, combinedKey.length);
+    SecretKeySpec encryptionKeySpec = new SecretKeySpec(encryptionKey, "AES");
+    SecretKeySpec macKeySpec = new SecretKeySpec(macKey, "HmacSHA1");
+    return new MasterSecret(encryptionKeySpec, macKeySpec);
+  }
+}

--- a/src/org/thoughtcrime/securesms/crypto/MasterSecretUtil.java
+++ b/src/org/thoughtcrime/securesms/crypto/MasterSecretUtil.java
@@ -264,7 +264,7 @@ public class MasterSecretUtil {
     }
   }
 
-  private static byte[] generateSalt() throws NoSuchAlgorithmException {
+  static byte[] generateSalt() throws NoSuchAlgorithmException {
     SecureRandom random = SecureRandom.getInstance("SHA1PRNG");
     byte[] salt         = new byte[16];
     random.nextBytes(salt);
@@ -272,7 +272,7 @@ public class MasterSecretUtil {
     return salt;
   }
 
-  private static int generateIterationCount(String passphrase, byte[] salt) {
+  static int generateIterationCount(String passphrase, byte[] salt) {
     int TARGET_ITERATION_TIME     = 50;   //ms
     int MINIMUM_ITERATION_COUNT   = 100;   //default for low-end devices
     int BENCHMARK_ITERATION_COUNT = 10000; //baseline starting iteration count

--- a/src/org/thoughtcrime/securesms/database/DatabaseFactory.java
+++ b/src/org/thoughtcrime/securesms/database/DatabaseFactory.java
@@ -138,6 +138,7 @@ public class DatabaseFactory {
   private final RecipientDatabase recipientDatabase;
   private final ContactsDatabase contactsDatabase;
   private final GroupReceiptDatabase groupReceiptDatabase;
+  private final RawDatabase rawDatabase;
 
   public static DatabaseFactory getInstance(Context context) {
     synchronized (lock) {
@@ -204,6 +205,10 @@ public class DatabaseFactory {
     return getInstance(context).groupReceiptDatabase;
   }
 
+  public static RawDatabase getRawDatabase(Context context) {
+    return getInstance(context).rawDatabase;
+  }
+
   private DatabaseFactory(Context context) {
     this.databaseHelper       = new DatabaseHelper(context, DATABASE_NAME, null, DATABASE_VERSION);
     this.sms                  = new SmsDatabase(context, databaseHelper);
@@ -220,6 +225,7 @@ public class DatabaseFactory {
     this.recipientDatabase    = new RecipientDatabase(context, databaseHelper);
     this.groupReceiptDatabase = new GroupReceiptDatabase(context, databaseHelper);
     this.contactsDatabase     = new ContactsDatabase(context);
+    this.rawDatabase                 = new RawDatabase(context, databaseHelper);
   }
 
   public void reset(Context context) {
@@ -238,6 +244,7 @@ public class DatabaseFactory {
     this.groupDatabase.reset(databaseHelper);
     this.recipientDatabase.reset(databaseHelper);
     this.groupReceiptDatabase.reset(databaseHelper);
+    this.rawDatabase.reset(databaseHelper);
     old.close();
   }
 

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
@@ -14,17 +14,11 @@ public class PlaintextBackupExporter {
 
   private static final String FILENAME = "SignalPlaintextBackup.xml";
 
-  public static void exportPlaintextToSd(Context context, MasterSecret masterSecret)
-      throws NoExternalStorageException, IOException
-  {
-    exportPlaintext(context, masterSecret);
-  }
-
   public static File getPlaintextExportFile() throws NoExternalStorageException {
     return new File(StorageUtil.getBackupDir(), FILENAME);
   }
 
-  private static void exportPlaintext(Context context, MasterSecret masterSecret)
+  public static void exportPlaintextToSd(Context context, MasterSecret masterSecret)
       throws NoExternalStorageException, IOException
   {
     int count               = DatabaseFactory.getSmsDatabase(context).getMessageCount();

--- a/src/org/thoughtcrime/securesms/database/RawDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/RawDatabase.java
@@ -1,0 +1,15 @@
+package org.thoughtcrime.securesms.database;
+
+import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+
+public class RawDatabase extends Database {
+  public RawDatabase(Context context, SQLiteOpenHelper databaseHelper) {
+    super(context, databaseHelper);
+  }
+
+  public SQLiteDatabase getWritableDatabase() {
+    return databaseHelper.getWritableDatabase();
+  }
+}

--- a/src/org/thoughtcrime/securesms/database/SmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/SmsDatabase.java
@@ -639,7 +639,7 @@ public class SmsDatabase extends MessagingDatabase {
     return messageId;
   }
 
-  Cursor getMessages(int skip, int limit) {
+  public Cursor getMessages(int skip, int limit) {
     SQLiteDatabase db = databaseHelper.getReadableDatabase();
     return db.query(TABLE_NAME, MESSAGE_PROJECTION, null, null, null, null, ID, skip + "," + limit);
   }

--- a/src/org/thoughtcrime/securesms/service/KeyCachingService.java
+++ b/src/org/thoughtcrime/securesms/service/KeyCachingService.java
@@ -69,6 +69,7 @@ public class KeyCachingService extends Service {
   public  static final String ACTIVITY_START_EVENT     = "org.thoughtcrime.securesms.service.action.ACTIVITY_START_EVENT";
   public  static final String ACTIVITY_STOP_EVENT      = "org.thoughtcrime.securesms.service.action.ACTIVITY_STOP_EVENT";
   public  static final String LOCALE_CHANGE_EVENT      = "org.thoughtcrime.securesms.service.action.LOCALE_CHANGE_EVENT";
+  public  static final String BACKUP_RESTORED_EVENT    = "org.thoughtcrime.securesms.service.action.BACKUP_RESTORED_EVENT";
 
   private DynamicLanguage dynamicLanguage = new DynamicLanguage();
 
@@ -135,6 +136,9 @@ public class KeyCachingService extends Service {
         case PASSPHRASE_EXPIRED_EVENT: handleClearKey();        break;
         case DISABLE_ACTION:           handleDisableService();  break;
         case LOCALE_CHANGE_EVENT:      handleLocaleChanged();   break;
+        case BACKUP_RESTORED_EVENT:
+          handleClearKey();
+          break;
       }
     }
 


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Oneplus 3, Android 8.0.0
 * Virtual device Nexus 5X, Android 7.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Add an encrypted full (media, mms, sms, group chats) backup import/export to Signal

With the current plaintext backup mechanism only backups of plaintext messages are possible.
This change adds the functionality to export and import a password-based-encrypted full backup of your Signal app-data. The user can choose a password for this encrypted backup.

This will fix many open issues (like #7097, #7144 and #1619) and resolve the discusson on https://whispersystems.discoursehosting.net/t/encrypted-backup/1227/39 !

Limitation:
The functionality for importing a backup is limited to a clean app, right after the installation you can choose import instead of registration.

The company I work for (bevuta IT GmbH) gave me the task to code this. If you have any questions regarding the code or want it to be changed in some way, let me know, so I can implement/change it the way you want.

Screenshots:
![screenshot_1517490053](https://user-images.githubusercontent.com/398796/35683429-2ae56cce-0764-11e8-88c4-fb091d3ab00d.png)
![screenshot_1517489257](https://user-images.githubusercontent.com/398796/35683432-2dc9293a-0764-11e8-90e4-d7612bb8f3e3.png)
