### PR TITLE
Fill in attachment sizes when sending media.

### DIFF
--- a/src/org/thoughtcrime/securesms/attachments/UriAttachment.java
+++ b/src/org/thoughtcrime/securesms/attachments/UriAttachment.java
@@ -12,15 +12,15 @@ public class UriAttachment extends Attachment {
   public UriAttachment(@NonNull Uri uri, @NonNull String contentType, int transferState, long size,
                        @Nullable String fileName, boolean voiceNote)
   {
-    this(uri, uri, contentType, transferState, size, fileName, null, voiceNote);
+    this(uri, uri, contentType, transferState, size, fileName, null, voiceNote, 0, 0);
   }
 
   public UriAttachment(@NonNull Uri dataUri, @Nullable Uri thumbnailUri,
                        @NonNull String contentType, int transferState, long size,
                        @Nullable String fileName, @Nullable String fastPreflightId,
-                       boolean voiceNote)
+                       boolean voiceNote, int width, int height)
   {
-    super(contentType, transferState, size, fileName, null, null, null, null, fastPreflightId, voiceNote, 0, 0);
+    super(contentType, transferState, size, fileName, null, null, null, null, fastPreflightId, voiceNote, width, height);
     this.dataUri      = dataUri;
     this.thumbnailUri = thumbnailUri;
   }

--- a/src/org/thoughtcrime/securesms/mms/AudioSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/AudioSlide.java
@@ -38,7 +38,7 @@ public class AudioSlide extends Slide {
   }
 
   public AudioSlide(Context context, Uri uri, long dataSize, String contentType, boolean voiceNote) {
-    super(context,  new UriAttachment(uri, null, contentType, AttachmentDatabase.TRANSFER_PROGRESS_STARTED, dataSize, null, null, voiceNote));
+    super(context,  new UriAttachment(uri, null, contentType, AttachmentDatabase.TRANSFER_PROGRESS_STARTED, dataSize, null, null, voiceNote, 0, 0));
   }
 
   public AudioSlide(Context context, Attachment attachment) {

--- a/src/org/thoughtcrime/securesms/mms/Slide.java
+++ b/src/org/thoughtcrime/securesms/mms/Slide.java
@@ -22,6 +22,7 @@ import android.net.Uri;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.util.Pair;
 
 import org.thoughtcrime.securesms.attachments.Attachment;
 import org.thoughtcrime.securesms.attachments.UriAttachment;
@@ -137,9 +138,19 @@ public abstract class Slide {
                                                                    boolean  voiceNote)
   {
     try {
-      Optional<String> resolvedType    = Optional.fromNullable(MediaUtil.getMimeType(context, uri));
-      String           fastPreflightId = String.valueOf(SecureRandom.getInstance("SHA1PRNG").nextLong());
-      return new UriAttachment(uri, hasThumbnail ? uri : null, resolvedType.or(defaultMime), AttachmentDatabase.TRANSFER_PROGRESS_STARTED, size, fileName, fastPreflightId, voiceNote);
+      String                 resolvedType    = Optional.fromNullable(MediaUtil.getMimeType(context, uri)).or(defaultMime);
+      String                 fastPreflightId = String.valueOf(SecureRandom.getInstance("SHA1PRNG").nextLong());
+      Pair<Integer, Integer> dimens          = MediaUtil.getDimensions(context, resolvedType, uri);
+      return new UriAttachment(uri,
+                               hasThumbnail ? uri : null,
+                               resolvedType,
+                               AttachmentDatabase.TRANSFER_PROGRESS_STARTED,
+                               size,
+                               fileName,
+                               fastPreflightId,
+                               voiceNote,
+                               dimens.first,
+                               dimens.second);
     } catch (NoSuchAlgorithmException e) {
       throw new AssertionError(e);
     }


### PR DESCRIPTION
We need to populate the UriAttachment models with width and height so that when we build DatabaseAttachment models from them, the dimensions are saved to the database.

I did this by adding a width and height field to the UriAttachment constructor, and then making sure that got filled in during the sending flow. All images should have a width and height populated (including GIFs), but otherwise the fields are left empty (0, 0).

**Test Cases**
* Attached a JPEG
* Attached a PNG
* Attached a GIF
* Attached an audio file (read 0, 0)
* Attached a video (read 0, 0)
* Used logging to verify that the attachment models that were part of the conversation adapter had widths and heights set, setting us up to be able to use them for sizing the ThumbnailView appropriately.

**Test Devices**
* [Moto X (2nd Generation), Android 6.0](https://www.gsmarena.com/motorola_moto_x_(2nd_gen)-6649.php)