### PR TITLE
Allow hiding top bars in MediaPreview

### DIFF
--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -23,6 +23,7 @@
     <color name="gray78">#ff383838</color>
     <color name="gray95">#ff111111</color>
     <color name="gray95_transparent50">#7F111111</color>
+    <color name="gray95_transparent80">#CC111111</color>
 
     <color name="transparent_black_05">#05000000</color>
     <color name="transparent_black_10">#10000000</color>

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -22,6 +22,7 @@
     <color name="gray70">#ff4d4d4d</color>
     <color name="gray78">#ff383838</color>
     <color name="gray95">#ff111111</color>
+    <color name="gray95_transparent50">#7F111111</color>
 
     <color name="transparent_black_05">#05000000</color>
     <color name="transparent_black_10">#10000000</color>

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -18,7 +18,6 @@ package org.thoughtcrime.securesms;
 
 import android.Manifest;
 import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -102,9 +101,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     this.setTheme(R.style.TextSecure_DarkTheme);
     dynamicLanguage.onCreate(this);
 
-    setFullscreenIfPossible();
-    getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
-                         WindowManager.LayoutParams.FLAG_FULLSCREEN);
+    setFullscreen();
 
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     setContentView(R.layout.media_preview_activity);
@@ -118,10 +115,13 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     Permissions.onRequestPermissionsResult(this, requestCode, permissions, grantResults);
   }
 
-  @TargetApi(VERSION_CODES.JELLY_BEAN)
-  private void setFullscreenIfPossible() {
+  private void setFullscreen() {
     if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN) {
-      getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_FULLSCREEN);
+      getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
+                                                       View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
+    } else {
+      getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
+                           WindowManager.LayoutParams.FLAG_FULLSCREEN);
     }
   }
 

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -22,6 +22,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
+import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build.VERSION;
@@ -30,6 +31,7 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.LoaderManager;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.content.Loader;
 import android.support.v4.util.Pair;
 import android.support.v4.view.PagerAdapter;
@@ -104,6 +106,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     setFullscreen();
 
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    getSupportActionBar().setBackgroundDrawable(new ColorDrawable(ContextCompat.getColor(this, R.color.gray95_transparent50)));
     setContentView(R.layout.media_preview_activity);
 
     initializeViews();

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -107,6 +107,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
 
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     getSupportActionBar().setBackgroundDrawable(new ColorDrawable(ContextCompat.getColor(this, R.color.gray95_transparent50)));
+    setStatusBarColor(ContextCompat.getColor(this, R.color.gray95_transparent80));
     setContentView(R.layout.media_preview_activity);
 
     initializeViews();

--- a/src/org/thoughtcrime/securesms/components/MediaView.java
+++ b/src/org/thoughtcrime/securesms/components/MediaView.java
@@ -12,6 +12,8 @@ import android.view.View;
 import android.view.Window;
 import android.widget.FrameLayout;
 
+import com.google.android.exoplayer2.ui.PlaybackControlView;
+
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.mms.GlideRequests;
 import org.thoughtcrime.securesms.mms.VideoSlide;
@@ -55,7 +57,7 @@ public class MediaView extends FrameLayout {
 
   public void set(@NonNull  GlideRequests glideRequests,
                   @NonNull  Window window,
-                  @Nullable View.OnClickListener onClickListener,
+                  @Nullable MediaViewListener listener,
                   @NonNull  Uri source,
                   @NonNull  String mediaType,
                   long size,
@@ -66,12 +68,13 @@ public class MediaView extends FrameLayout {
       imageView.setVisibility(View.VISIBLE);
       if (videoView.resolved()) videoView.get().setVisibility(View.GONE);
       imageView.setImageUri(glideRequests, source, mediaType);
-      imageView.setOnClickListener(onClickListener);
+      imageView.setOnClickListener(listener);
     } else if (mediaType.startsWith("video/")) {
       imageView.setVisibility(View.GONE);
       videoView.get().setVisibility(View.VISIBLE);
       videoView.get().setWindow(window);
       videoView.get().setVideoSource(new VideoSlide(getContext(), source, size), autoplay);
+      videoView.get().setPlaybackControlVisibilityListener(listener);
     } else {
       throw new IOException("Unsupported media type: " + mediaType);
     }
@@ -89,4 +92,6 @@ public class MediaView extends FrameLayout {
       this.videoView.get().cleanup();
     }
   }
+
+  public interface MediaViewListener extends View.OnClickListener, PlaybackControlView.VisibilityListener {}
 }

--- a/src/org/thoughtcrime/securesms/components/MediaView.java
+++ b/src/org/thoughtcrime/securesms/components/MediaView.java
@@ -53,10 +53,11 @@ public class MediaView extends FrameLayout {
     this.videoView = new Stub<>(findViewById(R.id.video_player_stub));
   }
 
-  public void set(@NonNull GlideRequests glideRequests,
-                  @NonNull Window window,
-                  @NonNull Uri source,
-                  @NonNull String mediaType,
+  public void set(@NonNull  GlideRequests glideRequests,
+                  @NonNull  Window window,
+                  @Nullable View.OnClickListener onClickListener,
+                  @NonNull  Uri source,
+                  @NonNull  String mediaType,
                   long size,
                   boolean autoplay)
       throws IOException
@@ -65,6 +66,7 @@ public class MediaView extends FrameLayout {
       imageView.setVisibility(View.VISIBLE);
       if (videoView.resolved()) videoView.get().setVisibility(View.GONE);
       imageView.setImageUri(glideRequests, source, mediaType);
+      imageView.setOnClickListener(onClickListener);
     } else if (mediaType.startsWith("video/")) {
       imageView.setVisibility(View.GONE);
       videoView.get().setVisibility(View.VISIBLE);

--- a/src/org/thoughtcrime/securesms/components/ZoomingImageView.java
+++ b/src/org/thoughtcrime/securesms/components/ZoomingImageView.java
@@ -117,8 +117,16 @@ public class ZoomingImageView extends FrameLayout {
   }
 
   public void cleanup() {
+    photoView.setOnClickListener(null);
     photoView.setImageDrawable(null);
+    subsamplingImageView.setOnClickListener(null);
     subsamplingImageView.recycle();
+  }
+
+  @Override
+  public void setOnClickListener(@Nullable View.OnClickListener l) {
+    photoView.setOnClickListener(l);
+    subsamplingImageView.setOnClickListener(l);
   }
 
   private static class AttachmentBitmapDecoderFactory implements DecoderFactory<AttachmentBitmapDecoder> {

--- a/src/org/thoughtcrime/securesms/video/VideoPlayer.java
+++ b/src/org/thoughtcrime/securesms/video/VideoPlayer.java
@@ -46,6 +46,7 @@ import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
 import com.google.android.exoplayer2.trackselection.TrackSelection;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.google.android.exoplayer2.trackselection.TrackSelector;
+import com.google.android.exoplayer2.ui.PlaybackControlView;
 import com.google.android.exoplayer2.ui.SimpleExoPlayerView;
 import com.google.android.exoplayer2.upstream.BandwidthMeter;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
@@ -121,6 +122,10 @@ public class VideoPlayer extends FrameLayout {
 
   public void setWindow(@Nullable Window window) {
     this.window = window;
+  }
+
+  public void setPlaybackControlVisibilityListener(PlaybackControlView.VisibilityListener listener) {
+    if (exoView != null) exoView.setControllerVisibilityListener(listener);
   }
 
   private void setExoViewSource(@NonNull VideoSlide videoSource, boolean autoplay)


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Nexus 5X, Android 7.1.1
 * Sony Xperia U, Android 4.4.4 (CyanogenMod)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fixes #3192

All changes only affect Android versions Jelly Bean+ (4.1+ / sdk 16+) visibly, Android 4.0 look like before.

This PR reintroduces the status bar (transparent) and shows/hides action and status bar on tap in the media preview. For videos the visibility of the bars is synchronized with the video controls.

I intentionally don't hide the navigation bar (immersive mode -> #5934) because this change would clash with the video controls. The video controls are then partly hidden behind the navigation bar and it's hard/hacky to detect the height of the navigation bar to correctly react to its size. But the necessary flags for hiding navigation bar and immersive more can easily be added to the code of this PR.

### Screenshots

![bildschirmfoto von 2018-03-18 20-37-11](https://user-images.githubusercontent.com/16167751/37570295-68fd11ee-2aee-11e8-8f8a-42e79de5d2a8.png)
![bildschirmfoto von 2018-03-18 20-38-37](https://user-images.githubusercontent.com/16167751/37570297-6ba4baf0-2aee-11e8-955b-3408219e2ae9.png)
