### PR TITLE
Country name sorting respects accented characters

### DIFF
--- a/src/org/thoughtcrime/securesms/database/loaders/CountryListLoader.java
+++ b/src/org/thoughtcrime/securesms/database/loaders/CountryListLoader.java
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms.database.loaders;
 
 
+import java.text.Collator;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -24,7 +25,7 @@ public class CountryListLoader extends AsyncTaskLoader<ArrayList<Map<String, Str
   @Override
   public ArrayList<Map<String, String>> loadInBackground() {
     Set<String> regions                    = PhoneNumberUtil.getInstance().getSupportedRegions();
-    ArrayList<Map<String, String>> results = new ArrayList<Map<String, String>>(regions.size());
+    ArrayList<Map<String, String>> results = new ArrayList<>(regions.size());
 
     for (String region : regions) {
       Map<String, String> data = new HashMap<String, String>(2);
@@ -41,7 +42,11 @@ public class CountryListLoader extends AsyncTaskLoader<ArrayList<Map<String, Str
   private static class RegionComparator implements Comparator<Map<String, String>> {
     @Override
     public int compare(Map<String, String> lhs, Map<String, String> rhs) {
-      return lhs.get("country_name").compareTo(rhs.get("country_name"));
+      String a = lhs.get("country_name");
+      String b = rhs.get("country_name");
+      Collator collator = Collator.getInstance();
+      collator.setStrength(Collator.PRIMARY);
+      return collator.compare(a,b);
     }
   }
 }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Alcatel 5041C, Android 8.1.0
 * Virtual device Nexus 5X, Android 9
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Country sorting on the registration screen used a normal `Comparator` for Strings which doesn't respect alphabetizing Strings with accent marks. Åland Islands always was after Z. By sanitizing the Strings before comparing them, Åland Islands is at the top of the list near Algeria and other Al areas where users would expect to find it.

Screenshot of the bug: 
![47244716_258782231455161_5699854440006156288_n](https://user-images.githubusercontent.com/22125581/49335280-ac66b580-f5b8-11e8-876b-018319379e0f.png)
