### PR TITLE
fix keepAlive interval for non GCM Android #6644

### DIFF
--- a/src/org/thoughtcrime/securesms/service/MessageRetrievalService.java
+++ b/src/org/thoughtcrime/securesms/service/MessageRetrievalService.java
@@ -206,7 +206,7 @@ public class MessageRetrievalService extends Service implements InjectableType, 
 
   public class KeepAliveAlarmReceiver extends BroadcastReceiver {
 
-    private final int KEEPALIVE_TIMEOUT_SECONDS = 55;
+    private final int KEEPALIVE_TIMEOUT_SECONDS = 60;
 
     private int pipes;
 


### PR DESCRIPTION
This is a rewrite of #7100 with the suggested changes of Moxie. It should achieve the same thing as the original pull request while not braking the API.

I added an AlarmManager alarm, to periodically send a KeepAlive message and waking any threads that may be stuck in blocking wait, while the device is sleeping.

This fixes #6644
It depends on my changes in WhisperSystems/libsignal-service-java#48 

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Oneplus one, Android 7.1.2
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

