### PR TITLE
Fix URL to Signal profiles FAQ

### DIFF
--- a/src/org/thoughtcrime/securesms/CreateProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/CreateProfileActivity.java
@@ -254,7 +254,7 @@ public class CreateProfileActivity extends BaseActionBarActivity implements Inje
 
     informationLabel.setOnClickListener(view -> {
       Intent intent = new Intent(Intent.ACTION_VIEW);
-      intent.setData(Uri.parse("https://support.signal.org/hc/en-us/articles/115001434171"));
+      intent.setData(Uri.parse("https://support.signal.org/hc/en-us/articles/360007459591"));
 
       if (getPackageManager().queryIntentActivities(intent, 0).size() > 0) {
         startActivity(intent);


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 5X, Android 8.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

The old help URL for Signal profiles results in 404.