### PR TITLE
Allow selecting all media in overview

### DIFF
--- a/res/menu/media_overview_context.xml
+++ b/res/menu/media_overview_context.xml
@@ -4,4 +4,9 @@
         android:title="@string/delete"
         android:icon="@drawable/ic_delete_white_24dp"
         app:showAsAction="always"/>
+
+    <item android:id="@+id/select_all"
+        android:title="@string/MediaOverviewActivity_Select_all"
+        android:icon="?menu_selectall_icon"
+        app:showAsAction="always"/>
 </menu>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -386,6 +386,7 @@
     <string name="MediaOverviewActivity_Media_delete_progress_title">Deleting</string>
     <string name="MediaOverviewActivity_Media_delete_progress_message">Deleting messages...</string>
     <string name="MediaOverviewActivity_Documents">Documents</string>
+    <string name="MediaOverviewActivity_Select_all">Select all</string>
 
     <!--- NotificationBarManager -->
     <string name="NotificationBarManager_signal_call_in_progress">Signal call in progress</string>

--- a/src/org/thoughtcrime/securesms/MediaGalleryAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaGalleryAdapter.java
@@ -154,6 +154,15 @@ class MediaGalleryAdapter extends StickyHeaderGridAdapter {
     notifyDataSetChanged();
   }
 
+  void selectAllMedia() {
+    for (int section = 0; section < media.getSectionCount(); section++) {
+      for (int item = 0; item < media.getSectionItemCount(section); item++) {
+        selected.add(media.get(section, item));
+      }
+    }
+    this.notifyDataSetChanged();
+  }
+
   interface ItemClickListener {
     void onMediaClicked(@NonNull MediaRecord mediaRecord);
     void onMediaLongClicked(MediaRecord mediaRecord);

--- a/src/org/thoughtcrime/securesms/MediaOverviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaOverviewActivity.java
@@ -348,6 +348,11 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity  
       builder.show();
     }
 
+    private void handleSelectAllMedia() {
+      getListAdapter().selectAllMedia();
+      actionMode.setTitle(String.valueOf(getListAdapter().getSelectedMediaCount()));
+    }
+
     private MediaGalleryAdapter getListAdapter() {
       return (MediaGalleryAdapter) recyclerView.getAdapter();
     }
@@ -380,6 +385,9 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity  
           case R.id.delete:
             handleDeleteMedia(getListAdapter().getSelectedMedia());
             mode.finish();
+            return true;
+          case R.id.select_all:
+            handleSelectAllMedia();
             return true;
         }
         return false;


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Nexus 5X, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This change allows selecting all media in the media overview section. You can do so by long-pressing one item and then tap the select-all icon in the action bar.

This feature allows deleting all media of a conversation at once, e.g. to free some disk space. With a save button in the media overview one could export those media in advance.

### Screenshot
![bildschirmfoto vom 2018-07-18 19-29-22](https://user-images.githubusercontent.com/16167751/42897949-fbd8e6b8-8ac1-11e8-9481-cee609da1f79.png)
