### PR TITLE
Updated account (authenticator) icons (Fixes #7908)

### DIFF
--- a/res/xml/authenticator.xml
+++ b/res/xml/authenticator.xml
@@ -1,6 +1,6 @@
 <account-authenticator xmlns:android="http://schemas.android.com/apk/res/android"
                        android:accountType="org.thoughtcrime.securesms"
-                       android:icon="@drawable/icon"
-                       android:smallIcon="@drawable/icon"
+                       android:icon="@mipmap/ic_launcher"
+                       android:smallIcon="@mipmap/ic_launcher"
                        android:label="@string/app_name"/>
 


### PR DESCRIPTION
Fixes #7908 

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Physical device: Samsung Galaxy S7 Edge (Android 7.0)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
I've updated the icons in the authenticator.xml file. It should now display the same icon as used in the launcher. 

Before:
![screenshot_20180627-093208](https://user-images.githubusercontent.com/18502706/41960268-a22ae3e2-79ef-11e8-8675-4238158fa932.png)

After:
![screenshot_20180627-093344](https://user-images.githubusercontent.com/18502706/41960450-0d1b9804-79f0-11e8-993d-bdb7cf7939e6.png)

