### PR TITLE
Allow skipping registration lock PIN reminder intervals

### DIFF
--- a/src/org/thoughtcrime/securesms/lock/RegistrationLockReminders.java
+++ b/src/org/thoughtcrime/securesms/lock/RegistrationLockReminders.java
@@ -6,30 +6,21 @@ import android.support.annotation.NonNull;
 
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.NavigableSet;
+import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
 public class RegistrationLockReminders {
 
-  public static final long INITIAL_INTERVAL = TimeUnit.HOURS.toMillis(6);
-
-  private static Map<Long, Long> INTERVAL_PROGRESSION = new HashMap<Long, Long>() {{
-    put(TimeUnit.HOURS.toMillis(6), TimeUnit.HOURS.toMillis(12));
-    put(TimeUnit.HOURS.toMillis(12), TimeUnit.DAYS.toMillis(1));
-    put(TimeUnit.DAYS.toMillis(1), TimeUnit.DAYS.toMillis(3));
-    put(TimeUnit.DAYS.toMillis(3), TimeUnit.DAYS.toMillis(7));
-    put(TimeUnit.DAYS.toMillis(7), TimeUnit.DAYS.toMillis(7));
+  private static final NavigableSet<Long> INTERVALS = new TreeSet<Long>() {{
+    add(TimeUnit.HOURS.toMillis(6));
+    add(TimeUnit.HOURS.toMillis(12));
+    add(TimeUnit.DAYS.toMillis(1));
+    add(TimeUnit.DAYS.toMillis(3));
+    add(TimeUnit.DAYS.toMillis(7));
   }};
 
-
-  private static Map<Long, Long> INTERVAL_REGRESSION = new HashMap<Long, Long>() {{
-    put(TimeUnit.HOURS.toMillis(12), TimeUnit.HOURS.toMillis(6));
-    put(TimeUnit.DAYS.toMillis(1), TimeUnit.HOURS.toMillis(12));
-    put(TimeUnit.DAYS.toMillis(3), TimeUnit.DAYS.toMillis(1));
-    put(TimeUnit.DAYS.toMillis(7), TimeUnit.DAYS.toMillis(3));
-  }};
-
+  public static final long INITIAL_INTERVAL = INTERVALS.first();
 
   public static boolean needsReminder(@NonNull Context context) {
     if (!TextSecurePreferences.isRegistrationtLockEnabled(context)) return false;
@@ -41,15 +32,16 @@ public class RegistrationLockReminders {
   }
 
   public static void scheduleReminder(@NonNull Context context, boolean success) {
-    long lastReminderInterval     = TextSecurePreferences.getRegistrationLockNextReminderInterval(context);
-    long nextReminderInterval;
+    Long nextReminderInterval;
 
     if (success) {
-      if (INTERVAL_PROGRESSION.containsKey(lastReminderInterval)) nextReminderInterval = INTERVAL_PROGRESSION.get(lastReminderInterval);
-      else                                                        nextReminderInterval = INTERVAL_PROGRESSION.get(TimeUnit.HOURS.toMillis(6));
+      long timeSinceLastReminder = System.currentTimeMillis() - TextSecurePreferences.getRegistrationLockLastReminderTime(context);
+      nextReminderInterval = INTERVALS.higher(timeSinceLastReminder);
+      if (nextReminderInterval == null) nextReminderInterval = INTERVALS.last();
     } else {
-      if (INTERVAL_REGRESSION.containsKey(lastReminderInterval))  nextReminderInterval = INTERVAL_REGRESSION.get(lastReminderInterval);
-      else                                                        nextReminderInterval = INTERVAL_REGRESSION.get(TimeUnit.HOURS.toMillis(12));
+      long lastReminderInterval = TextSecurePreferences.getRegistrationLockNextReminderInterval(context);
+      nextReminderInterval = INTERVALS.lower(lastReminderInterval);
+      if (nextReminderInterval == null) nextReminderInterval = INTERVALS.first();
     }
 
     TextSecurePreferences.setRegistrationLockLastReminderTime(context, System.currentTimeMillis());

--- a/src/org/thoughtcrime/securesms/lock/RegistrationLockReminders.java
+++ b/src/org/thoughtcrime/securesms/lock/RegistrationLockReminders.java
@@ -13,7 +13,24 @@ import java.util.concurrent.TimeUnit;
 public class RegistrationLockReminders {
 
   public static final long INITIAL_INTERVAL = TimeUnit.HOURS.toMillis(6);
-  
+
+  private static Map<Long, Long> INTERVAL_PROGRESSION = new HashMap<Long, Long>() {{
+    put(TimeUnit.HOURS.toMillis(6), TimeUnit.HOURS.toMillis(12));
+    put(TimeUnit.HOURS.toMillis(12), TimeUnit.DAYS.toMillis(1));
+    put(TimeUnit.DAYS.toMillis(1), TimeUnit.DAYS.toMillis(3));
+    put(TimeUnit.DAYS.toMillis(3), TimeUnit.DAYS.toMillis(7));
+    put(TimeUnit.DAYS.toMillis(7), TimeUnit.DAYS.toMillis(7));
+  }};
+
+
+  private static Map<Long, Long> INTERVAL_REGRESSION = new HashMap<Long, Long>() {{
+    put(TimeUnit.HOURS.toMillis(12), TimeUnit.HOURS.toMillis(6));
+    put(TimeUnit.DAYS.toMillis(1), TimeUnit.HOURS.toMillis(12));
+    put(TimeUnit.DAYS.toMillis(3), TimeUnit.DAYS.toMillis(1));
+    put(TimeUnit.DAYS.toMillis(7), TimeUnit.DAYS.toMillis(3));
+  }};
+
+
   public static boolean needsReminder(@NonNull Context context) {
     if (!TextSecurePreferences.isRegistrationtLockEnabled(context)) return false;
 
@@ -24,20 +41,15 @@ public class RegistrationLockReminders {
   }
 
   public static void scheduleReminder(@NonNull Context context, boolean success) {
-    long lastReminderInterval = TextSecurePreferences.getRegistrationLockNextReminderInterval(context);
+    long lastReminderInterval     = TextSecurePreferences.getRegistrationLockNextReminderInterval(context);
     long nextReminderInterval;
 
     if (success) {
-      if      (lastReminderInterval <= TimeUnit.HOURS.toMillis(6))  nextReminderInterval = TimeUnit.HOURS.toMillis(12);
-      else if (lastReminderInterval <= TimeUnit.HOURS.toMillis(12)) nextReminderInterval = TimeUnit.DAYS.toMillis(1);
-      else if (lastReminderInterval <= TimeUnit.DAYS.toMillis(1))   nextReminderInterval = TimeUnit.DAYS.toMillis(3);
-      else if (lastReminderInterval <= TimeUnit.DAYS.toMillis(3))   nextReminderInterval = TimeUnit.DAYS.toMillis(7);
-      else                                                                  nextReminderInterval = TimeUnit.DAYS.toMillis(7);
+      if (INTERVAL_PROGRESSION.containsKey(lastReminderInterval)) nextReminderInterval = INTERVAL_PROGRESSION.get(lastReminderInterval);
+      else                                                        nextReminderInterval = INTERVAL_PROGRESSION.get(TimeUnit.HOURS.toMillis(6));
     } else {
-      if      (lastReminderInterval >= TimeUnit.DAYS.toMillis(7)) nextReminderInterval = TimeUnit.DAYS.toMillis(3);
-      else if (lastReminderInterval >= TimeUnit.DAYS.toMillis(3)) nextReminderInterval = TimeUnit.DAYS.toMillis(1);
-      else if (lastReminderInterval >= TimeUnit.DAYS.toMillis(1)) nextReminderInterval = TimeUnit.HOURS.toMillis(12);
-      else                                                                nextReminderInterval = TimeUnit.HOURS.toMillis(6);
+      if (INTERVAL_REGRESSION.containsKey(lastReminderInterval))  nextReminderInterval = INTERVAL_REGRESSION.get(lastReminderInterval);
+      else                                                        nextReminderInterval = INTERVAL_REGRESSION.get(TimeUnit.HOURS.toMillis(12));
     }
 
     TextSecurePreferences.setRegistrationLockLastReminderTime(context, System.currentTimeMillis());


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Nexus 5X, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Refers to https://github.com/signalapp/Signal-Android/pull/7515#issuecomment-372750293. I know, this change might not be as simple as you expected. But... doesn't chaining these ifs and elses hurt your developer soul? Or the redundancy of all those time values?