### PR TITLE
Call onPageSelected(0) during media preview init

### DIFF
--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -199,10 +199,8 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     if (conversationRecipient != null) {
       getSupportLoaderManager().restartLoader(0, null, this);
     } else {
-      ViewPager.OnPageChangeListener onPageChangeListener = new ViewPagerListener();
-      mediaPager.addOnPageChangeListener(onPageChangeListener);
       mediaPager.setAdapter(new SingleItemPagerAdapter(this, GlideApp.with(this), getWindow(), initialMediaUri, initialMediaType, initialMediaSize));
-      onPageChangeListener.onPageSelected(0);
+      initializeActionBar();
     }
   }
 

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -156,6 +156,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
   public void onPause() {
     super.onPause();
     restartItem = cleanupMedia();
+    mediaPager.clearOnPageChangeListeners();
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -168,7 +168,6 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
   private void initializeViews() {
     mediaPager = findViewById(R.id.media_pager);
     mediaPager.setOffscreenPageLimit(1);
-    mediaPager.addOnPageChangeListener(new ViewPagerListener());
   }
 
   private void initializeResources() {
@@ -199,7 +198,10 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     if (conversationRecipient != null) {
       getSupportLoaderManager().restartLoader(0, null, this);
     } else {
+      ViewPager.OnPageChangeListener onPageChangeListener = new ViewPagerListener();
+      mediaPager.addOnPageChangeListener(onPageChangeListener);
       mediaPager.setAdapter(new SingleItemPagerAdapter(this, GlideApp.with(this), getWindow(), initialMediaUri, initialMediaType, initialMediaSize));
+      onPageChangeListener.onPageSelected(0);
     }
   }
 
@@ -299,6 +301,8 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
   @Override
   public void onLoadFinished(Loader<Pair<Cursor, Integer>> loader, @Nullable Pair<Cursor, Integer> data) {
     if (data != null) {
+      ViewPager.OnPageChangeListener onPageChangeListener = new ViewPagerListener();
+      mediaPager.addOnPageChangeListener(onPageChangeListener);
       @SuppressWarnings("ConstantConditions")
       CursorPagerAdapter adapter = new CursorPagerAdapter(this, GlideApp.with(this), getWindow(), data.first, data.second, leftIsRecent);
       mediaPager.setAdapter(adapter);
@@ -306,6 +310,8 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
 
       if (restartItem < 0) mediaPager.setCurrentItem(data.second);
       else                 mediaPager.setCurrentItem(restartItem);
+
+      if (mediaPager.getCurrentItem() == 0) onPageChangeListener.onPageSelected(0);
     }
   }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Nexus 5X, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fixes #7385

The changes proposed in this PR make sure `onPageSelected(0)`/`initializeActionBar()` is called when `MediaPreviewActivity` is entered at `ViewPager` position 0. To call the former method I need access to the `OnPageChangeListener` of the `ViewPager`. The `ViewPager` class doesn't provide a method to access its `OnPageChangeListener`(s). So I decided to keep this listener in a local variable for a short time and so I am able to call `onPageSelected(0)`. Note that it is sufficient to attach the listener before the adapter is set. This condition is still satified after this PR.

### Alternative considered approaches

We could also use a global variable to keep the listener. But I don't think this is necessary because it is only needed in the local scope you can see in the commit.

Alternatively extending `ViewPager` to be able to access the listeners at a later point is not easily possible because the listeners are kept in a private variable there. Also the diff would be much larger and not worth the effort imho.