### PR TITLE
"got it" instead of "ok" to dismiss splash screen

### DIFF
--- a/res/layout/experience_upgrade_link_previews_fragment.xml
+++ b/res/layout/experience_upgrade_link_previews_fragment.xml
@@ -99,7 +99,7 @@
         android:layout_marginEnd="8dp"
         android:layout_marginRight="8dp"
         android:layout_marginBottom="24dp"
-        android:text="@string/ok"
+        android:text="@string/understood"
         android:textColor="@color/core_blue"
         app:backgroundTint="@color/core_white"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="delete">Delete</string>
     <string name="please_wait">Please wait...</string>
     <string name="save">Save</string>
+    <string name="understood">Got it</string>
 
     <!-- AbstractNotificationBuilder -->
     <string name="AbstractNotificationBuilder_new_message">New message</string>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
The words "Got it" are added as the text to dismiss a splash screen or notification without any confusion for the user that it may imply agreeing to anything.

It replaces the word "Ok", which has been reported to confuse some users, as it seems to apply agreeing to the new function, rather than dismissing the splash screen