### PR TITLE
Allow switching your camera in video calls.

### DIFF
--- a/res/drawable/webrtc_camera_flip_button.xml
+++ b/res/drawable/webrtc_camera_flip_button.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/webrtc_control_background"/>
+    <item android:top="5dp"
+          android:left="5dp"
+          android:right="5dp"
+          android:bottom="5dp"
+          android:drawable="@drawable/quick_camera_rear"/>
+</layer-list>

--- a/res/drawable/webrtc_camera_front_button.xml
+++ b/res/drawable/webrtc_camera_front_button.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:top="5dp"
+          android:left="5dp"
+          android:right="5dp"
+          android:bottom="5dp"
+          android:drawable="@drawable/quick_camera_front"/>
+</layer-list>

--- a/res/drawable/webrtc_camera_rear_button.xml
+++ b/res/drawable/webrtc_camera_rear_button.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@drawable/webrtc_control_background"/>
     <item android:top="5dp"
           android:left="5dp"
           android:right="5dp"

--- a/res/layout/webrtc_call_controls.xml
+++ b/res/layout/webrtc_call_controls.xml
@@ -34,6 +34,13 @@
         <org.thoughtcrime.securesms.components.AccessibleToggleButton
                 android:id="@+id/video_mute_button"
                 style="@style/WebRtcCallCompoundButton"
+                android:layout_marginRight="15dp"
                 android:background="@drawable/webrtc_video_mute_button"/>
+
+        <org.thoughtcrime.securesms.components.AccessibleToggleButton
+                android:id="@+id/camera_flip_button"
+                style="@style/WebRtcCallCompoundButton"
+                android:contentDescription="@string/redphone_call_controls__flip_camera_rear"
+                android:background="@drawable/webrtc_camera_flip_button"/>
 
 </merge>

--- a/res/layout/webrtc_call_controls.xml
+++ b/res/layout/webrtc_call_controls.xml
@@ -41,6 +41,7 @@
                 android:id="@+id/camera_flip_button"
                 style="@style/WebRtcCallCompoundButton"
                 android:contentDescription="@string/redphone_call_controls__flip_camera_rear"
-                android:background="@drawable/webrtc_camera_flip_button"/>
+                android:background="@drawable/webrtc_camera_rear_button"
+                android:visibility="gone"/>
 
 </merge>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -991,6 +991,7 @@
     <!--- redphone_call_controls -->
     <string name="redphone_call_card__signal_call">Signal Call</string>
     <string name="redphone_call_controls__mute">Mute</string>
+    <string name="redphone_call_controls__flip_camera_rear">Use rear camera</string>
     <string name="redphone_call_controls__signal_call">Signal Call</string>
 
     <!-- registration_activity -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -991,7 +991,7 @@
     <!--- redphone_call_controls -->
     <string name="redphone_call_card__signal_call">Signal Call</string>
     <string name="redphone_call_controls__mute">Mute</string>
-    <string name="redphone_call_controls__flip_camera_rear">Use rear camera</string>
+    <string name="redphone_call_controls__flip_camera_rear">Switch Cameras</string>
     <string name="redphone_call_controls__signal_call">Signal Call</string>
 
     <!-- registration_activity -->

--- a/src/org/thoughtcrime/securesms/WebRtcCallActivity.java
+++ b/src/org/thoughtcrime/securesms/WebRtcCallActivity.java
@@ -139,6 +139,7 @@ public class WebRtcCallActivity extends Activity {
     callScreen.setIncomingCallActionListener(new IncomingCallActionListener());
     callScreen.setAudioMuteButtonListener(new AudioMuteButtonListener());
     callScreen.setVideoMuteButtonListener(new VideoMuteButtonListener());
+    callScreen.setCameraFlipButtonListener(new CameraFlipButtonListener());
     callScreen.setSpeakerButtonListener(new SpeakerButtonListener());
     callScreen.setBluetoothButtonListener(new BluetoothButtonListener());
 
@@ -156,6 +157,13 @@ public class WebRtcCallActivity extends Activity {
     Intent intent = new Intent(this, WebRtcCallService.class);
     intent.setAction(WebRtcCallService.ACTION_SET_MUTE_VIDEO);
     intent.putExtra(WebRtcCallService.EXTRA_MUTE, muted);
+    startService(intent);
+  }
+
+  private void handleSetCameraFlip(boolean isRear) {
+    Intent intent = new Intent(this, WebRtcCallService.class);
+    intent.setAction(WebRtcCallService.ACTION_SET_CAMERA_FLIP);
+    intent.putExtra(WebRtcCallService.EXTRA_CAMERA_FLIP_REAR, isRear);
     startService(intent);
   }
 
@@ -346,6 +354,11 @@ public class WebRtcCallActivity extends Activity {
     public void onToggle(boolean isMuted) {
       WebRtcCallActivity.this.handleSetMuteVideo(isMuted);
     }
+  }
+
+  private class CameraFlipButtonListener implements WebRtcCallControls.CameraFlipButtonListener {
+    @Override
+    public void onToggle(boolean isRear) { WebRtcCallActivity.this.handleSetCameraFlip(isRear); }
   }
 
   private class SpeakerButtonListener implements WebRtcCallControls.SpeakerButtonListener {

--- a/src/org/thoughtcrime/securesms/WebRtcCallActivity.java
+++ b/src/org/thoughtcrime/securesms/WebRtcCallActivity.java
@@ -49,6 +49,7 @@ import org.thoughtcrime.securesms.service.WebRtcCallService;
 import org.thoughtcrime.securesms.util.ServiceUtil;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.util.ViewUtil;
+import org.thoughtcrime.securesms.webrtc.CameraState;
 import org.whispersystems.libsignal.IdentityKey;
 import org.whispersystems.libsignal.SignalProtocolAddress;
 
@@ -160,10 +161,9 @@ public class WebRtcCallActivity extends Activity {
     startService(intent);
   }
 
-  private void handleSetCameraFlip(boolean isRear) {
+  private void handleFlipCamera() {
     Intent intent = new Intent(this, WebRtcCallService.class);
-    intent.setAction(WebRtcCallService.ACTION_SET_CAMERA_FLIP);
-    intent.putExtra(WebRtcCallService.EXTRA_CAMERA_FLIP_REAR, isRear);
+    intent.setAction(WebRtcCallService.ACTION_FLIP_CAMERA);
     startService(intent);
   }
 
@@ -330,10 +330,10 @@ public class WebRtcCallActivity extends Activity {
       case UNTRUSTED_IDENTITY:      handleUntrustedIdentity(event);        break;
     }
 
-    callScreen.setLocalVideoEnabled(event.isLocalVideoEnabled());
     callScreen.setRemoteVideoEnabled(event.isRemoteVideoEnabled());
     callScreen.updateAudioState(event.isBluetoothAvailable(), event.isMicrophoneEnabled());
     callScreen.setControlsEnabled(event.getState() != WebRtcViewModel.State.CALL_INCOMING);
+    callScreen.setLocalVideoState(event.getLocalCameraState());
   }
 
   private class HangupButtonListener implements WebRtcCallScreen.HangupButtonListener {
@@ -358,7 +358,9 @@ public class WebRtcCallActivity extends Activity {
 
   private class CameraFlipButtonListener implements WebRtcCallControls.CameraFlipButtonListener {
     @Override
-    public void onToggle(boolean isRear) { WebRtcCallActivity.this.handleSetCameraFlip(isRear); }
+    public void onToggle() {
+      WebRtcCallActivity.this.handleFlipCamera();
+    }
   }
 
   private class SpeakerButtonListener implements WebRtcCallControls.SpeakerButtonListener {

--- a/src/org/thoughtcrime/securesms/components/webrtc/WebRtcCallControls.java
+++ b/src/org/thoughtcrime/securesms/components/webrtc/WebRtcCallControls.java
@@ -27,6 +27,7 @@ public class WebRtcCallControls extends LinearLayout {
 
   private AccessibleToggleButton audioMuteButton;
   private AccessibleToggleButton videoMuteButton;
+  private AccessibleToggleButton cameraFlipButton;
   private AccessibleToggleButton speakerButton;
   private AccessibleToggleButton bluetoothButton;
 
@@ -60,6 +61,8 @@ public class WebRtcCallControls extends LinearLayout {
     this.bluetoothButton = ViewUtil.findById(this, R.id.bluetoothButton);
     this.audioMuteButton = ViewUtil.findById(this, R.id.muteButton);
     this.videoMuteButton = ViewUtil.findById(this, R.id.video_mute_button);
+    this.cameraFlipButton = ViewUtil.findById(this, R.id.camera_flip_button);
+    this.cameraFlipButton.setVisibility(View.INVISIBLE); // shown once video is enabled
   }
 
   public void setAudioMuteButtonListener(final MuteButtonListener listener) {
@@ -75,7 +78,18 @@ public class WebRtcCallControls extends LinearLayout {
     videoMuteButton.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
       @Override
       public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-        listener.onToggle(!isChecked);
+        boolean videoMuted = !isChecked;
+        listener.onToggle(videoMuted);
+        cameraFlipButton.setVisibility(videoMuted ? View.INVISIBLE : View.VISIBLE);
+      }
+    });
+  }
+
+  public void setCameraFlipButtonListener(final CameraFlipButtonListener listener) {
+    cameraFlipButton.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+      @Override
+      public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+        listener.onToggle(isChecked);
       }
     });
   }
@@ -138,21 +152,25 @@ public class WebRtcCallControls extends LinearLayout {
       speakerButton.setAlpha(1.0f);
       bluetoothButton.setAlpha(1.0f);
       videoMuteButton.setAlpha(1.0f);
+      cameraFlipButton.setAlpha(1.0f);
       audioMuteButton.setAlpha(1.0f);
 
       speakerButton.setEnabled(true);
       bluetoothButton.setEnabled(true);
       videoMuteButton.setEnabled(true);
+      cameraFlipButton.setEnabled(true);
       audioMuteButton.setEnabled(true);
     } else if (!enabled && Build.VERSION.SDK_INT >= 11) {
       speakerButton.setAlpha(0.3f);
       bluetoothButton.setAlpha(0.3f);
       videoMuteButton.setAlpha(0.3f);
+      cameraFlipButton.setAlpha(0.3f);
       audioMuteButton.setAlpha(0.3f);
       
       speakerButton.setEnabled(false);
       bluetoothButton.setEnabled(false);
       videoMuteButton.setEnabled(false);
+      cameraFlipButton.setEnabled(false);
       audioMuteButton.setEnabled(false);
     }
   }
@@ -177,6 +195,10 @@ public class WebRtcCallControls extends LinearLayout {
 
   public static interface MuteButtonListener {
     public void onToggle(boolean isMuted);
+  }
+
+  public static interface CameraFlipButtonListener {
+    public void onToggle(boolean isRear);
   }
 
   public static interface SpeakerButtonListener {

--- a/src/org/thoughtcrime/securesms/components/webrtc/WebRtcCallControls.java
+++ b/src/org/thoughtcrime/securesms/components/webrtc/WebRtcCallControls.java
@@ -5,8 +5,8 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.media.AudioManager;
 import android.os.Build;
+import android.support.annotation.NonNull;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -20,6 +20,7 @@ import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.AccessibleToggleButton;
 import org.thoughtcrime.securesms.util.ServiceUtil;
 import org.thoughtcrime.securesms.util.ViewUtil;
+import org.thoughtcrime.securesms.webrtc.CameraState;
 
 public class WebRtcCallControls extends LinearLayout {
 
@@ -27,9 +28,10 @@ public class WebRtcCallControls extends LinearLayout {
 
   private AccessibleToggleButton audioMuteButton;
   private AccessibleToggleButton videoMuteButton;
-  private AccessibleToggleButton cameraFlipButton;
   private AccessibleToggleButton speakerButton;
   private AccessibleToggleButton bluetoothButton;
+  private AccessibleToggleButton cameraFlipButton;
+  private boolean                cameraFlipAvailable;
 
   @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   public WebRtcCallControls(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
@@ -62,7 +64,6 @@ public class WebRtcCallControls extends LinearLayout {
     this.audioMuteButton = ViewUtil.findById(this, R.id.muteButton);
     this.videoMuteButton = ViewUtil.findById(this, R.id.video_mute_button);
     this.cameraFlipButton = ViewUtil.findById(this, R.id.camera_flip_button);
-    this.cameraFlipButton.setVisibility(View.INVISIBLE); // shown once video is enabled
   }
 
   public void setAudioMuteButtonListener(final MuteButtonListener listener) {
@@ -80,7 +81,7 @@ public class WebRtcCallControls extends LinearLayout {
       public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
         boolean videoMuted = !isChecked;
         listener.onToggle(videoMuted);
-        cameraFlipButton.setVisibility(videoMuted ? View.INVISIBLE : View.VISIBLE);
+        cameraFlipButton.setVisibility(!videoMuted && cameraFlipAvailable ? View.VISIBLE : View.GONE);
       }
     });
   }
@@ -89,7 +90,10 @@ public class WebRtcCallControls extends LinearLayout {
     cameraFlipButton.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
       @Override
       public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-        listener.onToggle(isChecked);
+        listener.onToggle();
+        cameraFlipButton.setBackgroundResource(isChecked ? R.drawable.webrtc_camera_front_button
+                                                         : R.drawable.webrtc_camera_rear_button);
+        cameraFlipButton.setEnabled(false);
       }
     });
   }
@@ -143,40 +147,46 @@ public class WebRtcCallControls extends LinearLayout {
     videoMuteButton.setChecked(enabled, false);
   }
 
+  public void setVideoAvailable(boolean available) {
+    videoMuteButton.setVisibility(available ? VISIBLE : GONE);
+  }
+
+  public void setCameraFlipButtonEnabled(boolean enabled) {
+    cameraFlipButton.setChecked(enabled, false);
+  }
+
+  public void setCameraFlipAvailable(boolean available) {
+    cameraFlipAvailable = available;
+  }
+
+  public void setCameraFlipClickable(boolean clickable) {
+    setControlEnabled(cameraFlipButton, clickable);
+  }
+
   public void setMicrophoneEnabled(boolean enabled) {
     audioMuteButton.setChecked(!enabled, false);
   }
 
   public void setControlsEnabled(boolean enabled) {
-    if (enabled && Build.VERSION.SDK_INT >= 11) {
-      speakerButton.setAlpha(1.0f);
-      bluetoothButton.setAlpha(1.0f);
-      videoMuteButton.setAlpha(1.0f);
-      cameraFlipButton.setAlpha(1.0f);
-      audioMuteButton.setAlpha(1.0f);
+    setControlEnabled(speakerButton, enabled);
+    setControlEnabled(bluetoothButton, enabled);
+    setControlEnabled(videoMuteButton, enabled);
+    setControlEnabled(cameraFlipButton, enabled);
+    setControlEnabled(audioMuteButton, enabled);
+  }
 
-      speakerButton.setEnabled(true);
-      bluetoothButton.setEnabled(true);
-      videoMuteButton.setEnabled(true);
-      cameraFlipButton.setEnabled(true);
-      audioMuteButton.setEnabled(true);
-    } else if (!enabled && Build.VERSION.SDK_INT >= 11) {
-      speakerButton.setAlpha(0.3f);
-      bluetoothButton.setAlpha(0.3f);
-      videoMuteButton.setAlpha(0.3f);
-      cameraFlipButton.setAlpha(0.3f);
-      audioMuteButton.setAlpha(0.3f);
-      
-      speakerButton.setEnabled(false);
-      bluetoothButton.setEnabled(false);
-      videoMuteButton.setEnabled(false);
-      cameraFlipButton.setEnabled(false);
-      audioMuteButton.setEnabled(false);
+  private void setControlEnabled(@NonNull View view, boolean enabled) {
+    if (enabled) {
+      view.setAlpha(1.0f);
+      view.setEnabled(true);
+    } else {
+      view.setAlpha(0.3f);
+      view.setEnabled(false);
     }
   }
 
   public void displayVideoTooltip(ViewGroup viewGroup) {
-    if (Build.VERSION.SDK_INT > 15) {
+    if (Build.VERSION.SDK_INT > 15 && videoMuteButton.getVisibility() == VISIBLE) {
       final ToolTipsManager toolTipsManager = new ToolTipsManager();
 
       ToolTip toolTip = new ToolTip.Builder(getContext(), videoMuteButton, viewGroup,
@@ -184,12 +194,7 @@ public class WebRtcCallControls extends LinearLayout {
                                             ToolTip.POSITION_BELOW).build();
       toolTipsManager.show(toolTip);
 
-      videoMuteButton.postDelayed(new Runnable() {
-        @Override
-        public void run() {
-          toolTipsManager.findAndDismiss(videoMuteButton);
-        }
-      }, 4000);
+      videoMuteButton.postDelayed(() -> toolTipsManager.findAndDismiss(videoMuteButton), 4000);
     }
   }
 
@@ -198,7 +203,7 @@ public class WebRtcCallControls extends LinearLayout {
   }
 
   public static interface CameraFlipButtonListener {
-    public void onToggle(boolean isRear);
+    public void onToggle();
   }
 
   public static interface SpeakerButtonListener {

--- a/src/org/thoughtcrime/securesms/components/webrtc/WebRtcCallScreen.java
+++ b/src/org/thoughtcrime/securesms/components/webrtc/WebRtcCallScreen.java
@@ -154,6 +154,10 @@ public class WebRtcCallScreen extends FrameLayout implements RecipientModifiedLi
     this.controls.setVideoMuteButtonListener(listener);
   }
 
+  public void setCameraFlipButtonListener(WebRtcCallControls.CameraFlipButtonListener listener) {
+    this.controls.setCameraFlipButtonListener(listener);
+  }
+
   public void setSpeakerButtonListener(WebRtcCallControls.SpeakerButtonListener listener) {
     this.controls.setSpeakerButtonListener(listener);
   }

--- a/src/org/thoughtcrime/securesms/events/WebRtcViewModel.java
+++ b/src/org/thoughtcrime/securesms/events/WebRtcViewModel.java
@@ -4,6 +4,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import org.thoughtcrime.securesms.recipients.Recipient;
+import org.thoughtcrime.securesms.webrtc.CameraState;
 import org.whispersystems.libsignal.IdentityKey;
 
 public class WebRtcViewModel {
@@ -30,29 +31,40 @@ public class WebRtcViewModel {
   private final @Nullable IdentityKey identityKey;
 
   private final boolean remoteVideoEnabled;
-  private final boolean localVideoEnabled;
 
   private final boolean isBluetoothAvailable;
   private final boolean isMicrophoneEnabled;
 
-  public WebRtcViewModel(@NonNull State state, @NonNull Recipient recipient,
-                         boolean localVideoEnabled, boolean remoteVideoEnabled,
-                         boolean isBluetoothAvailable, boolean isMicrophoneEnabled)
+  private final CameraState localCameraState;
+
+  public WebRtcViewModel(@NonNull State       state,
+                         @NonNull Recipient   recipient,
+                         @NonNull CameraState localCameraState,
+                                  boolean     remoteVideoEnabled,
+                                  boolean     isBluetoothAvailable,
+                                  boolean     isMicrophoneEnabled)
   {
-    this(state, recipient, null,
-         localVideoEnabled, remoteVideoEnabled,
-         isBluetoothAvailable, isMicrophoneEnabled);
+    this(state,
+         recipient,
+         null,
+         localCameraState,
+         remoteVideoEnabled,
+         isBluetoothAvailable,
+         isMicrophoneEnabled);
   }
 
-  public WebRtcViewModel(@NonNull State state, @NonNull Recipient recipient,
+  public WebRtcViewModel(@NonNull  State       state,
+                         @NonNull  Recipient   recipient,
                          @Nullable IdentityKey identityKey,
-                         boolean localVideoEnabled, boolean remoteVideoEnabled,
-                         boolean isBluetoothAvailable, boolean isMicrophoneEnabled)
+                         @NonNull  CameraState localCameraState,
+                                   boolean     remoteVideoEnabled,
+                                   boolean     isBluetoothAvailable,
+                                   boolean     isMicrophoneEnabled)
   {
     this.state                = state;
     this.recipient            = recipient;
+    this.localCameraState     = localCameraState;
     this.identityKey          = identityKey;
-    this.localVideoEnabled    = localVideoEnabled;
     this.remoteVideoEnabled   = remoteVideoEnabled;
     this.isBluetoothAvailable = isBluetoothAvailable;
     this.isMicrophoneEnabled  = isMicrophoneEnabled;
@@ -66,17 +78,16 @@ public class WebRtcViewModel {
     return recipient;
   }
 
-  @Nullable
-  public IdentityKey getIdentityKey() {
+  public @NonNull CameraState getLocalCameraState() {
+    return localCameraState;
+  }
+
+  public @Nullable IdentityKey getIdentityKey() {
     return identityKey;
   }
 
   public boolean isRemoteVideoEnabled() {
     return remoteVideoEnabled;
-  }
-
-  public boolean isLocalVideoEnabled() {
-    return localVideoEnabled;
   }
 
   public boolean isBluetoothAvailable() {
@@ -87,7 +98,8 @@ public class WebRtcViewModel {
     return isMicrophoneEnabled;
   }
 
+
   public String toString() {
-    return "[State: " + state + ", recipient: " + recipient.getAddress() + ", identity: " + identityKey + ", remoteVideo: " + remoteVideoEnabled + ", localVideo: " + localVideoEnabled + "]";
+    return "[State: " + state + ", recipient: " + recipient.getAddress() + ", identity: " + identityKey + ", remoteVideo: " + remoteVideoEnabled + ", localVideo: " + localCameraState.isEnabled() + "]";
   }
 }

--- a/src/org/thoughtcrime/securesms/service/WebRtcCallService.java
+++ b/src/org/thoughtcrime/securesms/service/WebRtcCallService.java
@@ -116,6 +116,7 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
 
   public static final String EXTRA_REMOTE_ADDRESS     = "remote_address";
   public static final String EXTRA_MUTE               = "mute_value";
+  public static final String EXTRA_CAMERA_FLIP_REAR   = "camera_flip_rear_value";
   public static final String EXTRA_AVAILABLE          = "enabled_value";
   public static final String EXTRA_REMOTE_DESCRIPTION = "remote_description";
   public static final String EXTRA_TIMESTAMP          = "timestamp";
@@ -132,6 +133,7 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
   public static final String ACTION_LOCAL_HANGUP         = "LOCAL_HANGUP";
   public static final String ACTION_SET_MUTE_AUDIO       = "SET_MUTE_AUDIO";
   public static final String ACTION_SET_MUTE_VIDEO       = "SET_MUTE_VIDEO";
+  public static final String ACTION_SET_CAMERA_FLIP      = "SET_CAMERA_FLIP";
   public static final String ACTION_BLUETOOTH_CHANGE     = "BLUETOOTH_CHANGE";
   public static final String ACTION_WIRED_HEADSET_CHANGE = "WIRED_HEADSET_CHANGE";
   public static final String ACTION_SCREEN_OFF           = "SCREEN_OFF";
@@ -208,6 +210,7 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
       else if (intent.getAction().equals(ACTION_REMOTE_HANGUP))             handleRemoteHangup(intent);
       else if (intent.getAction().equals(ACTION_SET_MUTE_AUDIO))            handleSetMuteAudio(intent);
       else if (intent.getAction().equals(ACTION_SET_MUTE_VIDEO))            handleSetMuteVideo(intent);
+      else if (intent.getAction().equals(ACTION_SET_CAMERA_FLIP))           handleSetCameraFlip(intent);
       else if (intent.getAction().equals(ACTION_BLUETOOTH_CHANGE))          handleBluetoothChange(intent);
       else if (intent.getAction().equals(ACTION_WIRED_HEADSET_CHANGE))      handleWiredHeadsetChange(intent);
       else if (intent.getAction().equals((ACTION_SCREEN_OFF)))              handleScreenOffChange(intent);
@@ -802,6 +805,17 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
     }
 
     sendMessage(viewModelStateFor(callState), this.recipient, localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+  }
+
+  private void handleSetCameraFlip(Intent intent) {
+    boolean isRear = intent.getBooleanExtra(EXTRA_CAMERA_FLIP_REAR, false);
+    Log.w(TAG, "handleSetCameraFlip(isRear=" + isRear + ")...");
+
+    if (this.localVideoEnabled) {
+      if (this.peerConnection != null) {
+        this.peerConnection.flipCameras(isRear);
+      }
+    }
   }
 
   private void handleBluetoothChange(Intent intent) {

--- a/src/org/thoughtcrime/securesms/service/WebRtcCallService.java
+++ b/src/org/thoughtcrime/securesms/service/WebRtcCallService.java
@@ -30,7 +30,6 @@ import org.thoughtcrime.securesms.WebRtcCallActivity;
 import org.thoughtcrime.securesms.contacts.ContactAccessor;
 import org.thoughtcrime.securesms.database.Address;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
-import org.thoughtcrime.securesms.database.RecipientDatabase;
 import org.thoughtcrime.securesms.database.RecipientDatabase.VibrateState;
 import org.thoughtcrime.securesms.dependencies.InjectableType;
 import org.thoughtcrime.securesms.events.WebRtcViewModel;
@@ -43,6 +42,7 @@ import org.thoughtcrime.securesms.util.ServiceUtil;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.webrtc.CallNotificationBuilder;
+import org.thoughtcrime.securesms.webrtc.CameraState;
 import org.thoughtcrime.securesms.webrtc.IncomingPstnCallReceiver;
 import org.thoughtcrime.securesms.webrtc.PeerConnectionFactoryOptions;
 import org.thoughtcrime.securesms.webrtc.PeerConnectionWrapper;
@@ -104,7 +104,12 @@ import static org.thoughtcrime.securesms.webrtc.CallNotificationBuilder.TYPE_INC
 import static org.thoughtcrime.securesms.webrtc.CallNotificationBuilder.TYPE_INCOMING_RINGING;
 import static org.thoughtcrime.securesms.webrtc.CallNotificationBuilder.TYPE_OUTGOING_RINGING;
 
-public class WebRtcCallService extends Service implements InjectableType, PeerConnection.Observer, DataChannel.Observer, BluetoothStateManager.BluetoothStateListener {
+public class WebRtcCallService extends Service implements InjectableType,
+                                                          PeerConnection.Observer,
+                                                          DataChannel.Observer,
+                                                          BluetoothStateManager.BluetoothStateListener,
+                                                          PeerConnectionWrapper.CameraEventListener
+{
 
   private static final String TAG = WebRtcCallService.class.getSimpleName();
 
@@ -116,7 +121,6 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
 
   public static final String EXTRA_REMOTE_ADDRESS     = "remote_address";
   public static final String EXTRA_MUTE               = "mute_value";
-  public static final String EXTRA_CAMERA_FLIP_REAR   = "camera_flip_rear_value";
   public static final String EXTRA_AVAILABLE          = "enabled_value";
   public static final String EXTRA_REMOTE_DESCRIPTION = "remote_description";
   public static final String EXTRA_TIMESTAMP          = "timestamp";
@@ -133,7 +137,7 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
   public static final String ACTION_LOCAL_HANGUP         = "LOCAL_HANGUP";
   public static final String ACTION_SET_MUTE_AUDIO       = "SET_MUTE_AUDIO";
   public static final String ACTION_SET_MUTE_VIDEO       = "SET_MUTE_VIDEO";
-  public static final String ACTION_SET_CAMERA_FLIP      = "SET_CAMERA_FLIP";
+  public static final String ACTION_FLIP_CAMERA          = "FLIP_CAMERA";
   public static final String ACTION_BLUETOOTH_CHANGE     = "BLUETOOTH_CHANGE";
   public static final String ACTION_WIRED_HEADSET_CHANGE = "WIRED_HEADSET_CHANGE";
   public static final String ACTION_SCREEN_OFF           = "SCREEN_OFF";
@@ -149,11 +153,11 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
   public static final String ACTION_REMOTE_VIDEO_MUTE = "REMOTE_VIDEO_MUTE";
   public static final String ACTION_ICE_CONNECTED     = "ICE_CONNECTED";
 
-  private CallState callState          = CallState.STATE_IDLE;
-  private boolean   microphoneEnabled  = true;
-  private boolean   localVideoEnabled  = false;
-  private boolean   remoteVideoEnabled = false;
-  private boolean   bluetoothAvailable = false;
+  private CallState   callState          = CallState.STATE_IDLE;
+  private CameraState localCameraState   = CameraState.UNKNOWN;
+  private boolean     microphoneEnabled  = true;
+  private boolean     remoteVideoEnabled = false;
+  private boolean     bluetoothAvailable = false;
 
   @Inject public SignalServiceMessageSender  messageSender;
   @Inject public SignalServiceAccountManager accountManager;
@@ -210,7 +214,7 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
       else if (intent.getAction().equals(ACTION_REMOTE_HANGUP))             handleRemoteHangup(intent);
       else if (intent.getAction().equals(ACTION_SET_MUTE_AUDIO))            handleSetMuteAudio(intent);
       else if (intent.getAction().equals(ACTION_SET_MUTE_VIDEO))            handleSetMuteVideo(intent);
-      else if (intent.getAction().equals(ACTION_SET_CAMERA_FLIP))           handleSetCameraFlip(intent);
+      else if (intent.getAction().equals(ACTION_FLIP_CAMERA))           handleSetCameraFlip(intent);
       else if (intent.getAction().equals(ACTION_BLUETOOTH_CHANGE))          handleBluetoothChange(intent);
       else if (intent.getAction().equals(ACTION_WIRED_HEADSET_CHANGE))      handleWiredHeadsetChange(intent);
       else if (intent.getAction().equals((ACTION_SCREEN_OFF)))              handleScreenOffChange(intent);
@@ -264,6 +268,15 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
 
     startService(intent);
   }
+
+  @Override
+  public void onCameraSwitchCompleted(@NonNull CameraState newCameraState) {
+    this.localCameraState = newCameraState;
+    if (recipient != null) {
+      sendMessage(viewModelStateFor(callState), recipient, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+    }
+  }
+
 
   // Initializers
 
@@ -358,7 +371,8 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
 
           boolean isAlwaysTurn = TextSecurePreferences.isTurnOnly(WebRtcCallService.this);
 
-          WebRtcCallService.this.peerConnection = new PeerConnectionWrapper(WebRtcCallService.this, peerConnectionFactory, WebRtcCallService.this, localRenderer, result, !isSystemContact || isAlwaysTurn);
+          WebRtcCallService.this.peerConnection   = new PeerConnectionWrapper(WebRtcCallService.this, peerConnectionFactory, WebRtcCallService.this, localRenderer, result, WebRtcCallService.this, !isSystemContact || isAlwaysTurn);
+          WebRtcCallService.this.localCameraState = WebRtcCallService.this.peerConnection.getCameraState();
           WebRtcCallService.this.peerConnection.setRemoteDescription(new SessionDescription(SessionDescription.Type.OFFER, offer));
           WebRtcCallService.this.lockManager.updatePhoneState(LockManager.PhoneState.PROCESSING);
 
@@ -379,6 +393,10 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
               terminate();
             }
           });
+
+          if (recipient != null) {
+            sendMessage(viewModelStateFor(callState), recipient, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+          }
         } catch (PeerConnectionException e) {
           Log.w(TAG, e);
           terminate();
@@ -400,7 +418,7 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
 
       initializeVideo();
 
-      sendMessage(WebRtcViewModel.State.CALL_OUTGOING, recipient, localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+      sendMessage(WebRtcViewModel.State.CALL_OUTGOING, recipient, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
       lockManager.updatePhoneState(LockManager.PhoneState.IN_CALL);
       audioManager.initializeAudioForCall();
       audioManager.startOutgoingRinger(OutgoingRinger.Type.SONAR);
@@ -417,7 +435,8 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
           try {
             boolean isAlwaysTurn = TextSecurePreferences.isTurnOnly(WebRtcCallService.this);
 
-            WebRtcCallService.this.peerConnection = new PeerConnectionWrapper(WebRtcCallService.this, peerConnectionFactory, WebRtcCallService.this, localRenderer, result, isAlwaysTurn);
+            WebRtcCallService.this.peerConnection = new PeerConnectionWrapper(WebRtcCallService.this, peerConnectionFactory, WebRtcCallService.this, localRenderer, result, WebRtcCallService.this, isAlwaysTurn);
+            WebRtcCallService.this.localCameraState = WebRtcCallService.this.peerConnection.getCameraState();
             WebRtcCallService.this.dataChannel    = WebRtcCallService.this.peerConnection.createDataChannel(DATA_CHANNEL_NAME);
             WebRtcCallService.this.dataChannel.registerObserver(WebRtcCallService.this);
 
@@ -434,16 +453,20 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
                 Log.w(TAG, error);
 
                 if (error instanceof UntrustedIdentityException) {
-                  sendMessage(WebRtcViewModel.State.UNTRUSTED_IDENTITY, recipient, ((UntrustedIdentityException)error).getIdentityKey(), localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+                  sendMessage(WebRtcViewModel.State.UNTRUSTED_IDENTITY, recipient, ((UntrustedIdentityException)error).getIdentityKey(), localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
                 } else if (error instanceof UnregisteredUserException) {
-                  sendMessage(WebRtcViewModel.State.NO_SUCH_USER, recipient, localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+                  sendMessage(WebRtcViewModel.State.NO_SUCH_USER, recipient, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
                 } else if (error instanceof IOException) {
-                  sendMessage(WebRtcViewModel.State.NETWORK_FAILURE, recipient, localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+                  sendMessage(WebRtcViewModel.State.NETWORK_FAILURE, recipient, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
                 }
 
                 terminate();
               }
             });
+
+            if (recipient != null) {
+              sendMessage(viewModelStateFor(callState), recipient, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+            }
           } catch (PeerConnectionException e) {
             Log.w(TAG, e);
             terminate();
@@ -475,7 +498,7 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
           @Override
           public void onFailureContinue(Throwable error) {
             Log.w(TAG, error);
-            sendMessage(WebRtcViewModel.State.NETWORK_FAILURE, recipient, localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+            sendMessage(WebRtcViewModel.State.NETWORK_FAILURE, recipient, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
 
             terminate();
           }
@@ -529,7 +552,7 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
       @Override
       public void onFailureContinue(Throwable error) {
         Log.w(TAG, error);
-        sendMessage(WebRtcViewModel.State.NETWORK_FAILURE, recipient, localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+        sendMessage(WebRtcViewModel.State.NETWORK_FAILURE, recipient, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
 
         terminate();
       }
@@ -543,7 +566,7 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
       this.callState = CallState.STATE_LOCAL_RINGING;
       this.lockManager.updatePhoneState(LockManager.PhoneState.INTERACTIVE);
 
-      sendMessage(WebRtcViewModel.State.CALL_INCOMING, recipient, localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+      sendMessage(WebRtcViewModel.State.CALL_INCOMING, recipient, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
       startCallCardActivity();
       audioManager.initializeAudioForCall();
 
@@ -565,7 +588,7 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
       this.callState = CallState.STATE_REMOTE_RINGING;
       this.audioManager.startOutgoingRinger(OutgoingRinger.Type.RINGING);
 
-      sendMessage(WebRtcViewModel.State.CALL_RINGING, recipient, localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+      sendMessage(WebRtcViewModel.State.CALL_RINGING, recipient, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
     }
   }
 
@@ -589,10 +612,10 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
 
     callState = CallState.STATE_CONNECTED;
 
-    if (localVideoEnabled) lockManager.updatePhoneState(LockManager.PhoneState.IN_VIDEO);
-    else                   lockManager.updatePhoneState(LockManager.PhoneState.IN_CALL);
+    if (localCameraState.isEnabled()) lockManager.updatePhoneState(LockManager.PhoneState.IN_VIDEO);
+    else                              lockManager.updatePhoneState(LockManager.PhoneState.IN_CALL);
 
-    sendMessage(WebRtcViewModel.State.CALL_CONNECTED, recipient, localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+    sendMessage(WebRtcViewModel.State.CALL_CONNECTED, recipient, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
 
     unregisterPowerButtonReceiver();
 
@@ -600,12 +623,12 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
 
     this.peerConnection.setCommunicationMode();
     this.peerConnection.setAudioEnabled(microphoneEnabled);
-    this.peerConnection.setVideoEnabled(localVideoEnabled);
+    this.peerConnection.setVideoEnabled(localCameraState.isEnabled());
 
     this.dataChannel.send(new DataChannel.Buffer(ByteBuffer.wrap(Data.newBuilder()
                                                                      .setVideoStreamingStatus(WebRtcDataProtos.VideoStreamingStatus.newBuilder()
                                                                                                                                    .setId(this.callId)
-                                                                                                                                   .setEnabled(localVideoEnabled))
+                                                                                                                                   .setEnabled(localCameraState.isEnabled()))
                                                                      .build().toByteArray()), false));
   }
 
@@ -644,7 +667,7 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
       return;
     }
 
-    sendMessage(WebRtcViewModel.State.CALL_BUSY, recipient, localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+    sendMessage(WebRtcViewModel.State.CALL_BUSY, recipient, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
 
     audioManager.startOutgoingRinger(OutgoingRinger.Type.BUSY);
     Util.runOnMainDelayed(new Runnable() {
@@ -666,7 +689,7 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
         this.callState != CallState.STATE_CONNECTED)
     {
       Log.w(TAG, "Timing out call: " + this.callId);
-      sendMessage(WebRtcViewModel.State.CALL_DISCONNECTED, this.recipient, localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+      sendMessage(WebRtcViewModel.State.CALL_DISCONNECTED, this.recipient, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
 
       if (this.callState == CallState.STATE_ANSWERING || this.callState == CallState.STATE_LOCAL_RINGING) {
         insertMissedCall(this.recipient, true);
@@ -735,7 +758,7 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
 
       this.dataChannel.send(new DataChannel.Buffer(ByteBuffer.wrap(Data.newBuilder().setHangup(Hangup.newBuilder().setId(this.callId)).build().toByteArray()), false));
       sendMessage(this.recipient, SignalServiceCallMessage.forHangup(new HangupMessage(this.callId)));
-      sendMessage(WebRtcViewModel.State.CALL_DISCONNECTED, this.recipient, localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+      sendMessage(WebRtcViewModel.State.CALL_DISCONNECTED, this.recipient, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
     }
 
     terminate();
@@ -752,9 +775,9 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
     }
 
     if (this.callState == CallState.STATE_DIALING || this.callState == CallState.STATE_REMOTE_RINGING) {
-      sendMessage(WebRtcViewModel.State.RECIPIENT_UNAVAILABLE, this.recipient, localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+      sendMessage(WebRtcViewModel.State.RECIPIENT_UNAVAILABLE, this.recipient, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
     } else {
-      sendMessage(WebRtcViewModel.State.CALL_DISCONNECTED, this.recipient, localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+      sendMessage(WebRtcViewModel.State.CALL_DISCONNECTED, this.recipient, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
     }
 
     if (this.callState == CallState.STATE_ANSWERING || this.callState == CallState.STATE_LOCAL_RINGING) {
@@ -777,26 +800,25 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
     AudioManager audioManager = ServiceUtil.getAudioManager(this);
     boolean      muted        = intent.getBooleanExtra(EXTRA_MUTE, false);
 
-    this.localVideoEnabled = !muted;
-
     if (this.peerConnection != null) {
-      this.peerConnection.setVideoEnabled(this.localVideoEnabled);
+      this.peerConnection.setVideoEnabled(!muted);
+      this.localCameraState = this.peerConnection.getCameraState();
     }
 
     if (this.callId != null && this.dataChannel != null) {
       this.dataChannel.send(new DataChannel.Buffer(ByteBuffer.wrap(Data.newBuilder()
                                                                        .setVideoStreamingStatus(WebRtcDataProtos.VideoStreamingStatus.newBuilder()
                                                                                                                                      .setId(this.callId)
-                                                                                                                                     .setEnabled(localVideoEnabled))
+                                                                                                                                     .setEnabled(!muted))
                                                                        .build().toByteArray()), false));
     }
 
     if (callState == CallState.STATE_CONNECTED) {
-      if (localVideoEnabled) this.lockManager.updatePhoneState(LockManager.PhoneState.IN_VIDEO);
-      else                   this.lockManager.updatePhoneState(LockManager.PhoneState.IN_CALL);
+      if (localCameraState.isEnabled()) this.lockManager.updatePhoneState(LockManager.PhoneState.IN_VIDEO);
+      else                              this.lockManager.updatePhoneState(LockManager.PhoneState.IN_CALL);
     }
 
-    if (localVideoEnabled &&
+    if (localCameraState.isEnabled() &&
         !audioManager.isSpeakerphoneOn() &&
         !audioManager.isBluetoothScoOn() &&
         !audioManager.isWiredHeadsetOn())
@@ -804,16 +826,17 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
       audioManager.setSpeakerphoneOn(true);
     }
 
-    sendMessage(viewModelStateFor(callState), this.recipient, localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+    sendMessage(viewModelStateFor(callState), this.recipient, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
   }
 
   private void handleSetCameraFlip(Intent intent) {
-    boolean isRear = intent.getBooleanExtra(EXTRA_CAMERA_FLIP_REAR, false);
-    Log.w(TAG, "handleSetCameraFlip(isRear=" + isRear + ")...");
+    Log.w(TAG, "handleSetCameraFlip()...");
 
-    if (this.localVideoEnabled) {
-      if (this.peerConnection != null) {
-        this.peerConnection.flipCameras(isRear);
+    if (localCameraState.isEnabled() && peerConnection != null) {
+      peerConnection.flipCamera();
+      localCameraState = peerConnection.getCameraState();
+      if (recipient != null) {
+        sendMessage(viewModelStateFor(callState), recipient, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
       }
     }
   }
@@ -822,7 +845,7 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
     this.bluetoothAvailable = intent.getBooleanExtra(EXTRA_AVAILABLE, false);
 
     if (recipient != null) {
-      sendMessage(viewModelStateFor(callState), recipient, localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+      sendMessage(viewModelStateFor(callState), recipient, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
     }
   }
 
@@ -839,12 +862,12 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
       if (present && audioManager.isSpeakerphoneOn()) {
         audioManager.setSpeakerphoneOn(false);
         audioManager.setBluetoothScoOn(false);
-      } else if (!present && !audioManager.isSpeakerphoneOn() && !audioManager.isBluetoothScoOn() && localVideoEnabled) {
+      } else if (!present && !audioManager.isSpeakerphoneOn() && !audioManager.isBluetoothScoOn() && localCameraState.isEnabled()) {
         audioManager.setSpeakerphoneOn(true);
       }
 
       if (recipient != null) {
-        sendMessage(viewModelStateFor(callState), recipient, localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+        sendMessage(viewModelStateFor(callState), recipient, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
       }
     }
   }
@@ -868,7 +891,7 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
     }
 
     this.remoteVideoEnabled = !muted;
-    sendMessage(WebRtcViewModel.State.CALL_CONNECTED, this.recipient, localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
+    sendMessage(WebRtcViewModel.State.CALL_CONNECTED, this.recipient, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
   }
 
   /// Helper Methods
@@ -932,10 +955,10 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
     }
 
     this.callState                 = CallState.STATE_IDLE;
+    this.localCameraState          = CameraState.UNKNOWN;
     this.recipient                 = null;
     this.callId                    = null;
     this.microphoneEnabled         = true;
-    this.localVideoEnabled         = false;
     this.remoteVideoEnabled        = false;
     this.pendingOutgoingIceUpdates = null;
     this.pendingIncomingIceUpdates = null;
@@ -944,20 +967,24 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
 
 
   private void sendMessage(@NonNull WebRtcViewModel.State state,
-                           @NonNull Recipient recipient,
-                           boolean localVideoEnabled, boolean remoteVideoEnabled,
-                           boolean bluetoothAvailable, boolean microphoneEnabled)
+                           @NonNull Recipient             recipient,
+                           @NonNull CameraState           localCameraState,
+                                    boolean               remoteVideoEnabled,
+                                    boolean               bluetoothAvailable,
+                                    boolean               microphoneEnabled)
   {
-    EventBus.getDefault().postSticky(new WebRtcViewModel(state, recipient, localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled));
+    EventBus.getDefault().postSticky(new WebRtcViewModel(state, recipient, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled));
   }
 
   private void sendMessage(@NonNull WebRtcViewModel.State state,
-                           @NonNull Recipient recipient,
-                           @NonNull IdentityKey identityKey,
-                           boolean localVideoEnabled, boolean remoteVideoEnabled,
-                           boolean bluetoothAvailable, boolean microphoneEnabled)
+                           @NonNull Recipient             recipient,
+                           @NonNull IdentityKey           identityKey,
+                           @NonNull CameraState           localCameraState,
+                                    boolean               remoteVideoEnabled,
+                                    boolean               bluetoothAvailable,
+                                    boolean               microphoneEnabled)
   {
-    EventBus.getDefault().postSticky(new WebRtcViewModel(state, recipient, identityKey, localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled));
+    EventBus.getDefault().postSticky(new WebRtcViewModel(state, recipient, identityKey, localCameraState, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled));
   }
 
   private ListenableFutureTask<Boolean> sendMessage(@NonNull final Recipient recipient,

--- a/src/org/thoughtcrime/securesms/webrtc/CameraState.java
+++ b/src/org/thoughtcrime/securesms/webrtc/CameraState.java
@@ -1,0 +1,32 @@
+package org.thoughtcrime.securesms.webrtc;
+
+import android.support.annotation.NonNull;
+
+public class CameraState {
+
+  public static final CameraState UNKNOWN = new CameraState(Direction.NONE, 0);
+
+  private final Direction activeDirection;
+  private final int       cameraCount;
+
+  public CameraState(@NonNull Direction activeDirection, int cameraCount) {
+    this.activeDirection = activeDirection;
+    this.cameraCount = cameraCount;
+  }
+
+  public int getCameraCount() {
+    return cameraCount;
+  }
+
+  public Direction getActiveDirection() {
+    return activeDirection;
+  }
+
+  public boolean isEnabled() {
+    return this.activeDirection != Direction.NONE;
+  }
+
+  public enum Direction {
+    FRONT, BACK, NONE, PENDING
+  }
+}


### PR DESCRIPTION
A button has been added to allow switching between the front and back camera during video calls. 

![camera-flip](https://user-images.githubusercontent.com/37311915/39281376-134016dc-48b9-11e8-9270-c955de87d333.png)


**To-Do**
- [x] Get design approval
- [x] Test with Google Pixel devices (there may be issues, according to [this comment](https://github.com/signalapp/Signal-Android/pull/7559#issuecomment-376314034))

**Test Cases**
* Simulate missing a back camera
* Simulate missing a front camera
* Simulate missing both cameras
* Being both the initiator and receiver of the call
* Pressing the toggle button really fast

**Test Devices**
* [Moto E (2nd Gen), Android 5.1, API 22](https://www.gsmarena.com/motorola_moto_e_(2nd_gen)-6986.php)
* [Moto X (2nd Gen), Android 7.1, API 25](https://www.gsmarena.com/motorola_moto_x_(2nd_gen)-6649.php)
* [Galaxy S3 Mini, Android 4.2.2. API 17](https://www.gsmarena.com/samsung_i8200_galaxy_s_iii_mini_ve-6190.php)
* [Google Pixel, Android 8.1, API 27](https://www.gsmarena.com/google_pixel-8346.php)

