### PR TITLE
Fixed #8151 Documents name not readable in dark theme

### DIFF
--- a/res/layout/media_overview_document_item.xml
+++ b/res/layout/media_overview_document_item.xml
@@ -16,6 +16,8 @@
             android:layout_gravity="center_vertical"
             android:layout_weight="1"
             android:visibility="visible"
+            app:doc_titleColor="?conversation_item_received_text_primary_color"
+            app:doc_captionColor="?conversation_item_received_text_secondary_color"
             tools:visibility="visible"/>
 
     <TextView android:id="@+id/date"


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on this device:
 * Huawei P8 Lite 2017, Android 8.0.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
In res/layout/media_overview_document_item.xml there aren't these 2 lines inside org.thoughtcrime.securesms.components.DocumentView:
app:doc_titleColor="?conversation_item_received_text_primary_color" app:doc_captionColor="?conversation_item_received_text_secondary_color"
On the other hand they are present in res/layout/conversation_item_received_document.xml, res/layout/conversation_item_sent_document.xml and res/layout/conversation_activity_attachment_editor_stub.xml.