### PR TITLE
Add: Toogle if recipient number is shown in coversation

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -961,6 +961,8 @@ Schlüsselaustausch-Nachricht für eine ungültige Protokollversion empfangen</s
   <string name="preferences__pressing_the_enter_key_will_send_text_messages">Antippen der Eingabetaste versendet Nachrichten sofort</string>
   <string name="preferences__send_link_previews">Link-Vorschauen senden</string>
   <string name="preferences__previews_are_supported_for">Vorschauen werden unterstützt für Links von Imgur, Instagram, Reddit und YouTube</string>
+  <string name="preferences__show_phone_number">Telefonnummern anzeigen</string>
+  <string name="preferences__show_phone_number_of_recipient_in_conversation">Telefonnummer des Empfängers in einer Konversation anzeigen</string>
   <string name="preferences__choose_identity">Kontakt auswählen</string>
   <string name="preferences__choose_your_contact_entry_from_the_contacts_list">Wähle deinen Kontakt aus der Kontaktliste.</string>
   <string name="preferences__change_passphrase">Passphrase ändern</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1156,6 +1156,8 @@
     <string name="preferences__pressing_the_enter_key_will_send_text_messages">Pressing the Enter key will send text messages</string>
     <string name="preferences__send_link_previews">Send link previews</string>
     <string name="preferences__previews_are_supported_for">Previews are supported for Imgur, Instagram, Reddit, and YouTube links</string>
+    <string name="preferences__show_phone_number">Show phone number</string>
+    <string name="preferences__show_phone_number_of_recipient_in_conversation">Phone number of recipient will be shown in conversation</string>
     <string name="preferences__choose_identity">Choose identity</string>
     <string name="preferences__choose_your_contact_entry_from_the_contacts_list">Choose your contact entry from the contacts list.</string>
     <string name="preferences__change_passphrase">Change passphrase</string>

--- a/res/xml/preferences_app_protection.xml
+++ b/res/xml/preferences_app_protection.xml
@@ -75,6 +75,12 @@
             android:summary="@string/preferences__previews_are_supported_for"
             android:title="@string/preferences__send_link_previews"/>
 
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="pref_show_phone_number"
+            android:summary="@string/preferences__show_phone_number_of_recipient_in_conversation"
+            android:title="@string/preferences__show_phone_number"/>
+
         <Preference android:key="preference_category_blocked"
                     android:title="@string/preferences_app_protection__blocked_contacts" />
     </PreferenceCategory>

--- a/src/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -133,9 +133,14 @@ public class ConversationTitleView extends RelativeLayout {
   private void setContactRecipientTitle(Recipient recipient) {
     this.title.setText(recipient.getName());
 
-    if (recipient.getCustomLabel() != null) this.subtitle.setText(recipient.getCustomLabel());
-    else                                    this.subtitle.setText(recipient.getAddress().serialize());
+    if(TextSecurePreferences.isShowPhoneNumberEnabled(this.getContext())) {
+      if (recipient.getCustomLabel() != null) this.subtitle.setText(recipient.getCustomLabel());
+      else                                    this.subtitle.setText(recipient.getAddress().serialize());
 
-    this.subtitle.setVisibility(View.VISIBLE);
+      this.subtitle.setVisibility(View.VISIBLE);
+    } else
+      this.subtitle.setVisibility(View.GONE);
+
+
   }
 }

--- a/src/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
@@ -67,6 +67,7 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
     this.findPreference(TextSecurePreferences.READ_RECEIPTS_PREF).setOnPreferenceChangeListener(new ReadReceiptToggleListener());
     this.findPreference(TextSecurePreferences.TYPING_INDICATORS).setOnPreferenceChangeListener(new TypingIndicatorsToggleListener());
     this.findPreference(TextSecurePreferences.LINK_PREVIEWS).setOnPreferenceChangeListener(new LinkPreviewToggleListener());
+    this.findPreference(TextSecurePreferences.SHOW_PHONE_NUMBER).setOnPreferenceChangeListener(new ShowPhoneNumberToggleListener());
     this.findPreference(PREFERENCE_CATEGORY_BLOCKED).setOnPreferenceClickListener(new BlockedContactsClickListener());
     this.findPreference(TextSecurePreferences.SHOW_UNIDENTIFIED_DELIVERY_INDICATORS).setOnPreferenceChangeListener(new ShowUnidentifiedDeliveryIndicatorsChangedListener());
     this.findPreference(TextSecurePreferences.UNIVERSAL_UNIDENTIFIED_ACCESS).setOnPreferenceChangeListener(new UniversalUnidentifiedAccessChangedListener());
@@ -228,6 +229,16 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
                                                                    TextSecurePreferences.isTypingIndicatorsEnabled(requireContext()),
                                                                    TextSecurePreferences.isShowUnidentifiedDeliveryIndicatorsEnabled(requireContext()),
                                                                    enabled));
+
+      return true;
+    }
+  }
+
+  private class ShowPhoneNumberToggleListener implements Preference.OnPreferenceChangeListener {
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+      boolean enabled = (boolean)newValue;
+      TextSecurePreferences.setShowPhoneNumberEnabled(requireContext(), enabled);
 
       return true;
     }

--- a/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -173,6 +173,8 @@ public class TextSecurePreferences {
 
   public static final String TYPING_INDICATORS = "pref_typing_indicators";
 
+  public static final String SHOW_PHONE_NUMBER = "pref_show_phone_number";
+
   public static final String LINK_PREVIEWS = "pref_link_previews";
 
   public static boolean isScreenLockEnabled(@NonNull Context context) {
@@ -346,6 +348,14 @@ public class TextSecurePreferences {
 
   public static void setTypingIndicatorsEnabled(Context context, boolean enabled) {
     setBooleanPreference(context, TYPING_INDICATORS, enabled);
+  }
+
+  public static boolean isShowPhoneNumberEnabled(Context context) {
+    return getBooleanPreference(context, SHOW_PHONE_NUMBER, true);
+  }
+
+  public static void setShowPhoneNumberEnabled(Context context, boolean enabled) {
+    setBooleanPreference(context, SHOW_PHONE_NUMBER, enabled);
   }
 
   public static boolean isLinkPreviewsEnabled(Context context) {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * LeEco LePro 3 Elite (zl0), Android 9.0
 * Samsung Galaxy S3 mini (golden), Android 7.1.2
 * Virtual device (4.7 WXGA), Android 8.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
This commit adds a toggle that gives the user the option to hide the phone number of a recipient in a conversation. The toggle applies only to Conversations with a single persons in the contact list and not to unsaved contacts and group chats.