### PR TITLE
replace menuitem "help" by "use-guide and support"

### DIFF
--- a/res/menu/text_secure_normal.xml
+++ b/res/menu/text_secure_normal.xml
@@ -16,7 +16,7 @@
     <item android:title="@string/text_secure_normal__menu_settings"
           android:id="@+id/menu_settings" />
 
-    <item android:title="@string/text_secure_normal__Use-guide_and_support"
+    <item android:title="@string/text_secure_normal__use-guide_and_support"
           android:id="@+id/menu_help"/>
 
 </menu>

--- a/res/menu/text_secure_normal.xml
+++ b/res/menu/text_secure_normal.xml
@@ -16,7 +16,7 @@
     <item android:title="@string/text_secure_normal__menu_settings"
           android:id="@+id/menu_settings" />
 
-    <item android:title="@string/text_secure_normal__help"
+    <item android:title="@string/text_secure_normal__Use-guide_and_support"
           android:id="@+id/menu_help"/>
 
 </menu>

--- a/res/values-ar/strings.xml
+++ b/res/values-ar/strings.xml
@@ -1134,7 +1134,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">أقفل</string>
   <string name="text_secure_normal__mark_all_as_read">اعتبارها رسائل مقروءة</string>
   <string name="text_secure_normal__invite_friends">دعوة الأصدقاء</string>
-  <string name="text_secure_normal__Use-guide_and_support">مساعدة</string>
+  <string name="text_secure_normal__use-guide_and_support">مساعدة</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">نسخ إلى الحافظة</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">قارن مع الحافظة</string>

--- a/res/values-ar/strings.xml
+++ b/res/values-ar/strings.xml
@@ -1134,7 +1134,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">أقفل</string>
   <string name="text_secure_normal__mark_all_as_read">اعتبارها رسائل مقروءة</string>
   <string name="text_secure_normal__invite_friends">دعوة الأصدقاء</string>
-  <string name="text_secure_normal__help">مساعدة</string>
+  <string name="text_secure_normal__Use-guide_and_support">مساعدة</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">نسخ إلى الحافظة</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">قارن مع الحافظة</string>

--- a/res/values-be/strings.xml
+++ b/res/values-be/strings.xml
@@ -448,6 +448,7 @@
   <string name="text_secure_normal__menu_settings">Налады</string>
   <string name="text_secure_normal__menu_clear_passphrase">Заблакіраваць</string>
   <string name="text_secure_normal__mark_all_as_read">Пазначыць усе як прачытаныя</string>
+  <!--<string name="text_secure_normal__use-guide_and_support">This translation is missing!</string>-->
   <!--verify_display_fragment-->
   <!--reminder_header-->
   <!--media_preview-->

--- a/res/values-bg/strings.xml
+++ b/res/values-bg/strings.xml
@@ -1040,7 +1040,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">Заключи</string>
   <string name="text_secure_normal__mark_all_as_read">Маркиране на всички като прочетени</string>
   <string name="text_secure_normal__invite_friends">Покани приятели</string>
-  <string name="text_secure_normal__Use-guide_and_support">Помощ</string>
+  <string name="text_secure_normal__use-guide_and_support">Помощ</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Копиране</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Сравняване с копирани</string>

--- a/res/values-bg/strings.xml
+++ b/res/values-bg/strings.xml
@@ -1040,7 +1040,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">Заключи</string>
   <string name="text_secure_normal__mark_all_as_read">Маркиране на всички като прочетени</string>
   <string name="text_secure_normal__invite_friends">Покани приятели</string>
-  <string name="text_secure_normal__help">Помощ</string>
+  <string name="text_secure_normal__Use-guide_and_support">Помощ</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Копиране</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Сравняване с копирани</string>

--- a/res/values-ca/strings.xml
+++ b/res/values-ca/strings.xml
@@ -1110,7 +1110,7 @@ S\'ha rebut un missatge d\'intercanvi de claus per a una versió del protocol no
   <string name="text_secure_normal__menu_clear_passphrase">Bloca</string>
   <string name="text_secure_normal__mark_all_as_read">Marca-ho tot com a llegit</string>
   <string name="text_secure_normal__invite_friends">Convideu-hi amistats</string>
-  <string name="text_secure_normal__help">Ajuda</string>
+  <string name="text_secure_normal__use-guide_and_support">Ajuda</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Copia al porta-retalls</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Compara amb el porta-retalls</string>

--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -1151,7 +1151,7 @@ Obdržen požadavek na výměnu klíčů pro neplatnou verzi protokolu.</string>
   <string name="text_secure_normal__menu_clear_passphrase">Uzamknout</string>
   <string name="text_secure_normal__mark_all_as_read">Označit vše jako přečtené</string>
   <string name="text_secure_normal__invite_friends">Pozvat přátele</string>
-  <string name="text_secure_normal__help">Nápověda</string>
+  <string name="text_secure_normal__use-guide_and_support">Nápověda</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Zkopírovat do schránky</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Porovnat se schránkou</string>

--- a/res/values-cy/strings.xml
+++ b/res/values-cy/strings.xml
@@ -1155,7 +1155,7 @@ Send neges heb ei ddiogelu?</string>
   <string name="text_secure_normal__menu_clear_passphrase">Cloi</string>
   <string name="text_secure_normal__mark_all_as_read">Marcio popeth wedi\'i ddarllen</string>
   <string name="text_secure_normal__invite_friends">Gwahodd ffrindiau</string>
-  <string name="text_secure_normal__help">Cymorth</string>
+  <string name="text_secure_normal__use-guide_and_support">Cymorth</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Copïo i\'r clipfwrdd</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Cymharu â\'r clipfwrdd</string>

--- a/res/values-da/strings.xml
+++ b/res/values-da/strings.xml
@@ -978,7 +978,7 @@ Modtog en nøgle-besked for en ugyldig protokol-version.
   <string name="text_secure_normal__menu_clear_passphrase">Lås</string>
   <string name="text_secure_normal__mark_all_as_read">Markér alle som læst</string>
   <string name="text_secure_normal__invite_friends">Invitér venner</string>
-  <string name="text_secure_normal__help">Hjælp</string>
+  <string name="text_secure_normal__use-guide_and_support">Hjælp</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Kopier til udklipsholder</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Sammenlign med udklipsholder</string>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -1105,7 +1105,7 @@ Schlüsselaustausch-Nachricht für eine ungültige Protokollversion empfangen</s
   <string name="text_secure_normal__menu_clear_passphrase">Signal sperren</string>
   <string name="text_secure_normal__mark_all_as_read">Alle als gelesen markieren</string>
   <string name="text_secure_normal__invite_friends">Freunde einladen</string>
-  <string name="text_secure_normal__help">Hilfe</string>
+  <string name="text_secure_normal__use-guide_and_support">Benutzerhandbuch und Unterstützung</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">In Zwischenablage kopieren</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Mit Zwischenablage vergleichen</string>

--- a/res/values-el/strings.xml
+++ b/res/values-el/strings.xml
@@ -1095,7 +1095,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">Κλείδωμα</string>
   <string name="text_secure_normal__mark_all_as_read">Σημείωση όλων ως αναγνωσμένα</string>
   <string name="text_secure_normal__invite_friends">Πρόσκληση φίλων</string>
-  <string name="text_secure_normal__help">Βοήθεια</string>
+  <string name="text_secure_normal__use-guide_and_support">Βοήθεια</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Αντιγραφή στο πρόχειρο</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Σύγκριση με το πρόχειρο</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -1112,7 +1112,7 @@ Se recibió un mensaje de intercambio de claves para una versión no válida del
   <string name="text_secure_normal__menu_clear_passphrase">Bloquear</string>
   <string name="text_secure_normal__mark_all_as_read">Marcar todos como leídos</string>
   <string name="text_secure_normal__invite_friends">Invitar amigos</string>
-  <string name="text_secure_normal__help">Ayuda</string>
+  <string name="text_secure_normal__use-guide_and_support">Ayuda</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Copiar al portapapeles</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Comparar con el portapapeles</string>

--- a/res/values-et/strings.xml
+++ b/res/values-et/strings.xml
@@ -1085,7 +1085,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">Lukusta</string>
   <string name="text_secure_normal__mark_all_as_read">Märgi kõik loetuks</string>
   <string name="text_secure_normal__invite_friends">Kutsu sõpru</string>
-  <string name="text_secure_normal__help">Abi</string>
+  <string name="text_secure_normal__use-guide_and_support">Abi</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Kopeeri lõikelauale</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Võrdle lõikelauaga</string>

--- a/res/values-eu/strings.xml
+++ b/res/values-eu/strings.xml
@@ -1107,7 +1107,7 @@ Inportatu \'SMSBackup and Restorekin\' bateragarria den zifratu gabeko babeskopi
   <string name="text_secure_normal__menu_clear_passphrase">Blokeatu</string>
   <string name="text_secure_normal__mark_all_as_read">Irakurritako gisa markatu guztiak</string>
   <string name="text_secure_normal__invite_friends">Gonbidatu lagunak</string>
-  <string name="text_secure_normal__help">Laguntza</string>
+  <string name="text_secure_normal__use-guide_and_support">Laguntza</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Kopiatu arbelera</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Arbelarekin konparatu</string>

--- a/res/values-fa/strings.xml
+++ b/res/values-fa/strings.xml
@@ -923,7 +923,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">قفل</string>
   <string name="text_secure_normal__mark_all_as_read">علامت همه به عنوان خوانده شده</string>
   <string name="text_secure_normal__invite_friends">دعوت دوستان</string>
-  <string name="text_secure_normal__help">کمک</string>
+  <string name="text_secure_normal__use-guide_and_support">کمک</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">کپی به کلیپ بورد</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">مقایسه با کلیپ بورد</string>

--- a/res/values-fi/strings.xml
+++ b/res/values-fi/strings.xml
@@ -1110,7 +1110,7 @@ Vastaanotetiin avaintenvaihtoviesti, joka kuuluu väärälle protokollaversiolle
   <string name="text_secure_normal__menu_clear_passphrase">Lukitse</string>
   <string name="text_secure_normal__mark_all_as_read">Merkitse kaikki luetuiksi</string>
   <string name="text_secure_normal__invite_friends">Kutsu ystäviä</string>
-  <string name="text_secure_normal__help">Tuki </string>
+  <string name="text_secure_normal__use-guide_and_support">Tuki </string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Kopioi leikepöydälle</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Vertaa leikepöytään</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -1103,7 +1103,7 @@ Vous avez reçu un message d’échange de clés pour une version de protocole i
   <string name="text_secure_normal__menu_clear_passphrase">Verrouiller</string>
   <string name="text_secure_normal__mark_all_as_read">Tout marquer comme lu</string>
   <string name="text_secure_normal__invite_friends">Inviter des amis</string>
-  <string name="text_secure_normal__help">Aide</string>
+  <string name="text_secure_normal__use-guide_and_support">Aide</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Copier dans le presse-papiers</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Comparer avec le presse-papiers</string>

--- a/res/values-ga/strings.xml
+++ b/res/values-ga/strings.xml
@@ -956,7 +956,7 @@ a shonrú</string>
   <string name="text_secure_normal__menu_clear_passphrase">Glasáil</string>
   <string name="text_secure_normal__mark_all_as_read">Rianaigh uile mar léite</string>
   <string name="text_secure_normal__invite_friends">Tabhair cuirí do chairde</string>
-  <string name="text_secure_normal__help">Cabhair</string>
+  <string name="text_secure_normal__use-guide_and_support">Cabhair</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Macasamhlaigh chuig an ghearrthaisce</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Cuir i gcomórtas leis an ngearrthaisce</string>

--- a/res/values-gl/strings.xml
+++ b/res/values-gl/strings.xml
@@ -1091,7 +1091,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">Bloquear</string>
   <string name="text_secure_normal__mark_all_as_read">Marcar todas  como lidas</string>
   <string name="text_secure_normal__invite_friends">Convidar amizades</string>
-  <string name="text_secure_normal__help">Axuda</string>
+  <string name="text_secure_normal__use-guide_and_support">Axuda</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Copiar ao portapapeis</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Comparar co portapapeis</string>

--- a/res/values-hi-rIN/strings.xml
+++ b/res/values-hi-rIN/strings.xml
@@ -1068,7 +1068,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">ताला</string>
   <string name="text_secure_normal__mark_all_as_read">सभी को पढ़ा दिखाएं</string>
   <string name="text_secure_normal__invite_friends">मित्रों को आमंत्रित करें</string>
-  <string name="text_secure_normal__help">मदद</string>
+  <string name="text_secure_normal__use-guide_and_support">मदद</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">क्लिपबोर्ड पर कॉपी करें</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">क्लिपबोर्ड के साथ तुलना करें</string>

--- a/res/values-hi/strings.xml
+++ b/res/values-hi/strings.xml
@@ -1070,7 +1070,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">ताला</string>
   <string name="text_secure_normal__mark_all_as_read">सभी को पढ़ा दिखाएं</string>
   <string name="text_secure_normal__invite_friends">मित्रों को आमंत्रित करें</string>
-  <string name="text_secure_normal__help">मदद</string>
+  <string name="text_secure_normal__use-guide_and_support">मदद</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">क्लिपबोर्ड पर कॉपी करें</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">क्लिपबोर्ड के साथ तुलना करें</string>

--- a/res/values-hr/strings.xml
+++ b/res/values-hr/strings.xml
@@ -1004,7 +1004,7 @@ Uvezi nekriptiranu kopiju. Kompatibilno s \'SMSBackup And Restore\'.</string>
   <string name="text_secure_normal__menu_clear_passphrase">Zaključaj</string>
   <string name="text_secure_normal__mark_all_as_read">Označi sve pročitano</string>
   <string name="text_secure_normal__invite_friends">Pozovi prijatelje</string>
-  <string name="text_secure_normal__help">Pomoć</string>
+  <string name="text_secure_normal__use-guide_and_support">Pomoć</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Kopiraj u međuspremnik</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Usporedi s međuspremnikom</string>

--- a/res/values-hu/strings.xml
+++ b/res/values-hu/strings.xml
@@ -1119,7 +1119,7 @@ Kulcs-csere üzenet érkezett érvénytelen protokoll verzióhoz.
   <string name="text_secure_normal__menu_clear_passphrase">Lezárás</string>
   <string name="text_secure_normal__mark_all_as_read">Összes megjelölése olvasottként</string>
   <string name="text_secure_normal__invite_friends">Barátok meghívása</string>
-  <string name="text_secure_normal__help">Súgó</string>
+  <string name="text_secure_normal__use-guide_and_support">Súgó</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Másolás vágólapra</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Összehasonlítás vágólappal</string>

--- a/res/values-in/strings.xml
+++ b/res/values-in/strings.xml
@@ -1048,7 +1048,7 @@ Diterima pesan pertukaran kunci untuk versi protokol yang tidak valid.
   <string name="text_secure_normal__menu_clear_passphrase">Kunci</string>
   <string name="text_secure_normal__mark_all_as_read">Tandai semua dibaca</string>
   <string name="text_secure_normal__invite_friends">Undang teman</string>
-  <string name="text_secure_normal__help">Bantuan</string>
+  <string name="text_secure_normal__use-guide_and_support">Bantuan</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Salin ke papan klip</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Bandingkan dengan papan klip</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -1101,7 +1101,7 @@ Ricevuto un messaggio di scambio chiavi per una versione di protocollo non valid
   <string name="text_secure_normal__menu_clear_passphrase">Blocca</string>
   <string name="text_secure_normal__mark_all_as_read">Segna tutto come già letto</string>
   <string name="text_secure_normal__invite_friends">Invita amici</string>
-  <string name="text_secure_normal__help">Aiuto</string>
+  <string name="text_secure_normal__use-guide_and_support">Aiuto</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Copia negli appunti</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Confronta con gli appunti</string>

--- a/res/values-iw/strings.xml
+++ b/res/values-iw/strings.xml
@@ -1166,7 +1166,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">נעל</string>
   <string name="text_secure_normal__mark_all_as_read">סמן הכל כנקרא</string>
   <string name="text_secure_normal__invite_friends">הזמן חברים</string>
-  <string name="text_secure_normal__help">עזרה</string>
+  <string name="text_secure_normal__use-guide_and_support">עזרה</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">העתק ללוח העריכה</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">השווה עם לוח העריכה</string>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -1077,7 +1077,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">ロック</string>
   <string name="text_secure_normal__mark_all_as_read">すべて既読にする</string>
   <string name="text_secure_normal__invite_friends">友達にオススメする</string>
-  <string name="text_secure_normal__help">ヘルプ</string>
+  <string name="text_secure_normal__use-guide_and_support">ヘルプ</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">クリップボードにコピーする</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">クリップボードと比較する</string>

--- a/res/values-km-rKH/strings.xml
+++ b/res/values-km-rKH/strings.xml
@@ -1066,7 +1066,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">ចាក់សោរ</string>
   <string name="text_secure_normal__mark_all_as_read">សម្គាល់ការអានទាំងអស់</string>
   <string name="text_secure_normal__invite_friends">អញ្ជើញមិត្តភក្តិ</string>
-  <string name="text_secure_normal__help">ជំនួយ</string>
+  <string name="text_secure_normal__use-guide_and_support">ជំនួយ</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">ចម្លងទៅ clipboard</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">ប្រៀបធៀបជាមួយ clipboard</string>

--- a/res/values-km/strings.xml
+++ b/res/values-km/strings.xml
@@ -1077,7 +1077,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">ចាក់សោរ</string>
   <string name="text_secure_normal__mark_all_as_read">សម្គាល់ការអានទាំងអស់</string>
   <string name="text_secure_normal__invite_friends">អញ្ជើញមិត្តភក្តិ</string>
-  <string name="text_secure_normal__help">ជំនួយ</string>
+  <string name="text_secure_normal__use-guide_and_support">ជំនួយ</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">ចម្លងទៅ clipboard</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">ប្រៀបធៀបជាមួយ clipboard</string>

--- a/res/values-ko/strings.xml
+++ b/res/values-ko/strings.xml
@@ -842,7 +842,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">Signal 잠금</string>
   <string name="text_secure_normal__mark_all_as_read">모두 읽음으로 표시</string>
   <string name="text_secure_normal__invite_friends">친구 초대</string>
-  <string name="text_secure_normal__help">도움말</string>
+  <string name="text_secure_normal__use-guide_and_support">도움말</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">클립보드에 복사</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">클립보드와 비교</string>

--- a/res/values-ku/strings.xml
+++ b/res/values-ku/strings.xml
@@ -1049,7 +1049,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">Qilf bikin</string>
   <string name="text_secure_normal__mark_all_as_read">Hemû wek xwendin diyar bikin</string>
   <string name="text_secure_normal__invite_friends">Heval vexwînin</string>
-  <string name="text_secure_normal__help">Alîkarî</string>
+  <string name="text_secure_normal__use-guide_and_support">Alîkarî</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Kopîkirin</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Bi kopî hevberkirin</string>

--- a/res/values-lg/strings.xml
+++ b/res/values-lg/strings.xml
@@ -748,7 +748,7 @@ gy\'olonze (%s) sintuufu.</string>
   <string name="text_secure_normal__menu_clear_passphrase">Siba</string>
   <string name="text_secure_normal__mark_all_as_read">tikinga byona ebisomedwa</string>
   <string name="text_secure_normal__invite_friends">Yita  abemikwano </string>
-  <string name="text_secure_normal__help">obuyambi</string>
+  <string name="text_secure_normal__use-guide_and_support">obuyambi</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">copinga ku clipbodi</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">geraageranya ne kilipuboodi</string>

--- a/res/values-lt/strings.xml
+++ b/res/values-lt/strings.xml
@@ -1159,7 +1159,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">Užrakinti</string>
   <string name="text_secure_normal__mark_all_as_read">Žymėti visus skaitytais</string>
   <string name="text_secure_normal__invite_friends">Pakviesti draugus</string>
-  <string name="text_secure_normal__help">Pagalba</string>
+  <string name="text_secure_normal__use-guide_and_support">Pagalba</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Kopijuoti į iškarpinę</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Palyginti su iškarpine</string>

--- a/res/values-mk/strings.xml
+++ b/res/values-mk/strings.xml
@@ -543,7 +543,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">Заклучи</string>
   <string name="text_secure_normal__mark_all_as_read">Обележи ги сите како прочитани</string>
   <string name="text_secure_normal__invite_friends">Покани пријатели</string>
-  <string name="text_secure_normal__help">Помош</string>
+  <string name="text_secure_normal__use-guide_and_support">Помош</string>
   <!--verify_display_fragment-->
   <!--reminder_header-->
   <string name="reminder_header_outdated_build">Вашата верзија на Signal е застарена.</string>

--- a/res/values-my/strings.xml
+++ b/res/values-my/strings.xml
@@ -1015,7 +1015,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">ပိတ်မည်</string>
   <string name="text_secure_normal__mark_all_as_read">အားလုံးကို ဖတ်ပြီးသားအဖြစ် မှတ်ပါ။</string>
   <string name="text_secure_normal__invite_friends">သူငယ်ချင်းများကို ဖိတ်ပါ။</string>
-  <string name="text_secure_normal__help">အကူအညီ</string>
+  <string name="text_secure_normal__use-guide_and_support">အကူအညီ</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">ကူးယူလိုက်ပါ။</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">clipboard နဲ့ ယှဥ်လိုက်ပါ။</string>

--- a/res/values-nb/strings.xml
+++ b/res/values-nb/strings.xml
@@ -1102,7 +1102,7 @@ Mottok nøkkelutvekslingsmelding for ugyldig protokollversion.</string>
   <string name="text_secure_normal__menu_clear_passphrase">Lås</string>
   <string name="text_secure_normal__mark_all_as_read">Merk alle som lest</string>
   <string name="text_secure_normal__invite_friends">Inviter venner</string>
-  <string name="text_secure_normal__help">Hjelp</string>
+  <string name="text_secure_normal__use-guide_and_support">Hjelp</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Kopiere til utklippstavle</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Sammenlign med utklippstavlen</string>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -1105,7 +1105,7 @@ Sleuteluitwisselingsbericht ontvangen voor een verkeerde protocol-versie.</strin
   <string name="text_secure_normal__menu_clear_passphrase">Vergrendelen</string>
   <string name="text_secure_normal__mark_all_as_read">Alles markeren als gelezen</string>
   <string name="text_secure_normal__invite_friends">Vrienden uitnodigen</string>
-  <string name="text_secure_normal__help">Hulp</string>
+  <string name="text_secure_normal__Use-guide_and_support">Uitleg en ondersteuning</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Kopiëren naar klembord</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Vergelijken met klembord</string>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -1105,7 +1105,7 @@ Sleuteluitwisselingsbericht ontvangen voor een verkeerde protocol-versie.</strin
   <string name="text_secure_normal__menu_clear_passphrase">Vergrendelen</string>
   <string name="text_secure_normal__mark_all_as_read">Alles markeren als gelezen</string>
   <string name="text_secure_normal__invite_friends">Vrienden uitnodigen</string>
-  <string name="text_secure_normal__Use-guide_and_support">Uitleg en ondersteuning</string>
+  <string name="text_secure_normal__use-guide_and_support">Uitleg en ondersteuning</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Kopiëren naar klembord</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Vergelijken met klembord</string>

--- a/res/values-nn/strings.xml
+++ b/res/values-nn/strings.xml
@@ -1104,7 +1104,7 @@ Du er à jour!</string>
   <string name="text_secure_normal__menu_clear_passphrase">Lås</string>
   <string name="text_secure_normal__mark_all_as_read">Merk alle lesne</string>
   <string name="text_secure_normal__invite_friends">Inviter vennar</string>
-  <string name="text_secure_normal__help">Hjelp</string>
+  <string name="text_secure_normal__use-guide_and_support">Hjelp</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Kopiera til utklippstavle</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Samanlikn med utklippstavla</string>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -1141,7 +1141,7 @@ Otrzymano wiadomość wymiany klucz dla niepoprawnej wersji protokołu.</string>
   <string name="text_secure_normal__menu_clear_passphrase">Zablokuj</string>
   <string name="text_secure_normal__mark_all_as_read">Oznacz wszystkie jako przeczytane</string>
   <string name="text_secure_normal__invite_friends">Zaproś znajomych</string>
-  <string name="text_secure_normal__help">Pomoc</string>
+  <string name="text_secure_normal__use-guide_and_support">Pomoc</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Skopiuj do schowka </string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Porównaj ze schowkiem</string>

--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -1083,7 +1083,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">Trancar</string>
   <string name="text_secure_normal__mark_all_as_read">Marcar todas como lidas</string>
   <string name="text_secure_normal__invite_friends">Convidar amigos</string>
-  <string name="text_secure_normal__help">Ajuda</string>
+  <string name="text_secure_normal__use-guide_and_support">Ajuda</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Copiar para a área de transferência</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Comparar com a área de transferência</string>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -1112,7 +1112,7 @@ Mensagem de troca de chaves inválida para esta versão do protocolo.
   <string name="text_secure_normal__menu_clear_passphrase">Desbloquear</string>
   <string name="text_secure_normal__mark_all_as_read">Marcar todas como lidas</string>
   <string name="text_secure_normal__invite_friends">Convidar amigos</string>
-  <string name="text_secure_normal__help">Ajuda</string>
+  <string name="text_secure_normal__use-guide_and_support">Ajuda</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Copiar para a área de transferência</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Comparar com a área de transferência</string>

--- a/res/values-qu-rEC/strings.xml
+++ b/res/values-qu-rEC/strings.xml
@@ -1078,7 +1078,7 @@ Shuk ranti pakallayupay chaski chayamurka, shuk ñawpa mana alli protocolo kashk
   <string name="text_secure_normal__menu_clear_passphrase">Pakana</string>
   <string name="text_secure_normal__mark_all_as_read">Killkakatishkami nishpa tukuyllakunata churay</string>
   <string name="text_secure_normal__invite_friends">Mashikunata kayachina</string>
-  <string name="text_secure_normal__help">Yanapay</string>
+  <string name="text_secure_normal__use-guide_and_support">Yanapay</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Panka allichikman chayshina allichishka</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Panka allichikwan chimpapuray </string>

--- a/res/values-ro/strings.xml
+++ b/res/values-ro/strings.xml
@@ -1140,7 +1140,7 @@ Am primit mesajul conform căruia schimbul de chei a avut loc pentru o versiune 
   <string name="text_secure_normal__menu_clear_passphrase">Blochează</string>
   <string name="text_secure_normal__mark_all_as_read">Marchează tot ca citit</string>
   <string name="text_secure_normal__invite_friends">Invită prieteni</string>
-  <string name="text_secure_normal__help">Ajutor</string>
+  <string name="text_secure_normal__use-guide_and_support">Ajutor</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Copiază în clipboard</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Compară cu clipboard-ul</string>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -1153,7 +1153,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">Заблокировать</string>
   <string name="text_secure_normal__mark_all_as_read">Отметить все как прочитанные</string>
   <string name="text_secure_normal__invite_friends">Пригласить друзей в Signal</string>
-  <string name="text_secure_normal__help">Помощь</string>
+  <string name="text_secure_normal__use-guide_and_support">Помощь</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Копировать в буфер обмена</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Сравнить с буфером обмена</string>

--- a/res/values-sk/strings.xml
+++ b/res/values-sk/strings.xml
@@ -1132,7 +1132,7 @@ Bola prijatá správa výmeny kľúčov s neplatnou verziou protokolu.
   <string name="text_secure_normal__menu_clear_passphrase">Zamknúť</string>
   <string name="text_secure_normal__mark_all_as_read">Označiť všetko ako prečítané</string>
   <string name="text_secure_normal__invite_friends">Pozvať priateľov</string>
-  <string name="text_secure_normal__help">Pomocník</string>
+  <string name="text_secure_normal__use-guide_and_support">Pomocník</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Kopírovať</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Porovnať</string>

--- a/res/values-sl/strings.xml
+++ b/res/values-sl/strings.xml
@@ -1163,7 +1163,7 @@ Prejeto sporočilo za izmenjavo ključev za napačno različico protokola.</stri
   <string name="text_secure_normal__menu_clear_passphrase">Zakleni</string>
   <string name="text_secure_normal__mark_all_as_read">Označi vse kot prebrano</string>
   <string name="text_secure_normal__invite_friends">Povabi prijatelje</string>
-  <string name="text_secure_normal__help">Pomoč</string>
+  <string name="text_secure_normal__use-guide_and_support">Pomoč</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Kopiraj v odložišče</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Primerjaj preko odložišča</string>

--- a/res/values-sq/strings.xml
+++ b/res/values-sq/strings.xml
@@ -908,7 +908,7 @@ U pranua porosi për shkëmbim çelësash për një version protokolli të pavle
   <string name="text_secure_normal__menu_clear_passphrase">Kyç</string>
   <string name="text_secure_normal__mark_all_as_read">Shëno të gjitha si të lexuara</string>
   <string name="text_secure_normal__invite_friends">Fto shokët</string>
-  <string name="text_secure_normal__help">Ndihmë</string>
+  <string name="text_secure_normal__use-guide_and_support">Ndihmë</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Kopjo në memorie</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Krahaso me memorie</string>

--- a/res/values-sr/strings.xml
+++ b/res/values-sr/strings.xml
@@ -1020,7 +1020,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">Закључај</string>
   <string name="text_secure_normal__mark_all_as_read">Означи све прочитаним</string>
   <string name="text_secure_normal__invite_friends">Позовите пријатеље</string>
-  <string name="text_secure_normal__help">Помоћ</string>
+  <string name="text_secure_normal__use-guide_and_support">Помоћ</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Копирај на клипборд</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Упореди са клипбордом</string>

--- a/res/values-sv/strings.xml
+++ b/res/values-sv/strings.xml
@@ -1079,7 +1079,7 @@ Tog emot meddelande för nyckelutbyte för ogiltig protokollversion.</string>
   <string name="text_secure_normal__menu_clear_passphrase">Lås</string>
   <string name="text_secure_normal__mark_all_as_read">Markera alla lästa</string>
   <string name="text_secure_normal__invite_friends">Bjud in vänner</string>
-  <string name="text_secure_normal__help">Hjälp</string>
+  <string name="text_secure_normal__use-guide_and_support">Hjälp</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Kopiera till urklipp</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Jämför med urklipp</string>

--- a/res/values-ta/strings.xml
+++ b/res/values-ta/strings.xml
@@ -609,7 +609,7 @@
   <string name="text_secure_normal__menu_settings">அமைப்புகள்</string>
   <string name="text_secure_normal__menu_clear_passphrase">பூட்டு</string>
   <string name="text_secure_normal__mark_all_as_read">அனைத்தையும் படித்தாக குறியிடு</string>
-  <string name="text_secure_normal__help">உதவி</string>
+  <string name="text_secure_normal__use-guide_and_support">உதவி</string>
   <!--verify_display_fragment-->
   <!--reminder_header-->
   <string name="reminder_header_invite_title">சமிக்ஞைக்கு அழை</string>

--- a/res/values-te/strings.xml
+++ b/res/values-te/strings.xml
@@ -1105,7 +1105,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">బందించు</string>
   <string name="text_secure_normal__mark_all_as_read">మార్క్ చేసినవన్నీ చదవండి </string>
   <string name="text_secure_normal__invite_friends">స్నేహితులను ఆహ్వానించండి</string>
-  <string name="text_secure_normal__help">సహాయం</string>
+  <string name="text_secure_normal__use-guide_and_support">సహాయం</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">తాత్కాలికంగా  భద్రపరుచు  ప్రదేశముకు నకలు చెయ్యి</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard"> తాత్కాలికంగా  భద్రపరుచు ప్రదేశముతో పోల్చడం</string>

--- a/res/values-th/strings.xml
+++ b/res/values-th/strings.xml
@@ -1049,7 +1049,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">ล็อก</string>
   <string name="text_secure_normal__mark_all_as_read">ทำเครื่องหมายทั้งหมดว่าอ่านแล้ว</string>
   <string name="text_secure_normal__invite_friends">เชิญเพื่อน</string>
-  <string name="text_secure_normal__help">ช่วยเหลือ</string>
+  <string name="text_secure_normal__use-guide_and_support">ช่วยเหลือ</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">คัดลอกไปยังคลิปบอร์ด</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">เปรียบเทียบกับคลิปบอร์ด</string>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -1115,7 +1115,7 @@ Geçersiz protokol sürümünde anahtar değişim mesajı alındı.</string>
   <string name="text_secure_normal__menu_clear_passphrase">Kilitle</string>
   <string name="text_secure_normal__mark_all_as_read">Tümünü okundu olarak işaretle</string>
   <string name="text_secure_normal__invite_friends">Arkadaşlarını davet et</string>
-  <string name="text_secure_normal__help">Yardım</string>
+  <string name="text_secure_normal__use-guide_and_support">Yardım</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Panoya kopyala</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Pano ile karşılaştır</string>

--- a/res/values-uk/strings.xml
+++ b/res/values-uk/strings.xml
@@ -1115,7 +1115,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">Заблокувати</string>
   <string name="text_secure_normal__mark_all_as_read">Позначити усі як прочитані</string>
   <string name="text_secure_normal__invite_friends">Запросити друзів</string>
-  <string name="text_secure_normal__help">Допомога</string>
+  <string name="text_secure_normal__use-guide_and_support">Допомога</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Скопіювати до буфера обміну</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">Порівняти із буфером обміну</string>

--- a/res/values-vi/strings.xml
+++ b/res/values-vi/strings.xml
@@ -735,7 +735,7 @@ Các tin nhắn và cuộc gọi riêng tư miễn phí đến người dùng Si
   <string name="text_secure_normal__menu_clear_passphrase">Khóa</string>
   <string name="text_secure_normal__mark_all_as_read">Đánh dấu tất cả đã đọc</string>
   <string name="text_secure_normal__invite_friends">Mời bạn bè</string>
-  <string name="text_secure_normal__help">Trợ giúp</string>
+  <string name="text_secure_normal__use-guide_and_support">Trợ giúp</string>
   <!--verify_display_fragment-->
   <!--reminder_header-->
   <string name="reminder_header_outdated_build">Phiên bản Signal của bạn đã quá cũ</string>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -1074,7 +1074,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">锁定</string>
   <string name="text_secure_normal__mark_all_as_read">全部标记为已读</string>
   <string name="text_secure_normal__invite_friends">邀请好友</string>
-  <string name="text_secure_normal__help">帮助</string>
+  <string name="text_secure_normal__use-guide_and_support">帮助</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">复制到剪切板</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">与剪切板中的内容进行比较</string>

--- a/res/values-zh-rTW/strings.xml
+++ b/res/values-zh-rTW/strings.xml
@@ -1085,7 +1085,7 @@
   <string name="text_secure_normal__menu_clear_passphrase">鎖定</string>
   <string name="text_secure_normal__mark_all_as_read">全部標示為已讀</string>
   <string name="text_secure_normal__invite_friends">邀請好友</string>
-  <string name="text_secure_normal__help">說明</string>
+  <string name="text_secure_normal__use-guide_and_support">說明</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">複製到剪貼簿</string>
   <string name="verify_display_fragment_context_menu__compare_with_clipboard">與剪貼簿中的內容進行比較</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1319,7 +1319,7 @@
     <string name="text_secure_normal__menu_clear_passphrase">Lock</string>
     <string name="text_secure_normal__mark_all_as_read">Mark all read</string>
     <string name="text_secure_normal__invite_friends">Invite friends</string>
-    <string name="text_secure_normal__help">Help</string>
+    <string name="text_secure_normal__Use-guide_and_support">Use-guide_and_support</string>
 
     <!-- verify_display_fragment -->
     <string name="verify_display_fragment_context_menu__copy_to_clipboard">Copy to clipboard</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1319,7 +1319,7 @@
     <string name="text_secure_normal__menu_clear_passphrase">Lock</string>
     <string name="text_secure_normal__mark_all_as_read">Mark all read</string>
     <string name="text_secure_normal__invite_friends">Invite friends</string>
-    <string name="text_secure_normal__Use-guide_and_support">Use-guide_and_support</string>
+    <string name="text_secure_normal__use-guide_and_support">Use-guide_and_support</string>
 
     <!-- verify_display_fragment -->
     <string name="verify_display_fragment_context_menu__copy_to_clipboard">Copy to clipboard</string>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Part of effort to improve the user experience with the Signal Support Center.
https://community.signalusers.org/t/translate-support-pages-and-blog-posts-about-new-features/4941

I noticed that the support center is referenced in the app with a button "help". This word however is verbalizing what the user is looking for, but not what the button is offering. It is good practice for the text string to represent what the button is offering. It is up to the user to decide if this offered option is a match to what he is looking for.

The user is looking for a specific form of help. He might be looking for a use-guide, he might be looking for a community forum, he might be looking for a bug report system. By phrasing the button text as "Use-guide and support", the user is primed for what he will get to see if he presses this button. The text already confirms that he will find a use-guide if he presses this button. It also confirms that the same button offers at-least some form of support. Telling the user that this button offers "Help" is too vague. It does not define what kind of help. It leaves the user scrolling the support center trying to find out if he has reached the right place, because he has not yet been offered a clear indication of what to expect.

'Support' means “to receive help from others” and 'use-guide' means “a guide to proper use of something” a blog post about a new feature or a guide how to use the app are examples of a 'use-guide', a bug report system or a community forum are examples of 'support'. 

The in app menu option “Help” would best be replaced by “Use-guide and support” for clarity. The word help doesn't really specify in what form one might expect to find help. Users usually have a specific question on their mind, and they are either looking for support with an issue, or for more information about using Signal.  This small change offers some confirmation that they are on the right path to find the kind of help they are looking for.

In a future version of Signal, the community forums and a bug report system _might_ be referenced by splitting the words "use-guide" and "Support" into their own categories. Ideally users are encouraged to first check the use-guide when there is a chance to find the answer there.

It is not necessary to edit the translations for the word "help" on short notice. This PR changes the name of the text string and the Dutch, German and English text string. Other text strings can follow over time, there is no urgency.