### PR TITLE
Remove draft after leaving group

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -764,6 +764,9 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
         OutgoingGroupMediaMessage outgoingMessage = new OutgoingGroupMediaMessage(getRecipient(), context, null, System.currentTimeMillis(), 0);
         MessageSender.send(self, outgoingMessage, threadId, false, null);
         DatabaseFactory.getGroupDatabase(self).remove(groupId, Address.fromSerialized(TextSecurePreferences.getLocalNumber(self)));
+        DatabaseFactory.getDraftDatabase(self).clearDrafts(getThreadId());
+
+        composeText.setText("");
         initializeEnabledCheck();
       } catch (IOException e) {
         Log.w(TAG, e);


### PR DESCRIPTION
Fixes #7524

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Nexus 6, Android 7.0
 * AVD Pixel, Android 6
 * Nexus 6, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

This change will remove the text from the `composeText` field when a user leaves a Signal group and clear any drafts associated with the thread. Now a user can see that they have left a group from the conversation list instead of having the permanent draft displayed.
