### PR TITLE
Adds Fairphone 2 to HARDWARE_AEC_BLACKLIST

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -253,6 +253,7 @@ public class ApplicationContext extends MultiDexApplication implements Dependenc
         add("Mi A1");
         add("E5823"); // Sony z5 compact
         add("Redmi Note 5");
+        add("FP2"); // Fairphone 2
       }};
 
       Set<String> OPEN_SL_ES_WHITELIST = new HashSet<String>() {{


### PR DESCRIPTION
The Fairphone 2 has a lot of very loud echo when making Signal calls. No option is available in the app to test disabling hardware echo cancellation, so this change adds the model to a hardcoded list and then this can be tested once an update has shipped.

Related discussion can be found in #7635 for other devices.