### PR TITLE
Conversation fragments without text disable text copy.

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -201,7 +201,8 @@ public class ConversationFragment extends Fragment
   private void setCorrectMenuVisibility(Menu menu) {
     Set<MessageRecord> messageRecords = getListAdapter().getSelectedItems();
     boolean            actionMessage  = false;
-    boolean            mediaMessage  = false;
+    boolean            mediaMessage = false;
+    boolean            textMessage = true;
 
     if (actionMode != null && messageRecords.size() == 0) {
       actionMode.finish();
@@ -215,13 +216,17 @@ public class ConversationFragment extends Fragment
           messageRecord.isIdentityVerified() || messageRecord.isIdentityDefault())
       {
         actionMessage = true;
+        textMessage = false;
         break;
       } else if (messageRecord.isMms()              &&
                  !messageRecord.isMmsNotification() &&
                  ((MediaMmsMessageRecord)messageRecord).containsMediaSlide())
       {
         mediaMessage = true;
-        break;
+        if (messageRecord.getBody().isEmpty()) {
+            textMessage = false;
+            break;
+        }
       }
     }
 
@@ -230,19 +235,18 @@ public class ConversationFragment extends Fragment
       menu.findItem(R.id.menu_context_details).setVisible(false);
       menu.findItem(R.id.menu_context_save_attachment).setVisible(false);
       menu.findItem(R.id.menu_context_resend).setVisible(false);
-      menu.findItem(R.id.menu_context_copy).setVisible(!actionMessage  && !mediaMessage);
+      menu.findItem(R.id.menu_context_copy).setVisible(textMessage);
     } else {
       MessageRecord messageRecord = messageRecords.iterator().next();
 
       menu.findItem(R.id.menu_context_resend).setVisible(messageRecord.isFailed());
-      menu.findItem(R.id.menu_context_save_attachment).setVisible(!actionMessage                     &&
-                                                                  messageRecord.isMms()              &&
-                                                                  !messageRecord.isMmsNotification() &&
-                                                                  ((MediaMmsMessageRecord)messageRecord).containsMediaSlide());
+      menu.findItem(R.id.menu_context_save_attachment).setVisible(!actionMessage &&
+                                                                  mediaMessage   &&
+                                                                  !textMessage);
 
       menu.findItem(R.id.menu_context_forward).setVisible(!actionMessage);
       menu.findItem(R.id.menu_context_details).setVisible(!actionMessage);
-      menu.findItem(R.id.menu_context_copy).setVisible(!actionMessage && !mediaMessage);
+      menu.findItem(R.id.menu_context_copy).setVisible(textMessage);
     }
   }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 5X, Android 8.1.0
 * Virtual device Pixel, Android 7.1.1
* Virtual device Nexus One, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
The multi-select redo from 4bdb2acd29f06ec0782f33e20b3c8290a002bef3 omitted the ability to copy text from media messages with text. It also removed the ability to select a plain text message plus a media message with text and copy the text from both. This fix just disables text copying whenever there's a message which has no text (event, media message without text).

Please pardon my n00bness. This is my first Android PR.

Fixes #7472
