### PR TITLE
Filter backups in order to not delete other files in the same folder

### DIFF
--- a/src/org/thoughtcrime/securesms/util/BackupUtil.java
+++ b/src/org/thoughtcrime/securesms/util/BackupUtil.java
@@ -18,7 +18,19 @@ import java.util.Locale;
 
 public class BackupUtil {
 
+  private static class FilterBackups implements java.io.FilenameFilter {
+    public boolean accept(File dir, String name) {
+      return name.substring(0,6).equals("signal");
+    }
+  }
+
   private static final String TAG = BackupUtil.class.getSimpleName();
+
+  private static File[] listBackups() throws NoExternalStorageException {
+      File       backupDirectory = StorageUtil.getBackupDirectory();
+      FilterBackups filter = new FilterBackups();
+      return backupDirectory.listFiles(filter);
+  }
 
   public static @NonNull String getLastBackupTime(@NonNull Context context, @NonNull Locale locale) {
     try {
@@ -33,9 +45,9 @@ public class BackupUtil {
   }
 
   public static @Nullable BackupInfo getLatestBackup() throws NoExternalStorageException {
-    File       backupDirectory = StorageUtil.getBackupDirectory();
-    File[]     backups         = backupDirectory.listFiles();
+    
     BackupInfo latestBackup    = null;
+    File[] backups             = listBackups();
 
     for (File backup : backups) {
       long backupTimestamp = getBackupTimestamp(backup);
@@ -51,8 +63,7 @@ public class BackupUtil {
   @SuppressWarnings("ResultOfMethodCallIgnored")
   public static void deleteAllBackups() {
     try {
-      File   backupDirectory = StorageUtil.getBackupDirectory();
-      File[] backups         = backupDirectory.listFiles();
+      File[] backups = listBackups();
 
       for (File backup : backups) {
         if (backup.isFile()) backup.delete();
@@ -64,8 +75,7 @@ public class BackupUtil {
 
   public static void deleteOldBackups() {
     try {
-      File   backupDirectory = StorageUtil.getBackupDirectory();
-      File[] backups         = backupDirectory.listFiles();
+      File[] backups = listBackups();
 
       if (backups != null && backups.length > 2) {
         Arrays.sort(backups, (left, right) -> {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ x ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [ x ] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ x ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ x ] I have tested my contribution on these devices:
 * Oneplus 3T, Android 9
- [ x ] My contribution is fully baked and ready to be merged as is
- [ x  ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

I want to be able to use [syncthing](https://syncthing.net/) to backup my Signal backups to my local PC, but SIgnal keeps deleting the folder marker (´.stfolder´) that syncthing needs to sync the files. This PR makes Signal not delete other files but it's own backups.
