### PR TITLE
Allow app to be manually moved to SD-card

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
-          package="org.thoughtcrime.securesms">
+          package="org.thoughtcrime.securesms"
+          android:installLocation="auto">
 
     <uses-sdk tools:overrideLibrary="com.amulyakhare.textdrawable,com.astuetz.pagerslidingtabstrip,pl.tajchert.waitingdots,com.h6ah4i.android.multiselectlistpreferencecompat,android.support.v13,com.davemorrissey.labs.subscaleview,com.tomergoldst.tooltips,com.klinker.android.send_message,com.takisoft.colorpicker,android.support.v14.preference"/>
 


### PR DESCRIPTION
Fixes #4065 

### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
-> **Please help me here. I havn't been able to complete [the steps](https://github.com/signalapp/Signal-Android/wiki/How-to-build-Signal-from-the-sources)**
- [ ] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/) (-> It's in this text, which works as well)

----------

### Description

User can now manually move the app to the external storage (SD-card). 
(More technical information about the install-location on the [android developer page about manifest-element](https://developer.android.com/guide/topics/manifest/manifest-element#install) and [android developer page about the data](https://developer.android.com/guide/topics/data/install-location))

**Not yet tested** (I didnt manage to) could someone build and test it?

Here's the issue on the discourse forum:
[Allow installation on external storage location (SD-card)](https://community.signalusers.org/t/allow-installation-on-external-storage-location-sd-card/2638)
And 2 related topics there:
[Does “Move app to SD card” compromise security?](https://community.signalusers.org/t/does-move-app-to-sd-card-compromise-security/158)
[Support external SD card storage for local message store](https://community.signalusers.org/t/support-external-sd-card-storage-for-local-message-store/3216)