### PR TITLE
Use requireActivity, requireContext and requireFragmentManger from 27.1.0

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -178,13 +178,13 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
       ((ProfilePreference)this.findPreference(PREFERENCE_CATEGORY_PROFILE)).refresh();
 
       this.findPreference(PREFERENCE_CATEGORY_SMS_MMS)
-          .setSummary(SmsMmsPreferenceFragment.getSummary(getActivity()));
+          .setSummary(SmsMmsPreferenceFragment.getSummary(requireActivity()));
       this.findPreference(PREFERENCE_CATEGORY_NOTIFICATIONS)
-          .setSummary(NotificationsPreferenceFragment.getSummary(getActivity()));
+          .setSummary(NotificationsPreferenceFragment.getSummary(requireActivity()));
       this.findPreference(PREFERENCE_CATEGORY_APP_PROTECTION)
-          .setSummary(AppProtectionPreferenceFragment.getSummary(getActivity()));
+          .setSummary(AppProtectionPreferenceFragment.getSummary(requireActivity()));
       this.findPreference(PREFERENCE_CATEGORY_APPEARANCE)
-          .setSummary(AppearancePreferenceFragment.getSummary(getActivity()));
+          .setSummary(AppearancePreferenceFragment.getSummary(requireActivity()));
       this.findPreference(PREFERENCE_CATEGORY_CHATS)
           .setSummary(ChatsPreferenceFragment.getSummary(getActivity()));
     }
@@ -270,7 +270,7 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
           Bundle args = new Bundle();
           fragment.setArguments(args);
 
-          FragmentManager     fragmentManager     = getActivity().getSupportFragmentManager();
+          FragmentManager     fragmentManager     = requireActivity().getSupportFragmentManager();
           FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
           fragmentTransaction.replace(android.R.id.content, fragment);
           fragmentTransaction.addToBackStack(null);
@@ -287,7 +287,7 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
         Intent intent = new Intent(preference.getContext(), CreateProfileActivity.class);
         intent.putExtra(CreateProfileActivity.EXCLUDE_SYSTEM, true);
 
-        getActivity().startActivity(intent);
+        requireActivity().startActivity(intent);
 //        ((BaseActionBarActivity)getActivity()).startActivitySceneTransition(intent, getActivity().findViewById(R.id.avatar), "avatar");
         return true;
       }

--- a/src/org/thoughtcrime/securesms/BlockedContactsActivity.java
+++ b/src/org/thoughtcrime/securesms/BlockedContactsActivity.java
@@ -74,7 +74,7 @@ public class BlockedContactsActivity extends PassphraseRequiredActionBarActivity
     @Override
     public void onCreate(Bundle bundle) {
       super.onCreate(bundle);
-      setListAdapter(new BlockedContactAdapter(getActivity(), GlideApp.with(this), null));
+      setListAdapter(new BlockedContactAdapter(requireActivity(), GlideApp.with(this), null));
       getLoaderManager().initLoader(0, null, this);
     }
 

--- a/src/org/thoughtcrime/securesms/ContactSelectionListFragment.java
+++ b/src/org/thoughtcrime/securesms/ContactSelectionListFragment.java
@@ -110,9 +110,9 @@ public class ContactSelectionListFragment extends    Fragment
                  }
                })
                .onAnyDenied(() -> {
-                 getActivity().getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
+                 requireActivity().getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
 
-                 if (getActivity().getIntent().getBooleanExtra(RECENTS, false)) {
+                 if (requireActivity().getIntent().getBooleanExtra(RECENTS, false)) {
                    getLoaderManager().initLoader(0, null, ContactSelectionListFragment.this);
                  } else {
                    initializeNoContactsPermission();
@@ -135,7 +135,7 @@ public class ContactSelectionListFragment extends    Fragment
     showContactsProgress    = view.findViewById(R.id.progress);
     recyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
 
-    swipeRefresh.setEnabled(getActivity().getIntent().getBooleanExtra(REFRESHABLE, true) &&
+    swipeRefresh.setEnabled(requireActivity().getIntent().getBooleanExtra(REFRESHABLE, true) &&
                             Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN);
 
     return view;
@@ -156,11 +156,11 @@ public class ContactSelectionListFragment extends    Fragment
   }
 
   private boolean isMulti() {
-    return getActivity().getIntent().getBooleanExtra(MULTI_SELECT, false);
+    return requireActivity().getIntent().getBooleanExtra(MULTI_SELECT, false);
   }
 
   private void initializeCursor() {
-    ContactSelectionListAdapter adapter = new ContactSelectionListAdapter(getActivity(),
+    ContactSelectionListAdapter adapter = new ContactSelectionListAdapter(requireActivity(),
                                                                           GlideApp.with(this),
                                                                           null,
                                                                           new ListClickListener(),
@@ -216,9 +216,9 @@ public class ContactSelectionListFragment extends    Fragment
 
   @Override
   public Loader<Cursor> onCreateLoader(int id, Bundle args) {
-    return new ContactsCursorLoader(getActivity(),
-                                    getActivity().getIntent().getIntExtra(DISPLAY_MODE, DisplayMode.FLAG_ALL),
-                                    cursorFilter, getActivity().getIntent().getBooleanExtra(RECENTS, false));
+    return new ContactsCursorLoader(requireActivity(),
+                                    requireActivity().getIntent().getIntExtra(DISPLAY_MODE, DisplayMode.FLAG_ALL),
+                                    cursorFilter, requireActivity().getIntent().getBooleanExtra(RECENTS, false));
   }
 
   @Override
@@ -258,7 +258,7 @@ public class ContactSelectionListFragment extends    Fragment
       @Override
       protected Boolean doInBackground(Void... voids) {
         try {
-          DirectoryHelper.refreshDirectory(getContext(), false);
+          DirectoryHelper.refreshDirectory(requireContext(), false);
           return true;
         } catch (IOException e) {
           Log.w(TAG, e);

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -206,20 +206,20 @@ public class ConversationFragment extends Fragment
   }
 
   private void initializeResources() {
-    this.recipient         = Recipient.from(getActivity(), getActivity().getIntent().getParcelableExtra(ConversationActivity.ADDRESS_EXTRA), true);
-    this.threadId          = this.getActivity().getIntent().getLongExtra(ConversationActivity.THREAD_ID_EXTRA, -1);
-    this.lastSeen          = this.getActivity().getIntent().getLongExtra(ConversationActivity.LAST_SEEN_EXTRA, -1);
-    this.startingPosition  = this.getActivity().getIntent().getIntExtra(ConversationActivity.STARTING_POSITION_EXTRA, -1);
+    this.recipient         = Recipient.from(requireActivity(), requireActivity().getIntent().getParcelableExtra(ConversationActivity.ADDRESS_EXTRA), true);
+    this.threadId          = this.requireActivity().getIntent().getLongExtra(ConversationActivity.THREAD_ID_EXTRA, -1);
+    this.lastSeen          = this.requireActivity().getIntent().getLongExtra(ConversationActivity.LAST_SEEN_EXTRA, -1);
+    this.startingPosition  = this.requireActivity().getIntent().getIntExtra(ConversationActivity.STARTING_POSITION_EXTRA, -1);
     this.firstLoad         = true;
-    this.unknownSenderView = new UnknownSenderView(getActivity(), recipient, threadId);
+    this.unknownSenderView = new UnknownSenderView(requireActivity(), recipient, threadId);
 
-    OnScrollListener scrollListener = new ConversationScrollListener(getActivity());
+    OnScrollListener scrollListener = new ConversationScrollListener(requireActivity());
     list.addOnScrollListener(scrollListener);
   }
 
   private void initializeListAdapter() {
     if (this.recipient != null && this.threadId != -1) {
-      ConversationAdapter adapter = new ConversationAdapter(getActivity(), GlideApp.with(this), locale, selectionClickListener, null, this.recipient);
+      ConversationAdapter adapter = new ConversationAdapter(requireActivity(), GlideApp.with(this), locale, selectionClickListener, null, this.recipient);
       list.setAdapter(adapter);
       list.addItemDecoration(new StickyHeaderDecoration(adapter, false, false));
 
@@ -342,7 +342,7 @@ public class ConversationFragment extends Fragment
     });
 
     StringBuilder    bodyBuilder = new StringBuilder();
-    ClipboardManager clipboard   = (ClipboardManager) getActivity().getSystemService(Context.CLIPBOARD_SERVICE);
+    ClipboardManager clipboard   = (ClipboardManager) requireActivity().getSystemService(Context.CLIPBOARD_SERVICE);
 
     for (MessageRecord messageRecord : messageList) {
       String body = messageRecord.getDisplayBody().toString();
@@ -362,11 +362,11 @@ public class ConversationFragment extends Fragment
 
   private void handleDeleteMessages(final Set<MessageRecord> messageRecords) {
     int                 messagesCount = messageRecords.size();
-    AlertDialog.Builder builder       = new AlertDialog.Builder(getActivity());
+    AlertDialog.Builder builder       = new AlertDialog.Builder(requireActivity());
 
     builder.setIconAttribute(R.attr.dialog_alert_icon);
-    builder.setTitle(getActivity().getResources().getQuantityString(R.plurals.ConversationFragment_delete_selected_messages, messagesCount, messagesCount));
-    builder.setMessage(getActivity().getResources().getQuantityString(R.plurals.ConversationFragment_this_will_permanently_delete_all_n_selected_messages, messagesCount, messagesCount));
+    builder.setTitle(requireActivity().getResources().getQuantityString(R.plurals.ConversationFragment_delete_selected_messages, messagesCount, messagesCount));
+    builder.setMessage(requireActivity().getResources().getQuantityString(R.plurals.ConversationFragment_this_will_permanently_delete_all_n_selected_messages, messagesCount, messagesCount));
     builder.setCancelable(true);
 
     builder.setPositiveButton(R.string.delete, new DialogInterface.OnClickListener() {
@@ -428,7 +428,7 @@ public class ConversationFragment extends Fragment
   }
 
   private void handleResendMessage(final MessageRecord message) {
-    final Context context = getActivity().getApplicationContext();
+    final Context context = requireActivity().getApplicationContext();
     new AsyncTask<MessageRecord, Void, Void>() {
       @Override
       protected Void doInBackground(MessageRecord... messageRecords) {
@@ -814,7 +814,7 @@ public class ConversationFragment extends Fragment
       mode.setTitle("1");
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-        Window window = getActivity().getWindow();
+        Window window = requireActivity().getWindow();
         statusBarColor = window.getStatusBarColor();
         window.setStatusBarColor(getResources().getColor(R.color.action_mode_status_bar));
       }
@@ -834,7 +834,7 @@ public class ConversationFragment extends Fragment
       list.getAdapter().notifyDataSetChanged();
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-        getActivity().getWindow().setStatusBarColor(statusBarColor);
+        requireActivity().getWindow().setStatusBarColor(statusBarColor);
       }
 
       actionMode = null;

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -222,7 +222,7 @@ public class ConversationListFragment extends Fragment
   }
 
   private void initializeListAdapter() {
-    list.setAdapter(new ConversationListAdapter(getActivity(), GlideApp.with(this), locale, null, this));
+    list.setAdapter(new ConversationListAdapter(requireActivity(), GlideApp.with(this), locale, null, this));
     getLoaderManager().restartLoader(0, null, this);
   }
 
@@ -276,11 +276,11 @@ public class ConversationListFragment extends Fragment
   @SuppressLint("StaticFieldLeak")
   private void handleDeleteAllSelected() {
     int                 conversationsCount = getListAdapter().getBatchSelections().size();
-    AlertDialog.Builder alert              = new AlertDialog.Builder(getActivity());
+    AlertDialog.Builder alert              = new AlertDialog.Builder(requireActivity());
     alert.setIconAttribute(R.attr.dialog_alert_icon);
-    alert.setTitle(getActivity().getResources().getQuantityString(R.plurals.ConversationListFragment_delete_selected_conversations,
+    alert.setTitle(getResources().getQuantityString(R.plurals.ConversationListFragment_delete_selected_conversations,
                                                                   conversationsCount, conversationsCount));
-    alert.setMessage(getActivity().getResources().getQuantityString(R.plurals.ConversationListFragment_this_will_permanently_delete_all_n_selected_conversations,
+    alert.setMessage(getResources().getQuantityString(R.plurals.ConversationListFragment_this_will_permanently_delete_all_n_selected_conversations,
                                                                     conversationsCount, conversationsCount));
     alert.setCancelable(true);
 
@@ -295,15 +295,15 @@ public class ConversationListFragment extends Fragment
           @Override
           protected void onPreExecute() {
             dialog = ProgressDialog.show(getActivity(),
-                                         getActivity().getString(R.string.ConversationListFragment_deleting),
-                                         getActivity().getString(R.string.ConversationListFragment_deleting_selected_conversations),
+                                         getString(R.string.ConversationListFragment_deleting),
+                                         getString(R.string.ConversationListFragment_deleting_selected_conversations),
                                          true, false);
           }
 
           @Override
           protected Void doInBackground(Void... params) {
             DatabaseFactory.getThreadDatabase(getActivity()).deleteConversations(selectedConversations);
-            MessageNotifier.updateNotification(getActivity());
+            MessageNotifier.updateNotification(requireActivity());
             return null;
           }
 
@@ -329,7 +329,7 @@ public class ConversationListFragment extends Fragment
   }
 
   private void handleCreateConversation(long threadId, Recipient recipient, int distributionType, long lastSeen) {
-    ((ConversationSelectedListener)getActivity()).onCreateConversation(threadId, recipient, distributionType, lastSeen);
+    ((ConversationSelectedListener)requireActivity()).onCreateConversation(threadId, recipient, distributionType, lastSeen);
   }
 
   @Override
@@ -385,7 +385,7 @@ public class ConversationListFragment extends Fragment
 
   @Override
   public void onItemLongClick(ConversationListItem item) {
-    actionMode = ((AppCompatActivity)getActivity()).startSupportActionMode(ConversationListFragment.this);
+    actionMode = ((AppCompatActivity)requireActivity()).startSupportActionMode(ConversationListFragment.this);
 
     getListAdapter().initializeBatchMode(true);
     getListAdapter().toggleThreadInBatchSet(item.getThreadId());
@@ -394,7 +394,7 @@ public class ConversationListFragment extends Fragment
 
   @Override
   public void onSwitchToArchive() {
-    ((ConversationSelectedListener)getActivity()).onSwitchToArchive();
+    ((ConversationSelectedListener)requireActivity()).onSwitchToArchive();
   }
 
   public interface ConversationSelectedListener {
@@ -404,7 +404,7 @@ public class ConversationListFragment extends Fragment
 
   @Override
   public boolean onCreateActionMode(ActionMode mode, Menu menu) {
-    MenuInflater inflater = getActivity().getMenuInflater();
+    MenuInflater inflater = requireActivity().getMenuInflater();
 
     if (archive) inflater.inflate(R.menu.conversation_list_batch_unarchive, menu);
     else         inflater.inflate(R.menu.conversation_list_batch_archive, menu);
@@ -414,7 +414,7 @@ public class ConversationListFragment extends Fragment
     mode.setTitle("1");
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      getActivity().getWindow().setStatusBarColor(getResources().getColor(R.color.action_mode_status_bar));
+      requireActivity().getWindow().setStatusBarColor(getResources().getColor(R.color.action_mode_status_bar));
     }
 
     return true;
@@ -441,8 +441,8 @@ public class ConversationListFragment extends Fragment
     getListAdapter().initializeBatchMode(false);
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      TypedArray color = getActivity().getTheme().obtainStyledAttributes(new int[] {android.R.attr.statusBarColor});
-      getActivity().getWindow().setStatusBarColor(color.getColor(0, Color.BLACK));
+      TypedArray color = requireActivity().getTheme().obtainStyledAttributes(new int[] {android.R.attr.statusBarColor});
+      requireActivity().getWindow().setStatusBarColor(color.getColor(0, Color.BLACK));
       color.recycle();
     }
 
@@ -518,8 +518,8 @@ public class ConversationListFragment extends Fragment
 
             if (unreadCount > 0) {
               List<MarkedMessageInfo> messageIds = DatabaseFactory.getThreadDatabase(getActivity()).setRead(threadId, false);
-              MessageNotifier.updateNotification(getActivity());
-              MarkReadReceiver.process(getActivity(), messageIds);
+              MessageNotifier.updateNotification(requireActivity());
+              MarkReadReceiver.process(requireActivity(), messageIds);
             }
           }
 
@@ -529,7 +529,7 @@ public class ConversationListFragment extends Fragment
 
             if (unreadCount > 0) {
               DatabaseFactory.getThreadDatabase(getActivity()).incrementUnread(threadId, unreadCount);
-              MessageNotifier.updateNotification(getActivity());
+              MessageNotifier.updateNotification(requireActivity());
             }
           }
         }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, threadId);

--- a/src/org/thoughtcrime/securesms/DeviceListFragment.java
+++ b/src/org/thoughtcrime/securesms/DeviceListFragment.java
@@ -123,8 +123,8 @@ public class DeviceListFragment extends ListFragment
     final String deviceName = ((DeviceListItem)view).getDeviceName();
     final long   deviceId   = ((DeviceListItem)view).getDeviceId();
 
-    AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-    builder.setTitle(getActivity().getString(R.string.DeviceListActivity_unlink_s, deviceName));
+    AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity());
+    builder.setTitle(getString(R.string.DeviceListActivity_unlink_s, deviceName));
     builder.setMessage(R.string.DeviceListActivity_by_unlinking_this_device_it_will_no_longer_be_able_to_send_or_receive);
     builder.setNegativeButton(android.R.string.cancel, null);
     builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
@@ -137,7 +137,7 @@ public class DeviceListFragment extends ListFragment
   }
 
   private void handleLoaderFailed() {
-    AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+    AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity());
     builder.setMessage(R.string.DeviceListActivity_network_connection_failed);
     builder.setPositiveButton(R.string.DeviceListActivity_try_again,
                               new DialogInterface.OnClickListener() {
@@ -150,13 +150,13 @@ public class DeviceListFragment extends ListFragment
     builder.setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
       @Override
       public void onClick(DialogInterface dialog, int which) {
-        DeviceListFragment.this.getActivity().onBackPressed();
+        DeviceListFragment.this.requireActivity().onBackPressed();
       }
     });
     builder.setOnCancelListener(new DialogInterface.OnCancelListener() {
       @Override
       public void onCancel(DialogInterface dialog) {
-        DeviceListFragment.this.getActivity().onBackPressed();
+        DeviceListFragment.this.requireActivity().onBackPressed();
       }
     });
 

--- a/src/org/thoughtcrime/securesms/MediaOverviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaOverviewActivity.java
@@ -233,9 +233,9 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity {
       this.noMedia      = ViewUtil.findById(view, R.id.no_images);
       this.gridManager  = new StickyHeaderGridLayoutManager(getResources().getInteger(R.integer.media_overview_cols));
 
-      this.recyclerView.setAdapter(new MediaGalleryAdapter(getContext(),
+      this.recyclerView.setAdapter(new MediaGalleryAdapter(requireContext(),
                                                            GlideApp.with(this),
-                                                           new BucketedThreadMedia(getContext()),
+                                                           new BucketedThreadMedia(requireContext()),
                                                            locale,
                                                            this));
       this.recyclerView.setLayoutManager(gridManager);
@@ -255,7 +255,7 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity {
 
     @Override
     public Loader<BucketedThreadMedia> onCreateLoader(int i, Bundle bundle) {
-      return new BucketedThreadMediaLoader(getContext(), recipient.getAddress());
+      return new BucketedThreadMediaLoader(requireContext(), recipient.getAddress());
     }
 
     @Override
@@ -264,12 +264,12 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity {
       ((MediaGalleryAdapter) recyclerView.getAdapter()).notifyAllSectionsDataSetChanged();
 
       noMedia.setVisibility(recyclerView.getAdapter().getItemCount() > 0 ? View.GONE : View.VISIBLE);
-      getActivity().invalidateOptionsMenu();
+      requireActivity().invalidateOptionsMenu();
     }
 
     @Override
     public void onLoaderReset(Loader<BucketedThreadMedia> cursorLoader) {
-      ((MediaGalleryAdapter) recyclerView.getAdapter()).setMedia(new BucketedThreadMedia(getContext()));
+      ((MediaGalleryAdapter) recyclerView.getAdapter()).setMedia(new BucketedThreadMedia(requireContext()));
     }
 
     @Override
@@ -371,7 +371,7 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity {
     @SuppressLint("StaticFieldLeak")
     private void handleDeleteMedia(@NonNull Collection<MediaDatabase.MediaRecord> mediaRecords) {
       int recordCount       = mediaRecords.size();
-      Resources res         = getContext().getResources();
+      Resources res         = getResources();
       String confirmTitle   = res.getQuantityString(R.plurals.MediaOverviewActivity_Media_delete_confirm_title,
                                                     recordCount,
                                                     recordCount);
@@ -379,7 +379,7 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity {
                                                     recordCount,
                                                     recordCount);
 
-      AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
+      AlertDialog.Builder builder = new AlertDialog.Builder(requireContext());
       builder.setIconAttribute(R.attr.dialog_alert_icon);
       builder.setTitle(confirmTitle);
       builder.setMessage(confirmMessage);
@@ -418,8 +418,8 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity {
     }
 
     private void enterMultiSelect() {
-      actionMode = ((AppCompatActivity) getActivity()).startSupportActionMode(actionModeCallback);
-      ((MediaOverviewActivity) getActivity()).onEnterMultiSelect();
+      actionMode = ((AppCompatActivity) requireActivity()).startSupportActionMode(actionModeCallback);
+      ((MediaOverviewActivity) requireActivity()).onEnterMultiSelect();
     }
 
     private class ActionModeCallback implements ActionMode.Callback {
@@ -432,7 +432,7 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity {
         mode.setTitle("1");
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-          Window window = getActivity().getWindow();
+          Window window = requireActivity().getWindow();
           originalStatusBarColor = window.getStatusBarColor();
           window.setStatusBarColor(getResources().getColor(R.color.action_mode_status_bar));
         }
@@ -465,10 +465,10 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity {
       public void onDestroyActionMode(ActionMode mode) {
         actionMode = null;
         getListAdapter().clearSelection();
-        ((MediaOverviewActivity) getActivity()).onExitMultiSelect();
+        ((MediaOverviewActivity) requireActivity()).onExitMultiSelect();
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-          getActivity().getWindow().setStatusBarColor(originalStatusBarColor);
+          requireActivity().getWindow().setStatusBarColor(originalStatusBarColor);
         }
       }
     }
@@ -487,20 +487,20 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity {
       this.recyclerView.setAdapter(adapter);
       this.recyclerView.setLayoutManager(new LinearLayoutManager(getContext(), LinearLayoutManager.VERTICAL, false));
       this.recyclerView.addItemDecoration(new StickyHeaderDecoration(adapter, false, true));
-      this.recyclerView.addItemDecoration(new DividerItemDecoration(getContext(), DividerItemDecoration.VERTICAL));
+      this.recyclerView.addItemDecoration(new DividerItemDecoration(requireContext(), DividerItemDecoration.VERTICAL));
 
       return view;
     }
 
     @Override
     public Loader<Cursor> onCreateLoader(int id, Bundle args) {
-      return new ThreadMediaLoader(getContext(), recipient.getAddress(), false);
+      return new ThreadMediaLoader(requireContext(), recipient.getAddress(), false);
     }
 
     @Override
     public void onLoadFinished(Loader<Cursor> loader, Cursor data) {
       ((CursorRecyclerViewAdapter)this.recyclerView.getAdapter()).changeCursor(data);
-      getActivity().invalidateOptionsMenu();
+      requireActivity().invalidateOptionsMenu();
 
       this.noMedia.setVisibility(data.getCount() > 0 ? View.GONE : View.VISIBLE);
     }
@@ -508,7 +508,7 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity {
     @Override
     public void onLoaderReset(Loader<Cursor> loader) {
       ((CursorRecyclerViewAdapter)this.recyclerView.getAdapter()).changeCursor(null);
-      getActivity().invalidateOptionsMenu();
+      requireActivity().invalidateOptionsMenu();
     }
   }
 }

--- a/src/org/thoughtcrime/securesms/PlayServicesProblemFragment.java
+++ b/src/org/thoughtcrime/securesms/PlayServicesProblemFragment.java
@@ -31,11 +31,11 @@ public class PlayServicesProblemFragment extends DialogFragment {
 
   @Override
   public @NonNull Dialog onCreateDialog(@NonNull Bundle bundle) {
-    int    code   = GooglePlayServicesUtil.isGooglePlayServicesAvailable(getActivity());
+    int    code   = GooglePlayServicesUtil.isGooglePlayServicesAvailable(requireActivity());
     Dialog dialog = GooglePlayServicesUtil.getErrorDialog(code, getActivity(), 9111);
 
     if (dialog == null) {
-      return new AlertDialog.Builder(getActivity())
+      return new AlertDialog.Builder(requireActivity())
               .setNegativeButton(android.R.string.ok, null)
               .setMessage(R.string.PlayServicesProblemFragment_the_version_of_google_play_services_you_have_installed_is_not_functioning)
               .create();

--- a/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
+++ b/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
@@ -260,7 +260,7 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
 
       initializeRecipients();
 
-      this.canHaveSafetyNumber = getActivity().getIntent()
+      this.canHaveSafetyNumber = requireActivity().getIntent()
                                  .getBooleanExtra(RecipientPreferenceActivity.CAN_HAVE_SAFETY_NUMBER_EXTRA, false);
 
       Preference customNotificationsPref  = this.findPreference(PREFERENCE_CUSTOM_NOTIFICATIONS);
@@ -273,7 +273,7 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
         this.findPreference(PREFERENCE_MESSAGE_VIBRATE).setDependency(PREFERENCE_CUSTOM_NOTIFICATIONS);
 
         if (recipient.getNotificationChannel() != null) {
-          final Context context = getContext();
+          final Context context = requireContext();
           new AsyncTask<Void, Void, Void>() {
             @Override
             protected Void doInBackground(Void... voids) {
@@ -347,7 +347,7 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
     }
 
     private void initializeRecipients() {
-      this.recipient = Recipient.from(getActivity(), getArguments().getParcelable(ADDRESS_EXTRA), true);
+      this.recipient = Recipient.from(requireActivity(), getArguments().getParcelable(ADDRESS_EXTRA), true);
       this.recipient.addListener(this);
     }
 
@@ -368,11 +368,11 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
 
       mutePreference.setChecked(recipient.isMuted());
 
-      ringtoneMessagePreference.setSummary(ringtoneMessagePreference.isEnabled() ? getRingtoneSummary(getContext(), recipient.getMessageRingtone()) : "");
-      ringtoneCallPreference.setSummary(getRingtoneSummary(getContext(), recipient.getCallRingtone()));
+      ringtoneMessagePreference.setSummary(ringtoneMessagePreference.isEnabled() ? getRingtoneSummary(requireContext(), recipient.getMessageRingtone()) : "");
+      ringtoneCallPreference.setSummary(getRingtoneSummary(requireContext(), recipient.getCallRingtone()));
 
-      Pair<String, Integer> vibrateMessageSummary = getVibrateSummary(getContext(), recipient.getMessageVibrate());
-      Pair<String, Integer> vibrateCallSummary    = getVibrateSummary(getContext(), recipient.getCallVibrate());
+      Pair<String, Integer> vibrateMessageSummary = getVibrateSummary(requireContext(), recipient.getMessageVibrate());
+      Pair<String, Integer> vibrateCallSummary    = getVibrateSummary(requireContext(), recipient.getCallVibrate());
 
       vibrateMessagePreference.setSummary(vibrateMessagePreference.isEnabled() ? vibrateMessageSummary.first : "");
       vibrateMessagePreference.setValueIndex(vibrateMessageSummary.second);
@@ -386,8 +386,8 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
         if (aboutCategory      != null) getPreferenceScreen().removePreference(aboutCategory);
         if (aboutDivider       != null) getPreferenceScreen().removePreference(aboutDivider);
       } else {
-        colorPreference.setColors(MaterialColors.CONVERSATION_PALETTE.asConversationColorArray(getActivity()));
-        colorPreference.setColor(recipient.getColor().toActionBarColor(getActivity()));
+        colorPreference.setColors(MaterialColors.CONVERSATION_PALETTE.asConversationColorArray(requireActivity()));
+        colorPreference.setColor(recipient.getColor().toActionBarColor(requireActivity()));
 
         aboutPreference.setTitle(formatAddress(recipient.getAddress()));
         aboutPreference.setSummary(recipient.getCustomLabel());
@@ -753,12 +753,12 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
 
       @Override
       public void onMessageClicked() {
-        CommunicationActions.startConversation(getContext(), recipient, null);
+        CommunicationActions.startConversation(requireContext(), recipient, null);
       }
 
       @Override
       public void onSecureCallClicked() {
-        CommunicationActions.startVoiceCall(getActivity(), recipient);
+        CommunicationActions.startVoiceCall(requireActivity(), recipient);
       }
 
       @Override

--- a/src/org/thoughtcrime/securesms/VerifyIdentityActivity.java
+++ b/src/org/thoughtcrime/securesms/VerifyIdentityActivity.java
@@ -275,7 +275,7 @@ public class VerifyIdentityActivity extends PassphraseRequiredActionBarActivity 
       this.localNumber    = getArguments().getString(LOCAL_NUMBER);
       this.localIdentity  = localIdentityParcelable.get();
       this.remoteNumber   = getArguments().getString(REMOTE_NUMBER);
-      this.recipient      = Recipient.from(getActivity(), address, true);
+      this.recipient      = Recipient.from(requireActivity(), address, true);
       this.remoteIdentity = remoteIdentityParcelable.get();
 
       this.recipient.addListener(this);
@@ -291,7 +291,7 @@ public class VerifyIdentityActivity extends PassphraseRequiredActionBarActivity 
         protected void onPostExecute(Fingerprint fingerprint) {
           VerifyDisplayFragment.this.fingerprint = fingerprint;
           setFingerprintViews(fingerprint, true);
-          getActivity().supportInvalidateOptionsMenu();
+          requireActivity().supportInvalidateOptionsMenu();
         }
       }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
 
@@ -335,7 +335,7 @@ public class VerifyIdentityActivity extends PassphraseRequiredActionBarActivity 
       super.onCreateContextMenu(menu, view, menuInfo);
 
       if (fingerprint != null) {
-        MenuInflater inflater = getActivity().getMenuInflater();
+        MenuInflater inflater = requireActivity().getMenuInflater();
         inflater.inflate(R.menu.verify_display_fragment_context_menu, menu);
       }
     }
@@ -412,11 +412,11 @@ public class VerifyIdentityActivity extends PassphraseRequiredActionBarActivity 
     }
 
     private void handleCopyToClipboard(Fingerprint fingerprint, int segmentCount) {
-      Util.writeTextToClipboard(getActivity(), getFormattedSafetyNumbers(fingerprint, segmentCount));
+      Util.writeTextToClipboard(requireActivity(), getFormattedSafetyNumbers(fingerprint, segmentCount));
     }
 
     private void handleCompareWithClipboard(Fingerprint fingerprint) {
-      String clipboardData = Util.readTextFromClipboard(getActivity());
+      String clipboardData = Util.readTextFromClipboard(requireActivity());
 
       if (clipboardData == null) {
         Toast.makeText(getActivity(), R.string.VerifyIdentityActivity_no_safety_number_to_compare_was_found_in_the_clipboard, Toast.LENGTH_LONG).show();
@@ -455,7 +455,7 @@ public class VerifyIdentityActivity extends PassphraseRequiredActionBarActivity 
     }
 
     private void setRecipientText(Recipient recipient) {
-      description.setText(Html.fromHtml(String.format(getActivity().getString(R.string.verify_display_fragment__if_you_wish_to_verify_the_security_of_your_end_to_end_encryption_with_s), recipient.toShortString())));
+      description.setText(Html.fromHtml(String.format(getString(R.string.verify_display_fragment__if_you_wish_to_verify_the_security_of_your_end_to_end_encryption_with_s), recipient.toShortString())));
       description.setMovementMethod(LinkMovementMethod.getInstance());
     }
 
@@ -605,7 +605,7 @@ public class VerifyIdentityActivity extends PassphraseRequiredActionBarActivity 
                                           VerifiedStatus.DEFAULT);
             }
 
-            ApplicationContext.getInstance(getActivity())
+            ApplicationContext.getInstance(requireActivity())
                               .getJobManager()
                               .add(new MultiDeviceVerifiedUpdateJob(getActivity(),
                                                                     recipient.getAddress(),

--- a/src/org/thoughtcrime/securesms/giph/ui/GiphyFragment.java
+++ b/src/org/thoughtcrime/securesms/giph/ui/GiphyFragment.java
@@ -53,7 +53,7 @@ public abstract class GiphyFragment extends Fragment implements LoaderManager.Lo
   public void onActivityCreated(Bundle bundle) {
     super.onActivityCreated(bundle);
 
-    this.giphyAdapter = new GiphyAdapter(getActivity(), GlideApp.with(this), new LinkedList<>());
+    this.giphyAdapter = new GiphyAdapter(requireActivity(), GlideApp.with(this), new LinkedList<>());
     this.giphyAdapter.setListener(this);
 
     this.recyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));

--- a/src/org/thoughtcrime/securesms/giph/ui/GiphyGifFragment.java
+++ b/src/org/thoughtcrime/securesms/giph/ui/GiphyGifFragment.java
@@ -13,7 +13,7 @@ public class GiphyGifFragment extends GiphyFragment {
 
   @Override
   public Loader<List<GiphyImage>> onCreateLoader(int id, Bundle args) {
-    return new GiphyGifLoader(getActivity(), searchString);
+    return new GiphyGifLoader(requireActivity(), searchString);
   }
 
 }

--- a/src/org/thoughtcrime/securesms/giph/ui/GiphyStickerFragment.java
+++ b/src/org/thoughtcrime/securesms/giph/ui/GiphyStickerFragment.java
@@ -12,6 +12,6 @@ import java.util.List;
 public class GiphyStickerFragment extends GiphyFragment {
   @Override
   public Loader<List<GiphyImage>> onCreateLoader(int id, Bundle args) {
-    return new GiphyStickerLoader(getActivity(), searchString);
+    return new GiphyStickerLoader(requireActivity(), searchString);
   }
 }

--- a/src/org/thoughtcrime/securesms/logsubmit/SubmitLogFragment.java
+++ b/src/org/thoughtcrime/securesms/logsubmit/SubmitLogFragment.java
@@ -248,7 +248,7 @@ public class SubmitLogFragment extends Fragment {
 
   private void handleShowChooserForIntent(final Intent intent, String chooserTitle) {
     final AlertDialog.Builder    builder = new AlertDialog.Builder(getActivity());
-    final ShareIntentListAdapter adapter = ShareIntentListAdapter.getAdapterForIntent(getActivity(), intent);
+    final ShareIntentListAdapter adapter = ShareIntentListAdapter.getAdapterForIntent(requireActivity(), intent);
 
     builder.setTitle(chooserTitle)
            .setAdapter(adapter, new DialogInterface.OnClickListener() {
@@ -289,7 +289,7 @@ public class SubmitLogFragment extends Fragment {
       public boolean onLongClick(View v) {
         @SuppressWarnings("deprecation")
         ClipboardManager manager =
-            (ClipboardManager) getActivity().getSystemService(Activity.CLIPBOARD_SERVICE);
+            (ClipboardManager) requireActivity().getSystemService(Activity.CLIPBOARD_SERVICE);
         manager.setText(logUrl);
         Toast.makeText(getActivity(),
                        R.string.log_submit_activity__copied_to_clipboard,

--- a/src/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
@@ -175,7 +175,7 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
     @Override
     public boolean onPreferenceChange(Preference preference, Object newValue) {
       boolean enabled = (boolean)newValue;
-      ApplicationContext.getInstance(getContext())
+      ApplicationContext.getInstance(requireContext())
                         .getJobManager()
                         .add(new MultiDeviceReadReceiptUpdateJob(getContext(), enabled));
 
@@ -208,7 +208,7 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
   private class ChangePassphraseClickListener implements Preference.OnPreferenceClickListener {
     @Override
     public boolean onPreferenceClick(Preference preference) {
-      if (MasterSecretUtil.isPassphraseInitialized(getActivity())) {
+      if (MasterSecretUtil.isPassphraseInitialized(requireActivity())) {
         startActivity(new Intent(getActivity(), PassphraseChangeActivity.class));
       } else {
         Toast.makeText(getActivity(),
@@ -224,7 +224,7 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
 
     @Override
     public boolean onPreferenceClick(Preference preference) {
-      new TimeDurationPickerDialog(getContext(), (view, duration) -> {
+      new TimeDurationPickerDialog(requireContext(), (view, duration) -> {
         int timeoutMinutes = Math.max((int)TimeUnit.MILLISECONDS.toMinutes(duration), 1);
 
         TextSecurePreferences.setPassphraseTimeoutInterval(getActivity(), timeoutMinutes);
@@ -242,13 +242,13 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
     @Override
     public boolean onPreferenceChange(final Preference preference, Object newValue) {
       if (((CheckBoxPreference)preference).isChecked()) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity());
         builder.setTitle(R.string.ApplicationPreferencesActivity_disable_passphrase);
         builder.setMessage(R.string.ApplicationPreferencesActivity_this_will_permanently_unlock_signal_and_message_notifications);
         builder.setIconAttribute(R.attr.dialog_alert_icon);
         builder.setPositiveButton(R.string.ApplicationPreferencesActivity_disable, (dialog, which) -> {
           MasterSecretUtil.changeMasterSecretPassphrase(getActivity(),
-                                                        KeyCachingService.getMasterSecret(getContext()),
+                                                        KeyCachingService.getMasterSecret(requireContext()),
                                                         MasterSecretUtil.UNENCRYPTED_PASSPHRASE);
 
           TextSecurePreferences.setPasswordDisabled(getActivity(), true);
@@ -256,7 +256,7 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
 
           Intent intent = new Intent(getActivity(), KeyCachingService.class);
           intent.setAction(KeyCachingService.DISABLE_ACTION);
-          getActivity().startService(intent);
+          requireActivity().startService(intent);
 
           initializeVisibility();
         });

--- a/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -140,9 +140,9 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
                  .ifNecessary()
                  .onAllGranted(() -> {
                    if (!((SwitchPreferenceCompat)preference).isChecked()) {
-                     BackupDialog.showEnableBackupDialog(getActivity(), (SwitchPreferenceCompat)preference);
+                     BackupDialog.showEnableBackupDialog(requireActivity(), (SwitchPreferenceCompat)preference);
                    } else {
-                     BackupDialog.showDisableBackupDialog(getActivity(), (SwitchPreferenceCompat)preference);
+                     BackupDialog.showDisableBackupDialog(requireActivity(), (SwitchPreferenceCompat)preference);
                    }
                  })
                  .withPermanentDenialDialog(getString(R.string.ChatsPreferenceFragment_signal_requires_external_storage_permission_in_order_to_create_backups))
@@ -176,7 +176,7 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
     @Override
     public boolean onPreferenceClick(Preference preference) {
       final int threadLengthLimit = TextSecurePreferences.getThreadTrimLength(getActivity());
-      AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+      AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity());
       builder.setTitle(R.string.ApplicationPreferencesActivity_delete_all_old_messages_now);
       builder.setMessage(getResources().getQuantityString(R.plurals.ApplicationPreferencesActivity_this_will_immediately_trim_all_conversations_to_the_d_most_recent_messages,
                                                           threadLengthLimit, threadLengthLimit));

--- a/src/org/thoughtcrime/securesms/preferences/CorrectedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/CorrectedPreferenceFragment.java
@@ -47,7 +47,7 @@ public abstract class CorrectedPreferenceFragment extends PreferenceFragmentComp
 
     if (dialogFragment != null) {
       dialogFragment.setTargetFragment(this, 0);
-      dialogFragment.show(getFragmentManager(), "android.support.v7.preference.PreferenceFragment.DIALOG");
+      dialogFragment.show(requireFragmentManager(), "android.support.v7.preference.PreferenceFragment.DIALOG");
     } else {
       super.onDisplayPreferenceDialog(preference);
     }

--- a/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
@@ -228,7 +228,7 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
         new AsyncTask<Void, Void, Void>() {
           @Override
           protected Void doInBackground(Void... voids) {
-            NotificationChannels.updateMessagesLedColor(getActivity(), (String) value);
+            NotificationChannels.updateMessagesLedColor(requireActivity(), (String) value);
             return null;
           }
         }.execute();

--- a/src/org/thoughtcrime/securesms/preferences/SmsMmsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/SmsMmsPreferenceFragment.java
@@ -80,7 +80,7 @@ public class SmsMmsPreferenceFragment extends CorrectedPreferenceFragment {
       defaultPreference.setSummary(getString(R.string.ApplicationPreferencesActivity_touch_to_change_your_default_sms_app));
     } else {
       Intent intent = new Intent(Telephony.Sms.Intents.ACTION_CHANGE_DEFAULT);
-      intent.putExtra(Telephony.Sms.Intents.EXTRA_PACKAGE_NAME, getActivity().getPackageName());
+      intent.putExtra(Telephony.Sms.Intents.EXTRA_PACKAGE_NAME, requireActivity().getPackageName());
       defaultPreference.setIntent(intent);
       defaultPreference.setTitle(getString(R.string.ApplicationPreferencesActivity_sms_disabled));
       defaultPreference.setSummary(getString(R.string.ApplicationPreferencesActivity_touch_to_make_signal_your_default_sms_app));
@@ -92,7 +92,7 @@ public class SmsMmsPreferenceFragment extends CorrectedPreferenceFragment {
     @Override
     public boolean onPreferenceClick(Preference preference) {
       Fragment            fragment            = new MmsPreferencesFragment();
-      FragmentManager     fragmentManager     = getActivity().getSupportFragmentManager();
+      FragmentManager     fragmentManager     = requireActivity().getSupportFragmentManager();
       FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
       fragmentTransaction.replace(android.R.id.content, fragment);
       fragmentTransaction.addToBackStack(null);

--- a/src/org/thoughtcrime/securesms/preferences/widgets/ColorPickerPreferenceDialogFragmentCompat.java
+++ b/src/org/thoughtcrime/securesms/preferences/widgets/ColorPickerPreferenceDialogFragmentCompat.java
@@ -36,7 +36,7 @@ public class ColorPickerPreferenceDialogFragmentCompat extends PreferenceDialogF
         .setColumns(pref.getColumns())
         .build();
 
-    ColorPickerDialog dialog = new ColorPickerDialog(getActivity(), this, params);
+    ColorPickerDialog dialog = new ColorPickerDialog(requireActivity(), this, params);
     dialog.setTitle(pref.getDialogTitle());
 
     return dialog;

--- a/src/org/thoughtcrime/securesms/scribbles/ScribbleFragment.java
+++ b/src/org/thoughtcrime/securesms/scribbles/ScribbleFragment.java
@@ -97,7 +97,7 @@ public class ScribbleFragment extends Fragment implements ScribbleHud.EventListe
 
     scribbleHud.setEventListener(this);
     scribbleHud.setTransport(Optional.fromNullable(getArguments().getParcelable(KEY_TRANSPORT)));
-    scribbleHud.setFullscreen((getActivity().getWindow().getAttributes().flags & WindowManager.LayoutParams.FLAG_FULLSCREEN) > 0);
+    scribbleHud.setFullscreen((requireActivity().getWindow().getAttributes().flags & WindowManager.LayoutParams.FLAG_FULLSCREEN) > 0);
 
     scribbleView.setMotionViewCallback(motionViewCallback);
     scribbleView.setDrawingChangedListener(() -> scribbleHud.setColorPalette(scribbleView.getUniqueColors()));
@@ -187,7 +187,7 @@ public class ScribbleFragment extends Fragment implements ScribbleHud.EventListe
 
       LifecycleBoundTask.run(getLifecycle(), () -> {
         try {
-          return BitmapFactory.decodeStream(getContext().getAssets().open(stickerFile));
+          return BitmapFactory.decodeStream(requireContext().getAssets().open(stickerFile));
         } catch (IOException e) {
           Log.w(TAG, e);
           return null;

--- a/src/org/thoughtcrime/securesms/scribbles/StickerSelectFragment.java
+++ b/src/org/thoughtcrime/securesms/scribbles/StickerSelectFragment.java
@@ -83,7 +83,7 @@ public class StickerSelectFragment extends Fragment implements LoaderManager.Loa
 
   @Override
   public void onLoadFinished(Loader<String[]> loader, String[] data) {
-    recyclerView.setAdapter(new StickersAdapter(getActivity(), glideRequests, data));
+    recyclerView.setAdapter(new StickersAdapter(requireActivity(), glideRequests, data));
   }
 
   @Override


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 2XL, Android P
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Replace nullable instances of getActivity() with requireActivity(), getContext() with requireContext(), and getFragmentManager() with requireFragmentManager(), which are methods since 27.1.0 in the Fragment class that do null checks on the activity or context or fragment manager and throw an IllegalStateException if it's null, instead of letting the app crash with a NullPointerException. 

https://developer.android.com/topic/libraries/support-library/revisions#27-1-0

In this PR I only make changes in four scenarios:

1. The IDE gives a warning "Argument getActivity() might be null" or similar for the other methods
2. The IDE gives a warning "Method invocation ..... may produce NullPointerException"
3. getActivity().getString() is called from a fragment. In this case it can be changed to just getString(), which internally calls getResources(), which calls requireActivity()
4. getActivity().getResources() or getContext().getResources() is called, as in #3, can be changed to just getResources()
