### PR TITLE
Avoid hardware echo cancellation for Fairphone FP2

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -255,6 +255,7 @@ public class ApplicationContext extends MultiDexApplication implements Dependenc
         add("Mi A1");
         add("E5823"); // Sony z5 compact
         add("Redmi Note 5");
+        add("FP2"); // Fairphone FP2
       }};
 
       Set<String> OPEN_SL_ES_WHITELIST = new HashSet<String>() {{


### PR DESCRIPTION
The issue has as been confirmed by me with the stock ROM as of November
2018, and other users have complained for almost 18 months, see
https://forum.fairphone.com/t/fnord/28849 and
https://bugtracker.fairphone.com/project/fairphone-android-7/issue/179

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * FP2, Android 7
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

The (mediatek chipset in the) fairphone 2 has erratic hardware echo cancellation. AFAICT, Fairphone's Android 7 is better than 6.x was, but other users report no improvement (of course, users may not notice things that work well...) Even for me it varies, not every call is good/bad. My fix adds the FP2 to the list of devices for which hardware echo cancellation is not used.

I've tested it with an actual hardware device over dozens of calls and not had any bad echo. I have not tested every version of Android, though.

The commit date is old, because I hoped Fairpphone would find a driver fix. There's been no visible progress on the Fairphone ticket, so here goes.

