### PR TITLE
Reduce image stutter by using subsampling more often.

### DIFF
--- a/src/org/thoughtcrime/securesms/util/BitmapUtil.java
+++ b/src/org/thoughtcrime/securesms/util/BitmapUtil.java
@@ -277,7 +277,7 @@ public class BitmapUtil {
   }
 
   public static int getMaxTextureSize() {
-    final int IMAGE_MAX_BITMAP_DIMENSION = 2048;
+    final int MAX_ALLOWED_TEXTURE_SIZE = 2048;
 
     EGL10 egl = (EGL10) EGLContext.getEGL();
     EGLDisplay display = egl.eglGetDisplay(EGL10.EGL_DEFAULT_DISPLAY);
@@ -303,6 +303,6 @@ public class BitmapUtil {
 
     egl.eglTerminate(display);
 
-    return Math.max(maximumTextureSize, IMAGE_MAX_BITMAP_DIMENSION);
+    return Math.min(maximumTextureSize, MAX_ALLOWED_TEXTURE_SIZE);
   }
 }


### PR DESCRIPTION
Fixes #7208.

On some phones, zooming in on large images (say, a 4k image) would be slow and stutter a lot. This is due to ZoomingImageView using a regular PhotoView instead of a SubsamplingScaleImageView. ZoomingImageView decides whether or not to use a SubsamplingScaleImageView depending on whether the image has a dimension larger than BitmapUtil.getMaxTextureSize(). 

However, while that method will determine the maximum size of an image that is _possible_ to render, it doesn't necessarily mean it can be rendered _efficiently_. There is some size at which some phones will have to continually re-upload a bitmap to the GPU, as seen in this systrace taken from a Moto E.

![moto-e-zoom-stutter](https://user-images.githubusercontent.com/37311915/37359063-e1775fa6-26a9-11e8-9fcc-11ecdf11ae12.png)

We could just use SubsamplingScaleImageView all the time (it has built-in logic to prevent tiling on smaller images), but given that it doesn't use Glide to load Bitmaps, we shouldn't be over-using it. As a result, I altered BitmapUtil.getMaxTextureSize() to have a cap of 2048, which from research and experimentation seems to be a good number (OpenGL operates in powers of 2 -- if 4096 is too big, 2048 is the next best bet).

Tested on the following devices. No scroll jank on images >= 2048x2048. No scroll jank on images < 2048x2048.
* [Moto X (2nd Generation), Android 6.0](https://www.gsmarena.com/motorola_moto_x_(2nd_gen)-6649.php)
* [Moto E (2nd Generation), Android 5.1](https://www.gsmarena.com/motorola_moto_e_(2nd_gen)-6986.php)
* [Galaxy S3 Mini, Andoid 4.2.2](https://www.gsmarena.com/samsung_i8200_galaxy_s_iii_mini_ve-6190.php)

Example test image to induce jank:
![signal-2018-03-13-104700](https://user-images.githubusercontent.com/37311915/37359975-3823ea5c-26ac-11e8-8d52-0b3d01b83303.jpeg)
