### PR TITLE
Add IR to censored country code list

### DIFF
--- a/src/org/thoughtcrime/securesms/push/SignalServiceNetworkAccess.java
+++ b/src/org/thoughtcrime/securesms/push/SignalServiceNetworkAccess.java
@@ -26,6 +26,8 @@ public class SignalServiceNetworkAccess {
   private static final String COUNTRY_CODE_UAE   = "+971";
   private static final String COUNTRY_CODE_OMAN  = "+968";
   private static final String COUNTRY_CODE_QATAR = "+974";
+  private static final String COUNTRY_CODE_IRAN  = "+98";
+
 
   private static final String SERVICE_REFLECTOR_HOST = "textsecure-service-reflected.whispersystems.org";
 
@@ -62,6 +64,7 @@ public class SignalServiceNetworkAccess {
       put(COUNTRY_CODE_UAE, serviceConfig);
       put(COUNTRY_CODE_OMAN, serviceConfig);
       put(COUNTRY_CODE_QATAR, serviceConfig);
+      put(COUNTRY_CODE_IRAN, serviceConfig);
     }};
 
     this.uncensoredConfiguration = new SignalServiceConfiguration(new SignalServiceUrl[] {new SignalServiceUrl(BuildConfig.SIGNAL_URL, new SignalServiceTrustStore(context))},


### PR DESCRIPTION
Now that you've switched from Google meek, it makes sense to add +98 back to the list of country codes that should be using meek.

I tried to sign the cla but it gave me an error:
<img width="350" alt="signal-cla" src="https://user-images.githubusercontent.com/453701/38946690-c48d5372-4329-11e8-9d13-f2cc7277f424.png">