### PR TITLE
Fix `equals` in NotificationChannels.channelExists

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/NotificationChannels.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationChannels.java
@@ -517,7 +517,7 @@ public class NotificationChannels {
 
   @TargetApi(26)
   private static boolean channelExists(@Nullable NotificationChannel channel) {
-    return channel != null && !NotificationChannel.DEFAULT_CHANNEL_ID.equals(channel);
+    return channel != null && !NotificationChannel.DEFAULT_CHANNEL_ID.equals(channel.getId());
   }
 
   private interface ChannelUpdater {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
- [ ] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
`DEFAULT_CHANNEL_ID` is a String, but `channel` is a NotificationChannel. Equals will therefore always return `false`. I think my fix (using `getId()`) is what was intended, but I'm not familiar enough with the codebase (yet) to be 100% sure. Feel free to close/amend as you see fit.

This issue was flagged up by LGTM.com: https://lgtm.com/projects/g/signalapp/Signal-Android/alerts. Some of the other Signal repositories have been analysed there as well: https://lgtm.com/search?q=signalapp

If you like, you can use LGTM for automatically reviewing code in pull requests. Here's an example of how Google's AMPHTML use that to flag up security vulnerabilities in their code base: https://github.com/ampproject/amphtml/pull/13060

(full disclosure: I'm a Signal user, and also part of the team that runs LGTM.com)


