### PR TITLE
Ensure that local number is always a member of MMS groups

### DIFF
--- a/src/org/thoughtcrime/securesms/database/GroupDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/GroupDatabase.java
@@ -18,6 +18,7 @@ import org.thoughtcrime.securesms.database.helpers.SQLCipherOpenHelper;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.util.BitmapUtil;
 import org.thoughtcrime.securesms.util.GroupUtil;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.util.Util;
 import org.whispersystems.libsignal.util.guava.Optional;
 import org.whispersystems.signalservice.api.messages.SignalServiceAttachmentPointer;
@@ -113,6 +114,17 @@ public class GroupDatabase extends Database {
   }
 
   public String getOrCreateGroupForMembers(List<Address> members, boolean mms) {
+    boolean hasLocalNumber = false;
+    for (Address member : members) {
+      if (Util.isOwnNumber(context, member)) {
+        hasLocalNumber = true;
+        break;
+      }
+    }
+    if (!hasLocalNumber) {
+      members.add(Address.fromSerialized(TextSecurePreferences.getLocalNumber(context)));
+    }
+
     Collections.sort(members);
 
     Cursor cursor = databaseHelper.getReadableDatabase().query(TABLE_NAME, new String[] {GROUP_ID},


### PR DESCRIPTION
Fixes #7683

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S9, Android 8.0.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
New MMS groups do not initially have the local number as a member.  As stated in the bug report #7683, this caused subsequent responses to create a new group since the membership is different. 
 
Signal should behave similar for non-secure MMS groups as it does for Signal groups: the local number should always be a member of the group.

Tested this by:

1. Creating an MMS group from Signal
2. Receive response from another member
3. Verify that the group is properly threaded
![screenshot_20181021-145212_signal](https://user-images.githubusercontent.com/367976/47273308-3c8bf680-d547-11e8-96aa-e0c6a6049c2d.jpg)
![screenshot_20181021-145223_signal](https://user-images.githubusercontent.com/367976/47273309-3c8bf680-d547-11e8-93cd-16251a35aade.jpg)