### PR TITLE
Prevent unnecessary boxing and immediate unboxing

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationAdapter.java
+++ b/src/org/thoughtcrime/securesms/ConversationAdapter.java
@@ -283,7 +283,7 @@ public class ConversationAdapter <V extends View & BindableConversationItem>
     List<DatabaseAttachment> messageAttachments = Stream.of(attachments).filterNot(DatabaseAttachment::isQuote).toList();
 
     if (messageAttachments.size() > 0 && messageAttachments.get(0).getFastPreflightId() != null) {
-      return Long.valueOf(messageAttachments.get(0).getFastPreflightId());
+      return Long.parseLong(messageAttachments.get(0).getFastPreflightId());
     }
 
     final String unique = cursor.getString(cursor.getColumnIndexOrThrow(MmsSmsColumns.UNIQUE_ROW_ID));
@@ -297,7 +297,7 @@ public class ConversationAdapter <V extends View & BindableConversationItem>
       SlideDeck slideDeck = ((MmsMessageRecord)record).getSlideDeck();
 
       if (slideDeck.getThumbnailSlide() != null && slideDeck.getThumbnailSlide().getFastPreflightId() != null) {
-        return Long.valueOf(slideDeck.getThumbnailSlide().getFastPreflightId());
+        return Long.parseLong(slideDeck.getThumbnailSlide().getFastPreflightId());
       }
     }
 

--- a/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -354,11 +354,11 @@ public class TextSecurePreferences {
   }
 
   public static int getNotificationPriority(Context context) {
-    return Integer.valueOf(getStringPreference(context, NOTIFICATION_PRIORITY_PREF, String.valueOf(NotificationCompat.PRIORITY_HIGH)));
+    return Integer.parseInt(getStringPreference(context, NOTIFICATION_PRIORITY_PREF, String.valueOf(NotificationCompat.PRIORITY_HIGH)));
   }
 
   public static int getMessageBodyTextSize(Context context) {
-    return Integer.valueOf(getStringPreference(context, MESSAGE_BODY_TEXT_SIZE_PREF, "16"));
+    return Integer.parseInt(getStringPreference(context, MESSAGE_BODY_TEXT_SIZE_PREF, "16"));
   }
 
   public static boolean isTurnOnly(Context context) {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 2XL, Android P
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This is a "boxing/unboxing to parse a primitive" performance issue found with FindBugs. valueOf() returns a boxed primitive, but the method return values are primitives, so the value is immediately unboxed. I replaced them with parseInt() and parseLong() which return the primitives.
