### PR TITLE
Add button to flip camera (front vs rear). Fixes #6279

### DIFF
--- a/res/drawable/webrtc_camera_flip_button.xml
+++ b/res/drawable/webrtc_camera_flip_button.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/webrtc_control_background"/>
+    <item android:top="5dp"
+          android:left="5dp"
+          android:right="5dp"
+          android:bottom="5dp"
+          android:drawable="@drawable/quick_camera_rear"/>
+</layer-list>

--- a/res/layout/webrtc_call_controls.xml
+++ b/res/layout/webrtc_call_controls.xml
@@ -34,6 +34,13 @@
         <org.thoughtcrime.securesms.components.AccessibleToggleButton
                 android:id="@+id/video_mute_button"
                 style="@style/WebRtcCallCompoundButton"
+                android:layout_marginRight="15dp"
                 android:background="@drawable/webrtc_video_mute_button"/>
+
+        <org.thoughtcrime.securesms.components.AccessibleToggleButton
+                android:id="@+id/camera_flip_button"
+                style="@style/WebRtcCallCompoundButton"
+                android:contentDescription="@string/redphone_call_controls__flip_camera_rear"
+                android:background="@drawable/webrtc_camera_flip_button"/>
 
 </merge>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -970,6 +970,7 @@
     <!--- redphone_call_controls -->
     <string name="redphone_call_card__signal_call">Signal Call</string>
     <string name="redphone_call_controls__mute">Mute</string>
+    <string name="redphone_call_controls__flip_camera_rear">Use rear camera</string>
     <string name="redphone_call_controls__signal_call">Signal Call</string>
 
     <!-- registration_activity -->

--- a/src/org/thoughtcrime/securesms/WebRtcCallActivity.java
+++ b/src/org/thoughtcrime/securesms/WebRtcCallActivity.java
@@ -139,6 +139,7 @@ public class WebRtcCallActivity extends Activity {
     callScreen.setIncomingCallActionListener(new IncomingCallActionListener());
     callScreen.setAudioMuteButtonListener(new AudioMuteButtonListener());
     callScreen.setVideoMuteButtonListener(new VideoMuteButtonListener());
+    callScreen.setCameraFlipButtonListener(new CameraFlipButtonListener());
     callScreen.setSpeakerButtonListener(new SpeakerButtonListener());
     callScreen.setBluetoothButtonListener(new BluetoothButtonListener());
 
@@ -156,6 +157,13 @@ public class WebRtcCallActivity extends Activity {
     Intent intent = new Intent(this, WebRtcCallService.class);
     intent.setAction(WebRtcCallService.ACTION_SET_MUTE_VIDEO);
     intent.putExtra(WebRtcCallService.EXTRA_MUTE, muted);
+    startService(intent);
+  }
+
+  private void handleSetCameraFlip(boolean isRear) {
+    Intent intent = new Intent(this, WebRtcCallService.class);
+    intent.setAction(WebRtcCallService.ACTION_SET_CAMERA_FLIP);
+    intent.putExtra(WebRtcCallService.EXTRA_CAMERA_FLIP_REAR, isRear);
     startService(intent);
   }
 
@@ -346,6 +354,11 @@ public class WebRtcCallActivity extends Activity {
     public void onToggle(boolean isMuted) {
       WebRtcCallActivity.this.handleSetMuteVideo(isMuted);
     }
+  }
+
+  private class CameraFlipButtonListener implements WebRtcCallControls.CameraFlipButtonListener {
+    @Override
+    public void onToggle(boolean isRear) { WebRtcCallActivity.this.handleSetCameraFlip(isRear); }
   }
 
   private class SpeakerButtonListener implements WebRtcCallControls.SpeakerButtonListener {

--- a/src/org/thoughtcrime/securesms/components/webrtc/WebRtcCallControls.java
+++ b/src/org/thoughtcrime/securesms/components/webrtc/WebRtcCallControls.java
@@ -27,6 +27,7 @@ public class WebRtcCallControls extends LinearLayout {
 
   private AccessibleToggleButton audioMuteButton;
   private AccessibleToggleButton videoMuteButton;
+  private AccessibleToggleButton cameraFlipButton;
   private AccessibleToggleButton speakerButton;
   private AccessibleToggleButton bluetoothButton;
 
@@ -60,6 +61,8 @@ public class WebRtcCallControls extends LinearLayout {
     this.bluetoothButton = ViewUtil.findById(this, R.id.bluetoothButton);
     this.audioMuteButton = ViewUtil.findById(this, R.id.muteButton);
     this.videoMuteButton = ViewUtil.findById(this, R.id.video_mute_button);
+    this.cameraFlipButton = ViewUtil.findById(this, R.id.camera_flip_button);
+    this.cameraFlipButton.setVisibility(View.INVISIBLE); // shown once video is enabled
   }
 
   public void setAudioMuteButtonListener(final MuteButtonListener listener) {
@@ -75,7 +78,18 @@ public class WebRtcCallControls extends LinearLayout {
     videoMuteButton.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
       @Override
       public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-        listener.onToggle(!isChecked);
+        boolean videoMuted = !isChecked;
+        listener.onToggle(videoMuted);
+        cameraFlipButton.setVisibility(videoMuted ? View.INVISIBLE : View.VISIBLE);
+      }
+    });
+  }
+
+  public void setCameraFlipButtonListener(final CameraFlipButtonListener listener) {
+    cameraFlipButton.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+      @Override
+      public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+        listener.onToggle(isChecked);
       }
     });
   }
@@ -138,21 +152,25 @@ public class WebRtcCallControls extends LinearLayout {
       speakerButton.setAlpha(1.0f);
       bluetoothButton.setAlpha(1.0f);
       videoMuteButton.setAlpha(1.0f);
+      cameraFlipButton.setAlpha(1.0f);
       audioMuteButton.setAlpha(1.0f);
 
       speakerButton.setEnabled(true);
       bluetoothButton.setEnabled(true);
       videoMuteButton.setEnabled(true);
+      cameraFlipButton.setEnabled(true);
       audioMuteButton.setEnabled(true);
     } else if (!enabled && Build.VERSION.SDK_INT >= 11) {
       speakerButton.setAlpha(0.3f);
       bluetoothButton.setAlpha(0.3f);
       videoMuteButton.setAlpha(0.3f);
+      cameraFlipButton.setAlpha(0.3f);
       audioMuteButton.setAlpha(0.3f);
       
       speakerButton.setEnabled(false);
       bluetoothButton.setEnabled(false);
       videoMuteButton.setEnabled(false);
+      cameraFlipButton.setEnabled(false);
       audioMuteButton.setEnabled(false);
     }
   }
@@ -177,6 +195,10 @@ public class WebRtcCallControls extends LinearLayout {
 
   public static interface MuteButtonListener {
     public void onToggle(boolean isMuted);
+  }
+
+  public static interface CameraFlipButtonListener {
+    public void onToggle(boolean isRear);
   }
 
   public static interface SpeakerButtonListener {

--- a/src/org/thoughtcrime/securesms/components/webrtc/WebRtcCallScreen.java
+++ b/src/org/thoughtcrime/securesms/components/webrtc/WebRtcCallScreen.java
@@ -154,6 +154,10 @@ public class WebRtcCallScreen extends FrameLayout implements RecipientModifiedLi
     this.controls.setVideoMuteButtonListener(listener);
   }
 
+  public void setCameraFlipButtonListener(WebRtcCallControls.CameraFlipButtonListener listener) {
+    this.controls.setCameraFlipButtonListener(listener);
+  }
+
   public void setSpeakerButtonListener(WebRtcCallControls.SpeakerButtonListener listener) {
     this.controls.setSpeakerButtonListener(listener);
   }

--- a/src/org/thoughtcrime/securesms/service/WebRtcCallService.java
+++ b/src/org/thoughtcrime/securesms/service/WebRtcCallService.java
@@ -116,6 +116,7 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
 
   public static final String EXTRA_REMOTE_ADDRESS     = "remote_address";
   public static final String EXTRA_MUTE               = "mute_value";
+  public static final String EXTRA_CAMERA_FLIP_REAR   = "camera_flip_rear_value";
   public static final String EXTRA_AVAILABLE          = "enabled_value";
   public static final String EXTRA_REMOTE_DESCRIPTION = "remote_description";
   public static final String EXTRA_TIMESTAMP          = "timestamp";
@@ -132,6 +133,7 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
   public static final String ACTION_LOCAL_HANGUP         = "LOCAL_HANGUP";
   public static final String ACTION_SET_MUTE_AUDIO       = "SET_MUTE_AUDIO";
   public static final String ACTION_SET_MUTE_VIDEO       = "SET_MUTE_VIDEO";
+  public static final String ACTION_SET_CAMERA_FLIP      = "SET_CAMERA_FLIP";
   public static final String ACTION_BLUETOOTH_CHANGE     = "BLUETOOTH_CHANGE";
   public static final String ACTION_WIRED_HEADSET_CHANGE = "WIRED_HEADSET_CHANGE";
   public static final String ACTION_SCREEN_OFF           = "SCREEN_OFF";
@@ -208,6 +210,7 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
       else if (intent.getAction().equals(ACTION_REMOTE_HANGUP))             handleRemoteHangup(intent);
       else if (intent.getAction().equals(ACTION_SET_MUTE_AUDIO))            handleSetMuteAudio(intent);
       else if (intent.getAction().equals(ACTION_SET_MUTE_VIDEO))            handleSetMuteVideo(intent);
+      else if (intent.getAction().equals(ACTION_SET_CAMERA_FLIP))           handleSetCameraFlip(intent);
       else if (intent.getAction().equals(ACTION_BLUETOOTH_CHANGE))          handleBluetoothChange(intent);
       else if (intent.getAction().equals(ACTION_WIRED_HEADSET_CHANGE))      handleWiredHeadsetChange(intent);
       else if (intent.getAction().equals((ACTION_SCREEN_OFF)))              handleScreenOffChange(intent);
@@ -802,6 +805,17 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
     }
 
     sendMessage(viewModelStateFor(callState), this.recipient, localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+  }
+
+  private void handleSetCameraFlip(Intent intent) {
+    boolean isRear = intent.getBooleanExtra(EXTRA_CAMERA_FLIP_REAR, false);
+    Log.w(TAG, "handleSetCameraFlip(isRear=" + isRear + ")...");
+
+    if (this.localVideoEnabled) {
+      if (this.peerConnection != null) {
+        this.peerConnection.flipCameras(isRear);
+      }
+    }
   }
 
   private void handleBluetoothChange(Intent intent) {


### PR DESCRIPTION
### First time contributor checklist

- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist

- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Motorola Moto X (ghost), Android 6.0.1
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

This adds a button to flip the camera (from front to rear) in video calls, in the same fashion as other video call apps have it, and as Signal already has it in its "take-and-send-a-photo" functionality (my change also reuses the same icon from that functionality).

This is a highly requested feature (see #6279 and its many duplicates). I took the time to implement it for my mother and my friends; until now we had a bad time when trying to show things to each other with Signal, because "turning the phone around" to film with the front camera means you can no longer see what you're filming.

I have tested it between my Moto X devices, seems to work quite well.

There are two possible improvements that I would like to discuss; the feature works fine without them but it would be nice to figure out if there's a better way:

* The video preview (on the sender's side) his horizontally flipped when using the back camera. This is a minor UX annoyance. Please let me know how I can flip it. It's the right way around on the receiver's side.
* In `PeerConnectionWrapper.java` I create an additional `VideoCapturer`, `VideoSource` and `VideoTrack` for the rear camera, in addition to the corresponding triple of those for the front camera. This is because I am not sure whether I can swap the underlying hardware device of a `VideoCapturer` at runtime, in which case one triple might be sufficient. Note that, as expected, only one triple is recording at any given time.