### PR TITLE
Render emoji's properly in quote bubbles.

### DIFF
--- a/res/layout/quote_view.xml
+++ b/res/layout/quote_view.xml
@@ -61,7 +61,7 @@
                     tools:text="Photo"
                     tools:visibility="visible" />
 
-                <TextView
+                <org.thoughtcrime.securesms.components.emoji.EmojiTextView
                     android:id="@+id/quote_text"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/src/org/thoughtcrime/securesms/util/ViewUtil.java
+++ b/src/org/thoughtcrime/securesms/util/ViewUtil.java
@@ -28,9 +28,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.view.ViewCompat;
 import android.support.v4.view.animation.FastOutSlowInInterpolator;
-import android.text.TextUtils;
-import android.text.TextUtils.TruncateAt;
-import android.util.DisplayMetrics;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -95,17 +92,6 @@ public class ViewUtil {
     int childIndex = parent.indexOfChild(toRemove);
     if (childIndex > -1) parent.removeView(toRemove);
     parent.addView(toAdd, childIndex > -1 ? childIndex : defaultIndex);
-  }
-
-  public static CharSequence ellipsize(@Nullable CharSequence text, @NonNull TextView view) {
-    if (TextUtils.isEmpty(text) || view.getWidth() == 0 || view.getEllipsize() != TruncateAt.END) {
-      return text;
-    } else {
-      return TextUtils.ellipsize(text,
-                                 view.getPaint(),
-                                 view.getWidth() - view.getPaddingRight() - view.getPaddingLeft(),
-                                 TruncateAt.END);
-    }
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
Unfortunately, the change wasn't as simple as just switching to use our EmojiTextView. That view only supported single-line text. I added support for multi-line text.

Fixes #7704.

![emojitextview-ellipsis](https://user-images.githubusercontent.com/37311915/39073466-ba66b29c-44a2-11e8-9f89-a3704355d2b6.png)


**Test Devices**
* [Galaxy S3 Mini, Android 4.2.2. API 17](https://www.gsmarena.com/samsung_i8200_galaxy_s_iii_mini_ve-6190.php)
* [Moto X (2nd Gen), Android 7.1, API 25](https://www.gsmarena.com/motorola_moto_x_(2nd_gen)-6649.php)
