### PR TITLE
Add functionality to scroll to a quoted message by clicking on the quote view

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -689,6 +689,10 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     finish();
   }
 
+  public void handleQuoteViewClick(long originalMessageId) {
+    fragment.smoothScrollToMessageId(originalMessageId);
+  }
+
   private void handleSelectMessageExpiration() {
     if (isPushGroupConversation() && !isActiveGroup()) {
       return;
@@ -2402,9 +2406,11 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
       inputPanel.setQuote(GlideApp.with(this),
                           messageRecord.getDateSent(),
+                          messageRecord.getId(),
                           author,
                           body,
-                          slideDeck);
+                          slideDeck
+                          );
 
     } else if (messageRecord.isMms() && !((MmsMessageRecord) messageRecord).getLinkPreviews().isEmpty()) {
       LinkPreview linkPreview = ((MmsMessageRecord) messageRecord).getLinkPreviews().get(0);
@@ -2416,6 +2422,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
       inputPanel.setQuote(GlideApp.with(this),
                           messageRecord.getDateSent(),
+                          messageRecord.getId(),
                           author,
                           messageRecord.getBody(),
                           slideDeck);
@@ -2423,6 +2430,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     } else {
       inputPanel.setQuote(GlideApp.with(this),
                           messageRecord.getDateSent(),
+                          messageRecord.getId(),
                           author,
                           messageRecord.getBody(),
                           messageRecord.isMms() ? ((MmsMessageRecord) messageRecord).getSlideDeck() : new SlideDeck());

--- a/src/org/thoughtcrime/securesms/ConversationAdapter.java
+++ b/src/org/thoughtcrime/securesms/ConversationAdapter.java
@@ -17,6 +17,7 @@
 package org.thoughtcrime.securesms;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.database.Cursor;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
@@ -54,6 +55,7 @@ import java.lang.ref.SoftReference;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
@@ -358,6 +360,21 @@ public class ConversationAdapter <V extends View & BindableConversationItem>
       recordToPulseHighlight = getRecordForPositionOrThrow(position);
       notifyItemChanged(position);
     }
+  }
+
+  // find a message position by its timestamp
+  public int getMessagePositionByMessageId(long msgId) {
+    Collection<SoftReference<MessageRecord>> messages = messageRecordCache.values();
+    int counter = 0;
+    for (SoftReference<MessageRecord> m : messages) {
+      MessageRecord msg = m.get();
+      if (msg.getId() == msgId) {
+        //return messages.size() - counter;
+        return counter;
+      }
+      counter++;
+    }
+    throw new Resources.NotFoundException("No message with this timestamp.");
   }
 
   private boolean hasAudio(MessageRecord messageRecord) {

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -413,6 +413,19 @@ public class ConversationFragment extends Fragment
     }
   }
 
+  public void smoothScrollToMessageId(long msgId) {
+    list.post(() -> {
+      ConversationAdapter ca = getListAdapter();
+      int position = ca.getMessagePositionByMessageId(msgId);
+      if (position < SCROLL_ANIMATION_THRESHOLD) {
+        list.smoothScrollToPosition(position);
+      } else {
+        list.scrollToPosition(position);
+      }
+      ca.pulseHighlightItem(position);
+    });
+  }
+
   public void setLastSeen(long lastSeen) {
     this.lastSeen = lastSeen;
     if (lastSeenDecoration != null) {

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -671,7 +671,8 @@ public class ConversationItem extends LinearLayout
     if (current.isMms() && !current.isMmsNotification() && ((MediaMmsMessageRecord)current).getQuote() != null) {
       Quote quote = ((MediaMmsMessageRecord)current).getQuote();
       assert quote != null;
-      quoteView.setQuote(glideRequests, quote.getId(), Recipient.from(context, quote.getAuthor(), true), quote.getText(), quote.isOriginalMissing(), quote.getAttachment());
+      long msgId = quote.isOriginalMissing() ? -1 : current.getId();
+      quoteView.setQuote(glideRequests, quote.getId(), msgId, Recipient.from(context, quote.getAuthor(), true), quote.getText(), quote.isOriginalMissing(), quote.getAttachment());
       quoteView.setVisibility(View.VISIBLE);
       quoteView.getLayoutParams().width = ViewGroup.LayoutParams.WRAP_CONTENT;
 

--- a/src/org/thoughtcrime/securesms/components/InputPanel.java
+++ b/src/org/thoughtcrime/securesms/components/InputPanel.java
@@ -20,6 +20,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import org.thoughtcrime.securesms.ConversationActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.emoji.EmojiDrawer;
 import org.thoughtcrime.securesms.components.emoji.EmojiToggle;
@@ -118,6 +119,21 @@ public class InputPanel extends LinearLayout
         listener.onLinkPreviewCanceled();
       }
     });
+
+    this.quoteView.setOnClickListener(this::onQuoteViewClick);
+  }
+
+  protected void onQuoteViewClick(View v) {
+    if (quoteView.getOriginalMissing()) {
+      return;
+    }
+
+    long id = quoteView.getOriginalMessageId();
+    Context c = getContext();
+    ConversationActivity parent = (c instanceof ConversationActivity ? (ConversationActivity)c : null);
+    if (parent != null) {
+      parent.handleQuoteViewClick(id);
+    }
   }
 
   public void setListener(final @NonNull Listener listener) {
@@ -130,8 +146,8 @@ public class InputPanel extends LinearLayout
     composeText.setMediaListener(listener);
   }
 
-  public void setQuote(@NonNull GlideRequests glideRequests, long id, @NonNull Recipient author, @NonNull String body, @NonNull SlideDeck attachments) {
-    this.quoteView.setQuote(glideRequests, id, author, body, false, attachments);
+  public void setQuote(@NonNull GlideRequests glideRequests, long id, long msgId, @NonNull Recipient author, @NonNull String body, @NonNull SlideDeck attachments) {
+    this.quoteView.setQuote(glideRequests, id, msgId, author, body, false, attachments);
     this.quoteView.setVisibility(View.VISIBLE);
 
     if (this.linkPreview.getVisibility() == View.VISIBLE) {

--- a/src/org/thoughtcrime/securesms/components/QuoteView.java
+++ b/src/org/thoughtcrime/securesms/components/QuoteView.java
@@ -63,6 +63,8 @@ public class QuoteView extends FrameLayout implements RecipientModifiedListener 
   private int        smallCornerRadius;
   private CornerMask cornerMask;
 
+  private boolean    originalMissing;
+  private long       originalMessageId;
 
   public QuoteView(Context context) {
     super(context);
@@ -153,10 +155,12 @@ public class QuoteView extends FrameLayout implements RecipientModifiedListener 
 
   public void setQuote(GlideRequests glideRequests,
                        long id,
+                       long originalMessageId,
                        @NonNull Recipient author,
                        @Nullable String body,
                        boolean originalMissing,
-                       @NonNull SlideDeck attachments)
+                       @NonNull SlideDeck attachments
+                       )
   {
     if (this.author != null) this.author.removeListener(this);
 
@@ -164,6 +168,8 @@ public class QuoteView extends FrameLayout implements RecipientModifiedListener 
     this.author      = author;
     this.body        = body;
     this.attachments = attachments;
+    this.originalMissing = originalMissing;
+    this.originalMessageId = originalMessageId;
 
     author.addListener(this);
     setQuoteAuthor(author);
@@ -276,6 +282,12 @@ public class QuoteView extends FrameLayout implements RecipientModifiedListener 
   public long getQuoteId() {
     return id;
   }
+
+  public boolean getOriginalMissing() {
+    return originalMissing;
+  }
+
+  public long getOriginalMessageId() { return originalMessageId; }
 
   public Recipient getAuthor() {
     return author;


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Huawei P10 Pro, Android 8.0.0
 * Nokia 8, Android 9.0.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
The quote view now keeps track of the original message's id (if the message is not missing) to allow scrolling to the original message in the conversation when the quote view is tapped.