### PR TITLE
Escape single quotes in SQLite entries for message backups

### DIFF
--- a/src/org/thoughtcrime/securesms/backup/FullBackupExporter.java
+++ b/src/org/thoughtcrime/securesms/backup/FullBackupExporter.java
@@ -143,7 +143,7 @@ public class FullBackupExporter extends FullBackupBase {
           for (int i=0;i<cursor.getColumnCount();i++) {
             if (cursor.getType(i) == Cursor.FIELD_TYPE_STRING) {
               statement.append('\'');
-              statement.append(cursor.getString(i).replace("'", "\\'"));
+              statement.append(cursor.getString(i).replace("'", "''"));
               statement.append('\'');
             } else if (cursor.getType(i) == Cursor.FIELD_TYPE_FLOAT) {
               statement.append(cursor.getFloat(i));


### PR DESCRIPTION
Fixes #7491

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 6, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Properly escapes single quotes in message bodies for backups. Fixes closed issue #7491 and alters behavior of commit https://github.com/signalapp/Signal-Android/commit/a2d04f48061719bd40332101e23483c0057683e3
