### PR TITLE
Allow deletion of media through preview.

### DIFF
--- a/res/menu/media_preview.xml
+++ b/res/menu/media_preview.xml
@@ -13,4 +13,8 @@
           android:title="@string/media_preview__all_media_title"
           android:icon="@drawable/ic_photo_library_white_24dp"
           app:showAsAction="ifRoom"/>
+    <item android:id="@+id/delete"
+          android:title="@string/delete"
+          android:icon="@drawable/ic_delete_white_24dp"
+          app:showAsAction="ifRoom"/>
 </menu>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -664,6 +664,8 @@
     <string name="MediaPreviewActivity_draft">Draft</string>
     <string name="MediaPreviewActivity_signal_needs_the_storage_permission_in_order_to_write_to_external_storage_but_it_has_been_permanently_denied">Signal needs the Storage permission in order to save to external storage, but it has been permanently denied. Please continue to app settings, select \"Permissions\", and enable \"Storage\".</string>
     <string name="MediaPreviewActivity_unable_to_write_to_external_storage_without_permission">Unable to save to external storage without permissions</string>
+    <string name="MediaPreviewActivity_media_delete_confirmation_title">Delete message?</string>
+    <string name="MediaPreviewActivity_media_delete_confirmation_message">This will permanently delete this message.</string>
 
 
     <!-- MessageNotifier -->

--- a/src/org/thoughtcrime/securesms/database/Database.java
+++ b/src/org/thoughtcrime/securesms/database/Database.java
@@ -17,8 +17,10 @@
 package org.thoughtcrime.securesms.database;
 
 import android.content.Context;
+import android.database.ContentObserver;
 import android.database.Cursor;
 import android.net.Uri;
+import android.support.annotation.NonNull;
 
 import org.thoughtcrime.securesms.database.helpers.SQLCipherOpenHelper;
 
@@ -29,6 +31,7 @@ public abstract class Database {
   protected static final String ID_WHERE              = "_id = ?";
   private   static final String CONVERSATION_URI      = "content://textsecure/thread/";
   private   static final String CONVERSATION_LIST_URI = "content://textsecure/conversation-list";
+  private   static final String ATTACHMENT_URI        = "content://textsecure/attachment/";
 
   protected       SQLCipherOpenHelper databaseHelper;
   protected final Context             context;
@@ -57,6 +60,16 @@ public abstract class Database {
 
   protected void setNotifyConverationListListeners(Cursor cursor) {
     cursor.setNotificationUri(context.getContentResolver(), Uri.parse(CONVERSATION_LIST_URI));
+  }
+
+  protected void registerAttachmentListeners(@NonNull ContentObserver observer) {
+    context.getContentResolver().registerContentObserver(Uri.parse(ATTACHMENT_URI),
+                                                         true,
+                                                         observer);
+  }
+
+  protected void notifyAttachmentListeners() {
+    context.getContentResolver().notifyChange(Uri.parse(ATTACHMENT_URI), null);
   }
 
   public void reset(SQLCipherOpenHelper databaseHelper) {

--- a/src/org/thoughtcrime/securesms/database/MediaDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MediaDatabase.java
@@ -1,6 +1,8 @@
 package org.thoughtcrime.securesms.database;
 
 import android.content.Context;
+import android.database.ContentObservable;
+import android.database.ContentObserver;
 import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -55,6 +57,14 @@ public class MediaDatabase extends Database {
     return cursor;
   }
 
+  public void subscribeToMediaChanges(@NonNull ContentObserver observer) {
+    registerAttachmentListeners(observer);
+  }
+
+  public void unsubscribeToMediaChanges(@NonNull ContentObserver observer) {
+    context.getContentResolver().unregisterContentObserver(observer);
+  }
+
   public Cursor getDocumentMediaForThread(long threadId) {
     SQLiteDatabase database = databaseHelper.getReadableDatabase();
     Cursor cursor = database.rawQuery(DOCUMENT_MEDIA_QUERY, new String[]{threadId+""});
@@ -98,7 +108,7 @@ public class MediaDatabase extends Database {
       return new MediaRecord(attachment, address, date, outgoing);
     }
 
-    public Attachment getAttachment() {
+    public DatabaseAttachment getAttachment() {
       return attachment;
     }
 

--- a/src/org/thoughtcrime/securesms/database/loaders/BucketedThreadMediaLoader.java
+++ b/src/org/thoughtcrime/securesms/database/loaders/BucketedThreadMediaLoader.java
@@ -2,6 +2,7 @@ package org.thoughtcrime.securesms.database.loaders;
 
 
 import android.content.Context;
+import android.database.ContentObserver;
 import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.v4.content.AsyncTaskLoader;
@@ -10,6 +11,7 @@ import com.annimon.stream.Stream;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.database.Address;
+import org.thoughtcrime.securesms.database.Database;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.MediaDatabase;
 import org.thoughtcrime.securesms.recipients.Recipient;
@@ -30,11 +32,13 @@ public class BucketedThreadMediaLoader extends AsyncTaskLoader<BucketedThreadMed
   @SuppressWarnings("unused")
   private static final String TAG = BucketedThreadMediaLoader.class.getSimpleName();
 
-  private final Address      address;
+  private final Address         address;
+  private final ContentObserver observer;
 
   public BucketedThreadMediaLoader(@NonNull Context context, @NonNull Address address) {
     super(context);
-    this.address = address;
+    this.address  = address;
+    this.observer = new ForceLoadContentObserver();
 
     onContentChanged();
   }
@@ -52,10 +56,16 @@ public class BucketedThreadMediaLoader extends AsyncTaskLoader<BucketedThreadMed
   }
 
   @Override
+  protected void onAbandon() {
+    DatabaseFactory.getMediaDatabase(getContext()).unsubscribeToMediaChanges(observer);
+  }
+
+  @Override
   public BucketedThreadMedia loadInBackground() {
     BucketedThreadMedia result   = new BucketedThreadMedia(getContext());
     long                threadId = DatabaseFactory.getThreadDatabase(getContext()).getThreadIdFor(Recipient.from(getContext(), address, true));
 
+    DatabaseFactory.getMediaDatabase(getContext()).subscribeToMediaChanges(observer);
     try (Cursor cursor = DatabaseFactory.getMediaDatabase(getContext()).getGalleryMediaForThread(threadId)) {
       while (cursor != null && cursor.moveToNext()) {
         result.add(MediaDatabase.MediaRecord.from(getContext(), cursor));


### PR DESCRIPTION
Added the ability to delete media via the media preview. A delete option is added to the action bar of the MediaPreviewActivity. When pressed:

* The attachment entry representing the media is deleted.
* If there are no other attachments for the linked MMS message, then the MMS entry is also deleted.
* The preview is closed.

[Video](https://github.com/signalapp/Signal-Android/files/1809293/delete-media-preview.zip)

**TODO**
- [ ] Verify files are physically removed from the disk.

**Test Cases**
* Deleted static image
* Deleted GIF
* Deleted video
* Ensured that messages are gone from the conversation view.
* Ensured that media is gone from the "all media" screen.
* Ensured that the delete option is not present for previews of unsent media.
* Simulated the DeleteMediaTask taking a long time, so the preview closes before the deletion is finished. The conversation is updated when the message is deleted.
* Ensured that if you open the preview from the "all media" screen and then delete it, the "all media" screen is updated to reflect that.

**Unable to Test**
* Deleting one attachment from a message with multiple attachments. While this is technically possible, there's no way to create this scenario in the app today.

**Test Devices**
* [Moto X (2nd Generation), Android 6.0](https://www.gsmarena.com/motorola_moto_x_(2nd_gen)-6649.php)
* [Moto E (2nd Generation), Android 5.1](https://www.gsmarena.com/motorola_moto_e_(2nd_gen)-6986.php)
* [Galaxy S3 Mini, Andoid 4.2.2](https://www.gsmarena.com/samsung_i8200_galaxy_s_iii_mini_ve-6190.php)

**Follow-Up Tasks**
* Add a confirmation dialogue for deleting.
* Allow multi-select and delete from the "all media" screen.
