### PR TITLE
Prevent app from clearing the back stack on re-launch

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -178,7 +178,7 @@
 
     <activity android:name=".ConversationListActivity"
               android:label="@string/app_name"
-              android:launchMode="singleTask"
+              android:launchMode="standard"
               android:theme="@style/TextSecure.LightNoActionBar"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"
               android:exported="true" />


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Moto X4, Android 8.0.0
 * Pixel2, Android 9
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Fixes #8273

Changes the launchMode for the main activity to `standard` instead of `singleTask`. Previously it was launched with `singleTask`, which caused the app to clear the back stack down to the ConversationListActivity, closing whatever conversation the user had been looking at the last time the app was open. This occurs when a user reopens the app through the android launcher, which triggers the `MAIN` intent.

With this change, the app will resume to whatever Activity the user had open prior to switching apps or pressing the home button. If the app is actually closed, it will of course reopen to the `ConversationListActivity` as expected