### PR TITLE
Add pinterest domain and asset domains for link preview support

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1180,7 +1180,7 @@
     <string name="preferences__pref_enter_sends_title">Enter key sends</string>
     <string name="preferences__pressing_the_enter_key_will_send_text_messages">Pressing the Enter key will send text messages</string>
     <string name="preferences__send_link_previews">Send link previews</string>
-    <string name="preferences__previews_are_supported_for">Previews are supported for Imgur, Instagram, Reddit, and YouTube links</string>
+    <string name="preferences__previews_are_supported_for">Previews are supported for Imgur, Instagram, Pinterest, Reddit, and YouTube links</string>
     <string name="preferences__choose_identity">Choose identity</string>
     <string name="preferences__choose_your_contact_entry_from_the_contacts_list">Choose your contact entry from the contacts list.</string>
     <string name="preferences__change_passphrase">Change passphrase</string>

--- a/src/org/thoughtcrime/securesms/linkpreview/LinkPreviewDomains.java
+++ b/src/org/thoughtcrime/securesms/linkpreview/LinkPreviewDomains.java
@@ -18,7 +18,10 @@ public class LinkPreviewDomains {
       "m.imgur.com",
       "instagram.com",
       "www.instagram.com",
-      "m.instagram.com"
+      "m.instagram.com",
+      "pinterest.com",
+      "www.pinterest.com",
+      "pin.it"
   ));
 
   public static final Set<String> IMAGES = new HashSet<>(Arrays.asList(
@@ -26,6 +29,7 @@ public class LinkPreviewDomains {
       "cdninstagram.com",
       "fbcdn.net",
       "redd.it",
-      "imgur.com"
+      "imgur.com",
+      "pinimg.com"
   ));
 }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Pixel 2, Android Pie
<img width="288" alt="Screen Shot 2019-04-12 at 4 56 25 PM" src="https://user-images.githubusercontent.com/8467234/56071677-a9d55300-5d44-11e9-8ac6-9abc3a76335e.png">

- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
We'd like signal to show link previews for Pinterest 😄 

Desktop: https://github.com/signalapp/Signal-Desktop/pull/3308
iOS: https://github.com/signalapp/Signal-iOS/pull/4176