### PR TITLE
Pin text color now matches with dark mode text color.

### DIFF
--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -481,6 +481,10 @@
         <item name="android:windowBackground">@drawable/permission_rationale_dialog_corners</item>
     </style>
 
+    <style name="RationaleDialog.Dark">
+        <item name="android:editTextColor">@color/text_color_dark_theme</item>
+    </style>
+
     <style name="TextSecure.MediaSendProgressDialog" parent="@android:style/Theme.Dialog">
         <item name="android:background">@color/core_grey_95</item>
     </style>

--- a/src/org/thoughtcrime/securesms/lock/RegistrationLockDialog.java
+++ b/src/org/thoughtcrime/securesms/lock/RegistrationLockDialog.java
@@ -30,6 +30,7 @@ import android.widget.Toast;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.SwitchPreferenceCompat;
+import org.thoughtcrime.securesms.util.DynamicTheme;
 import org.thoughtcrime.securesms.util.ServiceUtil;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.whispersystems.libsignal.util.guava.Optional;
@@ -45,7 +46,11 @@ public class RegistrationLockDialog {
     if (!RegistrationLockReminders.needsReminder(context))    return;
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return;
 
-    AlertDialog dialog      = new AlertDialog.Builder(context, R.style.RationaleDialog)
+    int dialogStyle = DynamicTheme.DARK.equals(TextSecurePreferences.getTheme(context))
+            ? R.style.RationaleDialog_Dark
+            : R.style.RationaleDialog;
+
+    AlertDialog dialog      = new AlertDialog.Builder(context, dialogStyle)
                                              .setView(R.layout.registration_lock_reminder_view)
                                              .setCancelable(true)
                                              .setOnCancelListener(d -> RegistrationLockReminders.scheduleReminder(context, false))


### PR DESCRIPTION


### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Physical Device OnePlus 7 Pro, Android 9
 * Virtual device Pixel 1, Android 9
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fixes #7509

Test: Launch Signal in dark mode and light mode and ensure registration pin text color is correct