### PR TITLE
Fix restore from an old backup version

### DIFF
--- a/src/org/thoughtcrime/securesms/backup/FullBackupImporter.java
+++ b/src/org/thoughtcrime/securesms/backup/FullBackupImporter.java
@@ -8,14 +8,12 @@ import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.support.annotation.NonNull;
 
-import org.thoughtcrime.securesms.database.RecipientDatabase;
 import org.thoughtcrime.securesms.logging.Log;
 import android.util.Pair;
 
 import net.sqlcipher.database.SQLiteDatabase;
 
 import org.greenrobot.eventbus.EventBus;
-import org.thoughtcrime.securesms.attachments.AttachmentId;
 import org.thoughtcrime.securesms.backup.BackupProtos.Attachment;
 import org.thoughtcrime.securesms.backup.BackupProtos.BackupFrame;
 import org.thoughtcrime.securesms.backup.BackupProtos.DatabaseVersion;
@@ -25,14 +23,8 @@ import org.thoughtcrime.securesms.crypto.AttachmentSecret;
 import org.thoughtcrime.securesms.crypto.ModernEncryptingPartOutputStream;
 import org.thoughtcrime.securesms.database.Address;
 import org.thoughtcrime.securesms.database.AttachmentDatabase;
-import org.thoughtcrime.securesms.database.DatabaseFactory;
-import org.thoughtcrime.securesms.database.GroupReceiptDatabase;
-import org.thoughtcrime.securesms.database.MmsDatabase;
 import org.thoughtcrime.securesms.database.SearchDatabase;
-import org.thoughtcrime.securesms.database.ThreadDatabase;
-import org.thoughtcrime.securesms.notifications.NotificationChannels;
 import org.thoughtcrime.securesms.profiles.AvatarHelper;
-import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.util.Conversions;
 import org.thoughtcrime.securesms.util.Util;
 import org.whispersystems.libsignal.kdf.HKDFv3;
@@ -87,8 +79,6 @@ public class FullBackupImporter extends FullBackupBase {
         else if (frame.hasAttachment()) processAttachment(context, attachmentSecret, db, frame.getAttachment(), inputStream);
         else if (frame.hasAvatar())     processAvatar(context, frame.getAvatar(), inputStream);
       }
-
-      trimEntriesForExpiredMessages(context, db);
 
       db.setTransactionSuccessful();
     } finally {
@@ -171,28 +161,6 @@ public class FullBackupImporter extends FullBackupBase {
       }
     }
   }
-
-  private static void trimEntriesForExpiredMessages(@NonNull Context context, @NonNull SQLiteDatabase db) {
-    String trimmedCondition = " NOT IN (SELECT " + MmsDatabase.ID + " FROM " + MmsDatabase.TABLE_NAME + ")";
-
-    db.delete(GroupReceiptDatabase.TABLE_NAME, GroupReceiptDatabase.MMS_ID + trimmedCondition, null);
-
-    String[] columns = new String[] { AttachmentDatabase.ROW_ID, AttachmentDatabase.UNIQUE_ID };
-    String   where   = AttachmentDatabase.MMS_ID + trimmedCondition;
-
-    try (Cursor cursor = db.query(AttachmentDatabase.TABLE_NAME, columns, where, null, null, null, null)) {
-      while (cursor != null && cursor.moveToNext()) {
-        DatabaseFactory.getAttachmentDatabase(context).deleteAttachment(new AttachmentId(cursor.getLong(0), cursor.getLong(1)));
-      }
-    }
-
-    try (Cursor cursor = db.query(ThreadDatabase.TABLE_NAME, new String[] { ThreadDatabase.ID }, ThreadDatabase.EXPIRES_IN + " > 0", null, null, null, null)) {
-      while (cursor != null && cursor.moveToNext()) {
-        DatabaseFactory.getThreadDatabase(context).update(cursor.getLong(0), false);
-      }
-    }
-  }
-
 
   private static class BackupRecordInputStream extends BackupStream {
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device OnePlus2, OxygenOS 3.5.6, Android 6.0.1
 * Virtual device Nexus 5X API 28 x86, Android 9.0 (Google Play)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Fixes #8011 

I fixed this since I had trouble restoring a save made in `v4.29.7` into the latest build.

I found that this was the offending hunk in `trimEntriesForExpiredMessages()` (using debug logs):

```Java
try (Cursor cursor = db.query(ThreadDatabase.TABLE_NAME, new String[]{ThreadDatabase.ID}, ThreadDatabase.EXPIRES_IN + " > 0", null, null, null, null)) {
    while (cursor != null && cursor.moveToNext()) {
      DatabaseFactory.getThreadDatabase(context).update(cursor.getLong(0), false);
    }
}
```

What I did was basically move the `trimEntriesForExpiredMessages()` function to `RegistrationActivity.java` so it could be called in the restore handler `handleRestore()` right after `DatabaseFactory.upgradeRestored(context, database);` where we are sure the `database` would be on the latest schema.

A better place for this function might be the `SQLCipherOpenHelper.onUpgrade()` or the `DatabaseFactory.upgradeRestored()` methods?