### PR TITLE
increased number of recent chats from 5 to 50

### DIFF
--- a/src/org/thoughtcrime/securesms/contacts/ContactsCursorLoader.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactsCursorLoader.java
@@ -79,7 +79,7 @@ public class ContactsCursorLoader extends CursorLoader {
     ArrayList<Cursor> cursorList       = new ArrayList<>(4);
 
     if (recents && TextUtils.isEmpty(filter)) {
-      try (Cursor recentConversations = DatabaseFactory.getThreadDatabase(getContext()).getRecentConversationList(5)) {
+      try (Cursor recentConversations = DatabaseFactory.getThreadDatabase(getContext()).getRecentConversationList(50)) {
         MatrixCursor          synthesizedContacts = new MatrixCursor(CONTACT_PROJECTION);
         synthesizedContacts.addRow(new Object[] {getContext().getString(R.string.ContactsCursorLoader_recent_chats), "", ContactsContract.CommonDataKinds.Phone.TYPE_MOBILE, "", ContactsDatabase.DIVIDER_TYPE});
 


### PR DESCRIPTION
+ mitigating (but not finally fixing) issue #7202 problems

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * HUAWEI P8 LITE
- [X] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This is an ad-hoc mitigation of the problem as discussed in issue #7202. It simply increases the number of displayed recent chats when you want to "share" with Signal contacts. Usually, this increases also the number of displayed recent group chats which are not listed as regular contacts.