### PR TITLE
Add option for theme to follow system

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -102,11 +102,13 @@
     <string-array name="pref_theme_entries">
       <item>@string/preferences__light_theme</item>
       <item>@string/preferences__dark_theme</item>
+      <item>@string/preferences__system_theme</item>
   </string-array>
 
   <string-array name="pref_theme_values" translatable="false">
       <item>light</item>
       <item>dark</item>
+      <item>system</item>
   </string-array>
 
   <string-array name="pref_led_color_entries">

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1201,6 +1201,7 @@
     <string name="preferences__linked_devices">Linked devices</string>
     <string name="preferences__light_theme">Light</string>
     <string name="preferences__dark_theme">Dark</string>
+    <string name="preferences__system_theme">Follow system</string>
     <string name="preferences__appearance">Appearance</string>
     <string name="preferences__theme">Theme</string>
     <string name="preferences__default">Default</string>

--- a/src/org/thoughtcrime/securesms/util/DynamicNoActionBarTheme.java
+++ b/src/org/thoughtcrime/securesms/util/DynamicNoActionBarTheme.java
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms.util;
 
 import android.app.Activity;
+import android.content.res.Configuration;
 
 import org.thoughtcrime.securesms.R;
 
@@ -9,7 +10,15 @@ public class DynamicNoActionBarTheme extends DynamicTheme {
   protected int getSelectedTheme(Activity activity) {
     String theme = TextSecurePreferences.getTheme(activity);
 
-    if (theme.equals("dark")) return R.style.TextSecure_DarkNoActionBar;
+    if (theme.equals(SYSTEM)) {
+      int systemFlags = activity.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+      if(systemFlags == Configuration.UI_MODE_NIGHT_YES)
+        return R.style.TextSecure_DarkNoActionBar;
+      else
+        return R.style.TextSecure_LightNoActionBar;
+    }
+    else if (theme.equals(DARK))
+      return R.style.TextSecure_DarkNoActionBar;
 
     return R.style.TextSecure_LightNoActionBar;
   }

--- a/src/org/thoughtcrime/securesms/util/DynamicNoActionBarTheme.java
+++ b/src/org/thoughtcrime/securesms/util/DynamicNoActionBarTheme.java
@@ -1,7 +1,6 @@
 package org.thoughtcrime.securesms.util;
 
 import android.app.Activity;
-import android.content.res.Configuration;
 
 import org.thoughtcrime.securesms.R;
 
@@ -10,14 +9,7 @@ public class DynamicNoActionBarTheme extends DynamicTheme {
   protected int getSelectedTheme(Activity activity) {
     String theme = TextSecurePreferences.getTheme(activity);
 
-    if (theme.equals(SYSTEM)) {
-      int systemFlags = activity.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
-      if(systemFlags == Configuration.UI_MODE_NIGHT_YES)
-        return R.style.TextSecure_DarkNoActionBar;
-      else
-        return R.style.TextSecure_LightNoActionBar;
-    }
-    else if (theme.equals(DARK))
+    if (theme.equals(DARK) || (theme.equals(SYSTEM) && doesSystemWantDarkTheme(activity)))
       return R.style.TextSecure_DarkNoActionBar;
 
     return R.style.TextSecure_LightNoActionBar;

--- a/src/org/thoughtcrime/securesms/util/DynamicTheme.java
+++ b/src/org/thoughtcrime/securesms/util/DynamicTheme.java
@@ -32,16 +32,16 @@ public class DynamicTheme {
   protected int getSelectedTheme(Activity activity) {
     String theme = TextSecurePreferences.getTheme(activity);
 
-    if (theme.equals(SYSTEM)) {
-      int systemFlags = activity.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
-      if(systemFlags == Configuration.UI_MODE_NIGHT_YES)
-        return R.style.TextSecure_DarkTheme;
-      else
-        return R.style.TextSecure_LightTheme;
-    }
-    else if (theme.equals(DARK)) return R.style.TextSecure_DarkTheme;
+    if (theme.equals(DARK) || (theme.equals(SYSTEM) && doesSystemWantDarkTheme(activity)))
+      return R.style.TextSecure_DarkTheme;
 
     return R.style.TextSecure_LightTheme;
+  }
+
+  boolean doesSystemWantDarkTheme(Activity activity) {
+    int systemFlags = activity.getResources().getConfiguration().uiMode
+            & Configuration.UI_MODE_NIGHT_MASK;
+    return systemFlags == Configuration.UI_MODE_NIGHT_YES;
   }
 
   private static final class OverridePendingTransition {

--- a/src/org/thoughtcrime/securesms/util/DynamicTheme.java
+++ b/src/org/thoughtcrime/securesms/util/DynamicTheme.java
@@ -2,6 +2,7 @@ package org.thoughtcrime.securesms.util;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.content.res.Configuration;
 
 import org.thoughtcrime.securesms.R;
 
@@ -9,6 +10,7 @@ public class DynamicTheme {
 
   public static final String DARK  = "dark";
   public static final String LIGHT = "light";
+  public static final String SYSTEM = "system";
 
   private int currentTheme;
 
@@ -30,7 +32,14 @@ public class DynamicTheme {
   protected int getSelectedTheme(Activity activity) {
     String theme = TextSecurePreferences.getTheme(activity);
 
-    if (theme.equals(DARK)) return R.style.TextSecure_DarkTheme;
+    if (theme.equals(SYSTEM)) {
+      int systemFlags = activity.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+      if(systemFlags == Configuration.UI_MODE_NIGHT_YES)
+        return R.style.TextSecure_DarkTheme;
+      else
+        return R.style.TextSecure_LightTheme;
+    }
+    else if (theme.equals(DARK)) return R.style.TextSecure_DarkTheme;
 
     return R.style.TextSecure_LightTheme;
   }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Lenovo P2, Android 8.1
 * Pixel XL, Android P (DP2)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Adds an additional option to themes allowing the app to pick light/dark theme based on what the system is using.

Testing was done by trying different combinations of system and app theme to make sure that the correct theme was being chosen and that the new option wasn't interfering with the original options.
