### PR TITLE
Fix E164 pattern to redact shorter numbers

### DIFF
--- a/src/org/thoughtcrime/securesms/logsubmit/util/Scrubber.java
+++ b/src/org/thoughtcrime/securesms/logsubmit/util/Scrubber.java
@@ -32,9 +32,10 @@ public final class Scrubber {
 
   /**
    * The middle group will be censored.
+   * Supposedly, the shortest international phone numbers in use contain seven digits.
    * Handles URL encoded +, %2B
    */
-  private static final Pattern E164_PATTERN = Pattern.compile("(\\+|%2B)(\\d{8,13})(\\d{2})");
+  private static final Pattern E164_PATTERN = Pattern.compile("(\\+|%2B)(\\d{5,13})(\\d{2})");
   private static final String  E164_CENSOR  = "*************";
 
   /**

--- a/test/unitTest/java/org/thoughtcrime/securesms/logsubmit/util/ScrubberTest.java
+++ b/test/unitTest/java/org/thoughtcrime/securesms/logsubmit/util/ScrubberTest.java
@@ -28,11 +28,11 @@ public final class ScrubberTest {
     { "Multiple numbers +447700900001 +447700900002",
       "Multiple numbers +**********01 +**********02" },
 
-    { "One less than shortest number +155556789",
-      "One less than shortest number +155556789" },
+    { "One less than shortest number +155556",
+      "One less than shortest number +155556" },
 
-    { "Shortest number +1555567890",
-      "Shortest number +********90" },
+    { "Shortest number +1555567",
+      "Shortest number +*****67" },
 
     { "Longest number +155556789012345",
       "Longest number +*************45" },


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
  * Virtual device Intel Atom (x86), Android 9.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Some countries have phone numbers with fewer than ten digits. This PR updates the minimum required length for numbers in the log scrubber from 10 to 7 digits. Otherwise, it can fail to remove personally identifiable information (PII) from debuglogs in some countries.

* 7-digit countries
  * https://en.wikipedia.org/wiki/Telephone_numbers_in_Niue
  * https://en.wikipedia.org/wiki/Telephone_numbers_in_Saint_Helena_and_Tristan_da_Cunha
  * https://en.wikipedia.org/wiki/Telephone_numbers_in_Vanuatu
* 8-digit countries
  * https://en.wikipedia.org/wiki/Telephone_numbers_in_Tokelau
  * https://en.wikipedia.org/wiki/Telephone_numbers_in_the_Solomon_Islands
* 9-digit countries
  * https://en.wikipedia.org/wiki/Telephone_numbers_in_San_Marino

It can be are others, of course.

The maximum limit can also be extended to 17 digits, according to [libphonenumber's FAQ](https://github.com/google/libphonenumber/blob/master/FAQ.md#what-is-the-maximum-and-minimum-length-of-a-phone-number). However, it's difficult to prove that claim without additional information.

This PR is part of a series that were tested and reviewed in sigX+sigGesT thread https://community.signalusers.org/t/more-aggressively-remove-phone-numbers-metadata-from-logs/8424.
