### PR TITLE
Fixes #7458 - Fix failing tests that reference a master secret

### DIFF
--- a/test/unitTest/java/org/thoughtcrime/securesms/crypto/MasterCipherTest.java
+++ b/test/unitTest/java/org/thoughtcrime/securesms/crypto/MasterCipherTest.java
@@ -6,6 +6,8 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.thoughtcrime.securesms.BaseUnitTest;
 import org.whispersystems.libsignal.InvalidMessageException;
 
+import javax.crypto.spec.SecretKeySpec;
+
 @PowerMockIgnore("javax.crypto.*")
 public class MasterCipherTest extends BaseUnitTest {
   private MasterCipher masterCipher;
@@ -14,6 +16,8 @@ public class MasterCipherTest extends BaseUnitTest {
   @Override
   public void setUp() throws Exception {
     super.setUp();
+    MasterSecret masterSecret = new MasterSecret(new SecretKeySpec(new byte[16], "AES"),
+                                                 new SecretKeySpec(new byte[16], "HmacSHA1"));
     masterCipher = new MasterCipher(masterSecret);
   }
 

--- a/test/unitTest/java/org/thoughtcrime/securesms/jobs/AttachmentDownloadJobTest.java
+++ b/test/unitTest/java/org/thoughtcrime/securesms/jobs/AttachmentDownloadJobTest.java
@@ -26,7 +26,7 @@ public class AttachmentDownloadJobTest extends BaseUnitTest {
     when(attachment.getLocation()).thenReturn(null);
     when(attachment.getKey()).thenReturn("a long and acceptable valid key like we all want");
 
-    job.createAttachmentPointer(masterSecret, attachment);
+    job.createAttachmentPointer(attachment);
   }
 
   @Test(expected = InvalidPartException.class)
@@ -35,6 +35,6 @@ public class AttachmentDownloadJobTest extends BaseUnitTest {
     when(attachment.getLocation()).thenReturn("something");
     when(attachment.getKey()).thenReturn(null);
 
-    job.createAttachmentPointer(masterSecret, attachment);
+    job.createAttachmentPointer(attachment);
   }
 }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x ] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x ] My contribution is fully baked and ready to be merged as is
- [x ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

This PR fixes https://github.com/signalapp/Signal-Android/issues/7458.

That issue was caused because of the changes in [this commit](https://github.com/signalapp/Signal-Android/commits/3633d805c85f8e32a6fd326af553f3f23f369e3e) to remove `MasterSecret` from the golbal setup method for tests.