### PR TITLE
Added try with resources to multiple fileInputStream and fileOutputSt…

### DIFF
--- a/src/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/org/thoughtcrime/securesms/ShareActivity.java
@@ -353,15 +353,18 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity
     }
 
     private InputStream openFileUri(Uri uri) throws IOException {
-      FileInputStream fin   = new FileInputStream(uri.getPath());
-      int             owner = FileUtils.getFileDescriptorOwner(fin.getFD());
-      
-      if (owner == -1 || owner == Process.myUid()) {
-        fin.close();
-        throw new IOException("File owned by application");
-      }
 
-      return fin;
+      try (FileInputStream fin = new FileInputStream(uri.getPath())) {
+
+        int owner = FileUtils.getFileDescriptorOwner(fin.getFD());
+
+        if (owner == -1 || owner == Process.myUid()) {
+          fin.close();
+          throw new IOException("File owned by application");
+        }
+
+        return fin;
+      }
     }
   }
 }

--- a/src/org/thoughtcrime/securesms/backup/FullBackupExporter.java
+++ b/src/org/thoughtcrime/securesms/backup/FullBackupExporter.java
@@ -210,6 +210,8 @@ public class FullBackupExporter extends FullBackupBase {
         else                                       inputStream = ClassicDecryptingPartInputStream.createFor(attachmentSecret, new File(data));
 
         outputStream.write(new AttachmentId(rowId, uniqueId), inputStream, size);
+        outputStream.close();
+        inputStream.close();
       }
     } catch (IOException e) {
       Log.w(TAG, e);
@@ -229,6 +231,8 @@ public class FullBackupExporter extends FullBackupBase {
     while ((read = inputStream.read(buffer, 0, buffer.length)) != -1) {
       result += read;
     }
+
+    inputStream.close();
 
     return result;
   }

--- a/src/org/thoughtcrime/securesms/contacts/ContactAccessor.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactAccessor.java
@@ -364,9 +364,10 @@ public class ContactAccessor {
       ArrayList<ArrayList> wrap = new ArrayList<ArrayList>();
       wrap.add(result);
 
-      ArrayListCursor translated = new ArrayListCursor(PROJECTION_PHONE, wrap);
+      try(ArrayListCursor translated = new ArrayListCursor(PROJECTION_PHONE, wrap)) {
 
-      return new MergeCursor(new Cursor[] { translated, phoneCursor });
+        return new MergeCursor(new Cursor[]{translated, phoneCursor});
+      }
     } else {
       return phoneCursor;
     }

--- a/src/org/thoughtcrime/securesms/contacts/ContactsDatabase.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactsDatabase.java
@@ -238,10 +238,11 @@ public class ContactsDatabase {
         }
 
         if (shouldAdd) {
-          MatrixCursor selfCursor = new MatrixCursor(projection);
-          selfCursor.addRow(new Object[]{ context.getString(R.string.note_to_self), TextSecurePreferences.getLocalNumber(context)});
+          try(MatrixCursor selfCursor = new MatrixCursor(projection)) {
+            selfCursor.addRow(new Object[]{context.getString(R.string.note_to_self), TextSecurePreferences.getLocalNumber(context)});
 
-          cursor = cursor == null ? selfCursor : new MergeCursor(new Cursor[]{ cursor, selfCursor });
+            cursor = cursor == null ? selfCursor : new MergeCursor(new Cursor[]{cursor, selfCursor});
+          }
         }
       }
     }

--- a/src/org/thoughtcrime/securesms/crypto/ModernEncryptingPartOutputStream.java
+++ b/src/org/thoughtcrime/securesms/crypto/ModernEncryptingPartOutputStream.java
@@ -37,18 +37,19 @@ public class ModernEncryptingPartOutputStream {
       Mac mac = Mac.getInstance("HmacSHA256");
       mac.init(new SecretKeySpec(attachmentSecret.getModernKey(), "HmacSHA256"));
 
-      FileOutputStream fileOutputStream = new FileOutputStream(file);
-      byte[]           iv               = new byte[16];
-      byte[]           key              = mac.doFinal(random);
+      try(FileOutputStream fileOutputStream = new FileOutputStream(file)) {
+        byte[] iv = new byte[16];
+        byte[] key = mac.doFinal(random);
 
-      Cipher cipher = Cipher.getInstance("AES/CTR/NoPadding");
-      cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"), new IvParameterSpec(iv));
+        Cipher cipher = Cipher.getInstance("AES/CTR/NoPadding");
+        cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"), new IvParameterSpec(iv));
 
-      if (inline) {
-        fileOutputStream.write(random);
+        if (inline) {
+          fileOutputStream.write(random);
+        }
+
+        return new Pair<>(random, new CipherOutputStream(fileOutputStream, cipher));
       }
-
-      return new Pair<>(random, new CipherOutputStream(fileOutputStream, cipher));
     } catch (NoSuchAlgorithmException | InvalidKeyException | InvalidAlgorithmParameterException | NoSuchPaddingException e) {
       throw new AssertionError(e);
     }

--- a/src/org/thoughtcrime/securesms/database/AttachmentDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/AttachmentDatabase.java
@@ -491,15 +491,16 @@ public class AttachmentDatabase extends Database {
       if (dataInfo.random != null && dataInfo.random.length == 32) {
         return ModernDecryptingPartInputStream.createFor(attachmentSecret, dataInfo.random, dataInfo.file, offset);
       } else {
-        InputStream stream  = ClassicDecryptingPartInputStream.createFor(attachmentSecret, dataInfo.file);
-        long        skipped = stream.skip(offset);
+        try(InputStream stream  = ClassicDecryptingPartInputStream.createFor(attachmentSecret, dataInfo.file)) {
+          long skipped = stream.skip(offset);
 
-        if (skipped != offset) {
-          Log.w(TAG, "Skip failed: " + skipped + " vs " + offset);
-          return null;
+          if (skipped != offset) {
+            Log.w(TAG, "Skip failed: " + skipped + " vs " + offset);
+            return null;
+          }
+
+          return stream;
         }
-
-        return stream;
       }
     } catch (IOException e) {
       Log.w(TAG, e);

--- a/src/org/thoughtcrime/securesms/glide/cache/EncryptedCoder.java
+++ b/src/org/thoughtcrime/securesms/glide/cache/EncryptedCoder.java
@@ -39,20 +39,22 @@ class EncryptedCoder {
       Mac    mac    = Mac.getInstance("HmacSHA256");
       mac.init(new SecretKeySpec(masterKey, "HmacSHA256"));
 
-      FileOutputStream fileOutputStream = new FileOutputStream(file);
-      byte[]           iv               = new byte[16];
-      byte[]           key              = mac.doFinal(random);
+      try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
+        byte[] iv = new byte[16];
+        byte[] key = mac.doFinal(random);
 
-      Cipher cipher = Cipher.getInstance("AES/CTR/NoPadding");
-      cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"), new IvParameterSpec(iv));
+        Cipher cipher = Cipher.getInstance("AES/CTR/NoPadding");
+        cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"), new IvParameterSpec(iv));
 
-      fileOutputStream.write(MAGIC_BYTES);
-      fileOutputStream.write(random);
+        fileOutputStream.write(MAGIC_BYTES);
+        fileOutputStream.write(random);
 
-      CipherOutputStream outputStream = new CipherOutputStream(fileOutputStream, cipher);
-      outputStream.write(MAGIC_BYTES);
+        try (CipherOutputStream outputStream = new CipherOutputStream(fileOutputStream, cipher)) {
+          outputStream.write(MAGIC_BYTES);
 
-      return outputStream;
+          return outputStream;
+        }
+      }
     } catch (NoSuchAlgorithmException | InvalidKeyException | NoSuchPaddingException | InvalidAlgorithmParameterException e) {
       throw new AssertionError(e);
     }

--- a/src/org/thoughtcrime/securesms/jobs/MultiDeviceContactUpdateJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/MultiDeviceContactUpdateJob.java
@@ -255,17 +255,17 @@ public class MultiDeviceContactUpdateJob extends BaseJob implements InjectableTy
     Uri displayPhotoUri = Uri.withAppendedPath(uri, ContactsContract.Contacts.Photo.DISPLAY_PHOTO);
 
     try {
-      AssetFileDescriptor fd = context.getContentResolver().openAssetFileDescriptor(displayPhotoUri, "r");
+       try(AssetFileDescriptor fd = context.getContentResolver().openAssetFileDescriptor(displayPhotoUri, "r")) {
+         if (fd == null) {
+           return Optional.absent();
+         }
 
-      if (fd == null) {
-        return Optional.absent();
-      }
-
-      return Optional.of(SignalServiceAttachment.newStreamBuilder()
-                                                .withStream(fd.createInputStream())
-                                                .withContentType("image/*")
-                                                .withLength(fd.getLength())
-                                                .build());
+         return Optional.of(SignalServiceAttachment.newStreamBuilder()
+                 .withStream(fd.createInputStream())
+                 .withContentType("image/*")
+                 .withLength(fd.getLength())
+                 .build());
+       }
     } catch (IOException e) {
       Log.i(TAG, "Could not find avatar for URI: " + displayPhotoUri);
     }

--- a/src/org/thoughtcrime/securesms/jobs/UpdateApkJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/UpdateApkJob.java
@@ -178,12 +178,11 @@ public class UpdateApkJob extends BaseJob {
   private @Nullable byte[] getDigestForDownloadId(long downloadId) {
     try {
       DownloadManager downloadManager = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
-      FileInputStream fin             = new FileInputStream(downloadManager.openDownloadedFile(downloadId).getFileDescriptor());
-      byte[]          digest          = FileUtils.getFileDigest(fin);
+      try (FileInputStream fin             = new FileInputStream(downloadManager.openDownloadedFile(downloadId).getFileDescriptor())) {
+        byte[] digest = FileUtils.getFileDigest(fin);
 
-      fin.close();
-
-      return digest;
+        return digest;
+      }
     } catch (IOException e) {
       Log.w(TAG, e);
       return null;

--- a/src/org/thoughtcrime/securesms/profiles/AvatarHelper.java
+++ b/src/org/thoughtcrime/securesms/profiles/AvatarHelper.java
@@ -52,9 +52,9 @@ public class AvatarHelper {
     if (data == null)  {
       delete(context, address);
     } else {
-      FileOutputStream out = new FileOutputStream(getAvatarFile(context, address));
-      out.write(data);
-      out.close();
+      try (FileOutputStream out = new FileOutputStream(getAvatarFile(context, address))) {
+        out.write(data);
+      }
     }
   }
 

--- a/src/org/thoughtcrime/securesms/service/UpdateApkReadyListener.java
+++ b/src/org/thoughtcrime/securesms/service/UpdateApkReadyListener.java
@@ -106,12 +106,11 @@ public class UpdateApkReadyListener extends BroadcastReceiver {
 
       byte[]          theirDigest     = Hex.fromStringCondensed(theirEncodedDigest);
       DownloadManager downloadManager = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
-      FileInputStream fin             = new FileInputStream(downloadManager.openDownloadedFile(downloadId).getFileDescriptor());
-      byte[]          ourDigest       = FileUtils.getFileDigest(fin);
+      try(FileInputStream fin             = new FileInputStream(downloadManager.openDownloadedFile(downloadId).getFileDescriptor())) {
+        byte[] ourDigest = FileUtils.getFileDigest(fin);
 
-      fin.close();
-
-      return MessageDigest.isEqual(ourDigest, theirDigest);
+        return MessageDigest.isEqual(ourDigest, theirDigest);
+      }
     } catch (IOException e) {
       Log.w(TAG, e);
       return false;


### PR DESCRIPTION
…ream instances

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Device One Plus 6, Android 9, OxygenOS version 9.0.5
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

The objective of this pull request is to diminish the amount of streams leaks in the application. Added try with resources in different instances, 13 classes: ShareActivity.java, FullBackupExporter.java, ContactAccessor.java, ContactsDatabase.java, ClassicDecryptingPartInputStream.java, ModernEncryptingPartOutputStream.java, AttachmentDatabase.java, EncryptedCoder.java, MultiDeviceContactUpdateJob.java, UpdateApkJob.java, AvatarHelper.java, UpdateApkReadyListener.java, EncryptedMediaDataSource.java.


