### PR TITLE
Fix notch obscuring toolbar in PassphrasePromptActivity

### DIFF
--- a/src/org/thoughtcrime/securesms/PassphrasePromptActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphrasePromptActivity.java
@@ -25,6 +25,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
 import android.support.v4.os.CancellationSignal;
+import android.support.v4.view.ViewCompat;
 import android.support.v7.widget.Toolbar;
 import android.text.Editable;
 import android.text.InputType;
@@ -39,6 +40,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
+import android.view.ViewGroup.MarginLayoutParams;
 import android.view.WindowManager;
 import android.view.animation.Animation;
 import android.view.animation.BounceInterpolator;
@@ -220,6 +222,7 @@ public class PassphrasePromptActivity extends PassphraseActivity {
 
     setSupportActionBar(toolbar);
     getSupportActionBar().setTitle("");
+    adjustForNotch(toolbar);
 
     SpannableString hint = new SpannableString("  " + getString(R.string.PassphrasePromptActivity_enter_passphrase));
     hint.setSpan(new RelativeSizeSpan(0.9f), 0, hint.length(), Spanned.SPAN_INCLUSIVE_INCLUSIVE);
@@ -237,6 +240,14 @@ public class PassphrasePromptActivity extends PassphraseActivity {
     fingerprintPrompt.getBackground().setColorFilter(getResources().getColor(R.color.signal_primary), PorterDuff.Mode.SRC_IN);
 
     lockScreenButton.setOnClickListener(v -> resumeScreenLock());
+  }
+
+  private void adjustForNotch(Toolbar toolbar) {
+    ViewCompat.setOnApplyWindowInsetsListener(toolbar, (view, windowInsetsCompat) -> {
+      MarginLayoutParams params = (MarginLayoutParams) toolbar.getLayoutParams();
+      params.topMargin = windowInsetsCompat.getSystemWindowInsetTop();
+      return windowInsetsCompat;
+    });
   }
 
   private void setLockTypeVisibility() {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
* Virtual device Pixel 2XL, Android 9.0
* Physical device Pocophone F1, Android 9.0
* Physical device Nexus 6P, Android 9.0
* Physical device Moto G4, Android 7.0
* Virtual device Nexus 4, Android 4.1.2 (API 16)
* Virtual device Nexus 4, Android 4.4.2 (API 19)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
#### The problem
On devices with a top notch, the toolbar in the `PassphrasePromptActivity` is partially obscured. (See images below.)

#### The solution
Add new method `adjustForNotch(Toolbar toolbar)` which adjusts the top margin of the toolbar according to the top system window inset. This is performed by using `ViewCompat.setOnApplyWindowInsetsListener` to listen for the window insets, and then setting the  top margin on the toolbar's `MarginLayoutParams`.

It has been tested with the dark theme on one device (Pocophone) in addition to light themes on all devices, and some screenshots using the light theme are shown below.

##### Pixel 2XL (virtual device, API 28)

Old version             |  New version
:-------------------------:|:-------------------------:
![old_tall_notch](https://user-images.githubusercontent.com/20987172/50548287-f7202f80-0c41-11e9-941e-53094887a703.jpg) | ![new_tall_notch](https://user-images.githubusercontent.com/20987172/50548288-fb4c4d00-0c41-11e9-9a89-9c1639ccc33d.jpg)
 ![old_no_notch](https://user-images.githubusercontent.com/20987172/50548277-d8ba3400-0c41-11e9-99f8-ff09ffbd5349.jpg) | ![new_no_notch](https://user-images.githubusercontent.com/20987172/50548283-e2dc3280-0c41-11e9-99fa-36cf2c8c3612.jpg)
![old_double_notch](https://user-images.githubusercontent.com/20987172/50548293-0e5f1d00-0c42-11e9-96fc-37f3f2e1bfb9.jpg) | ![new_double_notch](https://user-images.githubusercontent.com/20987172/50548294-1323d100-0c42-11e9-86c3-d3a829896f9f.jpg)

##### New version on older devices
Nexus 4 (virtual device, API 16)             |  Nexus 4 (virtual device, API 19)
:-------------------------:|:-------------------------:
![new_api_16](https://user-images.githubusercontent.com/20987172/50548307-4cf4d780-0c42-11e9-8bf2-d158d92d28ce.jpg) | ![new_api_19](https://user-images.githubusercontent.com/20987172/50548309-50885e80-0c42-11e9-95d4-43f4a8ce996a.jpg)

