### PR TITLE
Fix search header rendering after rotation.

### DIFF
--- a/src/org/thoughtcrime/securesms/search/SearchFragment.java
+++ b/src/org/thoughtcrime/securesms/search/SearchFragment.java
@@ -3,6 +3,7 @@ package org.thoughtcrime.securesms.search;
 import android.annotation.SuppressLint;
 import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -11,7 +12,6 @@ import android.support.v4.app.Fragment;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -41,8 +41,9 @@ public class SearchFragment extends Fragment implements SearchListAdapter.EventL
   public static final String TAG          = "SearchFragment";
   public static final String EXTRA_LOCALE = "locale";
 
-  private TextView     noResultsView;
-  private RecyclerView listView;
+  private TextView               noResultsView;
+  private RecyclerView           listView;
+  private StickyHeaderDecoration listDecoration;
 
   private SearchViewModel   viewModel;
   private SearchListAdapter listAdapter;
@@ -90,10 +91,12 @@ public class SearchFragment extends Fragment implements SearchListAdapter.EventL
     noResultsView = view.findViewById(R.id.search_no_results);
     listView      = view.findViewById(R.id.search_list);
 
-    listAdapter = new SearchListAdapter(GlideApp.with(this), this, locale);
+    listAdapter    = new SearchListAdapter(GlideApp.with(this), this, locale);
+    listDecoration = new StickyHeaderDecoration(listAdapter, false, false);
+
     listView.setAdapter(listAdapter);
+    listView.addItemDecoration(listDecoration);
     listView.setLayoutManager(new LinearLayoutManager(getContext()));
-    listView.addItemDecoration(new StickyHeaderDecoration(listAdapter, false, false));
   }
 
   @Override
@@ -117,6 +120,16 @@ public class SearchFragment extends Fragment implements SearchListAdapter.EventL
       }
     });
   }
+
+  @Override
+  public void onConfigurationChanged(Configuration newConfig) {
+    super.onConfigurationChanged(newConfig);
+
+    if (listDecoration != null) {
+      listDecoration.invalidateLayouts();
+    }
+  }
+
 
   @Override
   public void onConversationClicked(@NonNull ThreadRecord threadRecord) {

--- a/src/org/thoughtcrime/securesms/util/StickyHeaderDecoration.java
+++ b/src/org/thoughtcrime/securesms/util/StickyHeaderDecoration.java
@@ -181,6 +181,10 @@ public class StickyHeaderDecoration extends RecyclerView.ItemDecoration {
         ((LinearLayoutManager)parent.getLayoutManager()).getReverseLayout();
   }
 
+  public void invalidateLayouts() {
+    headerCache.clear();
+  }
+
   /**
    * The adapter to assist the {@link StickyHeaderDecoration} in creating and binding the header views.
    *


### PR DESCRIPTION
The sticky header cache was keeping views across rotations, causing them to render incorrectly afterwards. I added a method to invalidate the header layouts after rotation.

Fixes #7890.

**Test Devices**
* [Google Pixel, Android 8.1, API 27](https://www.gsmarena.com/google_pixel-8346.php)