### PR TITLE
Show groups when searching for contacts.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -90,6 +90,7 @@
     <!-- ContactsCursorLoader -->
     <string name="ContactsCursorLoader_recent_chats">Recent chats</string>
     <string name="ContactsCursorLoader_contacts">Contacts</string>
+    <string name="ContactsCursorLoader_groups">Groups</string>
 
     <!-- ContactsDatabase -->
     <string name="ContactsDatabase_message_s">Message %s</string>

--- a/src/org/thoughtcrime/securesms/ContactSelectionActivity.java
+++ b/src/org/thoughtcrime/securesms/ContactSelectionActivity.java
@@ -23,6 +23,7 @@ import android.support.v4.widget.SwipeRefreshLayout;
 import android.util.Log;
 
 import org.thoughtcrime.securesms.components.ContactFilterToolbar;
+import org.thoughtcrime.securesms.contacts.ContactsCursorLoader.DisplayMode;
 import org.thoughtcrime.securesms.util.DirectoryHelper;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicNoActionBarTheme;
@@ -61,10 +62,9 @@ public abstract class ContactSelectionActivity extends PassphraseRequiredActionB
   @Override
   protected void onCreate(Bundle icicle, boolean ready) {
     if (!getIntent().hasExtra(ContactSelectionListFragment.DISPLAY_MODE)) {
-      getIntent().putExtra(ContactSelectionListFragment.DISPLAY_MODE,
-                           TextSecurePreferences.isSmsEnabled(this)
-                           ? ContactSelectionListFragment.DISPLAY_MODE_ALL
-                           : ContactSelectionListFragment.DISPLAY_MODE_PUSH_ONLY);
+      int displayMode = TextSecurePreferences.isSmsEnabled(this) ? DisplayMode.FLAG_ALL
+                                                                 : DisplayMode.FLAG_PUSH | DisplayMode.FLAG_GROUPS;
+      getIntent().putExtra(ContactSelectionListFragment.DISPLAY_MODE, displayMode);
     }
 
     setContentView(R.layout.contact_selection_activity);

--- a/src/org/thoughtcrime/securesms/ContactSelectionListFragment.java
+++ b/src/org/thoughtcrime/securesms/ContactSelectionListFragment.java
@@ -45,6 +45,7 @@ import org.thoughtcrime.securesms.components.RecyclerViewFastScroller;
 import org.thoughtcrime.securesms.contacts.ContactSelectionListAdapter;
 import org.thoughtcrime.securesms.contacts.ContactSelectionListItem;
 import org.thoughtcrime.securesms.contacts.ContactsCursorLoader;
+import org.thoughtcrime.securesms.contacts.ContactsCursorLoader.DisplayMode;
 import org.thoughtcrime.securesms.database.CursorRecyclerViewAdapter;
 import org.thoughtcrime.securesms.mms.GlideApp;
 import org.thoughtcrime.securesms.permissions.Permissions;
@@ -75,12 +76,7 @@ public class ContactSelectionListFragment extends    Fragment
   public static final String REFRESHABLE  = "refreshable";
   public static final String RECENTS      = "recents";
 
-  public final static int DISPLAY_MODE_ALL       = ContactsCursorLoader.MODE_ALL;
-  public final static int DISPLAY_MODE_PUSH_ONLY = ContactsCursorLoader.MODE_PUSH_ONLY;
-  public final static int DISPLAY_MODE_SMS_ONLY  = ContactsCursorLoader.MODE_SMS_ONLY;
-
-  private TextView emptyText;
-
+  private TextView                  emptyText;
   private Set<String>               selectedContacts;
   private OnContactSelectedListener onContactSelectedListener;
   private SwipeRefreshLayout        swipeRefresh;
@@ -221,7 +217,7 @@ public class ContactSelectionListFragment extends    Fragment
   @Override
   public Loader<Cursor> onCreateLoader(int id, Bundle args) {
     return new ContactsCursorLoader(getActivity(),
-                                    getActivity().getIntent().getIntExtra(DISPLAY_MODE, DISPLAY_MODE_ALL),
+                                    getActivity().getIntent().getIntExtra(DISPLAY_MODE, DisplayMode.FLAG_ALL),
                                     cursorFilter, getActivity().getIntent().getBooleanExtra(RECENTS, false));
   }
 

--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -44,6 +44,7 @@ import com.soundcloud.android.crop.Crop;
 
 import org.thoughtcrime.securesms.components.PushRecipientsPanel;
 import org.thoughtcrime.securesms.components.PushRecipientsPanel.RecipientsPanelChangedListener;
+import org.thoughtcrime.securesms.contacts.ContactsCursorLoader.DisplayMode;
 import org.thoughtcrime.securesms.contacts.RecipientsEditor;
 import org.thoughtcrime.securesms.contacts.avatars.ContactColors;
 import org.thoughtcrime.securesms.contacts.avatars.ResourceContactPhoto;
@@ -314,8 +315,11 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
     @Override
     public void onClick(View v) {
       Intent intent = new Intent(GroupCreateActivity.this, PushContactSelectionActivity.class);
-      if (groupToUpdate.isPresent()) intent.putExtra(ContactSelectionListFragment.DISPLAY_MODE,
-                                                     ContactSelectionListFragment.DISPLAY_MODE_PUSH_ONLY);
+      if (groupToUpdate.isPresent()) {
+        intent.putExtra(ContactSelectionListFragment.DISPLAY_MODE, DisplayMode.FLAG_PUSH);
+      } else {
+        intent.putExtra(ContactSelectionListFragment.DISPLAY_MODE, DisplayMode.FLAG_PUSH | DisplayMode.FLAG_SMS);
+      }
       startActivityForResult(intent, PICK_CONTACT);
     }
   }

--- a/src/org/thoughtcrime/securesms/InviteActivity.java
+++ b/src/org/thoughtcrime/securesms/InviteActivity.java
@@ -26,6 +26,7 @@ import android.widget.Toast;
 
 import org.thoughtcrime.securesms.components.ContactFilterToolbar;
 import org.thoughtcrime.securesms.components.ContactFilterToolbar.OnFilterChangedListener;
+import org.thoughtcrime.securesms.contacts.ContactsCursorLoader.DisplayMode;
 import org.thoughtcrime.securesms.database.Address;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.recipients.Recipient;
@@ -49,7 +50,7 @@ public class InviteActivity extends PassphraseRequiredActionBarActivity implemen
 
   @Override
   protected void onCreate(Bundle savedInstanceState, boolean ready) {
-    getIntent().putExtra(ContactSelectionListFragment.DISPLAY_MODE, ContactSelectionListFragment.DISPLAY_MODE_SMS_ONLY);
+    getIntent().putExtra(ContactSelectionListFragment.DISPLAY_MODE, DisplayMode.FLAG_SMS);
     getIntent().putExtra(ContactSelectionListFragment.MULTI_SELECT, true);
     getIntent().putExtra(ContactSelectionListFragment.REFRESHABLE, false);
 

--- a/src/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/org/thoughtcrime/securesms/ShareActivity.java
@@ -38,6 +38,8 @@ import android.view.View;
 import android.widget.ImageView;
 
 import org.thoughtcrime.securesms.components.SearchToolbar;
+import org.thoughtcrime.securesms.contacts.ContactsCursorLoader;
+import org.thoughtcrime.securesms.contacts.ContactsCursorLoader.DisplayMode;
 import org.thoughtcrime.securesms.database.Address;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.ThreadDatabase;
@@ -92,8 +94,8 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity
     if (!getIntent().hasExtra(ContactSelectionListFragment.DISPLAY_MODE)) {
       getIntent().putExtra(ContactSelectionListFragment.DISPLAY_MODE,
                            TextSecurePreferences.isSmsEnabled(this)
-                               ? ContactSelectionListFragment.DISPLAY_MODE_ALL
-                               : ContactSelectionListFragment.DISPLAY_MODE_PUSH_ONLY);
+                               ? DisplayMode.FLAG_ALL
+                               : DisplayMode.FLAG_PUSH | DisplayMode.FLAG_GROUPS);
     }
 
     getIntent().putExtra(ContactSelectionListFragment.REFRESHABLE, false);

--- a/src/org/thoughtcrime/securesms/database/GroupDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/GroupDatabase.java
@@ -22,6 +22,7 @@ import org.thoughtcrime.securesms.util.Util;
 import org.whispersystems.libsignal.util.guava.Optional;
 import org.whispersystems.signalservice.api.messages.SignalServiceAttachmentPointer;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -304,7 +305,7 @@ public class GroupDatabase extends Database {
     }
   }
 
-  public static class Reader {
+  public static class Reader implements Closeable {
 
     private final Cursor cursor;
 
@@ -338,6 +339,7 @@ public class GroupDatabase extends Database {
                              cursor.getInt(cursor.getColumnIndexOrThrow(MMS)) == 1);
     }
 
+    @Override
     public void close() {
       if (this.cursor != null)
         this.cursor.close();


### PR DESCRIPTION
Currently, if you're searching for a contact to start a conversation with or send a share to (via the Android sharing system), groups do not appear. With this change, groups will now appear when searching, located under their own  heading.

I also took the opportunity to clean up ContactsCursorLoader to increase readability, especially now that groups are thrown into the mix, which ups the complexity of the data that is returned.

[Demo Videos](https://github.com/signalapp/Signal-Android/files/1857177/groups-in-search.zip)

Fixes #7202.

**Test Cases**
* Groups show up in search when choosing a share recipient
* Groups show up in search when choosing a new conversation recipient
* Groups do not show up when adding a member to a group during group creation
* Groups do not show up when adding a member to an existing group
* SMS contacts do not show up when adding a member to an existing group, as before
* Whether or not SMS enabled is respected on all of the above use cases
* When groups show up, headings will appear based on the following logic:
  * If there are both groups and contacts, contacts will appear first under a "Contacts" heading, and groups will appear below all contacts under a "Groups" heading.
  * If there are no groups, there will be no headings -- only contacts.
  * If there are groups but no normal contacts, there will be no headings -- only groups.

**Test Devices**
* [Moto X (2nd Generation), Android 7.1](https://www.gsmarena.com/motorola_moto_x_(2nd_gen)-6649.php)