### PR TITLE
Improve batch selection mode

### DIFF
--- a/res/menu/conversation_context.xml
+++ b/res/menu/conversation_context.xml
@@ -18,7 +18,7 @@
     <item android:title="@string/conversation_context__menu_forward_message"
           android:id="@+id/menu_context_forward"
           android:icon="?menu_forward_icon"
-          app:showAsAction="ifRoom" />
+          app:showAsAction="always" />
 
     <item android:title="@string/conversation_context__menu_resend_message"
           android:id="@+id/menu_context_resend"

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -25,7 +25,7 @@
 
     <color name="conversation_compose_divider">#32000000</color>
 
-    <color name="action_mode_status_bar">#ff1f1f1f</color>
+    <color name="action_mode_status_bar">@color/gray65</color>
     <color name="touch_highlight">#400099cc</color>
 
     <color name="device_link_item_background_light">#ffffffff</color>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -107,6 +107,8 @@
         <item name="theme_type">light</item>
         <item name="actionBarStyle">@style/TextSecure.LightActionBar</item>
         <item name="actionBarTabBarStyle">@style/TextSecure.LightActionBar.TabBar</item>
+        <item name="actionModeBackground">@color/gray50</item>
+        <item name="actionModeCloseDrawable">@drawable/ic_close_white_24dp</item>
         <item name="colorPrimary">@color/textsecure_primary</item>
         <item name="colorPrimaryDark">@color/textsecure_primary_dark</item>
         <item name="colorAccent">@color/textsecure_primary_dark</item>
@@ -233,6 +235,8 @@
         <item name="actionBarStyle">@style/TextSecure.DarkActionBar</item>
         <item name="actionBarTabBarStyle">@style/TextSecure.DarkActionBar.TabBar</item>
         <item name="actionBarPopupTheme">@style/ThemeOverlay.AppCompat.Dark</item>
+        <item name="actionModeBackground">@color/gray50</item>
+        <item name="actionModeCloseDrawable">@drawable/ic_close_white_24dp</item>
         <item name="android:textColor">@color/text_color_dark_theme</item>
         <item name="android:textColorSecondary">@color/text_color_secondary_dark_theme</item>
         <item name="colorAccent">@color/textsecure_primary_dark</item>

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -211,10 +211,9 @@ public class ConversationFragment extends Fragment
       {
         actionMessage = true;
         break;
-      }
-      else if (messageRecord.isMms()             &&
-              !messageRecord.isMmsNotification() &&
-              ((MediaMmsMessageRecord)messageRecord).containsMediaSlide())
+      } else if (messageRecord.isMms()              &&
+                 !messageRecord.isMmsNotification() &&
+                 ((MediaMmsMessageRecord)messageRecord).containsMediaSlide())
       {
         mediaMessage = true;
         break;

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -201,6 +201,7 @@ public class ConversationFragment extends Fragment
   private void setCorrectMenuVisibility(Menu menu) {
     Set<MessageRecord> messageRecords = getListAdapter().getSelectedItems();
     boolean            actionMessage  = false;
+    boolean            mediaMessage  = false;
 
     for (MessageRecord messageRecord : messageRecords) {
       if (messageRecord.isGroupAction() || messageRecord.isCallLog() ||
@@ -211,6 +212,13 @@ public class ConversationFragment extends Fragment
         actionMessage = true;
         break;
       }
+      else if (messageRecord.isMms()             &&
+              !messageRecord.isMmsNotification() &&
+              ((MediaMmsMessageRecord)messageRecord).containsMediaSlide())
+      {
+        mediaMessage = true;
+        break;
+      }
     }
 
     if (messageRecords.size() > 1) {
@@ -218,7 +226,7 @@ public class ConversationFragment extends Fragment
       menu.findItem(R.id.menu_context_details).setVisible(false);
       menu.findItem(R.id.menu_context_save_attachment).setVisible(false);
       menu.findItem(R.id.menu_context_resend).setVisible(false);
-      menu.findItem(R.id.menu_context_copy).setVisible(!actionMessage);
+      menu.findItem(R.id.menu_context_copy).setVisible(!actionMessage  && !mediaMessage);
     } else {
       MessageRecord messageRecord = messageRecords.iterator().next();
 
@@ -230,7 +238,7 @@ public class ConversationFragment extends Fragment
 
       menu.findItem(R.id.menu_context_forward).setVisible(!actionMessage);
       menu.findItem(R.id.menu_context_details).setVisible(!actionMessage);
-      menu.findItem(R.id.menu_context_copy).setVisible(!actionMessage);
+      menu.findItem(R.id.menu_context_copy).setVisible(!actionMessage && !mediaMessage);
     }
   }
 

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -203,6 +203,11 @@ public class ConversationFragment extends Fragment
     boolean            actionMessage  = false;
     boolean            mediaMessage  = false;
 
+    if (actionMode != null && messageRecords.size() == 0) {
+      actionMode.finish();
+      return;
+    }
+
     for (MessageRecord messageRecord : messageRecords) {
       if (messageRecord.isGroupAction() || messageRecord.isCallLog() ||
           messageRecord.isJoined() || messageRecord.isExpirationTimerUpdate() ||

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -202,11 +202,6 @@ public class ConversationFragment extends Fragment
     Set<MessageRecord> messageRecords = getListAdapter().getSelectedItems();
     boolean            actionMessage  = false;
 
-    if (actionMode != null && messageRecords.size() == 0) {
-      actionMode.finish();
-      return;
-    }
-
     for (MessageRecord messageRecord : messageRecords) {
       if (messageRecord.isGroupAction() || messageRecord.isCallLog() ||
           messageRecord.isJoined() || messageRecord.isExpirationTimerUpdate() ||
@@ -578,7 +573,13 @@ public class ConversationFragment extends Fragment
         ((ConversationAdapter) list.getAdapter()).toggleSelection(messageRecord);
         list.getAdapter().notifyDataSetChanged();
 
-        setCorrectMenuVisibility(actionMode.getMenu());
+        if (getListAdapter().getSelectedItems().size() == 0) {
+          actionMode.finish();
+        } else {
+          setCorrectMenuVisibility(actionMode.getMenu());
+          actionMode.setTitle(String.valueOf(getListAdapter().getSelectedItems().size()));
+        }
+
       }
     }
 
@@ -601,6 +602,8 @@ public class ConversationFragment extends Fragment
     public boolean onCreateActionMode(ActionMode mode, Menu menu) {
       MenuInflater inflater = mode.getMenuInflater();
       inflater.inflate(R.menu.conversation_context, menu);
+
+      mode.setTitle("1");
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
         Window window = getActivity().getWindow();

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -322,8 +322,7 @@ public class ConversationListFragment extends Fragment
 
   private void handleSelectAllThreads() {
     getListAdapter().selectAllThreads();
-    actionMode.setSubtitle(getString(R.string.conversation_fragment_cab__batch_selection_amount,
-                                     String.valueOf(getListAdapter().getBatchSelections().size())));
+    actionMode.setTitle(String.valueOf(getListAdapter().getBatchSelections().size()));
   }
 
   private void handleCreateConversation(long threadId, Recipient recipient, int distributionType, long lastSeen) {
@@ -374,8 +373,7 @@ public class ConversationListFragment extends Fragment
       if (adapter.getBatchSelections().size() == 0) {
         actionMode.finish();
       } else {
-        actionMode.setSubtitle(getString(R.string.conversation_fragment_cab__batch_selection_amount,
-                                         String.valueOf(adapter.getBatchSelections().size())));
+        actionMode.setTitle(String.valueOf(getListAdapter().getBatchSelections().size()));
       }
 
       adapter.notifyDataSetChanged();
@@ -410,8 +408,7 @@ public class ConversationListFragment extends Fragment
 
     inflater.inflate(R.menu.conversation_list_batch, menu);
 
-    mode.setTitle(R.string.conversation_fragment_cab__batch_selection_mode);
-    mode.setSubtitle(getString(R.string.conversation_fragment_cab__batch_selection_amount, "1"));
+    mode.setTitle("1");
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       getActivity().getWindow().setStatusBarColor(getResources().getColor(R.color.action_mode_status_bar));


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S8, Android 7.0
 * Virtual Pixel 2, Android 8
 * Virtual Nexus 4, Android 4.4
- [x] My contribution is fully baked and ready to be merged as is

----------

### Description
- First commit updates the batch selection mode to a more modern style and is now the same in Conversation and ConversationList, too.
- Second commit removes the 'copy' icon from the menu when there is any media message selected. Rationale of this change is, that copying media messages does not work (but forwarding does).
- Since there is enough space left on the toolbar: make the forward icon always visible. Hidden as the only option in the overfow menu, this action gets only little attention otherwise.

### Screenshots

![screenrecord](https://user-images.githubusercontent.com/11131859/36217890-df8412f4-11b2-11e8-9050-4670b853e8f3.gif)

#### Before - After:
![anim](https://user-images.githubusercontent.com/11131859/36219030-6fa57924-11b6-11e8-8e1d-3555b456954a.gif)


