### PR TITLE
Check if the content of the EditText changed, only then set the cursor

### DIFF
--- a/src/org/thoughtcrime/securesms/components/emoji/EmojiEditText.java
+++ b/src/org/thoughtcrime/securesms/components/emoji/EmojiEditText.java
@@ -35,8 +35,12 @@ public class EmojiEditText extends AppCompatEditText {
     final int          start = getSelectionStart();
     final int          end   = getSelectionEnd();
 
-    getText().replace(Math.min(start, end), Math.max(start, end), emoji);
-    setSelection(start + emoji.length());
+    String beforeReplacing = getText().toString();
+    String afterReplacing = getText().replace(Math.min(start, end), Math.max(start, end), emoji).toString();
+    boolean messageHasChanged = !beforeReplacing.equals(afterReplacing);
+    if (messageHasChanged) {
+      setSelection(start + emoji.length());
+    }
   }
 
   @Override


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Oneplus 3T, Android 8.0.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This Pull Requests fixes the problem that the app crashes when you try to input an emoji, when you're near the 2000 characters limit. It does this by only setting the cursor to the new position if the message has changed.
I tested this by entering 2000 characters and had a look through the debugger as well as just from using the app.
I also tested that this doesn't trigger when it is not supposed to. 
I did so by creating a toast in the else part of the if clause(not included in the commit) and verifying that it only showed up when the message was too long