### PR TITLE
Add placeholder icons for missing quote thumbnails.

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1924,11 +1924,11 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   public void onMediaSelected(@NonNull Uri uri, String contentType) {
     if (!TextUtils.isEmpty(contentType) && contentType.trim().equals("image/gif")) {
       setMedia(uri, MediaType.GIF);
-    } else if (MediaUtil.isImageType(contentType)) {
+    } else if (MediaUtil.isImage(contentType)) {
       setMedia(uri, MediaType.IMAGE);
-    } else if (MediaUtil.isVideoType(contentType)) {
+    } else if (MediaUtil.isVideo(contentType)) {
       setMedia(uri, MediaType.VIDEO);
-    } else if (MediaUtil.isAudioType(contentType)) {
+    } else if (MediaUtil.isAudio(contentType)) {
       setMedia(uri, MediaType.AUDIO);
     }
   }

--- a/src/org/thoughtcrime/securesms/database/AttachmentDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/AttachmentDatabase.java
@@ -735,7 +735,7 @@ public class AttachmentDatabase extends Database {
 
       ThumbnailData data = null;
 
-      if (MediaUtil.isVideoType(attachment.getContentType())) {
+      if (MediaUtil.isVideo(attachment.getContentType())) {
         data = generateVideoThumbnail(attachmentId);
       }
 

--- a/src/org/thoughtcrime/securesms/database/helpers/ClassicOpenHelper.java
+++ b/src/org/thoughtcrime/securesms/database/helpers/ClassicOpenHelper.java
@@ -336,9 +336,9 @@ public class ClassicOpenHelper extends SQLiteOpenHelper {
             } catch (IOException e) {
               Log.w("DatabaseFactory", e);
             }
-          } else if (MediaUtil.isAudioType(contentType) ||
-              MediaUtil.isImageType(contentType) ||
-              MediaUtil.isVideoType(contentType))
+          } else if (MediaUtil.isAudio(contentType) ||
+              MediaUtil.isImage(contentType) ||
+              MediaUtil.isVideo(contentType))
           {
             partCount++;
           }

--- a/src/org/thoughtcrime/securesms/jobs/PushSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushSendJob.java
@@ -27,8 +27,6 @@ import org.whispersystems.jobqueue.JobParameters;
 import org.whispersystems.jobqueue.requirements.NetworkRequirement;
 import org.whispersystems.libsignal.util.guava.Optional;
 import org.whispersystems.signalservice.api.messages.SignalServiceAttachment;
-import org.whispersystems.signalservice.api.messages.SignalServiceAttachmentPointer;
-import org.whispersystems.signalservice.api.messages.SignalServiceAttachmentStream;
 import org.whispersystems.signalservice.api.messages.SignalServiceDataMessage;
 import org.whispersystems.signalservice.api.push.SignalServiceAddress;
 
@@ -131,9 +129,9 @@ public abstract class PushSendJob extends SendJob {
       SignalServiceAttachment thumbnail     = null;
 
       try {
-        if (MediaUtil.isImageType(attachment.getContentType()) && attachment.getDataUri() != null) {
+        if (MediaUtil.isImage(attachment.getContentType()) && attachment.getDataUri() != null) {
           thumbnailData = BitmapUtil.createScaledBytes(context, new DecryptableStreamUriLoader.DecryptableUri(attachment.getDataUri()), 100, 100, 500 * 1024);
-        } else if (MediaUtil.isVideoType(attachment.getContentType()) && attachment.getThumbnailUri() != null) {
+        } else if (MediaUtil.isVideo(attachment.getContentType()) && attachment.getThumbnailUri() != null) {
           thumbnailData = BitmapUtil.createScaledBytes(context, new DecryptableStreamUriLoader.DecryptableUri(attachment.getThumbnailUri()), 100, 100, 500 * 1024);
         }
 

--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -535,9 +535,9 @@ public class AttachmentManager {
     public static @Nullable MediaType from(final @Nullable String mimeType) {
       if (TextUtils.isEmpty(mimeType))     return null;
       if (MediaUtil.isGif(mimeType))       return GIF;
-      if (MediaUtil.isImageType(mimeType)) return IMAGE;
-      if (MediaUtil.isAudioType(mimeType)) return AUDIO;
-      if (MediaUtil.isVideoType(mimeType)) return VIDEO;
+      if (MediaUtil.isImage(mimeType)) return IMAGE;
+      if (MediaUtil.isAudio(mimeType)) return AUDIO;
+      if (MediaUtil.isVideo(mimeType)) return VIDEO;
 
       return DOCUMENT;
     }

--- a/src/org/thoughtcrime/securesms/util/AttachmentUtil.java
+++ b/src/org/thoughtcrime/securesms/util/AttachmentUtil.java
@@ -63,9 +63,9 @@ public class AttachmentUtil {
 
   private static boolean isNonDocumentType(String contentType) {
     return
-        MediaUtil.isImageType(contentType) ||
-        MediaUtil.isVideoType(contentType) ||
-        MediaUtil.isAudioType(contentType);
+        MediaUtil.isImage(contentType) ||
+        MediaUtil.isVideo(contentType) ||
+        MediaUtil.isAudio(contentType);
   }
 
   private static @NonNull Set<String> getAllowedAutoDownloadTypes(@NonNull Context context) {

--- a/src/org/thoughtcrime/securesms/util/MediaUtil.java
+++ b/src/org/thoughtcrime/securesms/util/MediaUtil.java
@@ -3,13 +3,11 @@ package org.thoughtcrime.securesms.util;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.graphics.drawable.BitmapDrawable;
 import android.net.Uri;
 import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.WorkerThread;
-import android.support.media.ExifInterface;
 import android.text.TextUtils;
 import android.util.Log;
 import android.util.Pair;
@@ -52,11 +50,11 @@ public class MediaUtil {
     Slide slide = null;
     if (isGif(attachment.getContentType())) {
       slide = new GifSlide(context, attachment);
-    } else if (isImageType(attachment.getContentType())) {
+    } else if (isImage(attachment.getContentType())) {
       slide = new ImageSlide(context, attachment);
-    } else if (isVideoType(attachment.getContentType())) {
+    } else if (isVideo(attachment.getContentType())) {
       slide = new VideoSlide(context, attachment);
-    } else if (isAudioType(attachment.getContentType())) {
+    } else if (isAudio(attachment.getContentType())) {
       slide = new AudioSlide(context, attachment);
     } else if (isMms(attachment.getContentType())) {
       slide = new MmsSlide(context, attachment);
@@ -113,7 +111,7 @@ public class MediaUtil {
 
   @WorkerThread
   public static Pair<Integer, Integer> getDimensions(@NonNull Context context, @Nullable String contentType, @Nullable Uri uri) {
-    if (uri == null || !MediaUtil.isImageType(contentType)) {
+    if (uri == null || !MediaUtil.isImage(contentType)) {
       return new Pair<>(0, 0);
     }
 
@@ -137,7 +135,7 @@ public class MediaUtil {
     } else {
       InputStream attachmentStream = null;
       try {
-        if (MediaUtil.isJpegType(contentType)) {
+        if (MediaUtil.isJpeg(contentType)) {
           attachmentStream = PartAuthority.getAttachmentStream(context, uri);
           dimens = BitmapUtil.getExifDimensions(attachmentStream);
           attachmentStream.close();
@@ -174,56 +172,56 @@ public class MediaUtil {
     return !TextUtils.isEmpty(contentType) && contentType.trim().equals("application/mms");
   }
 
-  public static boolean isGif(Attachment attachment) {
-    return isGif(attachment.getContentType());
+  public static boolean isImage(@NonNull Attachment attachment) {
+    return isImage(attachment.getContentType());
   }
 
-  public static boolean isJpeg(Attachment attachment) {
-    return isJpegType(attachment.getContentType());
+  public static boolean isImage(@Nullable String contentType) {
+    return !TextUtils.isEmpty(contentType) && contentType.trim().startsWith("image/");
   }
 
-  public static boolean isImage(Attachment attachment) {
-    return isImageType(attachment.getContentType());
+  public static boolean isJpeg(@NonNull Attachment attachment) {
+    return isJpeg(attachment.getContentType());
   }
 
-  public static boolean isAudio(Attachment attachment) {
-    return isAudioType(attachment.getContentType());
-  }
-
-  public static boolean isVideo(Attachment attachment) {
-    return isVideoType(attachment.getContentType());
-  }
-
-  public static boolean isVideo(String contentType) {
-    return !TextUtils.isEmpty(contentType) && contentType.trim().startsWith("video/");
-  }
-
-  public static boolean isGif(String contentType) {
-    return !TextUtils.isEmpty(contentType) && contentType.trim().equals("image/gif");
-  }
-
-  public static boolean isJpegType(String contentType) {
+  public static boolean isJpeg(@Nullable String contentType) {
     return !TextUtils.isEmpty(contentType) && contentType.trim().equals(IMAGE_JPEG);
   }
 
-  public static boolean isFile(Attachment attachment) {
-    return !isGif(attachment) && !isImage(attachment) && !isAudio(attachment) && !isVideo(attachment);
+  public static boolean isGif(@NonNull Attachment attachment) {
+    return isGif(attachment.getContentType());
+  }
+
+  public static boolean isGif(@Nullable String contentType) {
+    return !TextUtils.isEmpty(contentType) && contentType.trim().equals(IMAGE_GIF);
+  }
+
+  public static boolean isAudio(@NonNull Attachment attachment) {
+    return isAudio(attachment.getContentType());
+  }
+
+  public static boolean isAudio(@Nullable String contentType) {
+    return !TextUtils.isEmpty(contentType) && contentType.trim().startsWith("audio/");
+  }
+
+  public static boolean isVideo(@NonNull Attachment attachment) {
+    return isVideo(attachment.getContentType());
+  }
+
+  public static boolean isVideo(@Nullable String contentType) {
+    return !TextUtils.isEmpty(contentType) && contentType.trim().startsWith("video/");
+  }
+
+  public static boolean isFile(@NonNull Attachment attachment) {
+    return isFile(attachment.getContentType());
+  }
+
+  public static boolean isFile(@Nullable String contentType) {
+    return !TextUtils.isEmpty(contentType) && !isGif(contentType) && !isImage(contentType) && !isAudio(contentType) && !isVideo(contentType);
   }
 
   public static boolean isTextType(String contentType) {
-    return (null != contentType) && contentType.startsWith("text/");
-  }
-
-  public static boolean isImageType(String contentType) {
-    return (null != contentType) && contentType.startsWith("image/");
-  }
-
-  public static boolean isAudioType(String contentType) {
-    return (null != contentType) && contentType.startsWith("audio/");
-  }
-
-  public static boolean isVideoType(String contentType) {
-    return (null != contentType) && contentType.startsWith("video/");
+    return !TextUtils.isEmpty(contentType) && contentType.trim().startsWith("text/");
   }
 
   public static boolean hasVideoThumbnail(Uri uri) {


### PR DESCRIPTION
This PR puts in placeholder icons for quote thumbnails when they're not available. Also, for image attachments, if a thumbnail URI is not available, we'll first fallback to using the URI of the image itself before falling back to a placeholder icon.

Along the way, I did a small naming refactor for MediaUtil methods so that all of the names were consistent, and I also ended up refactoring how we set thumbnails/icons in QuoteView.

![quote-thumbnail-placeholders](https://user-images.githubusercontent.com/37311915/39152251-96bd795a-46fc-11e8-86fd-c2969c04ed53.png)

**Test Devices**
* [Moto X (2nd Gen), Android 7.1, API 25](https://www.gsmarena.com/motorola_moto_x_(2nd_gen)-6649.php)
* [Galaxy S3 Mini, Android 4.2.2. API 17](https://www.gsmarena.com/samsung_i8200_galaxy_s_iii_mini_ve-6190.php)

