### PR TITLE
Reproducable build: Ensure apkdiff.py works properly again

### DIFF
--- a/apkdiff/apkdiff.py
+++ b/apkdiff/apkdiff.py
@@ -35,10 +35,10 @@ class ApkDiff:
         return True
 
     def compareEntries(self, sourceZip, destinationZip):
-        sourceInfoList      = filter(lambda sourceInfo: sourceInfo.filename not in self.IGNORE_FILES, sourceZip.infolist())
-        destinationInfoList = filter(lambda destinationInfo: destinationInfo.filename not in self.IGNORE_FILES, destinationZip.infolist())
+        sourceInfoList      = list(filter(lambda sourceInfo: sourceInfo.filename not in self.IGNORE_FILES, sourceZip.infolist()))
+        destinationInfoList = list(filter(lambda destinationInfo: destinationInfo.filename not in self.IGNORE_FILES, destinationZip.infolist()))
 
-        if len(list(sourceInfoList)) != len(list(destinationInfoList)):
+        if len(sourceInfoList) != len(destinationInfoList):
             print("APK info lists of different length!")
             return False
 
@@ -61,7 +61,7 @@ class ApkDiff:
         sourceChunk      = sourceFile.read(1024)
         destinationChunk = destinationFile.read(1024)
 
-        while sourceChunk != "" or destinationChunk != "":
+        while sourceChunk != b"" or destinationChunk != b"":
             if sourceChunk != destinationChunk:
                 return False
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Python 3.5
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
The recent switch to Python3 (2ccdf0e396e82dd) introduced a regression
that led to file content no longer being compared:

   In compareEntries(), two generators/iterators are created:

     sourceInfoList      = filter(lambda sourceInfo: …, sourceZip.infolist())
     destinationInfoList = filter(lambda destinationInfo: …, destinationZip.infolist())

   Few lines later, those are exhausted:

     if len(sourceInfoList) != len(destinationInfoList):

   Yet another few lines later, the exhausted generator is used again:

     for sourceEntryInfo in sourceInfoList:
        …          # <-- unreachable

This is caused by behavioral differences between Python2 and Python3:

   ```
   user@z_signal:~$ python2
   Python 2.7.13 (default, Sep 26 2018, 18:42:22)
   [GCC 6.3.0 20170516] on linux2
   Type "help", "copyright", "credits" or "license" for more information.
   >>> f = filter(lambda i: i % 2 == 0, [0, 1, 2, 3, 4, 5, 6])
   >>> list(f)
   [0, 2, 4, 6]
   >>> list(f)
   [0, 2, 4, 6]
   >>>
   ```

   ```
   user@z_signal:~$ python3
   Python 3.5.3 (default, Sep 27 2018, 17:25:39)
   [GCC 6.3.0 20170516] on linux
   Type "help", "copyright", "credits" or "license" for more information.
   >>> f = filter(lambda i: i % 2 == 0, [0, 1, 2, 3, 4, 5, 6])
   >>> list(f)
   [0, 2, 4, 6]
   >>> list(f)
   []
   >>>
   ```

### Tests

I wonder if we should create some tests to avoid regressions like this to happen again. I already created a few zip files for testing my changes. I could not find any information about how you run tests or how I could integrate any tests though.