### PR TITLE
Fix backup/import issue with expiring messages.

### DIFF
--- a/src/org/thoughtcrime/securesms/DatabaseUpgradeActivity.java
+++ b/src/org/thoughtcrime/securesms/DatabaseUpgradeActivity.java
@@ -82,6 +82,7 @@ public class DatabaseUpgradeActivity extends BaseActivity {
   public static final int REMOVE_JOURNAL                       = 353;
   public static final int REMOVE_CACHE                         = 354;
   public static final int FULL_TEXT_SEARCH                     = 358;
+  public static final int BAD_IMPORT_CLEANUP                   = 373;
 
   private static final SortedSet<Integer> UPGRADE_VERSIONS = new TreeSet<Integer>() {{
     add(NO_MORE_KEY_EXCHANGE_PREFIX_VERSION);
@@ -103,6 +104,7 @@ public class DatabaseUpgradeActivity extends BaseActivity {
     add(SQLCIPHER_COMPLETE);
     add(REMOVE_CACHE);
     add(FULL_TEXT_SEARCH);
+    add(BAD_IMPORT_CLEANUP);
   }};
 
   private MasterSecret masterSecret;

--- a/src/org/thoughtcrime/securesms/database/AttachmentDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/AttachmentDatabase.java
@@ -76,7 +76,7 @@ public class AttachmentDatabase extends Database {
   public  static final String TABLE_NAME             = "part";
   public  static final String ROW_ID                 = "_id";
           static final String ATTACHMENT_JSON_ALIAS  = "attachment_json";
-          static final String MMS_ID                 = "mid";
+  public  static final String MMS_ID                 = "mid";
           static final String CONTENT_TYPE           = "ct";
           static final String NAME                   = "name";
           static final String CONTENT_DISPOSITION    = "cd";

--- a/src/org/thoughtcrime/securesms/database/GroupReceiptDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/GroupReceiptDatabase.java
@@ -18,7 +18,7 @@ public class GroupReceiptDatabase extends Database {
   public  static final String TABLE_NAME = "group_receipts";
 
   private static final String ID        = "_id";
-  private static final String MMS_ID    = "mms_id";
+  public  static final String MMS_ID    = "mms_id";
   private static final String ADDRESS   = "address";
   private static final String STATUS    = "status";
   private static final String TIMESTAMP = "timestamp";

--- a/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -55,7 +55,7 @@ public class ThreadDatabase extends Database {
 
   private static final String TAG = ThreadDatabase.class.getSimpleName();
 
-          static final String TABLE_NAME             = "thread";
+  public  static final String TABLE_NAME             = "thread";
   public  static final String ID                     = "_id";
   public  static final String DATE                   = "date";
   public  static final String MESSAGE_COUNT          = "message_count";

--- a/src/org/thoughtcrime/securesms/database/helpers/SQLCipherOpenHelper.java
+++ b/src/org/thoughtcrime/securesms/database/helpers/SQLCipherOpenHelper.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.database.Cursor;
 import android.os.SystemClock;
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 import android.util.Log;
 
 import net.sqlcipher.database.SQLiteDatabase;
@@ -48,8 +49,9 @@ public class SQLCipherOpenHelper extends SQLiteOpenHelper {
   private static final int QUOTED_REPLIES                   = 7;
   private static final int SHARED_CONTACTS                  = 8;
   private static final int FULL_TEXT_SEARCH                 = 9;
+  private static final int BAD_IMPORT_CLEANUP               = 10;
 
-  private static final int    DATABASE_VERSION = 9;
+  private static final int    DATABASE_VERSION = 10;
   private static final String DATABASE_NAME    = "signal.db";
 
   private final Context        context;
@@ -208,6 +210,31 @@ public class SQLCipherOpenHelper extends SQLiteOpenHelper {
         long mmsFinished = SystemClock.elapsedRealtime();
         Log.i(TAG, "Indexing MMS completed in " + (mmsFinished - smsFinished) + " ms");
         Log.i(TAG, "Indexing finished. Total time: " + (mmsFinished - start) + " ms");
+      }
+
+      if (oldVersion < BAD_IMPORT_CLEANUP) {
+        String trimmedCondition = " NOT IN (SELECT _id FROM mms)";
+
+        db.delete("group_receipts", "mms_id" + trimmedCondition, null);
+
+        String[] columns = new String[] { "_id", "unique_id", "_data", "thumbnail"};
+
+        try (Cursor cursor = db.query("part", columns, "mid" + trimmedCondition, null, null, null, null)) {
+          while (cursor != null && cursor.moveToNext()) {
+            db.delete("part", "_id = ? AND unique_id = ?", new String[] { String.valueOf(cursor.getLong(0)), String.valueOf(cursor.getLong(1)) });
+
+            String data      = cursor.getString(2);
+            String thumbnail = cursor.getString(3);
+
+            if (!TextUtils.isEmpty(data)) {
+              new File(data).delete();
+            }
+
+            if (!TextUtils.isEmpty(thumbnail)) {
+              new File(thumbnail).delete();
+            }
+          }
+        }
       }
 
       db.setTransactionSuccessful();


### PR DESCRIPTION
There was an issue where we were backing up group receipts and attachments that were for expiring messages (which are already excluded from the backup).

This PR excludes these items from the backup, and for backups made before this change, this PR also deletes these invalid entries at the end of the restore process.

**Test Devices**
* [Google Pixel, Android 8.1, API 27](https://www.gsmarena.com/google_pixel-8346.php)
