### PR TITLE
Hardcoded message switched

### DIFF
--- a/res/layout/permissions_rationale_dialog.xml
+++ b/res/layout/permissions_rationale_dialog.xml
@@ -24,6 +24,6 @@
               android:paddingRight="20dp"
               android:textSize="15sp"
               android:lineSpacingMultiplier="1.3"
-              tools:text="Signal needs access to your contacts and media in order to connect with friends, exchange messages, and make secure calls."/>
+              tools:text="@string/RegistrationActivity_signal_needs_access_to_your_contacts_and_media_in_order_to_connect_with_friends"/>
 
 </LinearLayout>

--- a/res/layout/permissions_rationale_dialog.xml
+++ b/res/layout/permissions_rationale_dialog.xml
@@ -24,6 +24,6 @@
               android:paddingRight="20dp"
               android:textSize="15sp"
               android:lineSpacingMultiplier="1.3"
-              tools:text="@string/RegistrationActivity_signal_needs_access_to_your_contacts_and_media_in_order_to_connect_with_friends"/>
+              tools:text="Signal needs access to your contacts and media in order to connect with friends, exchange messages, and make secure calls."/>
 
 </LinearLayout>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Changes the hardcoded message in the permissions_rationale_dialog.xml to refer to a string.xml value.
