### PR TITLE
Fixed #8083 More flexible verify display table

### DIFF
--- a/res/layout/verify_display_fragment.xml
+++ b/res/layout/verify_display_fragment.xml
@@ -58,7 +58,7 @@
 
 
         <TableLayout android:id="@+id/number_table"
-                     android:layout_width="wrap_content"
+                     android:layout_width="match_parent"
                      android:layout_height="wrap_content"
                      android:layout_marginTop="5dp"
                      android:clickable="true"
@@ -69,87 +69,114 @@
                       android:focusable="false">
 
                 <TextView android:id="@+id/code_first"
-                          android:layout_width="wrap_content"
+                          android:layout_width="0dp"
+                          android:layout_weight="1"
                           android:layout_height="wrap_content"
+                          android:layout_marginRight="2dp"
+                          android:gravity="center_horizontal"
                           style="@style/IdentityKey"
                           tools:text="22934"/>
 
                 <TextView android:id="@+id/code_second"
-                          android:layout_width="wrap_content"
+                          android:layout_width="0dp"
+                          android:layout_weight="1"
                           android:layout_height="wrap_content"
-                          android:layout_marginLeft="20dp"
+                          android:layout_marginHorizontal="2dp"
+                          android:gravity="center_horizontal"
                           style="@style/IdentityKey"
                           tools:text="56944"/>
 
                 <TextView android:id="@+id/code_third"
-                          android:layout_width="wrap_content"
+                          android:layout_width="0dp"
+                          android:layout_weight="1"
                           android:layout_height="wrap_content"
-                          android:layout_marginLeft="20dp"
+                          android:layout_marginHorizontal="2dp"
+                          android:gravity="center_horizontal"
                           style="@style/IdentityKey"
                           tools:text="42738"/>
 
                 <TextView android:id="@+id/code_fourth"
-                          android:layout_width="wrap_content"
+                          android:layout_width="0dp"
+                          android:layout_weight="1"
                           android:layout_height="wrap_content"
-                          android:layout_marginLeft="20dp"
+                          android:layout_marginLeft="2dp"
+                          android:gravity="center_horizontal"
                           style="@style/IdentityKey"
                           tools:text="20038"/>
             </TableRow>
 
             <TableRow android:gravity="center_horizontal">
                 <TextView android:id="@+id/code_fifth"
-                          android:layout_width="wrap_content"
+                          android:layout_width="0dp"
+                          android:layout_weight="1"
                           android:layout_height="wrap_content"
+                          android:layout_marginRight="2dp"
+                          android:gravity="center_horizontal"
                           style="@style/IdentityKey"
                           tools:text="34431"/>
 
                 <TextView android:id="@+id/code_sixth"
-                          android:layout_width="wrap_content"
+                          android:layout_width="0dp"
+                          android:layout_weight="1"
                           android:layout_height="wrap_content"
-                          android:layout_marginLeft="20dp"
+                          android:layout_marginHorizontal="2dp"
+                          android:gravity="center_horizontal"
                           style="@style/IdentityKey"
                           tools:text="24922"/>
 
                 <TextView android:id="@+id/code_seventh"
-                          android:layout_width="wrap_content"
+                          android:layout_width="0dp"
+                          android:layout_weight="1"
                           android:layout_height="wrap_content"
-                          android:layout_marginLeft="20dp"
+                          android:layout_marginHorizontal="2dp"
+                          android:gravity="center_horizontal"
                           style="@style/IdentityKey"
                           tools:text="58594"/>
 
                 <TextView android:id="@+id/code_eighth"
-                          android:layout_width="wrap_content"
+                          android:layout_width="0dp"
+                          android:layout_weight="1"
                           android:layout_height="wrap_content"
-                          android:layout_marginLeft="20dp"
+                          android:layout_marginLeft="2dp"
+                          android:gravity="center_horizontal"
                           style="@style/IdentityKey"
                           tools:text="24109"/>
             </TableRow>
 
             <TableRow android:gravity="center_horizontal">
                 <TextView android:id="@+id/code_ninth"
-                          android:layout_width="wrap_content"
+                          android:layout_width="0dp"
+                          android:layout_weight="1"
                           android:layout_height="wrap_content"
+                          android:layout_marginRight="2dp"
+                          android:gravity="center_horizontal"
                           style="@style/IdentityKey"
                           tools:text="00257"/>
 
                 <TextView android:id="@+id/code_tenth"
-                          android:layout_width="wrap_content"
+                          android:layout_width="0dp"
+                          android:layout_weight="1"
                           android:layout_height="wrap_content"
-                          android:layout_marginLeft="20dp"
+                          android:layout_marginHorizontal="2dp"
+                          android:gravity="center_horizontal"
                           style="@style/IdentityKey"
                           tools:text="34956"/>
 
                 <TextView android:id="@+id/code_eleventh"
-                          android:layout_width="wrap_content"
+                          android:layout_width="0dp"
+                          android:layout_weight="1"
                           android:layout_height="wrap_content"
-                          android:layout_marginLeft="20dp"
+                          android:layout_marginHorizontal="2dp"
+                          android:gravity="center_horizontal"
                           style="@style/IdentityKey"
                           tools:text="32440"/>
 
                 <TextView android:id="@+id/code_twelth"
-                          android:layout_width="wrap_content"
+                          android:layout_width="0dp"
+                          android:layout_weight="1"
                           android:layout_height="wrap_content"
-                          android:layout_marginLeft="20dp"
+                          android:layout_marginLeft="2dp"
+                          android:gravity="center_horizontal"
                           style="@style/IdentityKey"
                           tools:text="15774"/>
             </TableRow>

--- a/res/layout/verify_display_fragment.xml
+++ b/res/layout/verify_display_fragment.xml
@@ -81,7 +81,8 @@
                           android:layout_width="0dp"
                           android:layout_weight="1"
                           android:layout_height="wrap_content"
-                          android:layout_marginHorizontal="2dp"
+                          android:layout_marginLeft="2dp"
+                          android:layout_marginRight="2dp"
                           android:gravity="center_horizontal"
                           style="@style/IdentityKey"
                           tools:text="56944"/>
@@ -90,7 +91,8 @@
                           android:layout_width="0dp"
                           android:layout_weight="1"
                           android:layout_height="wrap_content"
-                          android:layout_marginHorizontal="2dp"
+                          android:layout_marginLeft="2dp"
+                          android:layout_marginRight="2dp"
                           android:gravity="center_horizontal"
                           style="@style/IdentityKey"
                           tools:text="42738"/>
@@ -119,7 +121,8 @@
                           android:layout_width="0dp"
                           android:layout_weight="1"
                           android:layout_height="wrap_content"
-                          android:layout_marginHorizontal="2dp"
+                          android:layout_marginLeft="2dp"
+                          android:layout_marginRight="2dp"
                           android:gravity="center_horizontal"
                           style="@style/IdentityKey"
                           tools:text="24922"/>
@@ -128,7 +131,8 @@
                           android:layout_width="0dp"
                           android:layout_weight="1"
                           android:layout_height="wrap_content"
-                          android:layout_marginHorizontal="2dp"
+                          android:layout_marginLeft="2dp"
+                          android:layout_marginRight="2dp"
                           android:gravity="center_horizontal"
                           style="@style/IdentityKey"
                           tools:text="58594"/>
@@ -157,7 +161,8 @@
                           android:layout_width="0dp"
                           android:layout_weight="1"
                           android:layout_height="wrap_content"
-                          android:layout_marginHorizontal="2dp"
+                          android:layout_marginLeft="2dp"
+                          android:layout_marginRight="2dp"
                           android:gravity="center_horizontal"
                           style="@style/IdentityKey"
                           tools:text="34956"/>
@@ -166,7 +171,8 @@
                           android:layout_width="0dp"
                           android:layout_weight="1"
                           android:layout_height="wrap_content"
-                          android:layout_marginHorizontal="2dp"
+                          android:layout_marginLeft="2dp"
+                          android:layout_marginRight="2dp"
                           android:gravity="center_horizontal"
                           style="@style/IdentityKey"
                           tools:text="32440"/>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on this device:
 * Huawei P8 Lite 2017, Android 8.0.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixed #8083 Verification number not displayed correctly, when using a larger font
This makes the table more flexible to the different screen dimensions and font sizes.