### PR TITLE
Add recipient preference to hide phone number from conversation screen

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -999,6 +999,7 @@
     <string name="recipient_preferences__notification_sound">Notification sound</string>
     <string name="recipient_preferences__vibrate">Vibrate</string>
     <string name="recipient_preferences__block">Block</string>
+    <string name="recipient_preferences__hide_phone_number">Hide phone number</string>
     <string name="recipient_preferences__color">Color</string>
     <string name="recipient_preferences__view_safety_number">View safety number</string>
     <string name="recipient_preferences__chat_settings">Chat settings</string>

--- a/res/xml/recipient_preferences.xml
+++ b/res/xml/recipient_preferences.xml
@@ -75,6 +75,12 @@
                     android:persistent="false"
                     android:enabled="false"/>
 
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+                    android:key="pref_key_recipient_hide_phone_number"
+                    android:title="@string/recipient_preferences__hide_phone_number"
+                    android:defaultValue="false"
+                    android:persistent="false"/>
+
         <Preference android:key="pref_key_recipient_block"
                     android:title="@string/recipient_preferences__block"
                     android:persistent="false"/>

--- a/src/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -68,6 +68,10 @@ public class ConversationTitleView extends RelativeLayout {
       title.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
     }
 
+    if (recipient != null && recipient.isPhoneNumberHidden()) {
+      subtitle.setVisibility(GONE);
+    }
+
     if (recipient != null) {
       this.avatar.setAvatar(glideRequests, recipient, false);
     }

--- a/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
+++ b/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
@@ -98,6 +98,7 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
   private static final String PREFERENCE_IDENTITY              = "pref_key_recipient_identity";
   private static final String PREFERENCE_ABOUT                 = "pref_key_number";
   private static final String PREFERENCE_CUSTOM_NOTIFICATIONS  = "pref_key_recipient_custom_notifications";
+  private static final String PREFERENCE_HIDE_PHONE_NUMBER     = "pref_key_recipient_hide_phone_number";
 
   private final DynamicTheme    dynamicTheme    = new DynamicNoActionBarTheme();
   private final DynamicLanguage dynamicLanguage = new DynamicLanguage();
@@ -306,6 +307,8 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
           .setOnPreferenceClickListener(new BlockClickedListener());
       this.findPreference(PREFERENCE_COLOR)
           .setOnPreferenceChangeListener(new ColorChangeListener());
+      this.findPreference(PREFERENCE_HIDE_PHONE_NUMBER)
+          .setOnPreferenceClickListener(new HidePhoneNumberClickedListener());
       ((ContactPreference)this.findPreference(PREFERENCE_ABOUT))
           .setListener(new AboutNumberClickedListener());
     }
@@ -353,6 +356,7 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
 
     private void setSummaries(Recipient recipient) {
       CheckBoxPreference    mutePreference            = (CheckBoxPreference) this.findPreference(PREFERENCE_MUTED);
+      CheckBoxPreference    hidePhoneNumberPreference = (CheckBoxPreference) this.findPreference(PREFERENCE_HIDE_PHONE_NUMBER);
       Preference            ringtoneMessagePreference = this.findPreference(PREFERENCE_MESSAGE_TONE);
       Preference            ringtoneCallPreference    = this.findPreference(PREFERENCE_CALL_TONE);
       ListPreference        vibrateMessagePreference  = (ListPreference) this.findPreference(PREFERENCE_MESSAGE_VIBRATE);
@@ -367,6 +371,8 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
       PreferenceCategory    divider                   = (PreferenceCategory) this.findPreference("divider");
 
       mutePreference.setChecked(recipient.isMuted());
+      
+      hidePhoneNumberPreference.setChecked(recipient.isPhoneNumberHidden());
 
       ringtoneMessagePreference.setSummary(ringtoneMessagePreference.isEnabled() ? getRingtoneSummary(getContext(), recipient.getMessageRingtone()) : "");
       ringtoneCallPreference.setSummary(getRingtoneSummary(getContext(), recipient.getCallRingtone()));
@@ -598,6 +604,29 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
         }
         return true;
       }
+    }
+
+    private class HidePhoneNumberClickedListener implements Preference.OnPreferenceClickListener {
+
+      @Override
+      public boolean onPreferenceClick(Preference preference) {
+        setIsPhoneNumberHidden(preference.getContext(), recipient, !recipient.isPhoneNumberHidden());
+        return true;
+      }
+
+      private void setIsPhoneNumberHidden(@NonNull final Context context, final Recipient recipient, final boolean isPhoneNumberHidden) {
+        recipient.setIsPhoneNumberHidden(isPhoneNumberHidden);
+
+        new AsyncTask<Void, Void, Void>() {
+          @Override
+          protected Void doInBackground(Void... params) {
+            DatabaseFactory.getRecipientDatabase(context)
+                    .setIsPhoneNumberHidden(recipient, isPhoneNumberHidden);
+            return null;
+          }
+        }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+      }
+
     }
 
     private class MuteClickedListener implements Preference.OnPreferenceClickListener {

--- a/src/org/thoughtcrime/securesms/recipients/Recipient.java
+++ b/src/org/thoughtcrime/securesms/recipients/Recipient.java
@@ -79,6 +79,7 @@ public class Recipient implements RecipientModifiedListener {
   private @Nullable Uri                  callRingtone          = null;
   private           long                 mutedUntil            = 0;
   private           boolean              blocked               = false;
+  private           boolean              isPhoneNumberHidden   = false;
   private           VibrateState         messageVibrate        = VibrateState.DEFAULT;
   private           VibrateState         callVibrate           = VibrateState.DEFAULT;
   private           int                  expireMessages        = 0;
@@ -131,6 +132,7 @@ public class Recipient implements RecipientModifiedListener {
       this.callRingtone          = stale.callRingtone;
       this.mutedUntil            = stale.mutedUntil;
       this.blocked               = stale.blocked;
+      this.isPhoneNumberHidden   = stale.isPhoneNumberHidden;
       this.messageVibrate        = stale.messageVibrate;
       this.callVibrate           = stale.callVibrate;
       this.expireMessages        = stale.expireMessages;
@@ -155,6 +157,7 @@ public class Recipient implements RecipientModifiedListener {
       this.callRingtone          = details.get().callRingtone;
       this.mutedUntil            = details.get().mutedUntil;
       this.blocked               = details.get().blocked;
+      this.isPhoneNumberHidden   = details.get().phoneNumberHidden;
       this.messageVibrate        = details.get().messageVibrateState;
       this.callVibrate           = details.get().callVibrateState;
       this.expireMessages        = details.get().expireMessages;
@@ -185,6 +188,7 @@ public class Recipient implements RecipientModifiedListener {
             Recipient.this.callRingtone          = result.callRingtone;
             Recipient.this.mutedUntil            = result.mutedUntil;
             Recipient.this.blocked               = result.blocked;
+            Recipient.this.isPhoneNumberHidden   = result.phoneNumberHidden;
             Recipient.this.messageVibrate        = result.messageVibrateState;
             Recipient.this.callVibrate           = result.callVibrateState;
             Recipient.this.expireMessages        = result.expireMessages;
@@ -232,6 +236,7 @@ public class Recipient implements RecipientModifiedListener {
     this.callRingtone          = details.callRingtone;
     this.mutedUntil            = details.mutedUntil;
     this.blocked               = details.blocked;
+    this.isPhoneNumberHidden   = details.phoneNumberHidden;
     this.messageVibrate        = details.messageVibrateState;
     this.callVibrate           = details.callVibrateState;
     this.expireMessages        = details.expireMessages;
@@ -514,6 +519,18 @@ public class Recipient implements RecipientModifiedListener {
   public void setBlocked(boolean blocked) {
     synchronized (this) {
       this.blocked = blocked;
+    }
+
+    notifyListeners();
+  }
+
+  public synchronized boolean isPhoneNumberHidden() {
+    return isPhoneNumberHidden;
+  }
+
+  public void setIsPhoneNumberHidden(boolean isPhoneNumberHidden) {
+    synchronized (this) {
+      this.isPhoneNumberHidden = isPhoneNumberHidden;
     }
 
     notifyListeners();

--- a/src/org/thoughtcrime/securesms/recipients/RecipientProvider.java
+++ b/src/org/thoughtcrime/securesms/recipients/RecipientProvider.java
@@ -164,6 +164,7 @@ class RecipientProvider {
     @Nullable final VibrateState         messageVibrateState;
     @Nullable final VibrateState         callVibrateState;
               final boolean              blocked;
+              final boolean              phoneNumberHidden;
               final int                  expireMessages;
     @NonNull  final List<Recipient>      participants;
     @Nullable final String               profileName;
@@ -191,6 +192,7 @@ class RecipientProvider {
       this.messageVibrateState   = settings     != null ? settings.getMessageVibrateState() : null;
       this.callVibrateState      = settings     != null ? settings.getCallVibrateState() : null;
       this.blocked               = settings     != null && settings.isBlocked();
+      this.phoneNumberHidden     = settings     != null && settings.isPhoneNumberHidden();
       this.expireMessages        = settings     != null ? settings.getExpireMessages() : 0;
       this.participants          = participants == null ? new LinkedList<>() : participants;
       this.profileName           = settings     != null ? settings.getProfileName() : null;


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 2XL, Android P
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This adds a preference that allows the user to hide the phone number of the contact (recipient in the conversation) from the conversation screen.
