### PR TITLE
Don't show a contact search result for someone you have a conversation with.

### DIFF
--- a/src/org/thoughtcrime/securesms/database/CursorList.java
+++ b/src/org/thoughtcrime/securesms/database/CursorList.java
@@ -30,8 +30,6 @@ public class CursorList<T> implements List<T>, Closeable {
   public CursorList(@NonNull Cursor cursor, @NonNull ModelBuilder<T> modelBuilder) {
     this.cursor       = cursor;
     this.modelBuilder = modelBuilder;
-
-    this.cursor.moveToFirst();
   }
 
   public static <T> CursorList<T> emptyList() {
@@ -58,6 +56,8 @@ public class CursorList<T> implements List<T>, Closeable {
   @Override
   public Iterator<T> iterator() {
     return new Iterator<T>() {
+      int index = 0;
+
       @Override
       public boolean hasNext() {
         return cursor.getCount() > 0 && !cursor.isLast();
@@ -65,9 +65,8 @@ public class CursorList<T> implements List<T>, Closeable {
 
       @Override
       public T next() {
-        T model = modelBuilder.build(cursor);
-        cursor.moveToNext();
-        return model;
+        cursor.moveToPosition(index++);
+        return modelBuilder.build(cursor);
       }
     };
   }
@@ -179,7 +178,7 @@ public class CursorList<T> implements List<T>, Closeable {
 
   @Override
   public void close() {
-    if (cursor != null) {
+    if (!cursor.isClosed()) {
       cursor.close();
     }
   }

--- a/src/org/thoughtcrime/securesms/search/SearchViewModel.java
+++ b/src/org/thoughtcrime/securesms/search/SearchViewModel.java
@@ -47,6 +47,7 @@ class SearchViewModel extends ViewModel {
 
   @Override
   protected void onCleared() {
+    debouncer.clear();
     searchResult.close();
   }
 

--- a/src/org/thoughtcrime/securesms/search/model/SearchResult.java
+++ b/src/org/thoughtcrime/securesms/search/model/SearchResult.java
@@ -17,12 +17,12 @@ public class SearchResult {
   public static final SearchResult EMPTY = new SearchResult("", CursorList.emptyList(), CursorList.emptyList(), CursorList.emptyList());
 
   private final String                    query;
-  private final CursorList<Recipient>     contacts;
+  private final List<Recipient>           contacts;
   private final CursorList<ThreadRecord>  conversations;
   private final CursorList<MessageResult> messages;
 
   public SearchResult(@NonNull String                    query,
-                      @NonNull CursorList<Recipient>     contacts,
+                      @NonNull List<Recipient>           contacts,
                       @NonNull CursorList<ThreadRecord>  conversations,
                       @NonNull CursorList<MessageResult> messages)
   {
@@ -57,7 +57,6 @@ public class SearchResult {
   }
 
   public void close() {
-    contacts.close();
     conversations.close();
     messages.close();
   }

--- a/src/org/thoughtcrime/securesms/util/Debouncer.java
+++ b/src/org/thoughtcrime/securesms/util/Debouncer.java
@@ -29,4 +29,8 @@ public class Debouncer {
     handler.removeCallbacksAndMessages(null);
     handler.postDelayed(runnable, threshold);
   }
+
+  public void clear() {
+    handler.removeCallbacksAndMessages(null);
+  }
 }


### PR DESCRIPTION
Right now, if you search for a contact "Susan" that you also have a conversation with, then she will show up as both a conversation result and a contact result. This change prevents showing these duplicate results by excluding them from the contact results.

I also found a bug in SearchViewModel with our debouncer. Because the debouncer delay could fire off a query after the SearchFragment was destroyed, it could leave around an unclosed cursor. This is prevented by simply clearing the debouncer when the ViewModel is cleared.