### PR TITLE
Import Activity: Set correct title and small clean up

### DIFF
--- a/res/layout/import_export_fragment.xml
+++ b/res/layout/import_export_fragment.xml
@@ -9,17 +9,6 @@
               android:layout_width="match_parent"
               android:layout_height="wrap_content">
 
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="48dp"
-        android:layout_marginLeft="16dp"
-        android:layout_marginStart="16dp"
-        android:gravity="center_vertical"
-        android:text="@string/ImportExportActivity_import"
-        android:textSize="14sp"
-        android:fontFamily="sans-serif-medium"
-        android:textColor="@color/signal_primary_dark"/>
-
     <LinearLayout android:layout_width="wrap_content"
                   android:layout_height="wrap_content"
                   android:orientation="vertical">

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -333,10 +333,6 @@
     <!-- GroupMembersDialog -->
     <string name="GroupMembersDialog_me">Me</string>
 
-    <!-- ImportExportActivity -->
-    <string name="ImportExportActivity_import">Import</string>
-    <string name="ImportExportActivity_export">Export</string>
-
     <!-- ImportFragment -->
     <string name="ImportFragment_import_system_sms_database">Import system SMS database?</string>
     <string name="ImportFragment_this_will_import_messages_from_the_system">This will import

--- a/src/org/thoughtcrime/securesms/ImportExportActivity.java
+++ b/src/org/thoughtcrime/securesms/ImportExportActivity.java
@@ -21,6 +21,7 @@ public class ImportExportActivity extends PassphraseRequiredActionBarActivity {
   protected void onCreate(Bundle savedInstanceState, boolean ready) {
     assert getSupportActionBar() != null;
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    getSupportActionBar().setTitle(R.string.arrays__import_export);
     initFragment(android.R.id.content, new ImportExportFragment(), dynamicLanguage.getCurrentLocale());
   }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung S8, Android 8.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
- Sets the title for the Import section correctly ("Import"). Before, since no title was set, it defaulted to "Signal"
- Removes subheader "Import" from Fragment, since importing actions are the only ones now.

Fixes #5389