### PR TITLE
Send/receive the expiring message timer for group updates.

### DIFF
--- a/src/org/thoughtcrime/securesms/jobs/PushDecryptJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushDecryptJob.java
@@ -380,8 +380,13 @@ public class PushDecryptJob extends ContextJob {
   private void handleGroupMessage(@NonNull SignalServiceEnvelope envelope,
                                   @NonNull SignalServiceDataMessage message,
                                   @NonNull Optional<Long> smsMessageId)
+      throws MmsException
   {
     GroupMessageProcessor.process(context, envelope, message, false);
+
+    if (message.getExpiresInSeconds() != 0 && message.getExpiresInSeconds() != getMessageDestination(envelope, message).getExpireMessages()) {
+      handleExpirationUpdate(envelope, message, Optional.absent());
+    }
 
     if (smsMessageId.isPresent()) {
       DatabaseFactory.getSmsDatabase(context).deleteMessage(smsMessageId.get());

--- a/src/org/thoughtcrime/securesms/jobs/PushGroupSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushGroupSendJob.java
@@ -168,6 +168,7 @@ public class PushGroupSendJob extends PushSendJob implements InjectableType {
       SignalServiceGroup        group            = new SignalServiceGroup(type, GroupUtil.getDecodedId(groupId), groupContext.getName(), groupContext.getMembersList(), avatar);
       SignalServiceDataMessage  groupDataMessage = SignalServiceDataMessage.newBuilder()
                                                                            .withTimestamp(message.getSentTimeMillis())
+                                                                           .withExpiration(message.getRecipient().getExpireMessages())
                                                                            .asGroupMessage(group)
                                                                            .build();
 

--- a/src/org/thoughtcrime/securesms/jobs/PushGroupUpdateJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushGroupUpdateJob.java
@@ -11,6 +11,7 @@ import org.thoughtcrime.securesms.database.GroupDatabase.GroupRecord;
 import org.thoughtcrime.securesms.dependencies.InjectableType;
 import org.thoughtcrime.securesms.jobmanager.JobParameters;
 import org.thoughtcrime.securesms.jobmanager.requirements.NetworkRequirement;
+import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.util.GroupUtil;
 import org.whispersystems.libsignal.util.guava.Optional;
 import org.whispersystems.signalservice.api.SignalServiceMessageSender;
@@ -88,9 +89,13 @@ public class PushGroupUpdateJob extends ContextJob implements InjectableType {
                                                         .withName(record.get().getTitle())
                                                         .build();
 
+    Address   groupAddress   = Address.fromSerialized(GroupUtil.getEncodedId(groupId, false));
+    Recipient groupRecipient = Recipient.from(context, groupAddress, false);
+
     SignalServiceDataMessage message = SignalServiceDataMessage.newBuilder()
                                                                .asGroupMessage(groupContext)
                                                                .withTimestamp(System.currentTimeMillis())
+                                                               .withExpiration(groupRecipient.getExpireMessages())
                                                                .build();
 
     messageSender.sendMessage(new SignalServiceAddress(source), message);


### PR DESCRIPTION
We will now check for updates to the expiring message time when receiving a group update event, as well as send the expiring message time when sending a group update event.

The primary use case of doing this is so when a new person is added to a group, they will also be told the expiring message timer. Previously, someone who was just added to the group wouldn't get the expiring message time until an actual message was sent.

**Test Devices**
* [Moto E (2nd Gen), Android 5.1, API 22](https://www.gsmarena.com/motorola_moto_e_(2nd_gen)-6986.php)
* [Google Pixel, Android 8.1, API 27](https://www.gsmarena.com/google_pixel-8346.php)

