### PR TITLE
Adds partial text selection of ConversationItem body text

### DIFF
--- a/res/layout/conversation_item_received.xml
+++ b/res/layout/conversation_item_received.xml
@@ -161,6 +161,9 @@
                 android:textColor="?conversation_item_received_text_primary_color"
                 android:textColorLink="?conversation_item_received_text_primary_color"
                 app:scaleEmojis="true"
+                android:clickable="false"
+                android:focusable="true"
+                android:textIsSelectable="true"
                 tools:text="Mango pickle lorem ipsum"/>
 
             <org.thoughtcrime.securesms.components.ConversationItemFooter

--- a/res/layout/conversation_item_sent.xml
+++ b/res/layout/conversation_item_sent.xml
@@ -97,6 +97,9 @@
                 android:textColor="?conversation_item_sent_text_primary_color"
                 android:textColorLink="?conversation_item_sent_text_primary_color"
                 app:scaleEmojis="true"
+                android:clickable="false"
+                android:focusable="true"
+                android:textIsSelectable="true"
                 tools:text="Mango pickle lorem ipsum"/>
 
             <View

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -384,8 +384,6 @@ public class ConversationItem extends LinearLayout
   }
 
   private void setBodyText(MessageRecord messageRecord) {
-    bodyText.setClickable(false);
-    bodyText.setFocusable(false);
     bodyText.setTextSize(TypedValue.COMPLEX_UNIT_SP, TextSecurePreferences.getMessageBodyTextSize(context));
 
     if (isCaptionlessMms(messageRecord)) {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * OnePlus 3, Android 6.0
 * OnePlus 3T, Android 7.0
 * Virtual device, Android 7.0
- [x] My contribution is fully baked and ready to be merged as is

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

This PR addresses the UX "issue" where user is unable to select portion of received or sent message and copy it. This is implemented on `ConversationItem` level, therefore select/copy (but also share, translate etc) is now available in all places this element is used incl. conversation list and message details activity.

![conversation_list](https://user-images.githubusercontent.com/8041294/46250246-df64bf80-c436-11e8-921a-0777618e9ea5.png)

![message_details](https://user-images.githubusercontent.com/8041294/46250248-e4297380-c436-11e8-9669-87a6b1864f9f.png)

