### PR TITLE
Added a choice between a passphrase and the Android screenlock.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1362,7 +1362,7 @@
     <string name="BackupUtil_never">Never</string>
     <string name="BackupUtil_unknown">Unknown</string>
     <string name="preferences_app_protection__method_passphrase">Use a passphrase</string>
-    <string name="preferences_app_protection__method_passphrase_summary">Use a passphrase to protect Signal instead of the Android screenlock or fingerprint</string>
+    <string name="preferences_app_protection__method_passphrase_summary">Use a passphrase to protect Signal instead of the Android screen lock or fingerprint</string>
     <string name="preferences_app_protection__screen_lock">Screen lock</string>
     <string name="preferences_app_protection__lock_signal_access_with_android_screen_lock_or_fingerprint">Lock Signal access with Android screen lock or fingerprint</string>
     <string name="preferences_app_protection__screen_lock_inactivity_timeout">Screen lock inactivity timeout</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="no">No</string>
     <string name="delete">Delete</string>
     <string name="please_wait">Please wait...</string>
+    <string name="save">Save</string>
 
     <!-- AbstractNotificationBuilder -->
     <string name="AbstractNotificationBuilder_new_message">New message</string>
@@ -77,9 +78,16 @@
     <!-- CallScreen -->
     <string name="CallScreen_Incoming_call">Incoming call</string>
 
+    <!-- CameraActivity -->
+    <string name="CameraActivity_camera_unavailable">Camera unavailable.</string>
+    <string name="CameraActivity_image_save_failure">Failed to save image.</string>
+
     <!-- ClearProfileActivity -->
     <string name="ClearProfileActivity_remove">Remove</string>
     <string name="ClearProfileActivity_remove_profile_photo">Remove profile photo?</string>
+
+    <!-- CommunicationActions -->
+    <string name="CommunicationActions_no_browser_found">No web browser found.</string>
 
     <!-- ConfirmIdentityDialog -->
     <string name="ConfirmIdentityDialog_your_safety_number_with_s_has_changed">Your safety number with %1$s has changed. This could either mean that someone is trying to intercept your communication, or that %2$s simply reinstalled Signal.</string>
@@ -148,7 +156,9 @@
     <string name="ConversationActivity_error_leaving_group">Error leaving group</string>
     <string name="ConversationActivity_specify_recipient">Please choose a contact</string>
     <string name="ConversationActivity_unblock_this_contact_question">Unblock this contact?</string>
+    <string name="ConversationActivity_unblock_this_group_question">Unblock this group?</string>
     <string name="ConversationActivity_you_will_once_again_be_able_to_receive_messages_and_calls_from_this_contact">You will once again be able to receive messages and calls from this contact.</string>
+    <string name="ConversationActivity_unblock_this_group_description">Existing members will be able to add you to the group again.</string>
     <string name="ConversationActivity_unblock">Unblock</string>
     <string name="ConversationActivity_attachment_exceeds_size_limits">Attachment exceeds size limits for the type of message you\'re sending.</string>
     <string name="ConversationActivity_quick_camera_unavailable">Camera unavailable</string>
@@ -304,6 +314,9 @@
     <string name="ExperienceUpgradeActivity_now_you_can_share_a_profile_photo_and_name_with_friends_on_signal">Now you can share a profile photo and name with friends on Signal</string>
     <string name="ExperienceUpgradeActivity_signal_profiles_are_here">Signal profiles are here</string>
 
+    <!-- GcmBroadcastReceiver -->
+    <string name="GcmBroadcastReceiver_retrieving_a_message">Retrieving a message...</string>
+
     <!-- GcmRefreshJob -->
     <string name="GcmRefreshJob_Permanent_Signal_communication_failure">Permanent Signal communication failure!</string>
     <string name="GcmRefreshJob_Signal_was_unable_to_register_with_Google_Play_Services">Signal was unable to register with Google Play Services. Signal messages and calls have been disabled, please try re-registering in Settings &gt; Advanced.</string>
@@ -364,6 +377,9 @@
     <string name="InviteActivity_no_app_to_share_to">It looks like you don\'t have any apps to share to.</string>
     <string name="InviteActivity_friends_dont_let_friends_text_unencrypted">Friends don\'t let friends chat unencrypted.</string>
 
+    <!-- Job -->
+    <string name="Job_working_in_the_background">Working in the background...</string>
+
     <!-- MessageDetailsRecipient -->
     <string name="MessageDetailsRecipient_failed_to_send">Failed to send</string>
     <string name="MessageDetailsRecipient_new_safety_number">New safety number</string>
@@ -388,6 +404,8 @@
     <string name="MediaOverviewActivity_Media_delete_progress_title">Deleting</string>
     <string name="MediaOverviewActivity_Media_delete_progress_message">Deleting messages...</string>
     <string name="MediaOverviewActivity_Documents">Documents</string>
+    <string name="MediaOverviewActivity_Select_all">Select all</string>
+    <string name="MediaOverviewActivity_collecting_attachments">Collecting attachments...</string>
 
     <!--- NotificationBarManager -->
     <string name="NotificationBarManager_signal_call_in_progress">Signal call in progress</string>
@@ -468,6 +486,9 @@
     <!-- PlayServicesProblemFragment -->
     <string name="PlayServicesProblemFragment_the_version_of_google_play_services_you_have_installed_is_not_functioning">The version of Google Play Services you have installed is not functioning correctly.  Please reinstall Google Play Services and try again.</string>
 
+    <!-- PushNotificationReceiveJob -->
+    <string name="PushNotificationReceiveJob_retrieving_a_message">Retrieving a message...</string>
+
     <!-- RatingManager -->
     <string name="RatingManager_rate_this_app">Rate this app</string>
     <string name="RatingManager_if_you_enjoy_using_this_app_please_take_a_moment">If you enjoy using this app, please take a moment to help us by rating it.</string>
@@ -479,9 +500,15 @@
     <!-- RecipientPreferencesActivity -->
     <string name="RecipientPreferenceActivity_block_this_contact_question">Block this contact?</string>
     <string name="RecipientPreferenceActivity_you_will_no_longer_receive_messages_and_calls_from_this_contact">You will no longer receive messages and calls from this contact.</string>
+    <string name="RecipientPreferenceActivity_block_and_leave_group">Block and leave this group?</string>
+    <string name="RecipientPreferenceActivity_block_group">Block this group?</string>
+    <string name="RecipientPreferenceActivity_block_and_leave_group_description">You will no longer receive messages or updates from this group.</string>
     <string name="RecipientPreferenceActivity_block">Block</string>
     <string name="RecipientPreferenceActivity_unblock_this_contact_question">Unblock this contact?</string>
     <string name="RecipientPreferenceActivity_you_will_once_again_be_able_to_receive_messages_and_calls_from_this_contact">You will once again be able to receive messages and calls from this contact.</string>
+    <string name="RecipientPreferenceActivity_unblock_this_group_question">Unblock this group?</string>
+    <string name="RecipientPreferenceActivity_unblock_this_group_description">Existing members will be able to add you to the group again.</string>
+    <string name="RecipientPreferenceActivity_error_leaving_group">Error leaving group</string>
     <string name="RecipientPreferenceActivity_unblock">Unblock</string>
     <string name="RecipientPreferenceActivity_enabled">Enabled</string>
     <string name="RecipientPreferenceActivity_disabled">Disabled</string>
@@ -527,6 +554,10 @@
     <string name="RegistrationActivity_signal_needs_access_to_your_contacts_and_media_in_order_to_connect_with_friends">Signal needs access to your contacts and media in order to connect with friends, exchange messages, and make secure calls</string>
     <string name="RegistrationActivity_unable_to_connect_to_service">Unable to connect to service. Please check network connection and try again.</string>
     <string name="RegistrationActivity_to_easily_verify_your_phone_number_signal_can_automatically_detect_your_verification_code">To easily verify your phone number, Signal can automatically detect your verification code if you allow Signal to view SMS messages.</string>
+    <plurals name="RegistrationActivity_debug_log_hint">
+        <item quantity="one">You are now %d step away from submitting a debug log.</item>
+        <item quantity="other">You are now %d steps away from submitting a debug log.</item>
+    </plurals>
 
     <!-- ScribbleActivity -->
     <string name="ScribbleActivity_save_failure">Failed to save image changes</string>
@@ -536,6 +567,9 @@
     <string name="SearchFragment_header_conversations">Conversations</string>
     <string name="SearchFragment_header_contacts">Contacts</string>
     <string name="SearchFragment_header_messages">Messages</string>
+
+    <!-- SendJob -->
+    <string name="SendJob_sending_a_message">Sending a message...</string>
 
     <!-- SharedContactDetailsActivity -->
     <string name="SharedContactDetailsActivity_add_to_contacts">Add to Contacts</string>
@@ -682,6 +716,7 @@
 
     <!-- SaveAttachmentTask -->
     <string name="SaveAttachmentTask_saved_to">Saved to %s</string>
+    <string name="SaveAttachmentTask_saved">Saved</string>
 
     <!-- SearchToolbar -->
     <string name="SearchToolbar_search">Search</string>
@@ -1172,6 +1207,12 @@
     <string name="preferences_chats__message_text_size">Message font size</string>
     <string name="preferences_events__contact_joined_signal">Contact joined Signal</string>
     <string name="preferences_notifications__priority">Priority</string>
+    <string name="preferences_communication__category_sealed_sender">Sealed Sender</string>
+    <string name="preferences_communication__sealed_sender_display_indicators">Display indicators</string>
+    <string name="preferences_communication__sealed_sender_display_indicators_description">Show a status icon when you select "Message details" on messages that were delivered using sealed sender.</string>
+    <string name="preferences_communication__sealed_sender_allow_from_anyone">Allow from anyone</string>
+    <string name="preferences_communication__sealed_sender_allow_from_anyone_description">Enable sealed sender for incoming messages from non-contacts and people with whom you have not shared your profile.</string>
+    <string name="preferences_communication__sealed_sender_learn_more">Learn more</string>
 
     <!-- **************************************** -->
     <!-- menus -->
@@ -1335,6 +1376,7 @@
     <string name="preferences_chats__create_backup">Create backup</string>
     <string name="RegistrationActivity_enter_backup_passphrase">Enter backup passphrase</string>
     <string name="RegistrationActivity_restore">Restore</string>
+    <string name="RegistrationActivity_backup_failure_downgrade">Cannot import backups from newer versions of Signal</string>
     <string name="RegistrationActivity_incorrect_backup_passphrase">Incorrect backup passphrase</string>
     <string name="RegistrationActivity_checking">Checking...</string>
     <string name="RegistrationActivity_d_messages_so_far">%d messages so far...</string>
@@ -1362,7 +1404,7 @@
     <string name="BackupUtil_never">Never</string>
     <string name="BackupUtil_unknown">Unknown</string>
     <string name="preferences_app_protection__method_passphrase">Use a passphrase</string>
-    <string name="preferences_app_protection__method_passphrase_summary">Use a passphrase to protect Signal instead of the Android screen lock or fingerprint</string>
+    <string name="preferences_app_protection__method_passphrase_summary">Use a passphrase to protect Signal instead of the Android screenlock or fingerprint</string>
     <string name="preferences_app_protection__screen_lock">Screen lock</string>
     <string name="preferences_app_protection__lock_signal_access_with_android_screen_lock_or_fingerprint">Lock Signal access with Android screen lock or fingerprint</string>
     <string name="preferences_app_protection__screen_lock_inactivity_timeout">Screen lock inactivity timeout</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1361,6 +1361,8 @@
     <string name="RegistrationActivity_available_in">Available in:\u0020</string>
     <string name="BackupUtil_never">Never</string>
     <string name="BackupUtil_unknown">Unknown</string>
+    <string name="preferences_app_protection__method_passphrase">Use a passphrase</string>
+    <string name="preferences_app_protection__method_passphrase_summary">Use a passphrase to protect Signal instead of the Android screenlock or fingerprint</string>
     <string name="preferences_app_protection__screen_lock">Screen lock</string>
     <string name="preferences_app_protection__lock_signal_access_with_android_screen_lock_or_fingerprint">Lock Signal access with Android screen lock or fingerprint</string>
     <string name="preferences_app_protection__screen_lock_inactivity_timeout">Screen lock inactivity timeout</string>

--- a/res/xml/preferences_app_protection.xml
+++ b/res/xml/preferences_app_protection.xml
@@ -4,6 +4,12 @@
     <PreferenceCategory android:title="@string/preferences_app_protection__app_access">
 
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:key="pref_signal_protection_method"
+            android:defaultValue="false"
+            android:title="@string/preferences_app_protection__method_passphrase"
+            android:summary="@string/preferences_app_protection__method_passphrase_summary"/>
+
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
                 android:key="pref_android_screen_lock"
                 android:defaultValue="false"
                 android:title="@string/preferences_app_protection__screen_lock"

--- a/res/xml/preferences_app_protection.xml
+++ b/res/xml/preferences_app_protection.xml
@@ -3,6 +3,7 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <PreferenceCategory android:title="@string/preferences_app_protection__app_access">
 
+        <!-- JW: added option to use the passphrase -->
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
             android:key="pref_signal_protection_method"
             android:defaultValue="false"
@@ -71,6 +72,27 @@
 
         <Preference android:key="preference_category_blocked"
                     android:title="@string/preferences_app_protection__blocked_contacts" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:layout="@layout/preference_divider"/>
+
+    <PreferenceCategory android:title="@string/preferences_communication__category_sealed_sender">
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="pref_show_unidentifed_delivery_indicators"
+            android:title="@string/preferences_communication__sealed_sender_display_indicators"
+            android:summary="@string/preferences_communication__sealed_sender_display_indicators_description"/>
+
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="pref_universal_unidentified_access"
+            android:title="@string/preferences_communication__sealed_sender_allow_from_anyone"
+            android:summary="@string/preferences_communication__sealed_sender_allow_from_anyone_description"/>
+
+        <Preference
+            android:key="pref_unidentified_learn_more"
+            android:layout="@layout/unidentified_delivery_learn_more" />
+
     </PreferenceCategory>
 
     <PreferenceCategory android:layout="@layout/preference_divider"/>

--- a/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -31,6 +31,7 @@ public class TextSecurePreferences {
 
   private static final String TAG = TextSecurePreferences.class.getSimpleName();
 
+  public  static final String PROTECTION_METHOD_PREF           = "pref_signal_protection_method";
   public  static final String IDENTITY_PREF                    = "pref_choose_identity";
   public  static final String CHANGE_PASSPHRASE_PREF           = "pref_change_passphrase";
   public  static final String DISABLE_PASSPHRASE_PREF          = "pref_disable_passphrase";
@@ -161,6 +162,14 @@ public class TextSecurePreferences {
 
   private static final String NOTIFICATION_CHANNEL_VERSION          = "pref_notification_channel_version";
   private static final String NOTIFICATION_MESSAGES_CHANNEL_VERSION = "pref_notification_messages_channel_version";
+
+  public static boolean isProtectionMethodPassphrase(@NonNull Context context) {
+    return getBooleanPreference(context, PROTECTION_METHOD_PREF, false);
+  }
+
+  public static void setProtectionMethod(@NonNull Context context, boolean value) {
+    setBooleanPreference(context, PROTECTION_METHOD_PREF, value);
+  }
 
   public static boolean isScreenLockEnabled(@NonNull Context context) {
     return getBooleanPreference(context, SCREEN_LOCK, false);
@@ -915,8 +924,8 @@ public class TextSecurePreferences {
 
   private static @NonNull Set<String> getMediaDownloadAllowed(Context context, String key, @ArrayRes int defaultValuesRes) {
     return getStringSetPreference(context,
-                                  key,
-                                  new HashSet<>(Arrays.asList(context.getResources().getStringArray(defaultValuesRes))));
+      key,
+      new HashSet<>(Arrays.asList(context.getResources().getStringArray(defaultValuesRes))));
   }
 
   public static void setLastOutageCheckTime(Context context, long timestamp) {

--- a/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -31,6 +31,7 @@ public class TextSecurePreferences {
 
   private static final String TAG = TextSecurePreferences.class.getSimpleName();
 
+  // JW: added: true = passphrase, false = Android lock or fingerprint
   public  static final String PROTECTION_METHOD_PREF           = "pref_signal_protection_method";
   public  static final String IDENTITY_PREF                    = "pref_choose_identity";
   public  static final String CHANGE_PASSPHRASE_PREF           = "pref_change_passphrase";
@@ -85,6 +86,7 @@ public class TextSecurePreferences {
   private static final String UPDATE_APK_DOWNLOAD_ID           = "pref_update_apk_download_id";
   private static final String UPDATE_APK_DIGEST                = "pref_update_apk_digest";
   private static final String SIGNED_PREKEY_ROTATION_TIME_PREF = "pref_signed_pre_key_rotation_time";
+
   private static final String IN_THREAD_NOTIFICATION_PREF      = "pref_key_inthread_notifications";
   private static final String SHOW_INVITE_REMINDER_PREF        = "pref_show_invite_reminder";
   public  static final String MESSAGE_BODY_TEXT_SIZE_PREF      = "pref_message_body_text_size";
@@ -163,10 +165,20 @@ public class TextSecurePreferences {
   private static final String NOTIFICATION_CHANNEL_VERSION          = "pref_notification_channel_version";
   private static final String NOTIFICATION_MESSAGES_CHANNEL_VERSION = "pref_notification_messages_channel_version";
 
+  private static final String NEEDS_MESSAGE_PULL = "pref_needs_message_pull";
+
+  private static final String UNIDENTIFIED_ACCESS_CERTIFICATE_ROTATION_TIME_PREF = "pref_unidentified_access_certificate_rotation_time";
+  private static final String UNIDENTIFIED_ACCESS_CERTIFICATE                    = "pref_unidentified_access_certificate";
+  public  static final String UNIVERSAL_UNIDENTIFIED_ACCESS                      = "pref_universal_unidentified_access";
+  public  static final String SHOW_UNIDENTIFIED_DELIVERY_INDICATORS              = "pref_show_unidentifed_delivery_indicators";
+  private static final String UNIDENTIFIED_DELIVERY_ENABLED                      = "pref_unidentified_delivery_enabled";
+
+  // JW: added for PROTECTION_METHOD_PREF
   public static boolean isProtectionMethodPassphrase(@NonNull Context context) {
     return getBooleanPreference(context, PROTECTION_METHOD_PREF, false);
   }
 
+  // JW added
   public static void setProtectionMethod(@NonNull Context context, boolean value) {
     setBooleanPreference(context, PROTECTION_METHOD_PREF, value);
   }
@@ -511,6 +523,47 @@ public class TextSecurePreferences {
 
   public static boolean isInThreadNotifications(Context context) {
     return getBooleanPreference(context, IN_THREAD_NOTIFICATION_PREF, true);
+  }
+
+  public static long getUnidentifiedAccessCertificateRotationTime(Context context) {
+    return getLongPreference(context, UNIDENTIFIED_ACCESS_CERTIFICATE_ROTATION_TIME_PREF, 0L);
+  }
+
+  public static void setUnidentifiedAccessCertificateRotationTime(Context context, long value) {
+    setLongPreference(context, UNIDENTIFIED_ACCESS_CERTIFICATE_ROTATION_TIME_PREF, value);
+  }
+
+  public static void setUnidentifiedAccessCertificate(Context context, byte[] value) {
+    setStringPreference(context, UNIDENTIFIED_ACCESS_CERTIFICATE, Base64.encodeBytes(value));
+  }
+
+  public static byte[] getUnidentifiedAccessCertificate(Context context) {
+    try {
+      String result = getStringPreference(context, UNIDENTIFIED_ACCESS_CERTIFICATE, null);
+      if (result != null) {
+        return Base64.decode(result);
+      }
+    } catch (IOException e) {
+      Log.w(TAG, e);
+    }
+
+    return null;
+  }
+
+  public static boolean isUniversalUnidentifiedAccess(Context context) {
+    return getBooleanPreference(context, UNIVERSAL_UNIDENTIFIED_ACCESS, false);
+  }
+
+  public static boolean isShowUnidentifiedDeliveryIndicatorsEnabled(Context context) {
+    return getBooleanPreference(context, SHOW_UNIDENTIFIED_DELIVERY_INDICATORS, false);
+  }
+
+  public static void setIsUnidentifiedDeliveryEnabled(Context context, boolean enabled) {
+    setBooleanPreference(context, UNIDENTIFIED_DELIVERY_ENABLED, enabled);
+  }
+
+  public static boolean isUnidentifiedDeliveryEnabled(Context context) {
+    return getBooleanPreference(context, UNIDENTIFIED_DELIVERY_ENABLED, true);
   }
 
   public static long getSignedPreKeyRotationTime(Context context) {
@@ -924,8 +977,8 @@ public class TextSecurePreferences {
 
   private static @NonNull Set<String> getMediaDownloadAllowed(Context context, String key, @ArrayRes int defaultValuesRes) {
     return getStringSetPreference(context,
-      key,
-      new HashSet<>(Arrays.asList(context.getResources().getStringArray(defaultValuesRes))));
+                                  key,
+                                  new HashSet<>(Arrays.asList(context.getResources().getStringArray(defaultValuesRes))));
   }
 
   public static void setLastOutageCheckTime(Context context, long timestamp) {
@@ -990,6 +1043,14 @@ public class TextSecurePreferences {
 
   public static void setNotificationMessagesChannelVersion(Context context, int version) {
     setIntegerPrefrence(context, NOTIFICATION_MESSAGES_CHANNEL_VERSION, version);
+  }
+
+  public static boolean getNeedsMessagePull(Context context) {
+    return getBooleanPreference(context, NEEDS_MESSAGE_PULL, false);
+  }
+
+  public static void setNeedsMessagePull(Context context, boolean needsMessagePull) {
+    setBooleanPreference(context, NEEDS_MESSAGE_PULL, needsMessagePull);
   }
 
   public static void setBooleanPreference(Context context, String key, boolean value) {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Z3 compact, Android 6.0.1
 * Sony Z1 compact, Android 4.4.4
 * Acer Z205, Android 4.4.2
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
In Settings - Privacy, a setting is added that lets the user switch between a passphrase and Android screenlock for app protection.
![screenshot_20180905-085623](https://user-images.githubusercontent.com/8427572/45088673-07982180-b10a-11e8-92f9-e6a87694a2c2.png)
or go back to Android system lock:
![screenshot_20180905-124057](https://user-images.githubusercontent.com/8427572/45088701-18489780-b10a-11e8-9b69-b34695d4910d.png)
