### PR TITLE
Improve registration exception handling

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/EnterCodeFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/EnterCodeFragment.java
@@ -32,6 +32,7 @@ import org.thoughtcrime.securesms.registration.service.RegistrationCodeRequest;
 import org.thoughtcrime.securesms.registration.service.RegistrationService;
 import org.thoughtcrime.securesms.registration.viewmodel.RegistrationViewModel;
 import org.thoughtcrime.securesms.util.concurrent.AssertedSuccessListener;
+import org.whispersystems.signalservice.api.push.exceptions.RateLimitException;
 import org.whispersystems.signalservice.internal.contacts.entities.TokenResponse;
 
 import java.util.ArrayList;
@@ -277,8 +278,12 @@ public final class EnterCodeFragment extends BaseRegistrationFragment {
         }
 
         @Override
-        public void onError() {
-          Toast.makeText(requireContext(), R.string.RegistrationActivity_unable_to_connect_to_service, Toast.LENGTH_LONG).show();
+        public void onError(Exception exception) {
+          if (exception instanceof RateLimitException) {
+            Toast.makeText(requireContext(), R.string.RegistrationActivity_attempted_to_register_too_many_times, Toast.LENGTH_LONG).show();
+          } else {
+            Toast.makeText(requireContext(), R.string.RegistrationActivity_unable_to_connect_to_service, Toast.LENGTH_LONG).show();
+          }
         }
       });
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/EnterPhoneNumberFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/EnterPhoneNumberFragment.java
@@ -41,6 +41,7 @@ import org.thoughtcrime.securesms.registration.viewmodel.NumberViewState;
 import org.thoughtcrime.securesms.registration.viewmodel.RegistrationViewModel;
 import org.thoughtcrime.securesms.util.Dialogs;
 import org.thoughtcrime.securesms.util.PlayServicesUtil;
+import org.whispersystems.signalservice.api.push.exceptions.RateLimitException;
 
 public final class EnterPhoneNumberFragment extends BaseRegistrationFragment {
 
@@ -245,8 +246,12 @@ public final class EnterPhoneNumberFragment extends BaseRegistrationFragment {
         }
 
         @Override
-        public void onError() {
-          Toast.makeText(register.getContext(), R.string.RegistrationActivity_unable_to_connect_to_service, Toast.LENGTH_LONG).show();
+        public void onError(Exception exception) {
+          if (exception instanceof RateLimitException) {
+            Toast.makeText(register.getContext(), R.string.RegistrationActivity_attempted_to_register_too_many_times, Toast.LENGTH_LONG).show();
+          } else {
+            Toast.makeText(register.getContext(), R.string.RegistrationActivity_unable_to_connect_to_service, Toast.LENGTH_LONG).show();
+          }
           cancelSpinning(register);
           enableAllEntries();
           model.getRequestLimiter().onUnsuccessfulRequest();

--- a/app/src/main/java/org/thoughtcrime/securesms/registration/service/RegistrationCodeRequest.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/service/RegistrationCodeRequest.java
@@ -68,10 +68,13 @@ public final class RegistrationCodeRequest {
       }
 
       protected void onPostExecute(@NonNull VerificationRequestResult result) {
-        if (result.exception.isPresent() && result.exception.get() instanceof CaptchaRequiredException) {
-          callback.onNeedCaptcha();
-        } else if (result.exception.isPresent()) {
-          callback.onError();
+        if (result.exception.isPresent()) {
+          Exception exception = result.exception.get();
+          if (exception instanceof CaptchaRequiredException) {
+            callback.onNeedCaptcha();
+          } else {
+            callback.onError(exception);
+          }
         } else {
           callback.requestSent(result.fcmToken);
         }
@@ -149,6 +152,6 @@ public final class RegistrationCodeRequest {
 
     void requestSent(@Nullable String fcmToken);
 
-    void onError();
+    void onError(Exception exception);
   }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -755,6 +755,7 @@
     <string name="RegistrationActivity_less_information">Less information</string>
     <string name="RegistrationActivity_signal_needs_access_to_your_contacts_and_media_in_order_to_connect_with_friends">Signal needs access to your contacts and media in order to connect with friends, exchange messages, and make secure calls</string>
     <string name="RegistrationActivity_unable_to_connect_to_service">Unable to connect to service. Please check network connection and try again.</string>
+    <string name="RegistrationActivity_attempted_to_register_too_many_times">You\'ve attempted to register this number too many times, please wait one day before you try again.</string>
     <string name="RegistrationActivity_to_easily_verify_your_phone_number_signal_can_automatically_detect_your_verification_code">To easily verify your phone number, Signal can automatically detect your verification code if you allow Signal to view SMS messages.</string>
     <plurals name="RegistrationActivity_debug_log_hint">
         <item quantity="one">You are now %d step away from submitting a debug log.</item>


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on this device:
 * Virtual device, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Handle rate limit exception during registration process. Handling of other exceptions can be added easily.

Fixes #7819, which is labeled as help wanted.

![registrationexception](https://user-images.githubusercontent.com/3845150/40890810-35e8d55c-677c-11e8-8acd-ac38f3bfab8b.png)
