### PR TITLE
Prevent inefficient use of keyset iterator

### DIFF
--- a/src/org/thoughtcrime/securesms/camera/OrderEnforcer.java
+++ b/src/org/thoughtcrime/securesms/camera/OrderEnforcer.java
@@ -49,10 +49,10 @@ public class OrderEnforcer<E> {
   }
 
   private boolean isCompletedThrough(@NonNull E stage) {
-    for (E s : stages.keySet()) {
-      if (s.equals(stage)) {
-        return stages.get(s).isCompleted();
-      } else if (!stages.get(s).isCompleted()) {
+    for (Map.Entry<E, StageDetails> entry : stages.entrySet()) {
+      if (entry.getKey().equals(stage)) {
+        return entry.getValue().isCompleted();
+      } else if (!entry.getValue().isCompleted()) {
         return false;
       }
     }

--- a/src/org/thoughtcrime/securesms/camera/OrderEnforcer.java
+++ b/src/org/thoughtcrime/securesms/camera/OrderEnforcer.java
@@ -29,9 +29,7 @@ public class OrderEnforcer<E> {
   public synchronized void markCompleted(@NonNull E stage) {
     stages.get(stage).setCompleted(true);
 
-    for (E s : stages.keySet()) {
-      StageDetails details = stages.get(s);
-
+    for (StageDetails details : stages.values()) {
       if (details.isCompleted()) {
         for (Runnable r : details.getActions()) {
           r.run();

--- a/src/org/thoughtcrime/securesms/notifications/MarkReadReceiver.java
+++ b/src/org/thoughtcrime/securesms/notifications/MarkReadReceiver.java
@@ -83,12 +83,12 @@ public class MarkReadReceiver extends BroadcastReceiver {
                                                          .map(MarkedMessageInfo::getSyncMessageId)
                                                          .collect(Collectors.groupingBy(SyncMessageId::getAddress));
 
-    for (Address address : addressMap.keySet()) {
-      List<Long> timestamps = Stream.of(addressMap.get(address)).map(SyncMessageId::getTimetamp).toList();
+    for (Map.Entry<Address, List<SyncMessageId>> entry : addressMap.entrySet()) {
+      List<Long> timestamps = Stream.of(entry.getValue()).map(SyncMessageId::getTimetamp).toList();
 
       ApplicationContext.getInstance(context)
                         .getJobManager()
-                        .add(new SendReadReceiptJob(context, address, timestamps));
+                        .add(new SendReadReceiptJob(context, entry.getKey(), timestamps));
     }
   }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 2XL, Android P
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This is an "inefficient use of keyset iterator" performance issue found with FindBugs. Instead of iterating over keySet() and calling get(), it's more efficient to iterate over values() or entrySet().
