### PR TITLE
Fixed #8146 Compose Text field height gets doubled (larger fonts)

### DIFF
--- a/src/org/thoughtcrime/securesms/components/ComposeText.java
+++ b/src/org/thoughtcrime/securesms/components/ComposeText.java
@@ -32,7 +32,6 @@ public class ComposeText extends EmojiEditText {
 
   private CharSequence    hint;
   private SpannableString subHint;
-  private boolean refreshLayout = false;
 
   @Nullable private InputPanel.MediaListener mediaListener;
 

--- a/src/org/thoughtcrime/securesms/components/ComposeText.java
+++ b/src/org/thoughtcrime/securesms/components/ComposeText.java
@@ -67,6 +67,7 @@ public class ComposeText extends EmojiEditText {
         setHint(ellipsizeToWidth(hint));
       }
     }
+    setLayoutParams(getLayoutParams());
   }
 
   private CharSequence ellipsizeToWidth(CharSequence text) {

--- a/src/org/thoughtcrime/securesms/components/ComposeText.java
+++ b/src/org/thoughtcrime/securesms/components/ComposeText.java
@@ -1,5 +1,6 @@
 package org.thoughtcrime.securesms.components;
 
+import android.app.ActionBar;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.os.Build;
@@ -32,6 +33,7 @@ public class ComposeText extends EmojiEditText {
 
   private CharSequence    hint;
   private SpannableString subHint;
+  private boolean refreshLayout = false;
 
   @Nullable private InputPanel.MediaListener mediaListener;
 
@@ -67,7 +69,10 @@ public class ComposeText extends EmojiEditText {
         setHint(ellipsizeToWidth(hint));
       }
     }
-    setLayoutParams(getLayoutParams());
+    if (refreshLayout) {
+      
+      refreshLayout = false;
+    }
   }
 
   private CharSequence ellipsizeToWidth(CharSequence text) {
@@ -94,6 +99,7 @@ public class ComposeText extends EmojiEditText {
     } else {
       super.setHint(ellipsizeToWidth(this.hint));
     }
+    refreshLayout = true;
   }
 
   public void appendInvite(String invite) {

--- a/src/org/thoughtcrime/securesms/components/ComposeText.java
+++ b/src/org/thoughtcrime/securesms/components/ComposeText.java
@@ -67,9 +67,9 @@ public class ComposeText extends EmojiEditText {
         setHint(ellipsizeToWidth(hint));
       }
     }
-    if (refreshLayout) {
-      
-      refreshLayout = false;
+
+    if(getText().toString().isEmpty()) {
+      setLayoutParams(getLayoutParams());
     }
   }
 
@@ -97,7 +97,6 @@ public class ComposeText extends EmojiEditText {
     } else {
       super.setHint(ellipsizeToWidth(this.hint));
     }
-    refreshLayout = true;
   }
 
   public void appendInvite(String invite) {

--- a/src/org/thoughtcrime/securesms/components/ComposeText.java
+++ b/src/org/thoughtcrime/securesms/components/ComposeText.java
@@ -1,6 +1,5 @@
 package org.thoughtcrime.securesms.components;
 
-import android.app.ActionBar;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.os.Build;


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on this device:
 * Huawei P8 Lite 2017, Android 8.0.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixed #8146
Call `setLayoutParams(getLayoutParams());` at the end of `onLayout()` method's definition (src/org/thoughtcrime/securesms/components/ComposeText.java).
The glitch probably happen because the text field's height (defined in the xml as adaptable) is set before the ellipsization of the hint text (done inside the java code). This refreshes the layout after ellipsization of the text.