### PR TITLE
Implemented RecentPhotosObserver to address #7632

### DIFF
--- a/src/org/thoughtcrime/securesms/conversation/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/conversation/ConversationActivity.java
@@ -463,6 +463,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     saveDraft();
     if (recipient != null)               recipient.removeListener(this);
     if (securityUpdateReceiver != null)  unregisterReceiver(securityUpdateReceiver);
+    if (attachmentTypeSelector != null)  attachmentTypeSelector.unregisterRecentPhotosObserver(this);
     super.onDestroy();
   }
 

--- a/src/org/thoughtcrime/securesms/database/loaders/RecentPhotosLoader.java
+++ b/src/org/thoughtcrime/securesms/database/loaders/RecentPhotosLoader.java
@@ -36,8 +36,7 @@ public class RecentPhotosLoader extends CursorLoader {
   @Override
   public Cursor loadInBackground() {
     if (Permissions.hasAll(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-      return context.getContentResolver().query(MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
-                                                PROJECTION, null, null,
+      return context.getContentResolver().query(BASE_URL, PROJECTION, null, null,
                                                 MediaStore.Images.ImageColumns.DATE_MODIFIED + " DESC");
     } else {
       return null;


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Pixel 2, Android 9.0
 * Virtual device Galaxy Nexus, Android 4.4
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fixes #7632.

A content observer was implemented to invalidate the cursor loader, that loads the recent images into the RecentPhotoViewRail.