### PR TITLE
Bump targetSdkVersion to 26.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -283,7 +283,7 @@ android {
         versionName "4.28.1"
 
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 26
         multiDexEnabled true
 
         vectorDrawables.useSupportLibrary = true

--- a/src/org/thoughtcrime/securesms/jobs/MmsDownloadJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/MmsDownloadJob.java
@@ -96,7 +96,7 @@ public class MmsDownloadJob extends MasterSecretJob {
 
   @Override
   public void onAdded() {
-    if (automatic && KeyCachingService.getMasterSecret(context) == null) {
+    if (automatic && KeyCachingService.isLocked(context)) {
       DatabaseFactory.getMmsDatabase(context).markIncomingNotificationReceived(threadId);
       MessageNotifier.updateNotification(context);
     }

--- a/src/org/thoughtcrime/securesms/service/BootReceiver.java
+++ b/src/org/thoughtcrime/securesms/service/BootReceiver.java
@@ -5,14 +5,13 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 
+import org.thoughtcrime.securesms.ApplicationContext;
+import org.thoughtcrime.securesms.jobs.PushNotificationReceiveJob;
+
 public class BootReceiver extends BroadcastReceiver {
 
   @Override
   public void onReceive(Context context, Intent intent) {
-    if (intent != null && Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
-      Intent messageRetrievalService = new Intent(context, MessageRetrievalService.class);
-      context.startService(messageRetrievalService);
-    }
+    ApplicationContext.getInstance(context).getJobManager().add(new PushNotificationReceiveJob(context));
   }
-
 }

--- a/src/org/thoughtcrime/securesms/service/KeyCachingService.java
+++ b/src/org/thoughtcrime/securesms/service/KeyCachingService.java
@@ -89,12 +89,7 @@ public class KeyCachingService extends Service {
   public static synchronized @Nullable MasterSecret getMasterSecret(Context context) {
     if (masterSecret == null && (TextSecurePreferences.isPasswordDisabled(context) && !TextSecurePreferences.isScreenLockEnabled(context))) {
       try {
-        MasterSecret masterSecret = MasterSecretUtil.getMasterSecret(context, MasterSecretUtil.UNENCRYPTED_PASSPHRASE);
-        Intent       intent       = new Intent(context, KeyCachingService.class);
-
-        context.startService(intent);
-
-        return masterSecret;
+        return MasterSecretUtil.getMasterSecret(context, MasterSecretUtil.UNENCRYPTED_PASSPHRASE);
       } catch (InvalidPassphraseException e) {
         Log.w("KeyCachingService", e);
       }


### PR DESCRIPTION
We need to increase our targetSdk version to 26 to comply with Play Store policy. A lot of the work that needed to happen for this migration was done through our migration to WorkManager. This PR cleans up the last few things that I've found.

1. GenericForegroundService needs to be started with startForegroundService, since it can be started when the app is in a backgrounded state. This means we also _always_ need to call startForeground in the service. However, by always posting with the same notification ID and content, no flickering occurs on my test devices.
1. We had a boot receiver that would start MessageRetrievalService. Instead, I just schedule a message pull, which should have a similar effect.
1. We previously were starting KeyCachingService if we went to get the MasterSecret. However, by my read, this was just an optimization to ensure the value was cached in the future. Now we just kind of deal with having to read a non-cached value when the app is backgrounded.

**Test Devices**
* [Nexus 5X, Android 8.1, API 27](https://www.gsmarena.com/lg_nexus_5x-7556.php)
* [Google Pixel 2, Android 9.0, API 28](https://www.gsmarena.com/google_pixel_2-8733.php)
