### PR TITLE
Convert vCard attachments into contact shares.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,6 +120,10 @@ dependencies {
     compile 'com.codewaves.stickyheadergrid:stickyheadergrid:0.9.4'
     compile 'com.github.dmytrodanylyk.circular-progress-button:library:1.1.3-S2'
     compile 'net.zetetic:android-database-sqlcipher:3.5.9'
+    compile ('com.googlecode.ez-vcard:ez-vcard:0.9.11') {
+        exclude group: 'com.fasterxml.jackson.core'
+        exclude group: 'org.freemarker'
+    }
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:1.7.1'
@@ -306,6 +310,7 @@ android {
                           'proguard-klinker.pro',
                           'proguard-retrolambda.pro',
                           'proguard-okhttp.pro',
+                          'proguard-ez-vcard.pro',
                           'proguard.cfg'
             testProguardFiles 'proguard-automation.pro',
                           'proguard.cfg'

--- a/proguard-ez-vcard.pro
+++ b/proguard-ez-vcard.pro
@@ -1,0 +1,1 @@
+-dontwarn ezvcard.io.html.HCardPage

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -426,11 +426,13 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       setMedia(data.getData(), MediaType.AUDIO);
       break;
     case PICK_CONTACT:
-      if (isSecureText && !isSmsForced()) {
-        openContactShareEditor(data.getData());
-      } else {
-        addAttachmentContactInfo(data.getData());
-      }
+      // TODO(greyson): Re-enable shared contact sending after receiving has been enabled for a few releases
+      addAttachmentContactInfo(data.getData());
+//      if (isSecureText && !isSmsForced()) {
+//        openContactShareEditor(data.getData());
+//      } else {
+//        addAttachmentContactInfo(data.getData());
+//      }
       break;
     case GET_CONTACT_DETAILS:
       sendSharedContact(data.getParcelableArrayListExtra(ContactShareEditActivity.KEY_CONTACTS));

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1393,12 +1393,16 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
   private void setMedia(@Nullable Uri uri, @NonNull MediaType mediaType, int width, int height) {
     if (uri == null) return;
-    attachmentManager.setMedia(glideRequests, uri, mediaType, getCurrentMediaConstraints(), width, height);
+
+    if (MediaType.VCARD.equals(mediaType) && isSecureText) {
+      openContactShareEditor(uri);
+    } else {
+      attachmentManager.setMedia(glideRequests, uri, mediaType, getCurrentMediaConstraints(), width, height);
+    }
   }
 
   private void openContactShareEditor(Uri contactUri) {
-    long id = ContactUtil.getContactIdFromUri(contactUri);
-    Intent intent = ContactShareEditActivity.getIntent(this, Collections.singletonList(id));
+    Intent intent = ContactShareEditActivity.getIntent(this, Collections.singletonList(contactUri));
     startActivityForResult(intent, GET_CONTACT_DETAILS);
   }
 

--- a/src/org/thoughtcrime/securesms/contactshare/ContactShareEditViewModel.java
+++ b/src/org/thoughtcrime/securesms/contactshare/ContactShareEditViewModel.java
@@ -4,6 +4,7 @@ import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.MutableLiveData;
 import android.arch.lifecycle.ViewModel;
 import android.arch.lifecycle.ViewModelProvider;
+import android.net.Uri;
 import android.support.annotation.NonNull;
 
 import com.annimon.stream.Stream;
@@ -20,14 +21,14 @@ class ContactShareEditViewModel extends ViewModel {
   private final SingleLiveEvent<Event>         events;
   private final ContactRepository              repo;
 
-  ContactShareEditViewModel(@NonNull List<Long>        contactIds,
+  ContactShareEditViewModel(@NonNull List<Uri>         contactUris,
                             @NonNull ContactRepository contactRepository)
   {
     contacts = new MutableLiveData<>();
     events              = new SingleLiveEvent<>();
     repo                = contactRepository;
 
-    repo.getContacts(contactIds, retrieved -> {
+    repo.getContacts(contactUris, retrieved -> {
       if (retrieved.isEmpty()) {
         events.postValue(Event.BAD_CONTACT);
       } else {
@@ -96,17 +97,17 @@ class ContactShareEditViewModel extends ViewModel {
 
   static class Factory extends ViewModelProvider.NewInstanceFactory {
 
-    private final List<Long>        contactIds;
+    private final List<Uri>         contactUris;
     private final ContactRepository contactRepository;
 
-    Factory(@NonNull List<Long> contactIds, @NonNull ContactRepository contactRepository) {
-      this.contactIds        = contactIds;
+    Factory(@NonNull List<Uri> contactUris, @NonNull ContactRepository contactRepository) {
+      this.contactUris       = contactUris;
       this.contactRepository = contactRepository;
     }
 
     @Override
     public @NonNull <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
-      return modelClass.cast(new ContactShareEditViewModel(contactIds, contactRepository));
+      return modelClass.cast(new ContactShareEditViewModel(contactUris, contactRepository));
     }
   }
 }

--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -508,7 +508,7 @@ public class AttachmentManager {
   }
 
   public enum MediaType {
-    IMAGE, GIF, AUDIO, VIDEO, DOCUMENT;
+    IMAGE, GIF, AUDIO, VIDEO, DOCUMENT, VCARD;
 
     public @NonNull Slide createSlide(@NonNull  Context context,
                                       @NonNull  Uri     uri,
@@ -527,6 +527,7 @@ public class AttachmentManager {
       case GIF:      return new GifSlide(context, uri, dataSize, width, height);
       case AUDIO:    return new AudioSlide(context, uri, dataSize, false);
       case VIDEO:    return new VideoSlide(context, uri, dataSize);
+      case VCARD:
       case DOCUMENT: return new DocumentSlide(context, uri, mimeType, dataSize, fileName);
       default:       throw  new AssertionError("unrecognized enum");
       }
@@ -538,6 +539,7 @@ public class AttachmentManager {
       if (MediaUtil.isImageType(mimeType)) return IMAGE;
       if (MediaUtil.isAudioType(mimeType)) return AUDIO;
       if (MediaUtil.isVideoType(mimeType)) return VIDEO;
+      if (MediaUtil.isVcard(mimeType))     return VCARD;
 
       return DOCUMENT;
     }

--- a/src/org/thoughtcrime/securesms/util/MediaUtil.java
+++ b/src/org/thoughtcrime/securesms/util/MediaUtil.java
@@ -44,6 +44,7 @@ public class MediaUtil {
   public static final String AUDIO_AAC         = "audio/aac";
   public static final String AUDIO_UNSPECIFIED = "audio/*";
   public static final String VIDEO_UNSPECIFIED = "video/*";
+  public static final String VCARD             = "text/x-vcard";
 
 
   public static Slide getSlideForAttachment(Context context, Attachment attachment) {
@@ -194,6 +195,10 @@ public class MediaUtil {
 
   public static boolean isVideo(String contentType) {
     return !TextUtils.isEmpty(contentType) && contentType.trim().startsWith("video/");
+  }
+
+  public static boolean isVcard(String contentType) {
+    return !TextUtils.isEmpty(contentType) && contentType.trim().equals(VCARD);
   }
 
   public static boolean isGif(String contentType) {


### PR DESCRIPTION
When you share a vCard from an external app (like the Contacts app) into Signal, we'll now convert it to a pretty Shared Contact message and allow you to choose which fields of the contact you wish to send.

To do this, we imported a new vCard parsing library. Then, the ContactShareEditActivity/ViewModel was adjusted to take in raw Uri's instead of system contact ID's. The ContactRepository will then convert the Uri to Contact by recognizing the authority and parsing as appropriate (either by reading the system contacts or the vCard).

Care was taken to ensure that vCard shares to non-signal users still use the legacy attachment flow.
[Demo Video](https://github.com/signalapp/Signal-Android/files/2014399/vcard-sharing.zip)
![Demo](https://user-images.githubusercontent.com/37311915/40197831-6b6b2cc2-59c9-11e8-85ab-6c2955e7d6e8.gif)




**Test Devices**

* [Moto E (2nd Gen), Android 5.1, API 22](https://www.gsmarena.com/motorola_moto_e_(2nd_gen)-6986.php)
* [Google Pixel, Android 8.1, API 27](https://www.gsmarena.com/google_pixel-8346.php)

