### PR TITLE
Allow batch saving of media

### DIFF
--- a/res/menu/media_overview_context.xml
+++ b/res/menu/media_overview_context.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item android:id="@+id/save"
+        android:title="@string/save"
+        android:icon="@drawable/ic_save_white_24dp"
+        app:showAsAction="always"/>
+
     <item android:id="@+id/delete"
         android:title="@string/delete"
         android:icon="@drawable/ic_delete_white_24dp"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="no">No</string>
     <string name="delete">Delete</string>
     <string name="please_wait">Please wait...</string>
+    <string name="save">Save</string>
 
     <!-- AbstractNotificationBuilder -->
     <string name="AbstractNotificationBuilder_new_message">New message</string>
@@ -386,6 +387,7 @@
     <string name="MediaOverviewActivity_Media_delete_progress_title">Deleting</string>
     <string name="MediaOverviewActivity_Media_delete_progress_message">Deleting messages...</string>
     <string name="MediaOverviewActivity_Documents">Documents</string>
+    <string name="MediaOverviewActivity_collecting_attachments">Collecting attachments...</string>
 
     <!--- NotificationBarManager -->
     <string name="NotificationBarManager_signal_call_in_progress">Signal call in progress</string>

--- a/src/org/thoughtcrime/securesms/MediaOverviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaOverviewActivity.java
@@ -16,6 +16,7 @@
  */
 package org.thoughtcrime.securesms;
 
+import android.Manifest;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
@@ -46,6 +47,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.codewaves.stickyheadergrid.StickyHeaderGridLayoutManager;
 
@@ -56,16 +58,20 @@ import org.thoughtcrime.securesms.database.loaders.BucketedThreadMediaLoader;
 import org.thoughtcrime.securesms.database.loaders.BucketedThreadMediaLoader.BucketedThreadMedia;
 import org.thoughtcrime.securesms.database.loaders.ThreadMediaLoader;
 import org.thoughtcrime.securesms.mms.GlideApp;
+import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.util.AttachmentUtil;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicNoActionBarTheme;
 import org.thoughtcrime.securesms.util.DynamicTheme;
+import org.thoughtcrime.securesms.util.SaveAttachmentTask;
 import org.thoughtcrime.securesms.util.StickyHeaderDecoration;
 import org.thoughtcrime.securesms.util.ViewUtil;
 import org.thoughtcrime.securesms.util.task.ProgressDialogAsyncTask;
 
 import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Locale;
 
 /**
@@ -308,6 +314,50 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity  
       }
     }
 
+    @SuppressWarnings("CodeBlock2Expr")
+    @SuppressLint({"InlinedApi","StaticFieldLeak"})
+    private void handleSaveMedia(@NonNull Collection<MediaDatabase.MediaRecord> batchMediaRecords) {
+      final Context context = getContext();
+      SaveAttachmentTask.showWarningDialog(context, (dialogInterface, which) -> {
+        Permissions.with(this)
+                   .request(android.Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE)
+                   .ifNecessary()
+                   .withPermanentDenialDialog(getString(R.string.MediaPreviewActivity_signal_needs_the_storage_permission_in_order_to_write_to_external_storage_but_it_has_been_permanently_denied))
+                   .onAnyDenied(() -> Toast.makeText(getContext(), R.string.MediaPreviewActivity_unable_to_write_to_external_storage_without_permission, Toast.LENGTH_LONG).show())
+                   .onAllGranted(() -> {
+                     new ProgressDialogAsyncTask<MediaDatabase.MediaRecord, Void, List<SaveAttachmentTask.Attachment>>(context,
+                                                                                                                       R.string.MediaOverviewActivity_collecting_attachments,
+                                                                                                                       R.string.please_wait) {
+                       @Override
+                       protected List<SaveAttachmentTask.Attachment> doInBackground(MediaDatabase.MediaRecord... mediaRecords) {
+                         List<SaveAttachmentTask.Attachment> attachments = new LinkedList<>();
+
+                         for (MediaDatabase.MediaRecord mediaRecord : mediaRecords) {
+                           if (mediaRecord.getAttachment().getDataUri() != null) {
+                             attachments.add(new SaveAttachmentTask.Attachment(mediaRecord.getAttachment().getDataUri(),
+                                                                               mediaRecord.getContentType(),
+                                                                               mediaRecord.getDate(),
+                                                                               mediaRecord.getAttachment().getFileName()));
+                           }
+                         }
+
+                         return attachments;
+                       }
+
+                       @Override
+                       protected void onPostExecute(List<SaveAttachmentTask.Attachment> attachments) {
+                         super.onPostExecute(attachments);
+                         SaveAttachmentTask saveTask = new SaveAttachmentTask(context,
+                                                                              attachments.size());
+                         saveTask.executeOnExecutor(THREAD_POOL_EXECUTOR,
+                                                    attachments.toArray(new SaveAttachmentTask.Attachment[attachments.size()]));
+                       }
+                     }.execute(batchMediaRecords.toArray(new MediaDatabase.MediaRecord[batchMediaRecords.size()]));
+                   })
+                   .execute();
+      }, batchMediaRecords.size());
+    }
+
     @SuppressLint("StaticFieldLeak")
     private void handleDeleteMedia(@NonNull Collection<MediaDatabase.MediaRecord> mediaRecords) {
       int recordCount       = mediaRecords.size();
@@ -377,6 +427,9 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity  
       @Override
       public boolean onActionItemClicked(ActionMode mode, MenuItem menuItem) {
         switch (menuItem.getItemId()) {
+          case R.id.save:
+            handleSaveMedia(getListAdapter().getSelectedMedia());
+            return true;
           case R.id.delete:
             handleDeleteMedia(getListAdapter().getSelectedMedia());
             mode.finish();

--- a/src/org/thoughtcrime/securesms/MediaOverviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaOverviewActivity.java
@@ -316,7 +316,7 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity  
 
     @SuppressWarnings("CodeBlock2Expr")
     @SuppressLint({"InlinedApi","StaticFieldLeak"})
-    private void handleSaveMedia(@NonNull Collection<MediaDatabase.MediaRecord> batchMediaRecords) {
+    private void handleSaveMedia(@NonNull Collection<MediaDatabase.MediaRecord> mediaRecords) {
       final Context context = getContext();
       SaveAttachmentTask.showWarningDialog(context, (dialogInterface, which) -> {
         Permissions.with(this)
@@ -325,11 +325,11 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity  
                    .withPermanentDenialDialog(getString(R.string.MediaPreviewActivity_signal_needs_the_storage_permission_in_order_to_write_to_external_storage_but_it_has_been_permanently_denied))
                    .onAnyDenied(() -> Toast.makeText(getContext(), R.string.MediaPreviewActivity_unable_to_write_to_external_storage_without_permission, Toast.LENGTH_LONG).show())
                    .onAllGranted(() -> {
-                     new ProgressDialogAsyncTask<MediaDatabase.MediaRecord, Void, List<SaveAttachmentTask.Attachment>>(context,
-                                                                                                                       R.string.MediaOverviewActivity_collecting_attachments,
-                                                                                                                       R.string.please_wait) {
+                     new ProgressDialogAsyncTask<Void, Void, List<SaveAttachmentTask.Attachment>>(context,
+                                                                                                  R.string.MediaOverviewActivity_collecting_attachments,
+                                                                                                  R.string.please_wait) {
                        @Override
-                       protected List<SaveAttachmentTask.Attachment> doInBackground(MediaDatabase.MediaRecord... mediaRecords) {
+                       protected List<SaveAttachmentTask.Attachment> doInBackground(Void... params) {
                          List<SaveAttachmentTask.Attachment> attachments = new LinkedList<>();
 
                          for (MediaDatabase.MediaRecord mediaRecord : mediaRecords) {
@@ -352,10 +352,10 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity  
                          saveTask.executeOnExecutor(THREAD_POOL_EXECUTOR,
                                                     attachments.toArray(new SaveAttachmentTask.Attachment[attachments.size()]));
                        }
-                     }.execute(batchMediaRecords.toArray(new MediaDatabase.MediaRecord[batchMediaRecords.size()]));
+                     }.execute();
                    })
                    .execute();
-      }, batchMediaRecords.size());
+      }, mediaRecords.size());
     }
 
     @SuppressLint("StaticFieldLeak")


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Nexus 5X, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This change allows selecting an arbitrary number of media items in media overview and then saving them to the phone's storage.

Most of the code is just a restoration of the code which was removed [here](https://github.com/signalapp/Signal-Android/commit/020e5b22ebff279c40773b2bd64b570030c9c81f#diff-978497c8da0623480ac14da5b105d5fbL124).