### PR TITLE
Add Mi A1 to hardware AEC blacklist

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -173,6 +173,7 @@ public class ApplicationContext extends MultiDexApplication implements Dependenc
         add("Moto G (5S) Plus");
         add("Moto G4");
         add("TA-1053");
+        add("Mi A1");
       }};
 
       Set<String> OPEN_SL_ES_WHITELIST = new HashSet<String>() {{


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Mi A1, Android 8.0.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Adds the Mi A1 to the Hardware AEC Blacklist, as echo canceling does not work, see #7635.