### PR TITLE
Allow skipping registration lock PIN reminder intervals (less diff)

### DIFF
--- a/src/org/thoughtcrime/securesms/lock/RegistrationLockReminders.java
+++ b/src/org/thoughtcrime/securesms/lock/RegistrationLockReminders.java
@@ -6,8 +6,6 @@ import android.support.annotation.NonNull;
 
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 public class RegistrationLockReminders {
@@ -24,16 +22,17 @@ public class RegistrationLockReminders {
   }
 
   public static void scheduleReminder(@NonNull Context context, boolean success) {
-    long lastReminderInterval = TextSecurePreferences.getRegistrationLockNextReminderInterval(context);
     long nextReminderInterval;
 
     if (success) {
-      if      (lastReminderInterval <= TimeUnit.HOURS.toMillis(6))  nextReminderInterval = TimeUnit.HOURS.toMillis(12);
-      else if (lastReminderInterval <= TimeUnit.HOURS.toMillis(12)) nextReminderInterval = TimeUnit.DAYS.toMillis(1);
-      else if (lastReminderInterval <= TimeUnit.DAYS.toMillis(1))   nextReminderInterval = TimeUnit.DAYS.toMillis(3);
-      else if (lastReminderInterval <= TimeUnit.DAYS.toMillis(3))   nextReminderInterval = TimeUnit.DAYS.toMillis(7);
-      else                                                                  nextReminderInterval = TimeUnit.DAYS.toMillis(7);
+      long timeSinceLastReminder = System.currentTimeMillis() - TextSecurePreferences.getRegistrationLockLastReminderTime(context);
+      if      (timeSinceLastReminder >= TimeUnit.DAYS.toMillis(3))   nextReminderInterval = TimeUnit.DAYS.toMillis(7);
+      else if (timeSinceLastReminder >= TimeUnit.DAYS.toMillis(1))   nextReminderInterval = TimeUnit.DAYS.toMillis(3);
+      else if (timeSinceLastReminder >= TimeUnit.HOURS.toMillis(12)) nextReminderInterval = TimeUnit.DAYS.toMillis(1);
+      else if (timeSinceLastReminder >= TimeUnit.HOURS.toMillis(6))  nextReminderInterval = TimeUnit.HOURS.toMillis(12);
+      else                                                           nextReminderInterval = TimeUnit.HOURS.toMillis(6);
     } else {
+      long lastReminderInterval = TextSecurePreferences.getRegistrationLockNextReminderInterval(context);
       if      (lastReminderInterval >= TimeUnit.DAYS.toMillis(7)) nextReminderInterval = TimeUnit.DAYS.toMillis(3);
       else if (lastReminderInterval >= TimeUnit.DAYS.toMillis(3)) nextReminderInterval = TimeUnit.DAYS.toMillis(1);
       else if (lastReminderInterval >= TimeUnit.DAYS.toMillis(1)) nextReminderInterval = TimeUnit.HOURS.toMillis(12);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Nexus 5X, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Version of #7517 with less diff but also less nice.

I introduced this new variable `timeSinceLastReminder`, flipped the comparator to `>=` and therefore I had to reverse the order of all the time values.