### PR TITLE
Ignore swipe events for ConversationListItemInboxZero

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -484,6 +484,7 @@ public class ConversationListFragment extends Fragment
     @SuppressLint("StaticFieldLeak")
     @Override
     public void onSwiped(RecyclerView.ViewHolder viewHolder, int direction) {
+      if (viewHolder.itemView instanceof ConversationListItemInboxZero) return;
       final long threadId    = ((ConversationListItem)viewHolder.itemView).getThreadId();
       final int  unreadCount = ((ConversationListItem)viewHolder.itemView).getUnreadCount();
 
@@ -541,6 +542,7 @@ public class ConversationListFragment extends Fragment
                             float dX, float dY, int actionState,
                             boolean isCurrentlyActive)
     {
+      if (viewHolder.itemView instanceof ConversationListItemInboxZero) return;
       if (actionState == ItemTouchHelper.ACTION_STATE_SWIPE) {
         View  itemView = viewHolder.itemView;
         Paint p        = new Paint();


### PR DESCRIPTION
Fixes #7423

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
* Virtual Nexus 6, Android 6.0
* Virtual Nexus 6, Android 7.0
- [X] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This PR fixes the crash that occurs when a user swipes away the "empty inbox" view. Before this change, the `onSwipe` event would be interpreted as a conversation archiving. The `ConversationListItemInboxZero` object would be cast to a `ConversationListItem`, causing a `ClassCastException` which would cause Signal to crash. In this change, each handler for a swipe (the archival action and the animation) will check if the view is of type `ConversationListItemInboxZero`, and if so will simply return.

This was tested on a virtual Nexus 6 on Android 6.0 and 7.0 by archiving conversations until an inbox is empty and attempting to swipe away the zero'd graphic. The view and archival actions then go back to normal behavior when conversations populate the inbox once more.
