### PR TITLE
Remove PROCESS_OUTGOING_CALLS permission

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -45,7 +45,6 @@
 
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
-    <uses-permission android:name="android.permission.PROCESS_OUTGOING_CALLS" />
     <uses-permission android:name="android.permission.READ_CALL_STATE"/>
 
     <!-- For sending/receiving events -->


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [X] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description


According to Twitter, Signal doesn't require the PROCESS_OUTGOING_CALLS permission. So there should be no harm in simply removing it:

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Signal supports runtime permissions. Users are asked to approve things as they are needed (e.g. the first time they try to send a photo) and the Phone permissions are not required. Signal Android is completely open source and the build process is reproducible.</p>&mdash; Signal (@signalapp) <a href="https://twitter.com/signalapp/status/973332351156547584?ref_src=twsrc%5Etfw">March 12, 2018</a></blockquote>

