### PR TITLE
Fix video/audio losing file extension when forwarded (Fixes #7783)

### DIFF
--- a/src/org/thoughtcrime/securesms/database/AttachmentDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/AttachmentDatabase.java
@@ -668,7 +668,7 @@ public class AttachmentDatabase extends Database {
     }
 
     if (!hasThumbnail && dataInfo != null) {
-      if (MediaUtil.hasVideoThumbnail(attachment.getDataUri())) {
+      if (MediaUtil.hasVideoThumbnail(context, attachment.getDataUri())) {
         Bitmap bitmap = MediaUtil.getVideoThumbnail(context, attachment.getDataUri());
 
         if (bitmap != null) {

--- a/src/org/thoughtcrime/securesms/mms/DecryptableStreamLocalUriFetcher.java
+++ b/src/org/thoughtcrime/securesms/mms/DecryptableStreamLocalUriFetcher.java
@@ -30,7 +30,7 @@ class DecryptableStreamLocalUriFetcher extends StreamLocalUriFetcher {
 
   @Override
   protected InputStream loadResource(Uri uri, ContentResolver contentResolver) throws FileNotFoundException {
-    if (MediaUtil.hasVideoThumbnail(uri)) {
+    if (MediaUtil.hasVideoThumbnail(context, uri)) {
       Bitmap thumbnail = MediaUtil.getVideoThumbnail(context, uri);
 
       if (thumbnail != null) {

--- a/src/org/thoughtcrime/securesms/mms/VideoSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/VideoSlide.java
@@ -30,7 +30,7 @@ import org.thoughtcrime.securesms.util.ResUtil;
 public class VideoSlide extends Slide {
 
   public VideoSlide(Context context, Uri uri, long dataSize) {
-    super(context, constructAttachmentFromUri(context, uri, MediaUtil.VIDEO_UNSPECIFIED, dataSize, 0, 0, MediaUtil.hasVideoThumbnail(uri), null, false, false));
+    super(context, constructAttachmentFromUri(context, uri, MediaUtil.VIDEO_UNSPECIFIED, dataSize, 0, 0, MediaUtil.hasVideoThumbnail(context, uri), null, false, false));
   }
 
   public VideoSlide(Context context, Attachment attachment) {

--- a/src/org/thoughtcrime/securesms/util/MediaUtil.java
+++ b/src/org/thoughtcrime/securesms/util/MediaUtil.java
@@ -73,6 +73,10 @@ public class MediaUtil {
       return PersistentBlobProvider.getMimeType(context, uri);
     }
 
+    if (PartAuthority.isLocalUri(uri)) {
+      return PartAuthority.getAttachmentContentType(context, uri);
+    }
+
     String type = context.getContentResolver().getType(uri);
     if (type == null) {
       final String extension = MimeTypeMap.getFileExtensionFromUrl(uri.toString());


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S3, Android 7.1.2
 * Google Pixel XL, Android 8.1.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes 1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
When video/audio being forwarded, getting the MIME type fails as the Uri is in local form, which causes the file extension to lose.