### PR TITLE
Toolbar elevation & icon color fix

### DIFF
--- a/res/layout/contact_selection_activity.xml
+++ b/res/layout/contact_selection_activity.xml
@@ -12,6 +12,7 @@
             android:layout_width="match_parent"
             android:minHeight="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
+            android:elevation="4dp"
             android:theme="?attr/actionBarStyle"
             app:contentInsetStartWithNavigation="0dp"/>
 

--- a/res/layout/conversation_list_activity.xml
+++ b/res/layout/conversation_list_activity.xml
@@ -13,6 +13,7 @@
             android:layout_height="?attr/actionBarSize"
             android:minHeight="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
+            android:elevation="4dp"
             android:theme="?attr/actionBarStyle">
 
         <RelativeLayout
@@ -65,6 +66,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
+            android:elevation="4dp"
             android:visibility="invisible"
             tools:visibility="visible"/>
 

--- a/res/layout/giphy_activity.xml
+++ b/res/layout/giphy_activity.xml
@@ -14,7 +14,6 @@
         <android.support.design.widget.AppBarLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:theme="?attr/actionBarStyle"
                 android:background="?attr/colorPrimary">
 
             <org.thoughtcrime.securesms.giph.ui.GiphyActivityToolbar
@@ -29,6 +28,7 @@
                     android:id="@+id/tab_layout"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:theme="?attr/actionBarTabBarStyle"
                     android:scrollbars="horizontal"/>
 
         </android.support.design.widget.AppBarLayout>

--- a/res/layout/invite_activity.xml
+++ b/res/layout/invite_activity.xml
@@ -90,6 +90,7 @@
             android:layout_width="match_parent"
             android:minHeight="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
+            android:elevation="4dp"
             android:theme="@style/TextSecure.LightActionBar" />
 
         <fragment android:id="@+id/contact_selection_list_fragment"

--- a/res/layout/search_toolbar.xml
+++ b/res/layout/search_toolbar.xml
@@ -13,7 +13,7 @@
             android:background="?attr/search_toolbar_background"/>
 
     <View android:layout_width="match_parent"
-          android:layout_height="7dp"
+          android:layout_height="4dp"
           android:background="@drawable/search_toolbar_shadow"/>
 
 </merge>

--- a/res/layout/share_activity.xml
+++ b/res/layout/share_activity.xml
@@ -14,6 +14,7 @@
             android:layout_height="?attr/actionBarSize"
             android:minHeight="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
+            android:elevation="4dp"
             android:theme="?attr/actionBarStyle">
 
         <RelativeLayout
@@ -55,6 +56,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
+            android:elevation="4dp"
             android:visibility="invisible"
             tools:visibility="invisible"/>
 

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -47,6 +47,7 @@
         <item name="popupTheme">@style/ThemeOverlay.AppCompat.Dark</item>
         <item name="titleTextStyle">@style/TextSecure.TitleTextStyle</item>
         <item name="subtitleTextStyle">@style/TextSecure.SubtitleTextStyle</item>
+        <item name="android:textColorSecondary">@color/white</item>
     </style>
 
     <style name="TextSecure.LightActionBar"
@@ -57,7 +58,7 @@
         <item name="titleTextStyle">@style/TextSecure.TitleTextStyle</item>
         <item name="subtitleTextStyle">@style/TextSecure.SubtitleTextStyle</item>
         <item name="android:textColorPrimary">@color/white</item>
-        <item name="android:textColorSecondary">#BFffffff</item>
+        <item name="android:textColorSecondary">@color/white</item>
     </style>
 
     <style name="TextSecure.FlatLightActionBar"
@@ -76,6 +77,8 @@
         parent="@style/Widget.AppCompat.ActionBar.TabBar">
         <item name="android:background">@color/textsecure_primary</item>
         <item name="background">@color/textsecure_primary</item>
+        <item name="android:textColorPrimary">@color/white</item>
+        <item name="android:textColorSecondary">#BFffffff</item>
         <item name="elevation">4dp</item>
     </style>
 

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -43,6 +43,7 @@
            parent="@style/Widget.AppCompat.ActionBar">
         <item name="background">@color/gray95</item>
         <item name="android:popupTheme">@style/ThemeOverlay.AppCompat.Dark</item>
+        <item name="elevation">4dp</item>
         <item name="popupTheme">@style/ThemeOverlay.AppCompat.Dark</item>
         <item name="titleTextStyle">@style/TextSecure.TitleTextStyle</item>
         <item name="subtitleTextStyle">@style/TextSecure.SubtitleTextStyle</item>
@@ -51,7 +52,7 @@
     <style name="TextSecure.LightActionBar"
            parent="@style/Widget.AppCompat.ActionBar">
         <item name="background">@color/textsecure_primary</item>
-        <item name="elevation">2dp</item>
+        <item name="elevation">4dp</item>
         <item name="popupTheme">@style/ThemeOverlay.AppCompat.Light</item>
         <item name="titleTextStyle">@style/TextSecure.TitleTextStyle</item>
         <item name="subtitleTextStyle">@style/TextSecure.SubtitleTextStyle</item>
@@ -68,12 +69,14 @@
         parent="@style/Widget.AppCompat.ActionBar.TabBar">
         <item name="background">@color/gray95</item>
         <item name="android:background">@color/gray95</item>
+        <item name="elevation">4dp</item>
     </style>
 
     <style name="TextSecure.LightActionBar.TabBar"
         parent="@style/Widget.AppCompat.ActionBar.TabBar">
         <item name="android:background">@color/textsecure_primary</item>
         <item name="background">@color/textsecure_primary</item>
+        <item name="elevation">4dp</item>
     </style>
 
     <style name="TextSecure.TitleTextStyle" parent="TextAppearance.AppCompat.Widget.ActionBar.Title">


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S8, Android 7.0
 * Virtual Pixel 2, Android 8
 * Virtual Nexus 4, Android 4.4
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

- Adds 4dp elevation to Signal's toolbars, according to the [MD specs](https://material.io/guidelines/material-design/elevation-shadows.html#elevation-shadows-elevation-android). Of course this will affect devices > Lollipop only.
- Fixes the color of the `back` and `menu` icons in toolbars to be white instead of grey. Makes it consistent with the title and the other icons, which are white, too.

### Screenshot
![output resized](https://user-images.githubusercontent.com/11131859/36166357-7aa07eb0-10f2-11e8-9d63-5769f371492d.gif)


