### PR TITLE
Fix backup MAC checking.

### DIFF
--- a/src/org/thoughtcrime/securesms/backup/FullBackupImporter.java
+++ b/src/org/thoughtcrime/securesms/backup/FullBackupImporter.java
@@ -293,7 +293,7 @@ public class FullBackupImporter extends FullBackupBase {
           throw new IOException(e);
         }
 
-        if (MessageDigest.isEqual(ourMac, theirMac)) {
+        if (!MessageDigest.isEqual(ByteUtil.trim(ourMac, 10), theirMac)) {
           //destination.delete();
           throw new IOException("Bad MAC");
         }
@@ -316,7 +316,7 @@ public class FullBackupImporter extends FullBackupBase {
         mac.update(frame, 0, frame.length - 10);
         byte[] ourMac = mac.doFinal();
 
-        if (MessageDigest.isEqual(ourMac, theirMac)) {
+        if (!MessageDigest.isEqual(ByteUtil.trim(ourMac, 10), theirMac)) {
           throw new IOException("Bad MAC");
         }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Pixel XL, Android 6.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

`if(MessageDigest.isEqual(ourMac, theirMac)` was always returning false since `ourMac` was of length 32 and `theirMac` was of length 10.

```
10-30 21:20:02.045 6562-6609/org.thoughtcrime.securesms D/MAC_CHECK: theirMac = C16A82AB25ACD6292668
10-30 21:20:02.046 6562-6609/org.thoughtcrime.securesms D/MAC_CHECK: ourMac   = C16A82AB25ACD6292668C5C4DFE3C8B3405EC4E87DC87E5B67B22536A68F8248
```

This issue most likely went under the radar since a `!` was forgotten in the condition.

I'm also not sure of what happens when an exception is thrown in case of a MAC missmatch to the output stream in `readAttachmentTo(OutputStream out, int length)`. There is a `out.close()` before the check, the file is written even if an exception is raised ?