### PR TITLE
Only append newline between messages.

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
@@ -260,8 +260,10 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
     SpannableStringBuilder content = new SpannableStringBuilder();
 
     for (CharSequence message : messageBodies) {
+      if (content.length() > 0){
+        content.append('\n');
+      }
       content.append(message);
-      content.append('\n');
     }
 
     return content;


### PR DESCRIPTION
Fixes #7905

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Google Pixel 2 XL, Android 8.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
When looping through messages to display in the notification, only include a newline between messages rather than after each of them.
![screen shot 2018-06-22 at 11](https://user-images.githubusercontent.com/367976/41806787-ef8a5da4-7678-11e8-9476-504ab65abf99.jpg)
![screen shot 2018-06-22 at 11](https://user-images.githubusercontent.com/367976/41806789-f1fd2bc0-7678-11e8-94dd-a3801037f9f2.png)

