### PR TITLE
Detect and recycle broken connections on non-GCM devices

### DIFF
--- a/src/org/thoughtcrime/securesms/dependencies/SignalCommunicationModule.java
+++ b/src/org/thoughtcrime/securesms/dependencies/SignalCommunicationModule.java
@@ -131,11 +131,10 @@ public class SignalCommunicationModule {
                                                           new SignalProtocolStoreImpl(context),
                                                           BuildConfig.USER_AGENT,
                                                           TextSecurePreferences.isMultiDevice(context),
-                                                          Optional.fromNullable(IncomingMessageObserver.getPipe()),
-                                                          Optional.fromNullable(IncomingMessageObserver.getUnidentifiedPipe()),
+                                                          IncomingMessageObserver.getPipeReference(),
+                                                          IncomingMessageObserver.getUnidentifiedPipeReference(),
                                                           Optional.of(new SecurityEventListener(context)));
     } else {
-      this.messageSender.setMessagePipe(IncomingMessageObserver.getPipe(), IncomingMessageObserver.getUnidentifiedPipe());
       this.messageSender.setIsMultiDevice(TextSecurePreferences.isMultiDevice(context));
     }
 

--- a/src/org/thoughtcrime/securesms/service/IncomingMessageObserver.java
+++ b/src/org/thoughtcrime/securesms/service/IncomingMessageObserver.java
@@ -36,6 +36,7 @@ import org.whispersystems.signalservice.api.SignalServiceMessagePipe;
 import org.whispersystems.signalservice.api.SignalServiceMessageReceiver;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -153,6 +154,14 @@ public class IncomingMessageObserver implements InjectableType, ConstraintObserv
     return unidentifiedPipe;
   }
 
+  public static AtomicReference<SignalServiceMessagePipe> getPipeReference() {
+    return pipeReference;
+  }
+
+  public static AtomicReference<SignalServiceMessagePipe> getUnidentifiedPipeReference() {
+    return unidentifiedPipeReference;
+  }
+
   private class MessageRetrievalThread extends Thread implements Thread.UncaughtExceptionHandler {
 
     MessageRetrievalThread() {
@@ -170,8 +179,11 @@ public class IncomingMessageObserver implements InjectableType, ConstraintObserv
         pipe             = receiver.createMessagePipe();
         unidentifiedPipe = receiver.createUnidentifiedMessagePipe();
 
-        SignalServiceMessagePipe localPipe             = pipe;
-        SignalServiceMessagePipe unidentifiedLocalPipe = unidentifiedPipe;
+        pipeReference.set(pipe);
+        unidentifiedPipeReference.set(unidentifiedPipe);
+
+        final SignalServiceMessagePipe localPipe             = pipe;
+        final SignalServiceMessagePipe unidentifiedLocalPipe = unidentifiedPipe;
 
         try {
           while (isConnectionNecessary() && !interrupted()) {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Xiaomi Mi 4, Android 7.1.2 (LineageOS 14.1, w/o GCM support)
 * Motorola Moto G3, Android 7.1.2 (LineageOS 14.1, w/o GCM support)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

For a detailed description of the problem and proposed fix, see the accompanying PR signalapp/libsignal-service-java#62. I'm fairly certain that this fixes #7638, but the supplied log doesn't allow me to confirm this. I therefore didn't mention it in the commit message.