### PR TITLE
rate limit group chat notifications

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -538,6 +538,7 @@ public class ConversationListFragment extends Fragment
 
             if (unreadCount > 0) {
               List<MarkedMessageInfo> messageIds = DatabaseFactory.getThreadDatabase(getActivity()).setRead(threadId, false);
+              MessageNotifier.updateThreadRead(threadId);
               MessageNotifier.updateNotification(getActivity());
               MarkReadReceiver.process(getActivity(), messageIds);
             }

--- a/src/org/thoughtcrime/securesms/conversation/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/conversation/ConversationActivity.java
@@ -2053,6 +2053,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
         Context                 context    = ConversationActivity.this;
         List<MarkedMessageInfo> messageIds = DatabaseFactory.getThreadDatabase(context).setRead(params[0], false);
 
+        MessageNotifier.updateThreadRead(params[0]);
         MessageNotifier.updateNotification(context);
         MarkReadReceiver.process(context, messageIds);
 

--- a/src/org/thoughtcrime/securesms/jobs/PushDecryptJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushDecryptJob.java
@@ -598,6 +598,7 @@ public class PushDecryptJob extends BaseJob {
 
       if (threadId != null) {
         DatabaseFactory.getThreadDatabase(context).setRead(threadId, true);
+        MessageNotifier.updateThreadRead(threadId);
         MessageNotifier.updateNotification(context);
       }
 

--- a/src/org/thoughtcrime/securesms/notifications/AndroidAutoHeardReceiver.java
+++ b/src/org/thoughtcrime/securesms/notifications/AndroidAutoHeardReceiver.java
@@ -62,6 +62,7 @@ public class AndroidAutoHeardReceiver extends BroadcastReceiver {
           for (long threadId : threadIds) {
             Log.i(TAG, "Marking meassage as read: " + threadId);
             List<MarkedMessageInfo> messageIds = DatabaseFactory.getThreadDatabase(context).setRead(threadId, true);
+            MessageNotifier.updateThreadRead(threadId);
 
             messageIdsCollection.addAll(messageIds);
           }

--- a/src/org/thoughtcrime/securesms/notifications/AndroidAutoReplyReceiver.java
+++ b/src/org/thoughtcrime/securesms/notifications/AndroidAutoReplyReceiver.java
@@ -85,6 +85,7 @@ public class AndroidAutoReplyReceiver extends BroadcastReceiver {
           }
 
           List<MarkedMessageInfo> messageIds = DatabaseFactory.getThreadDatabase(context).setRead(replyThreadId, true);
+          MessageNotifier.updateThreadRead(replyThreadId);
 
           MessageNotifier.updateNotification(context);
           MarkReadReceiver.process(context, messageIds);

--- a/src/org/thoughtcrime/securesms/notifications/MarkReadReceiver.java
+++ b/src/org/thoughtcrime/securesms/notifications/MarkReadReceiver.java
@@ -52,6 +52,7 @@ public class MarkReadReceiver extends BroadcastReceiver {
           for (long threadId : threadIds) {
             Log.i(TAG, "Marking as read: " + threadId);
             List<MarkedMessageInfo> messageIds = DatabaseFactory.getThreadDatabase(context).setRead(threadId, true);
+            MessageNotifier.updateThreadRead(threadId);
             messageIdsCollection.addAll(messageIds);
           }
 

--- a/src/org/thoughtcrime/securesms/notifications/RemoteReplyReceiver.java
+++ b/src/org/thoughtcrime/securesms/notifications/RemoteReplyReceiver.java
@@ -95,6 +95,7 @@ public class RemoteReplyReceiver extends BroadcastReceiver {
           }
 
           List<MarkedMessageInfo> messageIds = DatabaseFactory.getThreadDatabase(context).setRead(threadId, true);
+          MessageNotifier.updateThreadRead(threadId);
 
           MessageNotifier.updateNotification(context);
           MarkReadReceiver.process(context, messageIds);


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Nexus 5X, Android 9 (api 28)
 * Virtual device Nexus 5X, Android 5.1 (api 22)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
When discussion starts in medium-size group chats, the current behavior is to notify and vibrate up to every two seconds. This pull request adds rate-limiting on a per thread basis for group chats, so that subsequent messages will not trigger notification alarms for three minutes if the user did not interact with the thread in the meantime.