### PR TITLE
Restart camera preview on orientation change

### DIFF
--- a/src/org/thoughtcrime/securesms/components/camera/QuickAttachmentDrawer.java
+++ b/src/org/thoughtcrime/securesms/components/camera/QuickAttachmentDrawer.java
@@ -113,6 +113,7 @@ public class QuickAttachmentDrawer extends ViewGroup implements InputView, Camer
       }
       updateControlsView();
       setDrawerStateAndUpdate(drawerState, true);
+      cameraView.onResume();
     }
   }
 


### PR DESCRIPTION
//FREEBIE

Fixes #7442 (duplicate #5855)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device 'Nexus 5X', Android 6.0
 * Virtual device 'Pixel 2', Android 8.0.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Adding the call to **cameraView.onResume()** after it's paused in **onConfigurationChanged**.
