### PR TITLE
OLED friendly dark theme

### DIFF
--- a/res/drawable/compose_background_oled.xml
+++ b/res/drawable/compose_background_oled.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <stroke
+        android:width="1dp"
+        android:color="@color/core_grey_75" />
+
+    <solid
+        android:color="@color/black" />
+
+    <corners
+        android:radius="20dp" />
+
+</shape>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -109,12 +109,14 @@
 
     <string-array name="pref_theme_entries">
       <item>@string/preferences__light_theme</item>
-      <item>@string/preferences__dark_theme</item>
+        <item>@string/preferences__dark_theme</item>
+        <item>@string/preferences__oled_theme</item>
   </string-array>
 
   <string-array name="pref_theme_values" translatable="false">
       <item>light</item>
       <item>dark</item>
+      <item>oled</item>
   </string-array>
 
   <string-array name="pref_led_color_entries">

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1187,6 +1187,7 @@
     <string name="preferences__linked_devices">Linked devices</string>
     <string name="preferences__light_theme">Light</string>
     <string name="preferences__dark_theme">Dark</string>
+    <string name="preferences__oled_theme">OLED Dark</string>
     <string name="preferences__appearance">Appearance</string>
     <string name="preferences__theme">Theme</string>
     <string name="preferences__default">Default</string>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -49,6 +49,11 @@
         <item name="media_overview_document_secondary">@color/core_grey_25</item>
     </style>
 
+    <style name="TextSecure.DarkNoActionBarOled" parent="TextSecure.DarkNoActionBar">
+        <item name="android:windowBackground">@color/black</item>
+        <item name="colorPrimary">@color/black</item>
+    </style>
+
     <style name="TextSecure.HighlightTheme" parent="@style/TextSecure.LightTheme">
         <item name="actionBarStyle">@style/TextSecure.FlatLightActionBar</item>
         <item name="actionBarPopupTheme">@style/ThemeOverlay.AppCompat.Dark</item>
@@ -92,6 +97,10 @@
 
         <item name="login_top_background">@color/black</item>
         <item name="login_floating_background">@drawable/rounded_rectangle_dark</item>
+    </style>
+
+    <style name="TextSecure.DarkIntroThemeOled" parent="TextSecure.DarkIntroTheme">
+        <item name="android:windowBackground">@color/black</item>
     </style>
 
     <style name="PopupAnimation" parent="@android:style/Animation">
@@ -412,7 +421,16 @@
         <item name="shared_contact_details_titlebar">@color/grey_900</item>
         <item name="shared_contact_item_button_color">@color/core_grey_85</item>
     </style>
-    
+
+    <style name="TextSecure.DarkThemeOled" parent="TextSecure.DarkTheme">
+        <item name="android:windowBackground">@color/black</item>
+        <item name="attachment_type_selector_background">@color/black</item>
+        <item name="dialog_background_color">@color/black</item>
+        <item name="conversation_background">@color/black</item>
+        <item name="conversation_input_background">@drawable/compose_background_oled</item>
+        <item name="emoji_tab_strip_background">@color/black</item>
+    </style>
+
     <style name="RationaleDialog" parent="Theme.AppCompat.Light.Dialog.Alert">
         <item name="android:windowBackground">@drawable/permission_rationale_dialog_corners</item>
     </style>

--- a/src/org/thoughtcrime/securesms/util/DynamicIntroTheme.java
+++ b/src/org/thoughtcrime/securesms/util/DynamicIntroTheme.java
@@ -10,6 +10,7 @@ public class DynamicIntroTheme extends DynamicTheme {
     String theme = TextSecurePreferences.getTheme(activity);
 
     if (theme.equals("dark")) return R.style.TextSecure_DarkIntroTheme;
+    else if (theme.equals("oled")) return R.style.TextSecure_DarkIntroThemeOled;
 
     return R.style.TextSecure_LightIntroTheme;
   }

--- a/src/org/thoughtcrime/securesms/util/DynamicNoActionBarTheme.java
+++ b/src/org/thoughtcrime/securesms/util/DynamicNoActionBarTheme.java
@@ -10,6 +10,7 @@ public class DynamicNoActionBarTheme extends DynamicTheme {
     String theme = TextSecurePreferences.getTheme(activity);
 
     if (theme.equals("dark")) return R.style.TextSecure_DarkNoActionBar;
+    else if (theme.equals("oled")) return R.style.TextSecure_DarkNoActionBarOled;
 
     return R.style.TextSecure_LightNoActionBar;
   }

--- a/src/org/thoughtcrime/securesms/util/DynamicTheme.java
+++ b/src/org/thoughtcrime/securesms/util/DynamicTheme.java
@@ -9,6 +9,7 @@ public class DynamicTheme {
 
   public static final String DARK  = "dark";
   public static final String LIGHT = "light";
+  public static final String OLED = "oled";
 
   private int currentTheme;
 
@@ -31,6 +32,7 @@ public class DynamicTheme {
     String theme = TextSecurePreferences.getTheme(activity);
 
     if (theme.equals(DARK)) return R.style.TextSecure_DarkTheme;
+    else if (theme.equals(OLED)) return R.style.TextSecure_DarkThemeOled;
 
     return R.style.TextSecure_LightTheme;
   }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Lenovo P2, Android 7.0
 * Virtual device, Nexus 5X API 25, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Adds additional OLED friendly theme, which uses real black instead of dark gray.
It's a feature rather than a fix, but it has been mentioned here as an issue multiple times (#8376 #8304 #8261), and it has been requested on community forum.