### PR TITLE
reset window LayoutParams when rotating Quick Reply popup

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationPopupActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationPopupActivity.java
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms;
 
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
@@ -31,20 +32,15 @@ public class ConversationPopupActivity extends ConversationActivity {
   @Override
   protected void onCreate(Bundle bundle, boolean ready) {
     getWindow().setFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND,
-                         WindowManager.LayoutParams.FLAG_DIM_BEHIND);
+            WindowManager.LayoutParams.FLAG_DIM_BEHIND);
 
     WindowManager.LayoutParams params = getWindow().getAttributes();
     params.alpha     = 1.0f;
-    params.dimAmount = 0.1f;
+    params.dimAmount = 0.25f;
     params.gravity   = Gravity.TOP;
     getWindow().setAttributes(params);
 
-    Display display = getWindowManager().getDefaultDisplay();
-    int     width   = display.getWidth();
-    int     height  = display.getHeight();
-
-    if (height > width) getWindow().setLayout((int) (width * .85), (int) (height * .5));
-    else                getWindow().setLayout((int) (width * .7), (int) (height * .75));
+    updateWindowLayoutParams();
 
     super.onCreate(bundle, ready);
 
@@ -71,6 +67,21 @@ public class ConversationPopupActivity extends ConversationActivity {
 
     inflater.inflate(R.menu.conversation_popup, menu);
     return true;
+  }
+
+  @Override
+  public void onConfigurationChanged(Configuration newConfig) {
+    super.onConfigurationChanged(newConfig);
+    updateWindowLayoutParams();
+  }
+
+  private void updateWindowLayoutParams() {
+    Display display = getWindowManager().getDefaultDisplay();
+    int     width   = display.getWidth();
+    int     height  = display.getHeight();
+
+    if (height > width) getWindow().setLayout((int) (width * .85), (int) (height * .5));
+    else                getWindow().setLayout((int) (width * .7), (int) (height * .75));
   }
 
   @Override


### PR DESCRIPTION
// FREEBIE

Fixes #7846

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Pixel 2, Android 6.0.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
----------

### Description
reset window LayoutParams in `onConfigurationChanged()` and increase dimAmount from .1 to .25

Can someone please test on a real device?