### PR TITLE
Fixed 'All Media' toolbar color mismatch.

### DIFF
--- a/res/layout/media_overview_activity.xml
+++ b/res/layout/media_overview_activity.xml
@@ -23,6 +23,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="top"
+                android:background="?attr/media_overview_toolbar_background"
                 app:tabBackground="?attr/media_overview_toolbar_background"
                 app:tabIndicatorColor="@color/textsecure_primary"
                 app:tabSelectedTextColor="@color/textsecure_primary"/>


### PR DESCRIPTION
In landscape, you'd see that the tabs were a different color from the toolbar. This has been corrected so they're all the same color now.

Fixes #7578

After fix:
![allmedia-tablayout-glitch](https://user-images.githubusercontent.com/37311915/38062319-244e5690-32a8-11e8-9248-59b0bef23c63.png)


**Test Cases**
* Displays correctly in both portrait and landscape
* Displays correctly in both dark mode and light mode

**Test Devices**
* [Moto X (2nd Generation), Android 7.1](https://www.gsmarena.com/motorola_moto_x_(2nd_gen)-6649.php)
* [Galaxy S3 Mini, Andoid 4.2.2](https://www.gsmarena.com/samsung_i8200_galaxy_s_iii_mini_ve-6190.php)

