### PR TITLE
Increase call control button sizes

### DIFF
--- a/res/drawable/webrtc_bluetooth_button.xml
+++ b/res/drawable/webrtc_bluetooth_button.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@drawable/webrtc_control_background"/>
-    <item android:top="5dp"
-          android:left="5dp"
-          android:right="5dp"
-          android:bottom="5dp"
+    <item android:top="12dp"
+          android:left="12dp"
+          android:right="12dp"
+          android:bottom="12dp"
           android:drawable="@drawable/ic_bluetooth_white_24dp"/>
 </layer-list>

--- a/res/drawable/webrtc_camera_front_button.xml
+++ b/res/drawable/webrtc_camera_front_button.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:top="5dp"
-          android:left="5dp"
-          android:right="5dp"
-          android:bottom="5dp"
+    <item android:top="12dp"
+          android:left="12dp"
+          android:right="12dp"
+          android:bottom="12dp"
           android:drawable="@drawable/quick_camera_front"/>
 </layer-list>

--- a/res/drawable/webrtc_camera_rear_button.xml
+++ b/res/drawable/webrtc_camera_rear_button.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:top="5dp"
-          android:left="5dp"
-          android:right="5dp"
-          android:bottom="5dp"
+    <item android:top="12dp"
+          android:left="12dp"
+          android:right="12dp"
+          android:bottom="12dp"
           android:drawable="@drawable/quick_camera_rear"/>
 </layer-list>

--- a/res/drawable/webrtc_mute_button.xml
+++ b/res/drawable/webrtc_mute_button.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@drawable/webrtc_control_background"/>
-    <item android:top="5dp"
-          android:left="5dp"
-          android:right="5dp"
-          android:bottom="5dp"
+    <item android:top="12dp"
+          android:left="12dp"
+          android:right="12dp"
+          android:bottom="12dp"
           android:drawable="@drawable/ic_mic_off_white_24dp"/>
 </layer-list>

--- a/res/drawable/webrtc_speaker_button.xml
+++ b/res/drawable/webrtc_speaker_button.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@drawable/webrtc_control_background"/>
-    <item android:top="5dp"
-          android:left="5dp"
-          android:right="5dp"
-          android:bottom="5dp"
+    <item android:top="12dp"
+          android:left="12dp"
+          android:right="12dp"
+          android:bottom="12dp"
           android:drawable="@drawable/ic_volume_up_white_24dp"/>
 </layer-list>

--- a/res/drawable/webrtc_video_mute_button.xml
+++ b/res/drawable/webrtc_video_mute_button.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@drawable/webrtc_control_background"/>
-    <item android:top="5dp"
-          android:left="5dp"
-          android:right="5dp"
-          android:bottom="5dp"
+    <item android:top="12dp"
+          android:left="12dp"
+          android:right="12dp"
+          android:bottom="12dp"
           android:drawable="@drawable/ic_videocam_white_24dp"/>
 </layer-list>

--- a/res/layout/webrtc_call_controls.xml
+++ b/res/layout/webrtc_call_controls.xml
@@ -12,14 +12,14 @@
                 style="@style/WebRtcCallCompoundButton"
                 android:background="@drawable/webrtc_speaker_button"
                 tools:checked="true"
-                android:layout_marginRight="15dp"/>
+                android:layout_marginRight="8dp"/>
 
         <org.thoughtcrime.securesms.components.AccessibleToggleButton
                 android:id="@+id/bluetoothButton"
                 style="@style/WebRtcCallCompoundButton"
                 android:background="@drawable/webrtc_bluetooth_button"
                 tools:checked="true"
-                android:layout_marginRight="15dp"
+                android:layout_marginRight="8dp"
                 android:visibility="gone"/>
 
         <org.thoughtcrime.securesms.components.AccessibleToggleButton
@@ -27,14 +27,14 @@
                 style="@style/WebRtcCallCompoundButton"
                 android:background="@drawable/webrtc_mute_button"
                 android:contentDescription="@string/redphone_call_controls__mute"
-                android:layout_marginRight="15dp"
+                android:layout_marginRight="8dp"
                 tools:checked="false"
                 />
 
         <org.thoughtcrime.securesms.components.AccessibleToggleButton
                 android:id="@+id/video_mute_button"
                 style="@style/WebRtcCallCompoundButton"
-                android:layout_marginRight="15dp"
+                android:layout_marginRight="8dp"
                 android:background="@drawable/webrtc_video_mute_button"/>
 
         <org.thoughtcrime.securesms.components.AccessibleToggleButton

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -208,8 +208,8 @@
            text label behavior of the ToggleButton class.) -->
 
     <style name="WebRtcCallCompoundButton">
-        <item name="android:layout_height">31dp</item>
-        <item name="android:layout_width">31dp</item>
+        <item name="android:layout_height">48dp</item>
+        <item name="android:layout_width">48dp</item>
         <item name="android:textOn">@null</item>
         <item name="android:textOff">@null</item>
     </style>


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung S8, Android 8.0
 * Emulated Pixel 2, Android 8.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
- Increase the call control button paddings. Now the buttons match the recommended size (48dp), look more familiar and are easier to tap.

#### Before:
![call_controls resized](https://user-images.githubusercontent.com/11131859/43137233-95c6e4d6-8f4b-11e8-948c-d50c9c131194.png)

#### After:
![call_controls_new resized](https://user-images.githubusercontent.com/11131859/43137249-a3277bea-8f4b-11e8-828a-c270dc5b70d3.png)



