### PR TITLE
Keep screen on while audio player is playing so audio playback continues

### DIFF
--- a/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
+++ b/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
@@ -123,6 +123,9 @@ public class AudioSlidePlayer implements SensorEventListener {
       public void onPlayerStateChanged(boolean playWhenReady, int playbackState) {
         Log.d(TAG, "onPlayerStateChanged(" + playWhenReady + ", " + playbackState + ")");
         switch (playbackState) {
+          case Player.STATE_IDLE:
+            notifyOnStop();
+            break;
           case Player.STATE_READY:
             Log.i(TAG, "onPrepared() " + mediaPlayer.getBufferedPercentage() + "% buffered");
             synchronized (AudioSlidePlayer.this) {
@@ -167,6 +170,7 @@ public class AudioSlidePlayer implements SensorEventListener {
 
             notifyOnStop();
             progressEventHandler.removeMessages(0);
+            break;
         }
       }
 

--- a/src/org/thoughtcrime/securesms/components/AudioView.java
+++ b/src/org/thoughtcrime/securesms/components/AudioView.java
@@ -133,6 +133,7 @@ public class AudioView extends FrameLayout implements AudioSlidePlayer.Listener 
     if (this.audioSlidePlayer != null && pauseButton.getVisibility() == View.VISIBLE) {
       this.audioSlidePlayer.stop();
     }
+    setKeepScreenOn(false);
   }
 
   public void setDownloadClickListener(@Nullable SlideClickListener listener) {
@@ -144,6 +145,7 @@ public class AudioView extends FrameLayout implements AudioSlidePlayer.Listener 
     if (this.pauseButton.getVisibility() != View.VISIBLE) {
       togglePlayToPause();
     }
+    setKeepScreenOn(true);
   }
 
   @Override
@@ -156,6 +158,7 @@ public class AudioView extends FrameLayout implements AudioSlidePlayer.Listener 
       backwardsCounter = 4;
       onProgress(0.0, 0);
     }
+    setKeepScreenOn(false);
   }
 
   @Override


### PR DESCRIPTION
Fixes #8462

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual device Google Pixel 2, Android 8.1
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
While the audio player is playing, keep the screen on so that the audio doesn't stop in the middle of playback.
