### PR TITLE
Fix: typo in AttachmentSecretProvider

### DIFF
--- a/src/org/thoughtcrime/securesms/crypto/AttachmentSecretProvider.java
+++ b/src/org/thoughtcrime/securesms/crypto/AttachmentSecretProvider.java
@@ -73,7 +73,7 @@ public class AttachmentSecretProvider {
 
   private AttachmentSecret getEncryptedAttachmentSecret(@NonNull String serializedEncryptedSecret) {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-      throw new AssertionError("OS downgrade not supported. KeyStore sealed data exists on platform < M!");
+      throw new AssertionError("OS downgrade not supported. KeyStore sealed data exists on platform >= M!");
     } else {
       KeyStoreHelper.SealedData encryptedSecret = KeyStoreHelper.SealedData.fromString(serializedEncryptedSecret);
       return AttachmentSecret.fromString(new String(KeyStoreHelper.unseal(encryptedSecret)));


### PR DESCRIPTION
### First time contributor checklist

- [ ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

Nope, too much paperwork for this simple fix

### Contributor checklist

- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
- [x] My contribution is fully baked and ready to be merged as is

----------

### Description

There is a little typo in an error message in `AttachmentSecretProvider.java`, indicating the wrong platform support for Android's KeyStore.
