### PR TITLE
Generate key material in the secure element (StrongBox) if available

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -241,7 +241,7 @@ dependencyVerification {
 
 android {
     flavorDimensions "none"
-    compileSdkVersion 27
+    compileSdkVersion 28
     buildToolsVersion '27.0.1'
     useLibrary 'org.apache.http.legacy'
 

--- a/src/org/thoughtcrime/securesms/components/camera/QuickAttachmentDrawer.java
+++ b/src/org/thoughtcrime/securesms/components/camera/QuickAttachmentDrawer.java
@@ -254,7 +254,7 @@ public class QuickAttachmentDrawer extends ViewGroup implements InputView, Camer
   @Override
   protected boolean drawChild(@NonNull Canvas canvas, @NonNull View child, long drawingTime) {
     boolean result;
-    final int save = canvas.save(Canvas.CLIP_SAVE_FLAG);
+    final int save = canvas.save();
 
     canvas.getClipBounds(drawChildrenRect);
     if (child == coverView) {

--- a/src/org/thoughtcrime/securesms/crypto/KeyStoreHelper.java
+++ b/src/org/thoughtcrime/securesms/crypto/KeyStoreHelper.java
@@ -2,6 +2,7 @@ package org.thoughtcrime.securesms.crypto;
 
 
 import android.os.Build;
+import android.os.Build.VERSION_CODES;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
 import android.support.annotation.NonNull;
@@ -84,12 +85,15 @@ public class KeyStoreHelper {
   private static SecretKey createKeyStoreEntry() {
     try {
       KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
-      KeyGenParameterSpec keyGenParameterSpec = new KeyGenParameterSpec.Builder(KEY_ALIAS, KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+      KeyGenParameterSpec.Builder keyGenParameterSpec = new KeyGenParameterSpec.Builder(KEY_ALIAS, KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
           .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
-          .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-          .build();
+          .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE);
 
-      keyGenerator.init(keyGenParameterSpec);
+      if (Build.VERSION.SDK_INT >= VERSION_CODES.P) {
+        keyGenParameterSpec.setIsStrongBoxBacked(true);
+      }
+
+      keyGenerator.init(keyGenParameterSpec.build());
 
       return keyGenerator.generateKey();
     } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel, Android 9
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Android 9 the concept of a "StrongBox Keymaster", which is a discreet secure element that Android devices may have. This PR changes KeyGenParameterSpec to request the key material be generated in the secure element, if available.

https://developer.android.com/training/articles/keystore#HardwareSecurityModule
