### PR TITLE
Upgrade SQLCipher to respect a max window size.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ dependencies {
     }
     compile 'com.codewaves.stickyheadergrid:stickyheadergrid:0.9.4'
     compile 'com.github.dmytrodanylyk.circular-progress-button:library:1.1.3-S2'
-    compile 'org.signal:android-database-sqlcipher:3.5.9-S1'
+    compile 'org.signal:android-database-sqlcipher:3.5.9-S2'
     compile ('com.googlecode.ez-vcard:ez-vcard:0.9.11') {
         exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'org.freemarker'
@@ -198,7 +198,7 @@ dependencyVerification {
         'com.annimon:stream:5da6e2e3e0551d61a3ea7014f04312276549e3dd739cf637996e4cf43c5535b9',
         'com.takisoft.fix:colorpicker:f5d0dbabe406a1800498ca9c1faf34db36e021d8488bf10360f29961fe3ab0d1',
         'com.github.dmytrodanylyk.circular-progress-button:library:8dc6a29a5a8db7b2ad5a9a7fda1dc9ae0893f4c8f0545732b2c63854ea693e8e',
-        'org.signal:android-database-sqlcipher:4302551df258883cc5dc5d62ddb141a6b5b8f113d77d70322dc2648c0856ccef',
+        'org.signal:android-database-sqlcipher:4d682fccefb21cdeb10f856a55c86ede381f91137eae8a7a5746c9df415a6aed',
         'com.googlecode.ez-vcard:ez-vcard:7e24ad50b222d2f70ac91bdccfa3c0f6200b078d797cb784837f75e77bb4210f',
         'com.google.android.gms:play-services-iid:54e919f9957b8b7820da7ee9b83471d00d0cac1cf08ddea8b5b41aea80bb1a70',
         'com.google.android.gms:play-services-base:0ca636a8fc9a5af45e607cdcd61783bf5d561cbbb0f862021ce69606eee5ad49',

--- a/src/org/thoughtcrime/securesms/database/helpers/SQLCipherOpenHelper.java
+++ b/src/org/thoughtcrime/securesms/database/helpers/SQLCipherOpenHelper.java
@@ -8,6 +8,9 @@ import android.os.SystemClock;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
+import net.sqlcipher.CursorWindow;
+import net.sqlcipher.CursorWindowAllocation;
+import net.sqlcipher.CustomCursorWindowAllocation;
 import net.sqlcipher.database.SQLiteDatabase;
 import net.sqlcipher.database.SQLiteDatabaseHook;
 import net.sqlcipher.database.SQLiteOpenHelper;
@@ -51,6 +54,14 @@ public class SQLCipherOpenHelper extends SQLiteOpenHelper {
 
   private static final int    DATABASE_VERSION = 9;
   private static final String DATABASE_NAME    = "signal.db";
+
+  private static final int                    MEMORY_INITIAL    = 128 * 1024;
+  private static final int                    MEMORY_GROW       = 1024 * 1024;
+  private static final int                    MEMORY_MAX        = 4 * 1024 * 1024;
+  private static final CursorWindowAllocation CURSOR_ALLOCATION = new CustomCursorWindowAllocation(MEMORY_INITIAL, MEMORY_GROW, MEMORY_MAX);
+  static {
+    CursorWindow.setCursorWindowAllocation(CURSOR_ALLOCATION);
+  }
 
   private final Context        context;
   private final DatabaseSecret databaseSecret;


### PR DESCRIPTION
Previously, SQLCipher's memory usage would grow indefinitely, up until it hit the end of the cursor. This leaves us open to OOM errors on large datasets. We've now switched to a release where the
memory used by the cursor can be bounded.

Performance seems largely unaffected. Basic query times appear to be the same on my 2014 Moto E. The main difference is that because there's a memory ceiling on a cursor, if it hits that memory ceiling, it has to requery and refill the cursor window. 

On a conversation with 18,500 messages (again, on my 2014 Moto E), this takes just under 1 second. Because the cursor is refilled on the main thread, that means the UI has a very noticeable "hiccup". However, I only experienced this hiccup when I set the memory ceiling very low (128 KB). At it's current value of 4MB, this hiccup should only be hit every 5000 messages or so (all depending on the message size, of course). On my 2016 Pixel, this hiccup is only ~250ms.

That said, while I think the hiccup is an acceptable compromise to avoid OOM errors on large conversations, it'd still be a good idea in the future to make some architectural changes to avoid the main-thread-requery pattern that is common with cursors.

**Test Devices**
* [Moto E (2nd Gen), Android 5.1, API 22](https://www.gsmarena.com/motorola_moto_e_(2nd_gen)-6986.php)
* [Google Pixel, Android 8.1, API 27](https://www.gsmarena.com/google_pixel-8346.php)

