### PR TITLE
Add devices to hardware AEC blacklist

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -171,6 +171,8 @@ public class ApplicationContext extends MultiDexApplication implements Dependenc
         add("Pixel XL");
         add("Moto G5");
         add("Moto G (5S) Plus");
+        add("Moto G4");
+        add("TA-1053");
       }};
 
       Set<String> OPEN_SL_ES_WHITELIST = new HashSet<String>() {{


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nokia 5, Android 8.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
This adds two devices to the hardware AEC blacklist
1. _Lenovo Moto G4_ (ro.product.model=`Moto G4`)
2. _Nokia 5_ (ro.product.model=`TA-1053`)

I don't have a _Moto G4_ so couldn't test with it but it was reported here https://github.com/signalapp/Signal-Android/issues/7635#issuecomment-390678223 to have an issue  with stock Android.

I did test with _Nokia 5_ using stock Android and this indeed fixes the issue.