### PR TITLE
Fix case of 'Signal call' text in call view

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -104,7 +104,7 @@
 
     <!-- ContactsDatabase -->
     <string name="ContactsDatabase_message_s">Message %s</string>
-    <string name="ContactsDatabase_signal_call_s">Signal Call %s</string>
+    <string name="ContactsDatabase_signal_call_s">Signal call %s</string>
 
     <!-- ContactNameEditActivity -->
     <string name="ContactNameEditActivity_given_name">Given name</string>


### PR DESCRIPTION
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/) 

After signing the CLA and connecting it to my Github account, the page came up blank and the error console said this, so not sure if it was sent in:
```
The character encoding of the HTML document was not declared.
The document will render with garbled text in some browser configurations if the document contains characters from outside the US-ASCII range.
The character encoding of the page must be declared in the document or in the transfer protocol.
```

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] My contribution is fully baked and ready to be merged as is
- Just a small 1 character case change so I didn’t do testing as I don’t have a full-blown dev environment setup, sorry.

----------

### Description
The expression is written "Signal call" with all-lowercase "call" everywhere. Except in the call view below the name of the person you are calling, where it is "Signal Call" with uppercase "C". This fixes that.

Here is a screenshot of how it looks on master, with "Signal **C**all" casing:
![signal call name ellipsis](https://user-images.githubusercontent.com/925062/50290977-8cb30680-046d-11e9-8ff9-1464952fcd21.png)
