### PR TITLE
do Toast and return if registration lock pin length > 20 instead 

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1435,6 +1435,7 @@
     <string name="prompt_passphrase_activity__tap_to_unlock">TAP TO UNLOCK</string>
     <string name="RegistrationLockDialog_reminder">Reminder:</string>
     <string name="recipient_preferences__about">About</string>
+    <string name="RegistrationLockDialog_the_pin_must_be_no_more_than_twenty_digits">The PIN must be no more than twenty digits.</string>
     <!-- EOF -->
 
 </resources>

--- a/src/org/thoughtcrime/securesms/lock/RegistrationLockDialog.java
+++ b/src/org/thoughtcrime/securesms/lock/RegistrationLockDialog.java
@@ -134,6 +134,11 @@ public class RegistrationLockDialog {
           return;
         }
 
+        if (pinValue.length() > 20) {
+          Toast.makeText(context, R.string.RegistrationLockDialog_the_pin_must_be_no_more_than_twenty_digits, Toast.LENGTH_LONG).show();
+          return;
+        }
+
         if (!pinValue.equals(repeatValue)) {
           Toast.makeText(context, R.string.RegistrationLockDialog_the_two_pins_you_entered_do_not_match, Toast.LENGTH_LONG).show();
           return;


### PR DESCRIPTION


### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S6
- [x] My contribution is fully baked and ready to be merged as is.
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
----------

### Description

Confirmed the reported bug at 32 characters and stepped back one at a time to see that 20 was the largest number of digits in a PIN that worked. Tested on android galaxy S6 using 21 character PIN. attaching screenshot here.
Fixes https://github.com/signalapp/Signal-Android/issues/8242

