### PR TITLE
prevent spaces from disrubting checkboxes

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,12 +10,12 @@ If you are looking for support, please visit our support center:
 https://support.signal.org/
 or email support@signal.org
 
-Let's begin with a checklist: Replace the empty checkboxes [ ] below with checked ones [x] accordingly. -->
+Let's begin with a checklist: Replace the empty checkboxes [] below with checked ones [x] accordingly. -->
 
-- [ ] I have searched open and closed issues for duplicates
-- [ ] I am submitting a bug report for existing functionality that does not work as intended
-- [ ] I have read https://github.com/signalapp/Signal-Android/wiki/Submitting-useful-bug-reports
-- [ ] This isn't a feature request or a discussion topic
+- [] I have searched open and closed issues for duplicates
+- [] I am submitting a bug report for existing functionality that does not work as intended
+- [] I have read https://github.com/signalapp/Signal-Android/wiki/Submitting-useful-bug-reports
+- [] This isn't a feature request or a discussion topic
 
 ----------------------------------------
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,18 @@
 <!-- You can remove this first section if you have contributed before -->
 ### First time contributor checklist
-<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
-- [ ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
-- [ ] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)
+<!-- replace the empty checkboxes [] below with checked ones [x] accordingly -->
+- [] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
+- [] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)
 
 ### Contributor checklist
-<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
-- [ ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
-- [ ] I have tested my contribution on these devices:
+<!-- replace the empty checkboxes [] below with checked ones [x] accordingly -->
+- [] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
+- [] I have tested my contribution on these devices:
  * Device A, Android X.Y.Z
  * Device B, Android Z.Y
  * Virtual device W, Android Y.Y.Z
-- [ ] My contribution is fully baked and ready to be merged as is
-- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
+- [] My contribution is fully baked and ready to be merged as is
+- [] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
 
 ----------
 


### PR DESCRIPTION
Many users leave the spaces when checking the boxes, causing github to not render the box and not who the count of checked boxes. removing the whitespaces will prevent that.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [ ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
