### PR TITLE
Incoming multipart MMS displaying

### DIFF
--- a/res/layout/conversation_item_received_multipart.xml
+++ b/res/layout/conversation_item_received_multipart.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<org.thoughtcrime.securesms.ConversationItem
+        android:id="@+id/conversation_item"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:paddingRight="10dip"
+        android:orientation="vertical"
+        android:background="@drawable/conversation_item_background"
+        android:focusable="true"
+        android:nextFocusLeft="@+id/container"
+        android:nextFocusRight="@+id/embedded_text_editor"
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <RelativeLayout android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="2dp"
+                    android:layout_marginLeft="9dp"
+                    android:layout_marginBottom="6dp"
+                    android:layout_marginRight="0dp">
+
+        <org.thoughtcrime.securesms.components.AvatarImageView
+            android:id="@+id/contact_photo"
+            android:foreground="@drawable/contact_photo_background"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentBottom="true"
+            android:cropToPadding="true"
+            android:contentDescription="@string/conversation_item_received__contact_photo_description" />
+
+        <LinearLayout android:id="@+id/body_bubble"
+                      android:layout_width="wrap_content"
+                      android:layout_height="wrap_content"
+                      android:layout_toRightOf="@id/contact_photo"
+                      android:layout_marginRight="35dp"
+                      android:background="@drawable/received_bubble"
+                      android:orientation="vertical"
+                      tools:backgroundTint="@color/blue_900">
+
+            <LinearLayout android:id="@+id/group_sender_holder"
+                          android:layout_width="wrap_content"
+                          android:layout_height="wrap_content"
+                          android:orientation="horizontal"
+                          android:visibility="gone"
+                          android:paddingRight="4dp"
+                          android:paddingLeft="4dp"
+                          android:layout_marginBottom="10dp"
+                          tools:visibility="visible">
+
+                <TextView android:id="@+id/group_message_sender"
+                          android:layout_width="wrap_content"
+                          android:layout_height="wrap_content"
+                          android:paddingRight="4sp"
+                          android:paddingEnd="4sp"
+                          android:textSize="13sp"
+                          android:textColor="?conversation_item_received_text_primary_color"
+                          android:maxLines="1"
+                          android:ellipsize="end"
+                          tools:visibility="visible"
+                          tools:text="+14152222222"/>
+
+                <TextView android:id="@+id/group_message_sender_profile"
+                          android:layout_width="wrap_content"
+                          android:layout_height="wrap_content"
+                          android:paddingRight="4sp"
+                          android:paddingLeft="4sp"
+                          android:fontFamily="sans-serif-light"
+                          android:textColor="?conversation_item_received_text_secondary_color"
+                          android:textSize="13sp"
+                          android:maxLines="1"
+                          android:ellipsize="end"
+                          tools:text="~Clement Duval"/>
+
+            </LinearLayout>
+
+            <LinearLayout android:id="@+id/view_parts"
+                          android:orientation="vertical"
+                          android:layout_width="210dp"
+                          android:layout_height="wrap_content"/>
+
+            <org.thoughtcrime.securesms.components.emoji.EmojiTextView
+                    android:id="@+id/conversation_item_body"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="4dp"
+                    android:paddingRight="4dp"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:textColor="?conversation_item_received_text_primary_color"
+                    android:textColorLink="?conversation_item_received_text_primary_color"
+                    android:textSize="@dimen/conversation_item_body_text_size"
+                    app:scaleEmojis="true"
+                    tools:text="boop"/>
+
+            <LinearLayout android:layout_width="wrap_content"
+                          android:layout_height="wrap_content"
+                          android:paddingTop="2dip"
+                          android:paddingLeft="4dp"
+                          android:paddingRight="4dp"
+                          android:orientation="horizontal"
+                          android:gravity="left">
+
+                <ImageView android:id="@+id/insecure_indicator"
+                           android:layout_width="12dp"
+                           android:layout_height="11dp"
+                           android:layout_gravity="center_vertical"
+                           android:layout_marginRight="3dp"
+                           android:layout_marginEnd="3dp"
+                           android:src="@drawable/ic_unlocked_white_18dp"
+                           android:contentDescription="@string/conversation_item__secure_message_description"
+                           android:visibility="gone"
+                           android:alpha=".65"
+                           android:tint="?conversation_item_received_text_secondary_color"
+                           android:tintMode="multiply"
+                           tools:visibility="visible"/>
+
+                <org.thoughtcrime.securesms.components.ExpirationTimerView
+                        android:id="@+id/expiration_indicator"
+                        app:empty="@drawable/ic_hourglass_empty_white_18dp"
+                        app:full="@drawable/ic_hourglass_full_white_18dp"
+                        app:tint="?conversation_item_received_text_secondary_color"
+                        app:percentage="0"
+                        app:offset="0"
+                        android:layout_gravity="center_vertical|end"
+                        android:alpha=".65"
+                        android:layout_width="8dp"
+                        android:layout_height="11dp"
+                        android:layout_marginRight="3dp"
+                        android:layout_marginEnd="3dp"
+                        android:visibility="gone"
+                        tools:visibility="visible"/>
+
+                <org.thoughtcrime.securesms.components.DeliveryStatusView
+                        android:id="@+id/delivery_status"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:visibility="gone"/>
+
+                <TextView android:id="@+id/conversation_item_date"
+                          android:layout_width="wrap_content"
+                          android:layout_height="wrap_content"
+                          android:layout_gravity="left"
+                          android:paddingTop="1dip"
+                          android:textAppearance="?android:attr/textAppearanceSmall"
+                          android:textColor="?conversation_item_received_text_secondary_color"
+                          android:textSize="@dimen/conversation_item_date_text_size"
+                          android:fontFamily="sans-serif-light"
+                          android:autoLink="none"
+                          android:linksClickable="false"
+                          tools:text="Now"
+                          tools:visibility="visible"/>
+
+                <TextView android:id="@+id/sim_info"
+                          android:layout_width="wrap_content"
+                          android:layout_height="wrap_content"
+                          android:layout_gravity="left"
+                          android:paddingTop="1dip"
+                          android:paddingLeft="4dp"
+                          android:paddingStart="4dp"
+                          android:textAppearance="?android:attr/textAppearanceSmall"
+                          android:textColor="?conversation_item_received_text_secondary_color"
+                          android:textSize="@dimen/conversation_item_date_text_size"
+                          android:fontFamily="sans-serif-light"
+                          android:autoLink="none"
+                          android:linksClickable="false"
+                          android:visibility="gone"
+                          tools:visibility="visible"
+                          tools:text="from SIM1"/>
+            </LinearLayout>
+        </LinearLayout>
+
+        <org.thoughtcrime.securesms.components.AlertView
+                android:id="@+id/indicators_parent"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentRight="true"
+                android:orientation="vertical"
+                android:gravity="center_vertical"/>
+
+        <TextView android:id="@+id/indicator_text"
+                  android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  android:layout_below="@id/body_bubble"
+                  android:layout_alignParentRight="true"
+                  android:paddingRight="5dip"
+                  android:paddingLeft="5dip"
+                  android:paddingTop="3dp"
+                  android:paddingBottom="3dp"
+                  android:layout_marginLeft="50dp"
+                  android:layout_marginRight="22dp"
+                  android:layout_marginTop="-2dp"
+                  android:textSize="12sp"
+                  android:textColor="?conversation_item_sent_text_indicator_tab_color"
+                  android:background="?conversation_item_sent_indicator_text_background"
+                  android:visibility="gone" />
+
+    </RelativeLayout>
+</org.thoughtcrime.securesms.ConversationItem>

--- a/src/org/thoughtcrime/securesms/ConversationAdapter.java
+++ b/src/org/thoughtcrime/securesms/ConversationAdapter.java
@@ -88,7 +88,7 @@ public class ConversationAdapter <V extends View & BindableConversationItem>
   private static final int MESSAGE_TYPE_THUMBNAIL_INCOMING = 6;
   private static final int MESSAGE_TYPE_DOCUMENT_OUTGOING  = 7;
   private static final int MESSAGE_TYPE_DOCUMENT_INCOMING  = 8;
-  private static final int MESSAGE_TYPE_INCOMING_MULTIPART = 9;
+  private static final int MESSAGE_TYPE_MULTIPART_INCOMING = 9;
 
   private final Set<MessageRecord> batchSelected = Collections.synchronizedSet(new HashSet<MessageRecord>());
 
@@ -228,7 +228,7 @@ public class ConversationAdapter <V extends View & BindableConversationItem>
       case MESSAGE_TYPE_THUMBNAIL_OUTGOING:
       case MESSAGE_TYPE_DOCUMENT_OUTGOING:
       case MESSAGE_TYPE_OUTGOING:        return R.layout.conversation_item_sent;
-      case MESSAGE_TYPE_INCOMING_MULTIPART: return R.layout.conversation_item_received_multipart;
+      case MESSAGE_TYPE_MULTIPART_INCOMING: return R.layout.conversation_item_received_multipart;
       case MESSAGE_TYPE_AUDIO_INCOMING:
       case MESSAGE_TYPE_THUMBNAIL_INCOMING:
       case MESSAGE_TYPE_DOCUMENT_INCOMING:
@@ -247,7 +247,7 @@ public class ConversationAdapter <V extends View & BindableConversationItem>
     {
       return MESSAGE_TYPE_UPDATE;
     } else if (messageRecord.isMultipart()) {
-      return MESSAGE_TYPE_INCOMING_MULTIPART;
+      return MESSAGE_TYPE_MULTIPART_INCOMING;
     } else if (hasAudio(messageRecord)) {
       if (messageRecord.isOutgoing()) return MESSAGE_TYPE_AUDIO_OUTGOING;
       else                            return MESSAGE_TYPE_AUDIO_INCOMING;

--- a/src/org/thoughtcrime/securesms/ConversationAdapter.java
+++ b/src/org/thoughtcrime/securesms/ConversationAdapter.java
@@ -88,6 +88,7 @@ public class ConversationAdapter <V extends View & BindableConversationItem>
   private static final int MESSAGE_TYPE_THUMBNAIL_INCOMING = 6;
   private static final int MESSAGE_TYPE_DOCUMENT_OUTGOING  = 7;
   private static final int MESSAGE_TYPE_DOCUMENT_INCOMING  = 8;
+  private static final int MESSAGE_TYPE_INCOMING_MULTIPART = 9;
 
   private final Set<MessageRecord> batchSelected = Collections.synchronizedSet(new HashSet<MessageRecord>());
 
@@ -227,6 +228,7 @@ public class ConversationAdapter <V extends View & BindableConversationItem>
       case MESSAGE_TYPE_THUMBNAIL_OUTGOING:
       case MESSAGE_TYPE_DOCUMENT_OUTGOING:
       case MESSAGE_TYPE_OUTGOING:        return R.layout.conversation_item_sent;
+      case MESSAGE_TYPE_INCOMING_MULTIPART: return R.layout.conversation_item_received_multipart;
       case MESSAGE_TYPE_AUDIO_INCOMING:
       case MESSAGE_TYPE_THUMBNAIL_INCOMING:
       case MESSAGE_TYPE_DOCUMENT_INCOMING:
@@ -244,6 +246,8 @@ public class ConversationAdapter <V extends View & BindableConversationItem>
         messageRecord.isIdentityDefault())
     {
       return MESSAGE_TYPE_UPDATE;
+    } else if (messageRecord.isMultipart()) {
+      return MESSAGE_TYPE_INCOMING_MULTIPART;
     } else if (hasAudio(messageRecord)) {
       if (messageRecord.isOutgoing()) return MESSAGE_TYPE_AUDIO_OUTGOING;
       else                            return MESSAGE_TYPE_AUDIO_INCOMING;

--- a/src/org/thoughtcrime/securesms/MessageDetailsActivity.java
+++ b/src/org/thoughtcrime/securesms/MessageDetailsActivity.java
@@ -264,7 +264,11 @@ public class MessageDetailsActivity extends PassphraseRequiredActionBarActivity 
       } else if (messageRecord.isOutgoing()) {
         conversationItem = (ConversationItem) inflater.inflate(R.layout.conversation_item_sent, itemParent, false);
       } else {
-        conversationItem = (ConversationItem) inflater.inflate(R.layout.conversation_item_received, itemParent, false);
+        if (messageRecord.isMultipart()) {
+          conversationItem = (ConversationItem) inflater.inflate(R.layout.conversation_item_received_multipart, itemParent, false);
+        } else {
+          conversationItem = (ConversationItem) inflater.inflate(R.layout.conversation_item_received, itemParent, false);
+        }
       }
       itemParent.addView(conversationItem);
     }

--- a/src/org/thoughtcrime/securesms/database/MmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MmsDatabase.java
@@ -69,6 +69,7 @@ import org.whispersystems.libsignal.util.guava.Optional;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -1193,7 +1194,10 @@ public class MmsDatabase extends MessagingDatabase {
       Recipient                 recipient       = getRecipientFor(address);
       List<IdentityKeyMismatch> mismatches      = getMismatchedIdentities(mismatchDocument);
       List<NetworkFailure>      networkFailures = getFailures(networkDocument);
-      SlideDeck                 slideDeck       = getSlideDeck(cursor);
+      // Load all attachments:
+      List<DatabaseAttachment>  attachments     = DatabaseFactory.getAttachmentDatabase(context).getAttachmentsForMessage(masterSecret, id);
+      SlideDeck                 slideDeck       = new SlideDeck(context, new ArrayList<Attachment>(attachments));
+      //SlideDeck                 slideDeck       = getSlideDeck(cursor);
 
       return new MediaMmsMessageRecord(context, id, recipient, recipient,
                                        addressDeviceId, dateSent, dateReceived, deliveryReceiptCount,
@@ -1258,10 +1262,10 @@ public class MmsDatabase extends MessagingDatabase {
       }
     }
 
-    private SlideDeck getSlideDeck(@NonNull Cursor cursor) {
-      Attachment attachment = DatabaseFactory.getAttachmentDatabase(context).getAttachment(masterSecret, cursor);
-      return new SlideDeck(context, attachment);
-    }
+//    private SlideDeck getSlideDeck(@NonNull Cursor cursor) {
+//      Attachment attachment = DatabaseFactory.getAttachmentDatabase(context).getAttachment(masterSecret, cursor);
+//      return new SlideDeck(context, attachment);
+//    }
 
     public void close() {
       cursor.close();

--- a/src/org/thoughtcrime/securesms/database/model/MediaMmsMessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/MediaMmsMessageRecord.java
@@ -72,6 +72,11 @@ public class MediaMmsMessageRecord extends MmsMessageRecord {
   }
 
   @Override
+  public boolean isMultipart() {
+    return !isOutgoing() && getSlideDeck().getSlides().size() > 1;
+  }
+
+  @Override
   public SpannableString getDisplayBody() {
     if (MmsDatabase.Types.isDecryptInProgressType(type)) {
       return emphasisAdded(context.getString(R.string.MmsMessageRecord_decrypting_mms_please_wait));

--- a/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -78,6 +78,8 @@ public abstract class MessageRecord extends DisplayRecord {
   public abstract boolean isMms();
   public abstract boolean isMmsNotification();
 
+  public abstract boolean isMultipart();
+
   public boolean isSecure() {
     return MmsSmsColumns.Types.isSecureType(type);
   }

--- a/src/org/thoughtcrime/securesms/database/model/NotificationMmsMessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/NotificationMmsMessageRecord.java
@@ -105,6 +105,9 @@ public class NotificationMmsMessageRecord extends MmsMessageRecord {
   }
 
   @Override
+  public boolean isMultipart() { return false; }
+
+  @Override
   public boolean isMediaPending() {
     return true;
   }

--- a/src/org/thoughtcrime/securesms/database/model/SmsMessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/SmsMessageRecord.java
@@ -102,4 +102,9 @@ public class SmsMessageRecord extends MessageRecord {
   public boolean isMmsNotification() {
     return false;
   }
+
+  @Override
+  public boolean isMultipart() {
+    return false;
+  }
 }


### PR DESCRIPTION
Fixes #1300

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Google Pixel, Android 8.1.0
 * Motorola Nexus 6, Android 7.1.1
- [ ] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Added support for displaying incoming multipart MMS messages which contain multiple supported attachments (images and/or audio files). Only displaying of incoming multipart MMS is supported, sending is still limited to one attachment per message (same for Signal messages).
Tested with several MMS messages, sent from standard Android Messaging app and containing 2-5 attachments (images and audio-recordings).
