### PR TITLE
Filter out inactive groups during contact selection

### DIFF
--- a/src/org/thoughtcrime/securesms/contacts/ContactsCursorLoader.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactsCursorLoader.java
@@ -204,11 +204,13 @@ public class ContactsCursorLoader extends CursorLoader {
     try (GroupDatabase.Reader reader = DatabaseFactory.getGroupDatabase(getContext()).getGroupsFilteredByTitle(filter)) {
       GroupDatabase.GroupRecord groupRecord;
       while ((groupRecord = reader.getNext()) != null) {
-        groupContacts.addRow(new Object[] { groupRecord.getTitle(),
-                                            groupRecord.getEncodedId(),
-                                            ContactsContract.CommonDataKinds.Phone.TYPE_CUSTOM,
-                                            "",
-                                            ContactsDatabase.NORMAL_TYPE });
+        if (groupRecord.isActive()) {
+          groupContacts.addRow(new Object[] { groupRecord.getTitle(),
+                                              groupRecord.getEncodedId(),
+                                              ContactsContract.CommonDataKinds.Phone.TYPE_CUSTOM,
+                                              "",
+                                              ContactsDatabase.NORMAL_TYPE });
+        }
       }
     }
     return groupContacts;


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 5X, Android 8.1.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

When "Leave group" is selected, the group is marked as not active in the local group database. However, after leaving a group, the inactive group still appears in the filtered contact list search results that appear when attempting to compose a new message. This is confusing to a number of fellow users that I have interacted with via groups. Once a group is left, a user must have another user of the group re-add them before the user that left the group can again send a message to the group. Thus the most intuitive action is to filter the results from possible contacts for new message compositions. That is what this PR does.

This effectively allows "deleting" a group (from the user's high-level perspective) by first leaving it, and then deleting all threads associated with the left group. The user will not see inactive groups while attempting to create new messages, unless re-invited (due to some "recents" processing, the inactive group still hangs around for sharing/invite actions, but these are out of scope for what I am interested in).

Technical note: The reason why I made the change like this is because when I originally made the change like the following diff, the conversation search (aka thread search filter) stopped working as I expected it too (basically that filter would not match existing threads/conversations). The reason is because `ContactAccessor.getNumbersForThreadSearchFilter` depends on `GroupDatabase.getGroupsFilteredByTitle` too.

```
diff --git a/src/org/thoughtcrime/securesms/database/GroupDatabase.java b/src/org/thoughtcrime/securesms/database/GroupDatabase.java
index 490d3ee0..ad7fcca8 100644
--- a/src/org/thoughtcrime/securesms/database/GroupDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/GroupDatabase.java
@@ -105,8 +105,8 @@ public class GroupDatabase extends Database {
 
   public Reader getGroupsFilteredByTitle(String constraint) {
     @SuppressLint("Recycle")
-    Cursor cursor = databaseHelper.getReadableDatabase().query(TABLE_NAME, null, TITLE + " LIKE ?",
-                                                                                        new String[]{"%" + constraint + "%"},
+    Cursor cursor = databaseHelper.getReadableDatabase().query(TABLE_NAME, null, TITLE + " LIKE ? AND " + ACTIVE + " = ?",
+                                                                                        new String[]{"%" + constraint + "%", "1"},
                                                                                         null, null, null);
```