### PR TITLE
Fix broken link to support page

### DIFF
--- a/src/org/thoughtcrime/securesms/CreateProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/CreateProfileActivity.java
@@ -254,7 +254,7 @@ public class CreateProfileActivity extends BaseActionBarActivity implements Inje
 
     informationLabel.setOnClickListener(view -> {
       Intent intent = new Intent(Intent.ACTION_VIEW);
-      intent.setData(Uri.parse("https://support.signal.org/hc/en-us/articles/115001434171"));
+      intent.setData(Uri.parse("https://support.signal.org/hc/en-us/articles/360007059952"));
 
       if (getPackageManager().queryIntentActivities(intent, 0).size() > 0) {
         startActivity(intent);


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Tapping on the "Who can see this information?" in the profile view opens up a support a page which has become stale. The link to the old support page redirects to the new page only when JavaScript is enabled.

So, replace the link to the old page with that of the new one to ensure the correct page is shown even when JavaScript is disabled.

I haven't tested this fix as I don't see anything that might break as a consequence of this change.