### PR TITLE
Fixes #8653 Changed default toolbar topMargin to 24dp (which is defau…

### DIFF
--- a/res/layout/prompt_passphrase_activity.xml
+++ b/res/layout/prompt_passphrase_activity.xml
@@ -26,7 +26,7 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
-            android:layout_marginTop="20dp">
+            android:layout_marginTop="24dp">
 
         <ImageView
                 android:layout_width="wrap_content"

--- a/src/org/thoughtcrime/securesms/PassphrasePromptActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphrasePromptActivity.java
@@ -57,6 +57,7 @@ import org.thoughtcrime.securesms.crypto.MasterSecretUtil;
 import org.thoughtcrime.securesms.util.DynamicIntroTheme;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
+import org.thoughtcrime.securesms.util.ViewUtil;
 
 /**
  * Activity that prompts for a user's passphrase.
@@ -206,6 +207,8 @@ public class PassphrasePromptActivity extends PassphraseActivity {
 
     ImageButton okButton = findViewById(R.id.ok_button);
     Toolbar     toolbar  = findViewById(R.id.toolbar);
+
+    ViewUtil.setTopMargin(toolbar, ViewUtil.getStatusBarHeight(this));
 
     showButton                    = findViewById(R.id.passphrase_visibility);
     hideButton                    = findViewById(R.id.passphrase_visibility_off);

--- a/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
+++ b/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
@@ -198,6 +198,7 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
     setSupportActionBar(toolbar);
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     getSupportActionBar().setLogo(null);
+    ViewUtil.setTopMargin(toolbar, ViewUtil.getStatusBarHeight(this));
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       getWindow().setFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS, WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);

--- a/src/org/thoughtcrime/securesms/util/ViewUtil.java
+++ b/src/org/thoughtcrime/securesms/util/ViewUtil.java
@@ -240,4 +240,9 @@ public class ViewUtil {
   public static void setPaddingBottom(@NonNull View view, int padding) {
     view.setPadding(view.getPaddingLeft(), view.getPaddingTop(), view.getPaddingRight(), padding);
   }
+
+  public static int getStatusBarHeight(@NonNull Context context) {
+    final int statusBarRes = context.getResources().getIdentifier("status_bar_height", "dimen", "android");
+    return statusBarRes > 0 ? context.getResources().getDimensionPixelSize(statusBarRes) : 0;
+  }
 }

--- a/src/org/thoughtcrime/securesms/util/ViewUtil.java
+++ b/src/org/thoughtcrime/securesms/util/ViewUtil.java
@@ -243,6 +243,6 @@ public class ViewUtil {
 
   public static int getStatusBarHeight(@NonNull Context context) {
     final int statusBarRes = context.getResources().getIdentifier("status_bar_height", "dimen", "android");
-    return statusBarRes > 0 ? context.getResources().getDimensionPixelSize(statusBarRes) : 0;
+    return statusBarRes > 0 ? context.getResources().getDimensionPixelSize(statusBarRes) : ViewUtil.dpToPx(context, 24);
   }
 }


### PR DESCRIPTION
…lt size), and added a function to get the statusbar in ViewUtils

Fixes #8653

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Pixel 3 XL, Android 9
 * Nexus 6P, Android 8
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
On the passphrase activity (PassphrasePromptActivity) the status bar and toolbar were overlapping. I created a ViewUtil function that retrieves the status bar size, and took advantage of an already existing function to set the top margin on the toolbar to have the appropriate space (the height of the status bar).
