### PR TITLE
Deselect expired messages (Fixes #8831) 

### DIFF
--- a/src/org/thoughtcrime/securesms/conversation/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/conversation/ConversationFragment.java
@@ -107,6 +107,8 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.GregorianCalendar;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -695,6 +697,17 @@ public class ConversationFragment extends Fragment
 
     if (lastSeenPosition <= 0) {
       setLastSeen(0);
+    }
+
+    if(actionMode != null) {
+      Iterator<MessageRecord> itr = getListAdapter().getSelectedItems().iterator();
+      while(itr.hasNext()) {
+        MessageRecord mr = itr.next();
+        if((mr.getExpireStarted() + mr.getExpiresIn()) - GregorianCalendar.getInstance().getTimeInMillis() < 0) {
+          getListAdapter().toggleSelection(mr);
+        }
+      }
+      setCorrectMenuVisibility(actionMode.getMenu());
     }
   }
 


### PR DESCRIPTION
Deselect expired messages (Fixes #8831)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Physical device Pixel 1, Android 9
 * Virtual device Pixel 2, Android 9
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This fixes #8831 by checking the expiry time of selected items on conversation loader finish and deselecting them if they have expired.
