### PR TITLE
Fix some Javadoc typos

### DIFF
--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -102,7 +102,7 @@ import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 /**
- * The register account activity.  Prompts ths user for their registration information
+ * The register account activity.  Prompts the user for their registration information
  * and begins the account registration process.
  *
  * @author Moxie Marlinspike

--- a/src/org/thoughtcrime/securesms/contacts/ContactAccessor.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactAccessor.java
@@ -46,7 +46,7 @@ import static org.thoughtcrime.securesms.database.GroupDatabase.GroupRecord;
 
 /**
  * This class was originally a layer of indirection between
- * ContactAccessorNewApi and ContactAccesorOldApi, which corresponded
+ * ContactAccessorNewApi and ContactAccessorOldApi, which corresponded
  * to the API changes between 1.x and 2.x.
  *
  * Now that we no longer support 1.x, this class mostly serves as a place

--- a/src/org/thoughtcrime/securesms/crypto/AsymmetricMasterCipher.java
+++ b/src/org/thoughtcrime/securesms/crypto/AsymmetricMasterCipher.java
@@ -34,7 +34,7 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
 /**
- * This class is used to asymmetricly encrypt local data.  This is used in the case
+ * This class is used to asymmetrically encrypt local data.  This is used in the case
  * where TextSecure receives an SMS, but the user's local encryption passphrase is
  * not cached (either because of a timeout, or because it hasn't yet been entered).
  * 

--- a/src/org/thoughtcrime/securesms/util/Base64.java
+++ b/src/org/thoughtcrime/securesms/util/Base64.java
@@ -65,7 +65,7 @@ package org.thoughtcrime.securesms.util;
  *      <a href="http://www.faqs.org/rfcs/rfc3548.html">RFC3548</a>.</li>
  *    <li><em>Throws exceptions instead of returning null values.</em> Because some operations
  *      (especially those that may permit the GZIP option) use IO streams, there
- *      is a possiblity of an java.io.IOException being thrown. After some discussion and
+ *      is a possibility of an java.io.IOException being thrown. After some discussion and
  *      thought, I've changed the behavior of the methods to throw java.io.IOExceptions
  *      rather than return null if ever there's an error. I think this is more
  *      appropriate, though it will require some changes to your code. Sorry,
@@ -479,7 +479,7 @@ public class Base64
      * anywhere along their length by specifying 
      * <var>srcOffset</var> and <var>destOffset</var>.
      * This method does not check to make sure your arrays
-     * are large enough to accomodate <var>srcOffset</var> + 3 for
+     * are large enough to accommodate <var>srcOffset</var> + 3 for
      * the <var>source</var> array or <var>destOffset</var> + 4 for
      * the <var>destination</var> array.
      * The actual number of significant bytes in your array is
@@ -1027,7 +1027,7 @@ public class Base64
      * anywhere along their length by specifying 
      * <var>srcOffset</var> and <var>destOffset</var>.
      * This method does not check to make sure your arrays
-     * are large enough to accomodate <var>srcOffset</var> + 4 for
+     * are large enough to accommodate <var>srcOffset</var> + 4 for
      * the <var>source</var> array or <var>destOffset</var> + 3 for
      * the <var>destination</var> array.
      * This method returns the actual number of bytes that 

--- a/src/org/thoughtcrime/securesms/util/MathUtils.java
+++ b/src/org/thoughtcrime/securesms/util/MathUtils.java
@@ -30,7 +30,7 @@ public class MathUtils {
      *
      * @param a beginning of 2 vectors
      * @param b end of vector 1
-     * @param c enf of vector 2
+     * @param c end of vector 2
      * @return cross product AB * AC
      */
     private static float crossProduct(@NonNull PointF a, @NonNull PointF b, @NonNull PointF c) {


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 No functional changes, only Javadoc changed, can't break anything
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
I checked the Javadocs for spelling mistakes and fixed them. Rebased #6136
