### PR TITLE
Fix conversation snippet for contact shares.

### DIFF
--- a/src/org/thoughtcrime/securesms/contactshare/ContactUtil.java
+++ b/src/org/thoughtcrime/securesms/contactshare/ContactUtil.java
@@ -18,12 +18,15 @@ import com.google.i18n.phonenumbers.NumberParseException;
 import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import com.google.i18n.phonenumbers.Phonenumber.PhoneNumber;
 
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.components.emoji.EmojiStrings;
 import org.thoughtcrime.securesms.contactshare.Contact.Email;
 import org.thoughtcrime.securesms.contactshare.Contact.Phone;
 import org.thoughtcrime.securesms.contactshare.Contact.PostalAddress;
 import org.thoughtcrime.securesms.database.Address;
 import org.thoughtcrime.securesms.mms.PartAuthority;
 import org.thoughtcrime.securesms.recipients.Recipient;
+import org.thoughtcrime.securesms.util.SpanUtil;
 import org.thoughtcrime.securesms.util.Util;
 
 import java.io.IOException;
@@ -41,6 +44,16 @@ public final class ContactUtil {
     } catch (NumberFormatException e) {
       return -1;
     }
+  }
+
+  public static @NonNull CharSequence getStringSummary(@NonNull Context context, @NonNull Contact contact) {
+    String  contactName = ContactUtil.getDisplayName(contact);
+
+    if (!TextUtils.isEmpty(contactName)) {
+      return context.getString(R.string.MessageNotifier_contact_message, EmojiStrings.BUST_IN_SILHOUETTE, contactName);
+    }
+
+    return SpanUtil.italic(context.getString(R.string.MessageNotifier_unknown_contact_message));
   }
 
   public static @NonNull String getDisplayName(@Nullable Contact contact) {

--- a/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -30,6 +30,8 @@ import com.annimon.stream.Stream;
 
 import net.sqlcipher.database.SQLiteDatabase;
 
+import org.thoughtcrime.securesms.contactshare.Contact;
+import org.thoughtcrime.securesms.contactshare.ContactUtil;
 import org.thoughtcrime.securesms.database.GroupDatabase.GroupRecord;
 import org.thoughtcrime.securesms.database.MessagingDatabase.MarkedMessageInfo;
 import org.thoughtcrime.securesms.database.RecipientDatabase.RecipientSettings;
@@ -567,7 +569,7 @@ public class ThreadDatabase extends Database {
       MessageRecord record;
 
       if (reader != null && (record = reader.getNext()) != null) {
-        updateThread(threadId, count, record.getBody(), getAttachmentUriFor(record),
+        updateThread(threadId, count, getFormattedBodyFor(record), getAttachmentUriFor(record),
                      record.getTimestamp(), record.getDeliveryStatus(), record.getDeliveryReceiptCount(),
                      record.getType(), unarchive, record.getExpiresIn(), record.getReadReceiptCount());
         notifyConversationListListeners();
@@ -581,6 +583,15 @@ public class ThreadDatabase extends Database {
       if (reader != null)
         reader.close();
     }
+  }
+
+  private @NonNull String getFormattedBodyFor(@NonNull MessageRecord messageRecord) {
+    if (messageRecord.isMms() && ((MediaMmsMessageRecord) messageRecord).getSharedContacts().size() > 0) {
+      Contact contact = ((MediaMmsMessageRecord) messageRecord).getSharedContacts().get(0);
+      return ContactUtil.getStringSummary(context, contact).toString();
+    }
+
+    return messageRecord.getBody();
   }
 
   private @Nullable Uri getAttachmentUriFor(MessageRecord record) {

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -39,7 +39,6 @@ import android.util.Log;
 
 import org.thoughtcrime.securesms.ConversationActivity;
 import org.thoughtcrime.securesms.R;
-import org.thoughtcrime.securesms.components.emoji.EmojiStrings;
 import org.thoughtcrime.securesms.contactshare.ContactUtil;
 import org.thoughtcrime.securesms.contactshare.Contact;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
@@ -433,14 +432,8 @@ public class MessageNotifier {
       if (KeyCachingService.isLocked(context)) {
         body = SpanUtil.italic(context.getString(R.string.MessageNotifier_locked_message));
       } else if (record.isMms() && !((MmsMessageRecord) record).getSharedContacts().isEmpty()) {
-        Contact contact     = ((MmsMessageRecord) record).getSharedContacts().get(0);
-        String  contactName = ContactUtil.getDisplayName(contact);
-
-        if (!TextUtils.isEmpty(contactName)) {
-          body = context.getString(R.string.MessageNotifier_contact_message, EmojiStrings.BUST_IN_SILHOUETTE, contactName);
-        } else {
-          body = SpanUtil.italic(context.getString(R.string.MessageNotifier_unknown_contact_message));
-        }
+        Contact contact = ((MmsMessageRecord) record).getSharedContacts().get(0);
+        body = ContactUtil.getStringSummary(context, contact);
       } else if (record.isMms() && TextUtils.isEmpty(body) && !((MmsMessageRecord) record).getSlideDeck().getSlides().isEmpty()) {
         body = SpanUtil.italic(context.getString(R.string.MessageNotifier_media_message));
         slideDeck = ((MediaMmsMessageRecord)record).getSlideDeck();


### PR DESCRIPTION
Previously, contact shares would be displayed as "Media Message". Now it'll show the same as it does in a notification, namely ":bust_in_silhouette: {contact-name}".

(Note: the Galaxy S3 Mini contact name is, in fact ":ghost: Galaxy S3 Mini".

![Screenshot](https://user-images.githubusercontent.com/37311915/41690055-a731ed32-74a8-11e8-9fd2-b7a3116eaa7b.png)

**Test Devices**
* [Moto E (2nd Gen), Android 5.1, API 22](https://www.gsmarena.com/motorola_moto_e_(2nd_gen)-6986.php)
* [Google Pixel, Android 8.1, API 27](https://www.gsmarena.com/google_pixel-8346.php)

