### PR TITLE
Move some menu items to context menu when there's not enough space

### DIFF
--- a/res/menu/conversation_context.xml
+++ b/res/menu/conversation_context.xml
@@ -13,7 +13,7 @@
     <item android:title="@string/conversation_context__menu_copy_text"
           android:id="@+id/menu_context_copy"
           android:icon="?menu_copy_icon"
-          app:showAsAction="always" />
+          app:showAsAction="ifRoom" />
 
     <item android:title="@string/conversation_context__menu_forward_message"
           android:id="@+id/menu_context_forward"
@@ -29,7 +29,7 @@
           android:id="@+id/menu_context_save_attachment"
           android:visible="false"
           android:icon="?menu_save_icon"
-          app:showAsAction="always" />
+          app:showAsAction="ifRoom" />
 
     <item android:title="@string/conversation_context__menu_reply_to_message"
           android:id="@+id/menu_context_reply"

--- a/res/menu/conversation_context.xml
+++ b/res/menu/conversation_context.xml
@@ -3,12 +3,12 @@
     <item android:title="@string/conversation_context__menu_message_details"
           android:id="@+id/menu_context_details"
           android:icon="?menu_info_icon"
-          app:showAsAction="always" />
+          app:showAsAction="ifRoom" />
 
     <item android:title="@string/conversation_context__menu_delete_message"
         android:id="@+id/menu_context_delete_message"
         android:icon="?menu_trash_icon"
-        app:showAsAction="always" />
+        app:showAsAction="ifRoom" />
 
     <item android:title="@string/conversation_context__menu_copy_text"
           android:id="@+id/menu_context_copy"


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung SM-J111F, Android 5.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fixes #8243.

In small screen devices the it's not possible to acces some menu items
of the menu shown when selecting a message.

So, specify that some of the items could be moved into the context menu
when there isn't enough space for all of them.
