### PR TITLE
Don't save white space drafts

### DIFF
--- a/src/org/thoughtcrime/securesms/util/Util.java
+++ b/src/org/thoughtcrime/securesms/util/Util.java
@@ -127,7 +127,7 @@ public class Util {
   }
 
   public static boolean isEmpty(EditText value) {
-    return value == null || value.getText() == null || TextUtils.isEmpty(value.getText().toString());
+    return value == null || value.getText() == null || TextUtils.isEmpty(value.getText().toString().trim());
   }
 
   public static CharSequence getBoldedString(String value) {

--- a/src/org/thoughtcrime/securesms/util/Util.java
+++ b/src/org/thoughtcrime/securesms/util/Util.java
@@ -40,7 +40,6 @@ import android.text.SpannableString;
 import android.text.TextUtils;
 import android.text.style.StyleSpan;
 import android.util.Log;
-import android.widget.EditText;
 
 import com.google.android.mms.pdu_alt.CharacterSets;
 import com.google.android.mms.pdu_alt.EncodedStringValue;
@@ -49,6 +48,7 @@ import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import com.google.i18n.phonenumbers.Phonenumber;
 
 import org.thoughtcrime.securesms.BuildConfig;
+import org.thoughtcrime.securesms.components.ComposeText;
 import org.thoughtcrime.securesms.database.Address;
 import org.thoughtcrime.securesms.mms.OutgoingLegacyMmsConnection;
 import org.whispersystems.libsignal.util.guava.Optional;
@@ -126,8 +126,8 @@ public class Util {
     return value == null || value.length == 0;
   }
 
-  public static boolean isEmpty(EditText value) {
-    return value == null || value.getText() == null || TextUtils.isEmpty(value.getText().toString().trim());
+  public static boolean isEmpty(ComposeText value) {
+    return value == null || value.getText() == null || TextUtils.isEmpty(value.getTextTrimmed());
   }
 
   public static CharSequence getBoldedString(String value) {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Nexus 5X, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fixes #7308
Here I explain what goes wrong: https://github.com/signalapp/Signal-Android/issues/7308#issuecomment-362638038

Commit 1 represents the minimal required change to fix #7308. But it is a small [duplication](https://github.com/signalapp/Signal-Android/blob/master/src/org/thoughtcrime/securesms/components/ComposeText.java#L54) of code.

Commit 2 represents a IMHO nicer fix which makes the [`Util.isEmpty(...)`](https://github.com/signalapp/Signal-Android/blob/master/src/org/thoughtcrime/securesms/util/Util.java#L129) use [`getTextTrimmed()`](https://github.com/signalapp/Signal-Android/blob/master/src/org/thoughtcrime/securesms/components/ComposeText.java#L53) which `ConversationActivity` also uses before saving the draft text. It ensures that the same string is checked for emptiness which is later saved as draft. Therefore it's necessary to specialize `Util.isEmpty(EditText)` to `Util.isEmpty(ComposeText)`.
This change is possible without problems because this method is only used in two places ([1](https://github.com/signalapp/Signal-Android/blob/master/src/org/thoughtcrime/securesms/ConversationActivity.java#L1419),[2](https://github.com/signalapp/Signal-Android/blob/master/src/org/thoughtcrime/securesms/ConversationActivity.java#L302) according to Android Studio) to check the content of `ComposeText`.

I also thought about a temporary variable like `String trimmedText` which is then checked for emptiness by [TextUtils.isEmpty(...)](https://developer.android.com/reference/android/text/TextUtils.html#isEmpty(java.lang.CharSequence)). But there are some `null` checks in `Util.isEmpty(...)` which would be bypassed in this case.

In case you really want to keep the change as small as possible, just use the first commit and drop the second one. I tested both commits separately.