### PR TITLE
Warn when setting a system screenlock on API < 21. Fixes #8603

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1336,6 +1336,8 @@
     <string name="preferences_advanced__always_relay_calls">Always relay calls</string>
     <string name="preferences_app_protection__app_access">App access</string>
     <string name="preferences_app_protection__communication">Communication</string>
+    <string name="preferences_app_protection__screenlock_requires_lollipop">Using the system screenlock requires Android 5.0 (Lollipop) or higher.</string>
+    <string name="preferences_app_protection__android_version_too_low">Android version too low</string>
     <string name="preferences_chats__chats">Chats</string>
     <string name="preferences_notifications__messages">Messages</string>
     <string name="preferences_notifications__events">Events</string>

--- a/src/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
@@ -318,19 +318,16 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
       if (Build.VERSION.SDK_INT >= 21) {
         TextSecurePreferences.setScreenLockEnabled(getContext(), screenlockEnabled);
         enableScreenLock.setChecked(screenlockEnabled);
-      }
-      else {
-        if (screenlockEnabled) {
-          TextSecurePreferences.setScreenLockEnabled(getContext(), false);
-          enableScreenLock.setChecked(false);
+      } else if (screenlockEnabled) {
+        TextSecurePreferences.setScreenLockEnabled(getContext(), false);
+        enableScreenLock.setChecked(false);
 
-          AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-          builder.setTitle(R.string.preferences_app_protection__android_version_too_low);
-          builder.setMessage(R.string.preferences_app_protection__screenlock_requires_lollipop);
-          builder.setIconAttribute(R.attr.dialog_alert_icon);
-          builder.setPositiveButton(android.R.string.ok, null);
-          builder.show();
-        }
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle(R.string.preferences_app_protection__android_version_too_low);
+        builder.setMessage(R.string.preferences_app_protection__screenlock_requires_lollipop);
+        builder.setIconAttribute(R.attr.dialog_alert_icon);
+        builder.setPositiveButton(android.R.string.ok, null);
+        builder.show();
       }
       return false;
     }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Xperia Z1 Compact, Android 4.4.4
 * Sony Xperia M4 Aqua, Android 5.0
 * Sony Xperia Z3 Compact, Android 6.0.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Locking Signal via a the Android screenlock can not be called on Android 4.4, but the user interface does not warn the user when he sets a screenlock on Android 4.4. It just silently does not work. This commit shows a user on Android 4.4 a popup screen that setting a screenlock is not possible and sets the toggle to disabled so the UI and the program agree with each orther.

On API >= 21 it changes nothing.