### PR TITLE
Add a content description for the inline add attachment button, fixes…

### DIFF
--- a/res/layout/conversation_input_panel.xml
+++ b/res/layout/conversation_input_panel.xml
@@ -150,6 +150,7 @@
                                 android:padding="8dp"
                                 android:src="@drawable/ic_add_white_24dp"
                                 android:tint="?attr/conversation_input_inline_attach_icon_tint"
+                                android:contentDescription="@string/ConversationActivity_add_attachment"
                                 android:background="?selectableItemBackgroundBorderless"/>
 
                         </org.thoughtcrime.securesms.components.HidingLinearLayout>


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ x I have tested my contribution on these devices:
 * Pixel 2, Android 9
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fixes #8730 by adding a content description. I'm reusing the same one from the image button that's visible before the user starts composing a message.