### PR TITLE
Strip EXIF metadata from JPEG attachments.

### DIFF
--- a/src/org/thoughtcrime/securesms/jobs/MmsSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/MmsSendJob.java
@@ -175,7 +175,7 @@ public class MmsSendJob extends SendJob {
     String           lineNumber        = getMyNumber(context);
     Address          destination       = message.getRecipient().getAddress();
     MediaConstraints mediaConstraints  = MediaConstraints.getMmsMediaConstraints(message.getSubscriptionId());
-    List<Attachment> scaledAttachments = scaleAttachments(mediaConstraints, message.getAttachments());
+    List<Attachment> scaledAttachments = scaleAndStripExifFromAttachments(mediaConstraints, message.getAttachments());
 
     if (!TextUtils.isEmpty(lineNumber)) {
       req.setFrom(new EncodedStringValue(lineNumber));

--- a/src/org/thoughtcrime/securesms/jobs/PushGroupSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushGroupSendJob.java
@@ -141,7 +141,7 @@ public class PushGroupSendJob extends PushSendJob implements InjectableType {
     Optional<byte[]>              profileKey        = getProfileKey(message.getRecipient());
     List<Address>                 recipients        = getGroupMessageRecipients(groupId, messageId);
     MediaConstraints              mediaConstraints  = MediaConstraints.getPushMediaConstraints();
-    List<Attachment>              scaledAttachments = scaleAttachments(mediaConstraints, message.getAttachments());
+    List<Attachment>              scaledAttachments = scaleAndStripExifFromAttachments(mediaConstraints, message.getAttachments());
     List<SignalServiceAttachment> attachmentStreams = getAttachmentsFor(scaledAttachments);
 
     List<SignalServiceAddress>    addresses;

--- a/src/org/thoughtcrime/securesms/jobs/PushMediaSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushMediaSendJob.java
@@ -107,7 +107,7 @@ public class PushMediaSendJob extends PushSendJob implements InjectableType {
     try {
       SignalServiceAddress          address           = getPushAddress(message.getRecipient().getAddress());
       MediaConstraints              mediaConstraints  = MediaConstraints.getPushMediaConstraints();
-      List<Attachment>              scaledAttachments = scaleAttachments(mediaConstraints, message.getAttachments());
+      List<Attachment>              scaledAttachments = scaleAndStripExifFromAttachments(mediaConstraints, message.getAttachments());
       List<SignalServiceAttachment> attachmentStreams = getAttachmentsFor(scaledAttachments);
       Optional<byte[]>              profileKey        = getProfileKey(message.getRecipient());
       SignalServiceDataMessage      mediaMessage      = SignalServiceDataMessage.newBuilder()

--- a/src/org/thoughtcrime/securesms/util/MediaUtil.java
+++ b/src/org/thoughtcrime/securesms/util/MediaUtil.java
@@ -149,6 +149,10 @@ public class MediaUtil {
     return isGif(attachment.getContentType());
   }
 
+  public static boolean isJpeg(Attachment attachment) {
+    return isJpegType(attachment.getContentType());
+  }
+
   public static boolean isImage(Attachment attachment) {
     return isImageType(attachment.getContentType());
   }
@@ -167,6 +171,10 @@ public class MediaUtil {
 
   public static boolean isGif(String contentType) {
     return !TextUtils.isEmpty(contentType) && contentType.trim().equals("image/gif");
+  }
+
+  public static boolean isJpegType(String contentType) {
+    return !TextUtils.isEmpty(contentType) && contentType.trim().equals(IMAGE_JPEG);
   }
 
   public static boolean isFile(Attachment attachment) {


### PR DESCRIPTION
This PR strips EXIF metadata from all JPEG attachments before sending. Previously, it was being stripped from most images by our re-scaling process. However, smaller images would slip through and keep their metadata, possibly exposing things like photo location. 

This PR removes all EXIF metadata by re-encoding the JPEG. This keeps all of the visual effects of the EXIF tags (like orientation) by updating the image data itself, while removing all EXIF tags.

Fixes #5968

**Test Cases**
* Sending a small JPEG (that doesn't get resized) with lots of metadata, including orientation
* Sending a small JPEG (that doesn't get resized) with lots of metadata, excluding orientation
* Sending a large JPEG (that does get resized)
* Sending a JPEG with no metadata
* Sending a GIF
* Sending a PNG

**Metadata Verification Process**
* Used the [Photo Exif Editor](https://play.google.com/store/apps/details?id=net.xnano.android.photoexifeditor&hl=en) app to view image metadata.
* Verified that if the image was rendering in the proper orientation (in both the thumbnail and the preview).

**Test Image**
![cat-rotated](https://user-images.githubusercontent.com/37311915/37608388-a705b748-2b57-11e8-8df5-9517f6ba28cf.jpg)
(Hilariously, the orientation field is not respected in my browser in the thumbnail, but it _is_ respected if you click the image and view it fullscreen).

**Things I Still Need to Test**
- [x] MMS messages
- [x] Group messages

**Test Devices**
* [Moto X (2nd Generation), Android 6.0](https://www.gsmarena.com/motorola_moto_x_(2nd_gen)-6649.php)
* [Galaxy S3 Mini, Andoid 4.2.2](https://www.gsmarena.com/samsung_i8200_galaxy_s_iii_mini_ve-6190.php)