### PR TITLE
Fix multiple threads notifications. Fixed #7710

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -59,6 +59,7 @@ import org.thoughtcrime.securesms.webrtc.CallNotificationBuilder;
 import org.whispersystems.signalservice.internal.util.Util;
 
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
@@ -260,13 +261,16 @@ public class MessageNotifier {
       }
 
       if (notificationState.hasMultipleThreads()) {
-        if (Build.VERSION.SDK_INT >= 23) {
-          for (long threadId : notificationState.getThreads()) {
-            sendSingleThreadNotification(context, new NotificationState(notificationState.getNotificationsForThread(threadId)), false, true);
+        boolean buildLaterThan23 = Build.VERSION.SDK_INT >= 23;
+        if (buildLaterThan23) {
+          Iterator<Long> threadsIttr = notificationState.getThreads().iterator();
+          while (threadsIttr.hasNext()) {
+            List<NotificationItem> notificationItems = notificationState.getNotificationsForThread(threadsIttr.next());
+            sendSingleThreadNotification(context, new NotificationState(notificationItems), !threadsIttr.hasNext() && signal, true);
           }
         }
 
-        sendMultipleThreadNotification(context, notificationState, signal);
+        sendMultipleThreadNotification(context, notificationState, signal && !buildLaterThan23);
       } else {
         sendSingleThreadNotification(context, notificationState, signal, false);
       }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel (Android 8.1.0)
 * Virtual Device, Lollypop API 21
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

> When there is an unread message of e.g. contact A in my messages and I get a new message from contact B in the meantime, the notification for the message of contact A is shown (including the time I received it).
I enabled the setting where only the contact name, not the message is shown in the notification (if this is important, idk).

Issue boils down to code block being executed for API above 23 calling single thread notification followed by also calling multiple thread notification that is called regardless of API version. This fix will signal only once depending on the API version ensuring the right notification is displayed to the user.