### PR TITLE
Update scheduling of ServiceOutageDetectionJob.

### DIFF
--- a/src/org/thoughtcrime/securesms/jobs/PushGroupSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushGroupSendJob.java
@@ -139,8 +139,6 @@ public class PushGroupSendJob extends PushSendJob implements InjectableType {
 
   @Override
   public void onCanceled() {
-    super.onCanceled();
-
     DatabaseFactory.getMmsDatabase(context).markAsSentFailed(messageId);
   }
 

--- a/src/org/thoughtcrime/securesms/jobs/PushMediaSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushMediaSendJob.java
@@ -94,8 +94,6 @@ public class PushMediaSendJob extends PushSendJob implements InjectableType {
 
   @Override
   public void onCanceled() {
-    super.onCanceled();
-
     DatabaseFactory.getMmsDatabase(context).markAsSentFailed(messageId);
     notifyMediaMessageDeliveryFailed(context, messageId);
   }

--- a/src/org/thoughtcrime/securesms/jobs/PushSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushSendJob.java
@@ -74,8 +74,12 @@ public abstract class PushSendJob extends SendJob {
   }
 
   @Override
-  public void onCanceled() {
-    ApplicationContext.getInstance(context).getJobManager().add(new ServiceOutageDetectionJob(context));
+  public void onRetry() {
+    super.onRetry();
+
+    if (getRunIteration() > 1) {
+      ApplicationContext.getInstance(context).getJobManager().add(new ServiceOutageDetectionJob(context));
+    }
   }
 
   protected Optional<byte[]> getProfileKey(@NonNull Recipient recipient) {

--- a/src/org/thoughtcrime/securesms/jobs/PushTextSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushTextSendJob.java
@@ -83,8 +83,6 @@ public class PushTextSendJob extends PushSendJob implements InjectableType {
 
   @Override
   public void onCanceled() {
-    super.onCanceled();
-
     DatabaseFactory.getSmsDatabase(context).markAsSentFailed(messageId);
 
     long      threadId  = DatabaseFactory.getSmsDatabase(context).getThreadIdForMessage(messageId);


### PR DESCRIPTION
Previously, we were running this job in PushSendJob#onCanceled(). However, with the new retry logic, this won't happen for 24 hours.

Instead, we now schedule the job in PushSendJob#onRetry().

It's worth noting that ServiceOutageDetectionJob throttles itself to be once every 60s and is non-persistent.

**Test Devices**
* [Google Pixel, Android 8.1, API 27](https://www.gsmarena.com/google_pixel-8346.php)