### PR TITLE
Added "Mute [chat conversation] for 8 hours"

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -183,6 +183,7 @@
   <string-array name="mute_durations">
       <item>@string/arrays__mute_for_one_hour</item>
       <item>@string/arrays__mute_for_two_hours</item>
+      <item>@string/arrays__mute_for_eight_hours</item>
       <item>@string/arrays__mute_for_one_day</item>
       <item>@string/arrays__mute_for_seven_days</item>
       <item>@string/arrays__mute_for_one_year</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1038,6 +1038,7 @@
 
     <string name="arrays__mute_for_one_hour">Mute for 1 hour</string>
     <string name="arrays__mute_for_two_hours">Mute for 2 hours</string>
+    <string name="arrays__mute_for_eight_hours">Mute for 8 hours</string>
     <string name="arrays__mute_for_one_day">Mute for 1 day</string>
     <string name="arrays__mute_for_seven_days">Mute for 7 days</string>
     <string name="arrays__mute_for_one_year">Mute for 1 year</string>

--- a/src/org/thoughtcrime/securesms/MuteDialog.java
+++ b/src/org/thoughtcrime/securesms/MuteDialog.java
@@ -33,9 +33,10 @@ public class MuteDialog extends AlertDialog {
         switch (which) {
           case 0:  muteUntil = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1);  break;
           case 1:  muteUntil = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(2);  break;
-          case 2:  muteUntil = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1);   break;
-          case 3:  muteUntil = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(7);   break;
-          case 4:  muteUntil = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(365); break;
+          case 2:  muteUntil = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(8);  break;
+          case 3:  muteUntil = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1);   break;
+          case 4:  muteUntil = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(7);   break;
+          case 5:  muteUntil = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(365); break;
           default: muteUntil = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1);  break;
         }
 


### PR DESCRIPTION
Translations NOT yet added

### First time contributor checklist
- [x ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x ] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
A new option value of 8 hours has been added to the "Mute notification" dialogue.
Currently there is indeed 2h or 24 hours (1 day) but nothing in between.
I believe the 8 hours dialogue will be useful for everyone that want to mute Signal conversations across the working time.
