### PR TITLE
Fix visual glitch with fingerprint unlock

### DIFF
--- a/src/org/thoughtcrime/securesms/PassphrasePromptActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphrasePromptActivity.java
@@ -352,9 +352,6 @@ public class PassphrasePromptActivity extends PassphraseActivity {
         @Override
         public void onAnimationEnd(Animator animation) {
           handleAuthenticated();
-
-          fingerprintPrompt.setImageResource(R.drawable.ic_fingerprint_white_48dp);
-          fingerprintPrompt.getBackground().setColorFilter(getResources().getColor(R.color.signal_primary), PorterDuff.Mode.SRC_IN);
         }
       }).start();
     }


### PR DESCRIPTION
Fixes #8491 

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Xiaomi Pocophone F1, Android 9.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixes issue where the tick (on green background) displaying successful authentication reverts to fingerprint icon (on blue background) in the instant before proceeding to allow access to the app. See gif files below for demonstration.

#### Why this occurs
In `PassphrasePromptActivity`, the `FingerprintListener` controls the UI when fingerprints are accepted or rejected. 
* When fingerprint is rejected, the appropriate animation finishes by returning the icon to its default state (expecting a fingerprint). This is desired.
* When fingerprint is accepted, the icon is also returned to its default state after the animation. _This is not desired, because the app is not expecting a fingerprint (and because the sudden change is jarring for the user)._ 

### My solution
Remove the code resetting the icon to its previous appearance at the end of its animation in `onAuthenticationSucceeded`. This does not affect the animations and UI changes in `onAuthenticationFailed`.

An instance of `FingerprintListener` is only read in one line of the codebase, so I expect no unintended side-effects.

Animation before the change (slightly cropped):
![20181229_151714](https://user-images.githubusercontent.com/20987172/50540143-3daf5480-0b84-11e9-8893-68e5e766f25e.gif)

Animation after the change (slightly cropped):
![20181229_151831](https://user-images.githubusercontent.com/20987172/50540144-46078f80-0b84-11e9-9a9f-8c093b766170.gif)