### PR TITLE
Allow copying of text from media messages.

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -201,6 +201,7 @@ public class ConversationFragment extends Fragment
   private void setCorrectMenuVisibility(Menu menu) {
     Set<MessageRecord> messageRecords = getListAdapter().getSelectedItems();
     boolean            actionMessage  = false;
+    boolean            hasText        = false;
 
     if (actionMode != null && messageRecords.size() == 0) {
       actionMode.finish();
@@ -214,6 +215,11 @@ public class ConversationFragment extends Fragment
           messageRecord.isIdentityVerified() || messageRecord.isIdentityDefault())
       {
         actionMessage = true;
+      }
+      if (messageRecord.getBody().length() > 0) {
+        hasText = true;
+      }
+      if (actionMessage && hasText) {
         break;
       }
     }
@@ -223,7 +229,6 @@ public class ConversationFragment extends Fragment
       menu.findItem(R.id.menu_context_details).setVisible(false);
       menu.findItem(R.id.menu_context_save_attachment).setVisible(false);
       menu.findItem(R.id.menu_context_resend).setVisible(false);
-      menu.findItem(R.id.menu_context_copy).setVisible(!actionMessage);
     } else {
       MessageRecord messageRecord = messageRecords.iterator().next();
 
@@ -235,8 +240,8 @@ public class ConversationFragment extends Fragment
 
       menu.findItem(R.id.menu_context_forward).setVisible(!actionMessage);
       menu.findItem(R.id.menu_context_details).setVisible(!actionMessage);
-      menu.findItem(R.id.menu_context_copy).setVisible(!actionMessage && messageRecord.getBody().length() > 0);
     }
+    menu.findItem(R.id.menu_context_copy).setVisible(!actionMessage && hasText);
   }
 
   private ConversationAdapter getListAdapter() {
@@ -286,16 +291,15 @@ public class ConversationFragment extends Fragment
 
     StringBuilder    bodyBuilder = new StringBuilder();
     ClipboardManager clipboard   = (ClipboardManager) getActivity().getSystemService(Context.CLIPBOARD_SERVICE);
-    boolean          first       = true;
 
     for (MessageRecord messageRecord : messageList) {
       String body = messageRecord.getDisplayBody().toString();
-
-      if (body != null) {
-        if (!first) bodyBuilder.append('\n');
-        bodyBuilder.append(body);
-        first = false;
+      if (!TextUtils.isEmpty(body)) {
+        bodyBuilder.append(body).append('\n');
       }
+    }
+    if (bodyBuilder.length() > 0 && bodyBuilder.charAt(bodyBuilder.length() - 1) == '\n') {
+      bodyBuilder.deleteCharAt(bodyBuilder.length() - 1);
     }
 
     String result = bodyBuilder.toString();

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -242,7 +242,7 @@ public class ConversationFragment extends Fragment
 
       menu.findItem(R.id.menu_context_forward).setVisible(!actionMessage);
       menu.findItem(R.id.menu_context_details).setVisible(!actionMessage);
-      menu.findItem(R.id.menu_context_copy).setVisible(!actionMessage && !mediaMessage);
+      menu.findItem(R.id.menu_context_copy).setVisible(!actionMessage && messageRecord.getBody().length() > 0);
     }
   }
 

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -201,7 +201,6 @@ public class ConversationFragment extends Fragment
   private void setCorrectMenuVisibility(Menu menu) {
     Set<MessageRecord> messageRecords = getListAdapter().getSelectedItems();
     boolean            actionMessage  = false;
-    boolean            mediaMessage  = false;
 
     if (actionMode != null && messageRecords.size() == 0) {
       actionMode.finish();
@@ -216,12 +215,6 @@ public class ConversationFragment extends Fragment
       {
         actionMessage = true;
         break;
-      } else if (messageRecord.isMms()              &&
-                 !messageRecord.isMmsNotification() &&
-                 ((MediaMmsMessageRecord)messageRecord).containsMediaSlide())
-      {
-        mediaMessage = true;
-        break;
       }
     }
 
@@ -230,7 +223,7 @@ public class ConversationFragment extends Fragment
       menu.findItem(R.id.menu_context_details).setVisible(false);
       menu.findItem(R.id.menu_context_save_attachment).setVisible(false);
       menu.findItem(R.id.menu_context_resend).setVisible(false);
-      menu.findItem(R.id.menu_context_copy).setVisible(!actionMessage  && !mediaMessage);
+      menu.findItem(R.id.menu_context_copy).setVisible(!actionMessage);
     } else {
       MessageRecord messageRecord = messageRecords.iterator().next();
 


### PR DESCRIPTION
Previously, the copy option was disabled for all media messages, even if they have text. This change enables the copy option for media messages that have text. Only the text is copied, not the media itself.

Fixes #7472.

**Test Cases**
* Copy regular message with text
* Copy option appears and copies text on media message with text
* Copy option does not appear on media message without text
* Sent media message with whitespace as the text -- whitespace is trimmed, no copy option appears after sending
* Copy option appears when multiple messages are selected, including media messages
* Copy multiple messages at once, including media messages both with and without text
  * Message with no text first, in the middle, and last -- verified pasted text had no extra newlines

**Test Devices**
* [OnePlus One, Android 5.0.2](https://www.gsmarena.com/oneplus_one-6327.php)


