### PR TITLE
Apply message bubble paddings to both top and bottom

### DIFF
--- a/res/layout/conversation_fragment.xml
+++ b/res/layout/conversation_fragment.xml
@@ -9,7 +9,7 @@
             android:id="@android:id/list"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:paddingBottom="24dp"
+            android:paddingBottom="16dp"
             android:scrollbars="vertical"
             android:cacheColorHint="?conversation_background"
             android:clipChildren="false"

--- a/res/layout/conversation_item_header.xml
+++ b/res/layout/conversation_item_header.xml
@@ -5,8 +5,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:paddingTop="20dp"
-    android:paddingBottom="21dp"
+    android:paddingTop="12dp"
+    android:paddingBottom="13dp"
     android:paddingLeft="28dp"
     android:paddingRight="28dp">
 

--- a/res/values/dimens.xml
+++ b/res/values/dimens.xml
@@ -37,8 +37,8 @@
     <dimen name="conversation_individual_right_gutter">16dp</dimen>
     <dimen name="conversation_individual_left_gutter">16dp</dimen>
     <dimen name="conversation_group_left_gutter">52dp</dimen>
-    <dimen name="conversation_vertical_message_spacing_default">16dp</dimen>
-    <dimen name="conversation_vertical_message_spacing_collapse">2dp</dimen>
+    <dimen name="conversation_vertical_message_spacing_default">8dp</dimen>
+    <dimen name="conversation_vertical_message_spacing_collapse">1dp</dimen>
 
     <dimen name="quote_corner_radius_large">10dp</dimen>
     <dimen name="quote_corner_radius_bottom">4dp</dimen>

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -215,7 +215,7 @@ public class ConversationItem extends LinearLayout
     setGroupMessageStatus(messageRecord, recipient);
     setAuthor(messageRecord, previousMessageRecord, nextMessageRecord, groupThread);
     setQuote(messageRecord, previousMessageRecord, nextMessageRecord, groupThread);
-    setMessageSpacing(context, messageRecord, nextMessageRecord);
+    setMessageSpacing(context, messageRecord, previousMessageRecord, nextMessageRecord, groupThread);
     setFooter(messageRecord, nextMessageRecord, locale, groupThread);
   }
 
@@ -771,19 +771,20 @@ public class ConversationItem extends LinearLayout
     return isStartOfMessageCluster(current, previous, isGroupThread) && isEndOfMessageCluster(current, next, isGroupThread);
   }
 
-  private void setMessageSpacing(@NonNull Context context, @NonNull MessageRecord current, @NonNull Optional<MessageRecord> next) {
-    int spacing = readDimen(context, R.dimen.conversation_vertical_message_spacing_collapse);
+  private void setMessageSpacing(@NonNull Context context, @NonNull MessageRecord current, @NonNull Optional<MessageRecord> previous, @NonNull Optional<MessageRecord> next, boolean isGroupThread) {
+    int spacingTop = readDimen(context, R.dimen.conversation_vertical_message_spacing_collapse);
+    int spacingBottom = spacingTop;
 
-    if (next.isPresent()) {
-      boolean recipientsMatch = current.getRecipient().getAddress().equals(next.get().getRecipient().getAddress());
-      boolean outgoingMatch   = current.isOutgoing() == next.get().isOutgoing();
-
-      if (!recipientsMatch || !outgoingMatch) {
-        spacing = readDimen(context, R.dimen.conversation_vertical_message_spacing_default);
-      }
+    if (isStartOfMessageCluster(current, previous, isGroupThread)) {
+      spacingTop = readDimen(context, R.dimen.conversation_vertical_message_spacing_default);
     }
 
-    ViewUtil.setPaddingBottom(this, spacing);
+    if (isEndOfMessageCluster(current, next, isGroupThread)) {
+      spacingBottom = readDimen(context, R.dimen.conversation_vertical_message_spacing_default);
+    }
+
+    ViewUtil.setPaddingTop(this, spacingTop);
+    ViewUtil.setPaddingBottom(this, spacingBottom);
   }
 
   private int readDimen(@NonNull Context context, @DimenRes int dimenId) {

--- a/src/org/thoughtcrime/securesms/util/ViewUtil.java
+++ b/src/org/thoughtcrime/securesms/util/ViewUtil.java
@@ -233,6 +233,10 @@ public class ViewUtil {
     view.requestLayout();
   }
 
+  public static void setPaddingTop(@NonNull View view, int padding) {
+    view.setPadding(view.getPaddingLeft(), padding, view.getPaddingRight(), view.getPaddingBottom());
+  }
+
   public static void setPaddingBottom(@NonNull View view, int padding) {
     view.setPadding(view.getPaddingLeft(), view.getPaddingTop(), view.getPaddingRight(), padding);
   }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung S8, Android 8.0
 * Emulated Pixel 2, Android 8.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
- Applies both top and bottom paddings of a message item in a conversation – message bubbles are now better centered in its list row when batch selecting them
- Note that this PR doen't change the total appearance of the conversation

Fixes #8035 


#### Before:

![conv_item_paddings resized](https://user-images.githubusercontent.com/11131859/43201622-4f3683ea-9019-11e8-8a19-de3ff85c6478.jpg)

#### After:
![conv_item_paddings_neu resized](https://user-images.githubusercontent.com/11131859/43201625-519f8ed8-9019-11e8-9150-1f12a6ab371f.jpg)