### PR TITLE
Use FileProvider for update file handling

### DIFF
--- a/res/xml/file_provider_paths.xml
+++ b/res/xml/file_provider_paths.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
     <external-cache-path name="external_cache" path="." />
+    <external-files-path name="external_files" path="." />
 
     <external-path name="external_pictures" path="Pictures"/>
     <external-path name="external_video" path="Movies"/>

--- a/src/org/thoughtcrime/securesms/service/UpdateApkReadyListener.java
+++ b/src/org/thoughtcrime/securesms/service/UpdateApkReadyListener.java
@@ -14,6 +14,7 @@ import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 
 import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.util.FileProviderUtil;
 import org.thoughtcrime.securesms.util.FileUtils;
 import org.thoughtcrime.securesms.util.Hex;
 import org.thoughtcrime.securesms.util.ServiceUtil;
@@ -55,7 +56,7 @@ public class UpdateApkReadyListener extends BroadcastReceiver {
 
   private void displayInstallNotification(Context context, Uri uri) {
     Intent intent = new Intent(Intent.ACTION_VIEW);
-    intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_GRANT_READ_URI_PERMISSION);
     intent.setDataAndType(uri, "application/vnd.android.package-archive");
 
     PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, 0);
@@ -87,7 +88,7 @@ public class UpdateApkReadyListener extends BroadcastReceiver {
 
         if (localUri != null) {
           File   localFile = new File(Uri.parse(localUri).getPath());
-          return Uri.fromFile(localFile);
+          return FileProviderUtil.getUriFor(context, localFile);
         }
       }
     } finally {


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD, Android 8.1.0
 * AVD, Android 4.4.4
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Fixes #7654 

Sharing URIs betweens apps requires the use of a `FileProvider` when targeting API level >= 24. The auto-update routine for devices without play store currently tries to share the URI of the downloaded APK with the installer without using a `FileProvider`, hence it just crashes. This change extends the existing `FileProvider` to serve files from external-files-dir and lets the update routine use it.