### PR TITLE
Keep retrying message sends for 24 hours.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -528,6 +528,7 @@
 
     <receiver android:name=".service.ExpirationListener" />
 
+    <receiver android:name=".jobmanager.requirements.BackoffReceiver" />
 
     <provider android:name=".providers.PartProvider"
               android:grantUriPermissions="true"

--- a/src/org/thoughtcrime/securesms/jobmanager/JobParameters.java
+++ b/src/org/thoughtcrime/securesms/jobmanager/JobParameters.java
@@ -28,26 +28,30 @@ import java.util.concurrent.TimeUnit;
  */
 public class JobParameters implements Serializable {
 
+  private static final long serialVersionUID = 4880456378402584584L;
+
   private transient EncryptionKeys encryptionKeys;
 
   private final List<Requirement> requirements;
   private final boolean           isPersistent;
   private final int               retryCount;
+  private final long              retryUntil;
   private final String            groupId;
   private final boolean           wakeLock;
   private final long              wakeLockTimeout;
 
   private JobParameters(List<Requirement> requirements,
-                       boolean isPersistent, String groupId,
-                       EncryptionKeys encryptionKeys,
-                       int retryCount, boolean wakeLock,
-                       long wakeLockTimeout)
+                        boolean isPersistent, String groupId,
+                        EncryptionKeys encryptionKeys,
+                        int retryCount, long retryUntil, boolean wakeLock,
+                        long wakeLockTimeout)
   {
     this.requirements    = requirements;
     this.isPersistent    = isPersistent;
     this.groupId         = groupId;
     this.encryptionKeys  = encryptionKeys;
     this.retryCount      = retryCount;
+    this.retryUntil      = retryUntil;
     this.wakeLock        = wakeLock;
     this.wakeLockTimeout = wakeLockTimeout;
   }
@@ -70,6 +74,10 @@ public class JobParameters implements Serializable {
 
   public int getRetryCount() {
     return retryCount;
+  }
+
+  public long getRetryUntil() {
+    return retryUntil;
   }
 
   /**
@@ -96,6 +104,7 @@ public class JobParameters implements Serializable {
     private boolean           isPersistent    = false;
     private EncryptionKeys    encryptionKeys  = null;
     private int               retryCount      = 100;
+    private long              retryDuration   = 0;
     private String            groupId         = null;
     private boolean           wakeLock        = false;
     private long              wakeLockTimeout = 0;
@@ -139,7 +148,14 @@ public class JobParameters implements Serializable {
      * @return the builder.
      */
     public Builder withRetryCount(int retryCount) {
-      this.retryCount = retryCount;
+      this.retryCount    = retryCount;
+      this.retryDuration = 0;
+      return this;
+    }
+
+    public Builder withRetryDuration(long duration) {
+      this.retryDuration = duration;
+      this.retryCount    = 0;
       return this;
     }
 
@@ -184,7 +200,7 @@ public class JobParameters implements Serializable {
      * @return the JobParameters instance that describes a Job.
      */
     public JobParameters create() {
-      return new JobParameters(requirements, isPersistent, groupId, encryptionKeys, retryCount, wakeLock, wakeLockTimeout);
+      return new JobParameters(requirements, isPersistent, groupId, encryptionKeys, retryCount, System.currentTimeMillis() + retryDuration, wakeLock, wakeLockTimeout);
     }
   }
 }

--- a/src/org/thoughtcrime/securesms/jobmanager/requirements/BackoffReceiver.java
+++ b/src/org/thoughtcrime/securesms/jobmanager/requirements/BackoffReceiver.java
@@ -1,0 +1,35 @@
+package org.thoughtcrime.securesms.jobmanager.requirements;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.support.annotation.NonNull;
+import android.util.Log;
+
+import org.thoughtcrime.securesms.ApplicationContext;
+import org.thoughtcrime.securesms.BuildConfig;
+
+import java.util.UUID;
+
+public class BackoffReceiver extends BroadcastReceiver {
+
+  private static final String TAG = BackoffReceiver.class.getSimpleName();
+
+  @Override
+  public void onReceive(Context context, Intent intent) {
+    Log.i(TAG, "Received an alarm to retry a job with ID: " + intent.getAction());
+    ApplicationContext.getInstance(context).getJobManager().onRequirementStatusChanged();
+  }
+
+  public static void setUniqueAlarm(@NonNull Context context, long time) {
+    AlarmManager  alarmManager  = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+    Intent        intent        = new Intent(context, BackoffReceiver.class);
+
+    intent.setAction(BuildConfig.APPLICATION_ID + UUID.randomUUID().toString());
+    alarmManager.set(AlarmManager.RTC_WAKEUP, time, PendingIntent.getBroadcast(context, 0, intent, 0));
+
+    Log.i(TAG, "Set an alarm to retry a job in " + (time - System.currentTimeMillis()) + " ms with ID: " + intent.getAction());
+  }
+}

--- a/src/org/thoughtcrime/securesms/jobmanager/requirements/NetworkBackoffRequirement.java
+++ b/src/org/thoughtcrime/securesms/jobmanager/requirements/NetworkBackoffRequirement.java
@@ -1,0 +1,50 @@
+package org.thoughtcrime.securesms.jobmanager.requirements;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import org.thoughtcrime.securesms.jobmanager.Job;
+import org.thoughtcrime.securesms.jobmanager.dependencies.ContextDependent;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Uses exponential backoff to re-schedule network jobs to be retried in the future.
+ */
+public class NetworkBackoffRequirement implements Requirement, ContextDependent {
+
+  private static final long MAX_WAIT = TimeUnit.SECONDS.toMillis(30);
+
+  private transient Context context;
+
+  public NetworkBackoffRequirement(@NonNull Context context) {
+    this.context = context.getApplicationContext();
+  }
+
+  @Override
+  public boolean isPresent(@NonNull Job job) {
+    return new NetworkRequirement(context).isPresent() && System.currentTimeMillis() >= calculateNextRunTime(job);
+  }
+
+  @Override
+  public void onRetry(@NonNull Job job) {
+    if (!(new NetworkRequirement(context).isPresent())) {
+      job.resetRunStats();
+      return;
+    }
+
+    BackoffReceiver.setUniqueAlarm(context, NetworkBackoffRequirement.calculateNextRunTime(job));
+  }
+
+  @Override
+  public void setContext(Context context) {
+    this.context = context.getApplicationContext();
+  }
+
+  private static long calculateNextRunTime(@NonNull Job job) {
+    long targetTime   = job.getLastRunTime() + (long) (Math.pow(2, job.getRunIteration() - 1) * 1000);
+    long furthestTime = System.currentTimeMillis() + MAX_WAIT;
+
+    return Math.min(targetTime, Math.min(furthestTime, job.getRetryUntil()));
+  }
+}

--- a/src/org/thoughtcrime/securesms/jobmanager/requirements/NetworkRequirement.java
+++ b/src/org/thoughtcrime/securesms/jobmanager/requirements/NetworkRequirement.java
@@ -25,7 +25,7 @@ import org.thoughtcrime.securesms.jobmanager.dependencies.ContextDependent;
 /**
  * A requirement that is satisfied when a network connection is present.
  */
-public class NetworkRequirement implements Requirement, ContextDependent {
+public class NetworkRequirement extends SimpleRequirement implements ContextDependent {
 
   private transient Context context;
 

--- a/src/org/thoughtcrime/securesms/jobmanager/requirements/Requirement.java
+++ b/src/org/thoughtcrime/securesms/jobmanager/requirements/Requirement.java
@@ -16,6 +16,10 @@
  */
 package org.thoughtcrime.securesms.jobmanager.requirements;
 
+import android.support.annotation.NonNull;
+
+import org.thoughtcrime.securesms.jobmanager.Job;
+
 import java.io.Serializable;
 
 /**
@@ -25,5 +29,7 @@ public interface Requirement extends Serializable {
   /**
    * @return true if the requirement is satisfied, false otherwise.
    */
-  public boolean isPresent();
+  boolean isPresent(@NonNull Job job);
+
+  void onRetry(@NonNull Job job);
 }

--- a/src/org/thoughtcrime/securesms/jobmanager/requirements/SimpleRequirement.java
+++ b/src/org/thoughtcrime/securesms/jobmanager/requirements/SimpleRequirement.java
@@ -1,0 +1,19 @@
+package org.thoughtcrime.securesms.jobmanager.requirements;
+
+import android.support.annotation.NonNull;
+
+import org.thoughtcrime.securesms.jobmanager.Job;
+
+public abstract class SimpleRequirement implements Requirement {
+
+  @Override
+  public boolean isPresent(@NonNull Job job) {
+    return isPresent();
+  }
+
+  @Override
+  public void onRetry(@NonNull Job job) {
+  }
+
+  public abstract boolean isPresent();
+}

--- a/src/org/thoughtcrime/securesms/jobs/PushContentReceiveJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushContentReceiveJob.java
@@ -12,7 +12,8 @@ import java.io.IOException;
 
 public class PushContentReceiveJob extends PushReceivedJob {
 
-  private static final String TAG = PushContentReceiveJob.class.getSimpleName();
+  private static final long   serialVersionUID = 5685475456901715638L;
+  private static final String TAG              = PushContentReceiveJob.class.getSimpleName();
 
   private final String data;
 

--- a/src/org/thoughtcrime/securesms/jobs/PushSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushSendJob.java
@@ -16,7 +16,7 @@ import org.thoughtcrime.securesms.database.Address;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.events.PartProgressEvent;
 import org.thoughtcrime.securesms.jobmanager.JobParameters;
-import org.thoughtcrime.securesms.jobmanager.requirements.NetworkRequirement;
+import org.thoughtcrime.securesms.jobmanager.requirements.NetworkBackoffRequirement;
 import org.thoughtcrime.securesms.jobs.requirements.MasterSecretRequirement;
 import org.thoughtcrime.securesms.mms.DecryptableStreamUriLoader;
 import org.thoughtcrime.securesms.mms.OutgoingMediaMessage;
@@ -38,10 +38,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public abstract class PushSendJob extends SendJob {
 
-  private static final String TAG = PushSendJob.class.getSimpleName();
+  private static final long   serialVersionUID = 5906098204770900739L;
+  private static final String TAG              = PushSendJob.class.getSimpleName();
 
   protected PushSendJob(Context context, JobParameters parameters) {
     super(context, parameters);
@@ -52,8 +54,8 @@ public abstract class PushSendJob extends SendJob {
     builder.withPersistence();
     builder.withGroupId(destination.serialize());
     builder.withRequirement(new MasterSecretRequirement(context));
-    builder.withRequirement(new NetworkRequirement(context));
-    builder.withRetryCount(5);
+    builder.withRequirement(new NetworkBackoffRequirement(context));
+    builder.withRetryDuration(TimeUnit.DAYS.toMillis(1));
 
     return builder.create();
   }

--- a/src/org/thoughtcrime/securesms/jobs/SmsSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/SmsSendJob.java
@@ -29,7 +29,8 @@ import java.util.ArrayList;
 
 public class SmsSendJob extends SendJob {
 
-  private static final String TAG = SmsSendJob.class.getSimpleName();
+  private static final long   serialVersionUID = -5118520036244759718L;
+  private static final String TAG              = SmsSendJob.class.getSimpleName();
 
   private final long messageId;
 

--- a/src/org/thoughtcrime/securesms/jobs/SmsSentJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/SmsSentJob.java
@@ -18,7 +18,8 @@ import org.thoughtcrime.securesms.service.SmsDeliveryListener;
 
 public class SmsSentJob extends MasterSecretJob {
 
-  private static final String TAG = SmsSentJob.class.getSimpleName();
+  private static final long   serialVersionUID = -2624694558755317560L;
+  private static final String TAG              = SmsSentJob.class.getSimpleName();
 
   private final long   messageId;
   private final String action;

--- a/src/org/thoughtcrime/securesms/jobs/requirements/MasterSecretRequirement.java
+++ b/src/org/thoughtcrime/securesms/jobs/requirements/MasterSecretRequirement.java
@@ -4,9 +4,10 @@ import android.content.Context;
 
 import org.thoughtcrime.securesms.jobmanager.dependencies.ContextDependent;
 import org.thoughtcrime.securesms.jobmanager.requirements.Requirement;
+import org.thoughtcrime.securesms.jobmanager.requirements.SimpleRequirement;
 import org.thoughtcrime.securesms.service.KeyCachingService;
 
-public class MasterSecretRequirement implements Requirement, ContextDependent {
+public class MasterSecretRequirement extends SimpleRequirement implements ContextDependent {
 
   private transient Context context;
 

--- a/src/org/thoughtcrime/securesms/jobs/requirements/NetworkOrServiceRequirement.java
+++ b/src/org/thoughtcrime/securesms/jobs/requirements/NetworkOrServiceRequirement.java
@@ -5,8 +5,9 @@ import android.content.Context;
 import org.thoughtcrime.securesms.jobmanager.dependencies.ContextDependent;
 import org.thoughtcrime.securesms.jobmanager.requirements.NetworkRequirement;
 import org.thoughtcrime.securesms.jobmanager.requirements.Requirement;
+import org.thoughtcrime.securesms.jobmanager.requirements.SimpleRequirement;
 
-public class NetworkOrServiceRequirement implements Requirement, ContextDependent {
+public class NetworkOrServiceRequirement extends SimpleRequirement implements ContextDependent {
 
   private transient Context context;
 

--- a/src/org/thoughtcrime/securesms/jobs/requirements/ServiceRequirement.java
+++ b/src/org/thoughtcrime/securesms/jobs/requirements/ServiceRequirement.java
@@ -4,9 +4,10 @@ import android.content.Context;
 
 import org.thoughtcrime.securesms.jobmanager.dependencies.ContextDependent;
 import org.thoughtcrime.securesms.jobmanager.requirements.Requirement;
+import org.thoughtcrime.securesms.jobmanager.requirements.SimpleRequirement;
 import org.thoughtcrime.securesms.sms.TelephonyServiceState;
 
-public class ServiceRequirement implements Requirement, ContextDependent {
+public class ServiceRequirement extends SimpleRequirement implements ContextDependent {
 
   private static final String TAG = ServiceRequirement.class.getSimpleName();
 

--- a/src/org/thoughtcrime/securesms/jobs/requirements/SqlCipherMigrationRequirement.java
+++ b/src/org/thoughtcrime/securesms/jobs/requirements/SqlCipherMigrationRequirement.java
@@ -6,9 +6,10 @@ import android.support.annotation.NonNull;
 
 import org.thoughtcrime.securesms.jobmanager.dependencies.ContextDependent;
 import org.thoughtcrime.securesms.jobmanager.requirements.Requirement;
+import org.thoughtcrime.securesms.jobmanager.requirements.SimpleRequirement;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 
-public class SqlCipherMigrationRequirement implements Requirement, ContextDependent {
+public class SqlCipherMigrationRequirement extends SimpleRequirement implements ContextDependent {
 
   @SuppressWarnings("unused")
   private static final String TAG = SqlCipherMigrationRequirement.class.getSimpleName();


### PR DESCRIPTION
Previously, we would retry messages a fixed number of times, then declare them to be failed, prompting the user to manually retry. Now we will keep retrying message sends for up to 24 hours, using exponential backoff to throttle attempts.

Fixes #7888

**Test Devices**
* [Google Pixel, Android 8.1, API 27](https://www.gsmarena.com/google_pixel-8346.php)