### PR TITLE
Add margin to registration activity countdown

### DIFF
--- a/res/layout/registration_call_me_view.xml
+++ b/res/layout/registration_call_me_view.xml
@@ -39,6 +39,8 @@
               android:layout_alignParentEnd="true"
               android:layout_alignParentRight="true"
               android:layout_centerVertical="true"
+              android:layout_marginStart="3dp"
+              android:layout_marginLeft="3dp"
               android:textSize="16sp"
               tools:text="1:04"/>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1431,7 +1431,7 @@
     <string name="RegistrationActivity_please_enter_the_verification_code_sent_to_s">Please enter the verification code sent to %s.</string>
     <string name="RegistrationActivity_wrong_number">Wrong number?</string>
     <string name="RegistrationActivity_call_me_instead">Call me instead</string>
-    <string name="RegistrationActivity_available_in">Available in:\u0020</string>
+    <string name="RegistrationActivity_available_in">Available in:</string>
     <string name="BackupUtil_never">Never</string>
     <string name="BackupUtil_unknown">Unknown</string>
     <string name="prompt_passphrase_activity__unlock_signal">Unlock Signal</string>


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 4, Android 7.1.2 (Lineage)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
The original string RegistrationActivity_available_in had a space at the end of the string, which is somewhat problematic in the context of Transifex (i. e. confusing to translators).

- Remove space in string "RegistrationActivity_available_in"
- Add margin to the left of the countdown

### Screenshot after PR:
(Btw, looking at that screenshot, that hyphen doesn't seem to be exactly centered below the icon - or vice versa. Just a thought.)

![screenshot_20180528-151226_cr](https://user-images.githubusercontent.com/12624674/40616047-bc7f95f8-6289-11e8-9d8b-9aff77ac37dc.png)

