### PR TITLE
Fix NPE during busy call.

### DIFF
--- a/src/org/thoughtcrime/securesms/service/WebRtcCallService.java
+++ b/src/org/thoughtcrime/securesms/service/WebRtcCallService.java
@@ -640,7 +640,7 @@ public class WebRtcCallService extends Service implements InjectableType,
       switch (callState) {
         case STATE_DIALING:
         case STATE_REMOTE_RINGING: setCallInProgressNotification(TYPE_OUTGOING_RINGING, this.recipient);    break;
-        case STATE_IDLE:
+        case STATE_IDLE:           setCallInProgressNotification(TYPE_INCOMING_CONNECTING, recipient);      break;
         case STATE_ANSWERING:      setCallInProgressNotification(TYPE_INCOMING_CONNECTING, this.recipient); break;
         case STATE_LOCAL_RINGING:  setCallInProgressNotification(TYPE_INCOMING_RINGING, this.recipient);    break;
         case STATE_CONNECTED:      setCallInProgressNotification(TYPE_ESTABLISHED, this.recipient);         break;


### PR DESCRIPTION
Addressing the following crash:

```
java.lang.NullPointerException: 
  at org.thoughtcrime.securesms.webrtc.CallNotificationBuilder.getCallInProgressNotification (CallNotificationBuilder.java:47)
  at org.thoughtcrime.securesms.service.WebRtcCallService.setCallInProgressNotification (WebRtcCallService.java:895)
  at org.thoughtcrime.securesms.service.WebRtcCallService.handleBusyCall (WebRtcCallService.java:618)
  at org.thoughtcrime.securesms.service.WebRtcCallService.lambda$onStartCommand$0$WebRtcCallService (WebRtcCallService.java:201)
  at org.thoughtcrime.securesms.service.WebRtcCallService$$Lambda$0.run (Unknown Source:4)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1162)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:636)
  at java.lang.Thread.run (Thread.java:764)
```

This means that at the time we get a busy call event, we have no recipient set. Normally, the recipient is set after receiving an incoming call, or placing an outgoing call. It's likely that we're getting into this state because the system dialer is busy, but not signal's.

To account for this, we don't bother setting a notification if the state is IDLE. We still want to note the missed call, however.