### PR TITLE
Allow batch deletion of media.

### DIFF
--- a/res/layout/media_overview_gallery_item.xml
+++ b/res/layout/media_overview_gallery_item.xml
@@ -11,4 +11,18 @@
             android:layout_height="match_parent"
             android:contentDescription="@string/media_preview_activity__media_content_description" />
 
+    <FrameLayout
+        android:id="@+id/selected_indicator"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/MediaOverview_Media_selected_overlay"
+        android:visibility="gone">
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/check"
+            android:layout_gravity="center"/>
+    </FrameLayout>
+
 </org.thoughtcrime.securesms.components.SquareFrameLayout>

--- a/res/menu/media_overview_context.xml
+++ b/res/menu/media_overview_context.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item android:id="@+id/delete"
+        android:title="@string/delete"
+        android:icon="@drawable/ic_delete_white_24dp"
+        app:showAsAction="always"/>
+</menu>

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -40,4 +40,6 @@
 
     <color name="sticker_selected_color">#8cf437</color>
     <color name="transparent">#00FFFFFF</color>
+
+    <color name="MediaOverview_Media_selected_overlay">#88000000</color>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -401,6 +401,16 @@
 
     <!-- MediaOverviewActivity -->
     <string name="MediaOverviewActivity_Media">Media</string>
+    <plurals name="MediaOverviewActivity_Media_delete_confirm_title">
+        <item quantity="one">Delete selected message?</item>
+        <item quantity="other">Delete selected messages?</item>
+    </plurals>
+    <plurals name="MediaOverviewActivity_Media_delete_confirm_message">
+        <item quantity="one">This will permanently delete the selected message.</item>
+        <item quantity="other">This will permanently delete all %1$d selected messages.</item>
+    </plurals>
+    <string name="MediaOverviewActivity_Media_delete_progress_title">Deleting</string>
+    <string name="MediaOverviewActivity_Media_delete_progress_message">Deleting messages...</string>
     <string name="MediaOverviewActivity_Documents">Documents</string>
 
     <!--- NotificationBarManager -->

--- a/src/org/thoughtcrime/securesms/MediaGalleryAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaGalleryAdapter.java
@@ -17,7 +17,6 @@
 package org.thoughtcrime.securesms;
 
 import android.content.Context;
-import android.content.Intent;
 import android.support.annotation.NonNull;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -27,14 +26,16 @@ import android.widget.TextView;
 import com.codewaves.stickyheadergrid.StickyHeaderGridAdapter;
 
 import org.thoughtcrime.securesms.components.ThumbnailView;
-import org.thoughtcrime.securesms.database.Address;
 import org.thoughtcrime.securesms.database.MediaDatabase.MediaRecord;
 import org.thoughtcrime.securesms.database.loaders.BucketedThreadMediaLoader.BucketedThreadMedia;
 import org.thoughtcrime.securesms.mms.GlideRequests;
 import org.thoughtcrime.securesms.mms.Slide;
 import org.thoughtcrime.securesms.util.MediaUtil;
 
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Locale;
+import java.util.Set;
 
 class MediaGalleryAdapter extends StickyHeaderGridAdapter {
 
@@ -44,16 +45,19 @@ class MediaGalleryAdapter extends StickyHeaderGridAdapter {
   private final Context             context;
   private final GlideRequests       glideRequests;
   private final Locale              locale;
-  private final Address             address;
+  private final ItemClickListener   itemClickListener;
+  private final Set<MediaRecord>    selected;
 
   private  BucketedThreadMedia media;
 
   private static class ViewHolder extends StickyHeaderGridAdapter.ItemViewHolder {
     ThumbnailView imageView;
+    View          selectedIndicator;
 
     ViewHolder(View v) {
       super(v);
-      imageView = v.findViewById(R.id.image);
+      imageView         = v.findViewById(R.id.image);
+      selectedIndicator = v.findViewById(R.id.selected_indicator);
     }
   }
 
@@ -66,14 +70,18 @@ class MediaGalleryAdapter extends StickyHeaderGridAdapter {
     }
   }
 
-  MediaGalleryAdapter(@NonNull Context context, @NonNull GlideRequests glideRequests,
-                      BucketedThreadMedia media, Locale locale, Address address)
+  MediaGalleryAdapter(@NonNull Context context,
+                      @NonNull GlideRequests glideRequests,
+                      BucketedThreadMedia media,
+                      Locale locale,
+                      ItemClickListener clickListener)
   {
-    this.context       = context;
-    this.glideRequests = glideRequests;
-    this.locale        = locale;
-    this.media         = media;
-    this.address       = address;
+    this.context           = context;
+    this.glideRequests     = glideRequests;
+    this.locale            = locale;
+    this.media             = media;
+    this.itemClickListener = clickListener;
+    this.selected          = new HashSet<>();
   }
 
   public void setMedia(BucketedThreadMedia media) {
@@ -97,16 +105,22 @@ class MediaGalleryAdapter extends StickyHeaderGridAdapter {
 
   @Override
   public void onBindItemViewHolder(ItemViewHolder viewHolder, int section, int offset) {
-    MediaRecord   mediaRecord   = media.get(section, offset);
-    ThumbnailView thumbnailView = ((ViewHolder)viewHolder).imageView;
-
-    Slide slide = MediaUtil.getSlideForAttachment(context, mediaRecord.getAttachment());
+    MediaRecord   mediaRecord       = media.get(section, offset);
+    ThumbnailView thumbnailView     = ((ViewHolder)viewHolder).imageView;
+    View          selectedIndicator = ((ViewHolder)viewHolder).selectedIndicator;
+    Slide         slide             = MediaUtil.getSlideForAttachment(context, mediaRecord.getAttachment());
 
     if (slide != null) {
       thumbnailView.setImageResource(glideRequests, slide, false, false);
     }
 
-    thumbnailView.setOnClickListener(new OnMediaClickListener(mediaRecord));
+    thumbnailView.setOnClickListener(view -> itemClickListener.onMediaClicked(mediaRecord));
+    thumbnailView.setOnLongClickListener(view -> {
+      itemClickListener.onMediaLongClicked(mediaRecord);
+      return true;
+    });
+
+    selectedIndicator.setVisibility(selected.contains(mediaRecord) ? View.VISIBLE : View.GONE);
   }
 
   @Override
@@ -119,32 +133,29 @@ class MediaGalleryAdapter extends StickyHeaderGridAdapter {
     return media.getSectionItemCount(section);
   }
 
-  private class OnMediaClickListener implements View.OnClickListener {
-
-    private final MediaRecord mediaRecord;
-
-    private OnMediaClickListener(MediaRecord mediaRecord) {
-      this.mediaRecord = mediaRecord;
+  public void toggleSelection(@NonNull MediaRecord mediaRecord) {
+    if (!selected.remove(mediaRecord)) {
+      selected.add(mediaRecord);
     }
-
-    @Override
-    public void onClick(View v) {
-      if (mediaRecord.getAttachment().getDataUri() != null) {
-        Intent intent = new Intent(context, MediaPreviewActivity.class);
-        intent.putExtra(MediaPreviewActivity.DATE_EXTRA, mediaRecord.getDate());
-        intent.putExtra(MediaPreviewActivity.SIZE_EXTRA, mediaRecord.getAttachment().getSize());
-        intent.putExtra(MediaPreviewActivity.ADDRESS_EXTRA, address);
-        intent.putExtra(MediaPreviewActivity.OUTGOING_EXTRA, mediaRecord.isOutgoing());
-        intent.putExtra(MediaPreviewActivity.LEFT_IS_RECENT_EXTRA, true);
-
-        if (mediaRecord.getAddress() != null) {
-          intent.putExtra(MediaPreviewActivity.ADDRESS_EXTRA, mediaRecord.getAddress());
-        }
-
-        intent.setDataAndType(mediaRecord.getAttachment().getDataUri(), mediaRecord.getContentType());
-        context.startActivity(intent);
-      }
-    }
+    notifyDataSetChanged();
   }
 
+  public int getSelectedMediaCount() {
+    return selected.size();
+  }
+
+  @NonNull
+  public Collection<MediaRecord> getSelectedMedia() {
+    return new HashSet<>(selected);
+  }
+
+  public void clearSelection() {
+    selected.clear();
+    notifyDataSetChanged();
+  }
+
+  interface ItemClickListener {
+    void onMediaClicked(@NonNull MediaRecord mediaRecord);
+    void onMediaLongClicked(MediaRecord mediaRecord);
+  }
 }

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -62,6 +62,7 @@ import org.thoughtcrime.securesms.mms.GlideRequests;
 import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.RecipientModifiedListener;
+import org.thoughtcrime.securesms.util.AttachmentUtil;
 import org.thoughtcrime.securesms.util.DateUtils;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.SaveAttachmentTask;
@@ -277,18 +278,8 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
           if (mediaItem.attachment == null) {
             return null;
           }
-          Context      context         = MediaPreviewActivity.this.getApplicationContext();
-          AttachmentId attachmentId    = mediaItem.attachment.getAttachmentId();
-          long         mmsId           = mediaItem.attachment.getMmsId();
-          int          attachmentCount = DatabaseFactory.getAttachmentDatabase(context)
-                                                     .getAttachmentsForMessage(mmsId)
-                                                     .size();
-
-          if (attachmentCount <= 1) {
-            DatabaseFactory.getMmsDatabase(context).delete(mmsId);
-          } else {
-            DatabaseFactory.getAttachmentDatabase(context).deleteAttachment(attachmentId);
-          }
+          AttachmentUtil.deleteAttachment(MediaPreviewActivity.this.getApplicationContext(),
+                                          mediaItem.attachment);
           return null;
         }
       }.execute();

--- a/src/org/thoughtcrime/securesms/util/AttachmentUtil.java
+++ b/src/org/thoughtcrime/securesms/util/AttachmentUtil.java
@@ -6,10 +6,14 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.WorkerThread;
 import android.text.TextUtils;
 import android.util.Log;
 
 import org.thoughtcrime.securesms.attachments.Attachment;
+import org.thoughtcrime.securesms.attachments.AttachmentId;
+import org.thoughtcrime.securesms.attachments.DatabaseAttachment;
+import org.thoughtcrime.securesms.database.DatabaseFactory;
 
 import java.util.Collections;
 import java.util.Set;
@@ -33,6 +37,27 @@ public class AttachmentUtil {
       return allowedTypes.contains(MediaUtil.getDiscreteMimeType(contentType));
     } else {
       return allowedTypes.contains("documents");
+    }
+  }
+
+  /**
+   * Deletes the specified attachment. If its the only attachment for its linked message, the entire
+   * message is deleted.
+   */
+  @WorkerThread
+  public static void deleteAttachment(@NonNull Context context,
+                                      @NonNull DatabaseAttachment attachment)
+  {
+    AttachmentId attachmentId    = attachment.getAttachmentId();
+    long         mmsId           = attachment.getMmsId();
+    int          attachmentCount = DatabaseFactory.getAttachmentDatabase(context)
+        .getAttachmentsForMessage(mmsId)
+        .size();
+
+    if (attachmentCount <= 1) {
+      DatabaseFactory.getMmsDatabase(context).delete(mmsId);
+    } else {
+      DatabaseFactory.getAttachmentDatabase(context).deleteAttachment(attachmentId);
     }
   }
 


### PR DESCRIPTION
It is now possible to batch-delete media in the "media overview" screen. You can long press to enter multi-select mode. Then a delete button appears on the menu bar. After pressing delete, you will get a confirmation, and if the user confirms, the items will delete while a progress dialog shows.

[video](https://github.com/signalapp/Signal-Android/files/1816757/batch-delete-media.zip)

**Test Cases**
* Deleted a single image.
* Deleted multiple images.
* Deleted multiple images across section headers.
* Rotate the phone at every possible point in the flow.

**Unable to Test**
* Deleting one attachment from a message with multiple attachments. While this is technically possible, there's no way to create this scenario in the app today.

**Test Devices**
* [Moto X (2nd Generation), Android 6.0](https://www.gsmarena.com/motorola_moto_x_(2nd_gen)-6649.php)
* [Moto E (2nd Generation), Android 5.1](https://www.gsmarena.com/motorola_moto_e_(2nd_gen)-6986.php)
* [Galaxy S3 Mini, Andoid 4.2.2](https://www.gsmarena.com/samsung_i8200_galaxy_s_iii_mini_ve-6190.php)