### PR TITLE
Changed security scheme in 3 classes to diminish the vulnerabilities …

### DIFF
--- a/src/org/thoughtcrime/securesms/crypto/ClassicDecryptingPartInputStream.java
+++ b/src/org/thoughtcrime/securesms/crypto/ClassicDecryptingPartInputStream.java
@@ -59,7 +59,7 @@ public class ClassicDecryptingPartInputStream {
       byte[]          ivBytes    = new byte[IV_LENGTH];
       readFully(fileStream, ivBytes);
 
-      Cipher          cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+      Cipher          cipher = Cipher.getInstance("AES/GCM/NoPadding");
       IvParameterSpec iv     = new IvParameterSpec(ivBytes);
       cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(attachmentSecret.getClassicCipherKey(), "AES"), iv);
 

--- a/src/org/thoughtcrime/securesms/crypto/MasterCipher.java
+++ b/src/org/thoughtcrime/securesms/crypto/MasterCipher.java
@@ -65,8 +65,8 @@ public class MasterCipher {
   public MasterCipher(MasterSecret masterSecret) {
     try {
       this.masterSecret = masterSecret;		
-      this.encryptingCipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
-      this.decryptingCipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+      this.encryptingCipher = Cipher.getInstance("AES/GCM/NoPadding");
+      this.decryptingCipher = Cipher.getInstance("AES/GCM/NoPadding");
       this.hmac             = Mac.getInstance("HmacSHA1");
     } catch (NoSuchPaddingException | NoSuchAlgorithmException nspe) {
       throw new AssertionError(nspe);

--- a/src/org/thoughtcrime/securesms/logging/LogFile.java
+++ b/src/org/thoughtcrime/securesms/logging/LogFile.java
@@ -45,7 +45,7 @@ class LogFile {
       this.outputStream = new BufferedOutputStream(new FileOutputStream(file, true));
 
       try {
-        this.cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        this.cipher = Cipher.getInstance("AES/GCM/NoPadding");
       } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
         throw new AssertionError(e);
       }
@@ -96,7 +96,7 @@ class LogFile {
       this.inputStream = new BufferedInputStream(new FileInputStream(file));
 
       try {
-        this.cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        this.cipher = Cipher.getInstance("AES/GCM/NoPadding");
       } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
         throw new AssertionError(e);
       }


### PR DESCRIPTION
…in the app

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device One Plus 6, Android 9, OxygenOS version 9.0.5
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

My Pullrequest proposes to fix a vulnerability presented when we use the security schema AES/CBC/PKCS5Padding in the classes MasterCipher.java, LogFile.java and ClassicDecryptingPartInputStream.java. I Changed the schema from AES/CBC/PKCS5Padding that can be vulnerable to oracle padding attacks to AES/GCM/NoPadding, which is the preferred method. These vulnerabilities where obtained running an analysis with SonarQube

