### PR TITLE
Add missing return to switch statement

### DIFF
--- a/src/org/thoughtcrime/securesms/components/RecyclerViewFastScroller.java
+++ b/src/org/thoughtcrime/securesms/components/RecyclerViewFastScroller.java
@@ -105,6 +105,7 @@ public class RecyclerViewFastScroller extends LinearLayout {
         showBubble();
       }
       handle.setSelected(true);
+      return true;
     case MotionEvent.ACTION_MOVE:
       final float y = event.getY();
       setBubbleAndHandlePosition(y / height);


### PR DESCRIPTION
Previously this would incorrectly fall through.  Found via
error-prone.