### PR TITLE
Specify sleep timing method for the websocket

### DIFF
--- a/src/org/thoughtcrime/securesms/dependencies/SignalCommunicationModule.java
+++ b/src/org/thoughtcrime/securesms/dependencies/SignalCommunicationModule.java
@@ -45,6 +45,8 @@ import org.whispersystems.signalservice.api.SignalServiceAccountManager;
 import org.whispersystems.signalservice.api.SignalServiceMessageReceiver;
 import org.whispersystems.signalservice.api.SignalServiceMessageSender;
 import org.whispersystems.signalservice.api.util.CredentialsProvider;
+import org.whispersystems.signalservice.api.util.UptimeSleepTimer;
+import org.whispersystems.signalservice.api.util.RealtimeSleepTimer;
 import org.whispersystems.signalservice.api.websocket.ConnectivityListener;
 
 import dagger.Module;
@@ -128,7 +130,10 @@ public class SignalCommunicationModule {
       this.messageReceiver = new SignalServiceMessageReceiver(networkAccess.getConfiguration(context),
                                                               new DynamicCredentialsProvider(context),
                                                               BuildConfig.USER_AGENT,
-                                                              new PipeConnectivityListener());
+                                                              new PipeConnectivityListener(),
+                                                              TextSecurePreferences.isGcmDisabled(context) ?
+                                                              new RealtimeSleepTimer(context) :
+                                                              new UptimeSleepTimer());
     }
 
     return this.messageReceiver;


### PR DESCRIPTION
Specify sleep timing method for the websocket's keep-alive sender,
based on whether GCM is disabled.

Fixes #6644
// FREEBIE

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Xiaomi Mi 4, Android 7.1.2 (LineageOS 14.1, w/o GCM support)
 * Motorola Moto G3, Android 7.1.2 (LineageOS 14.1, w/o GCM support)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
See its accompanying PR signalapp/libsignal-service-java#53 for more details.  This might be related to and partially or completely fix #7638, but the supplied log doesn't allow me to confirm this and the discussion makes me suspect it might alse be related to a different problem.  I'm therefore didn't mention it in the commit message.