### PR TITLE
Prevent WIFI_SERVICE memory leak

### DIFF
--- a/src/org/thoughtcrime/securesms/webrtc/locks/LockManager.java
+++ b/src/org/thoughtcrime/securesms/webrtc/locks/LockManager.java
@@ -48,7 +48,7 @@ public class LockManager {
     partialLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "RedPhone Partial");
     proximityLock = new ProximityLock(pm);
 
-    WifiManager wm = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
+    WifiManager wm = (WifiManager) context.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
     wifiLock = wm.createWifiLock(WifiManager.WIFI_MODE_FULL_HIGH_PERF, "RedPhone Wifi");
 
     fullLock.setReferenceCounted(false);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 2XL, Android P
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This change was made based on this IDE recommendation:

The WIFI_SERVICE must be looked up on the Application context or memory will leak on devices < Android N. Try changing context to context.getApplicationContext()

On versions prior to Android N (24), initializing the WifiManager via Context#getSystemService can cause a memory leak if the context is not the application context.  In many cases, it's not obvious from the code where the Context is coming from (e.g. it might be a parameter to a method, or a field initialized from various method calls). It's possible that the context being passed in is the application context, but to be on the safe side, you should consider changing context.getSystemService(...) to context.getApplicationContext().getSystemService(...). 
