### PR TITLE
Disappearing messages for call logs

### DIFF
--- a/res/layout/conversation_item_update.xml
+++ b/res/layout/conversation_item_update.xml
@@ -44,7 +44,7 @@
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="7dp"
+        android:layout_marginBottom="6dp"
         android:gravity="center"
         android:orientation="vertical">
 
@@ -59,13 +59,21 @@
             android:textColor="?attr/conversation_item_update_text_color"
             tools:text="Gwen Stacy set the disappearing message timer to 1 hour" />
 
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="7dp"
+        android:gravity="center"
+        android:orientation="horizontal">
+
         <TextView
             android:id="@+id/conversation_update_date"
             style="@style/Signal.Text.Caption"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:layout_marginTop="6dp"
             android:autoLink="none"
             android:gravity="center"
             android:linksClickable="false"
@@ -73,6 +81,15 @@
             android:textAllCaps="true"
             android:textColor="?conversation_item_update_text_color"
             tools:text="30 min ago" />
+
+        <org.thoughtcrime.securesms.components.ExpirationTimerView
+            android:id="@+id/conversation_update_expiration_timer"
+            android:layout_gravity="center_vertical|end"
+            android:layout_marginStart="6dp"
+            android:layout_width="12dp"
+            android:layout_height="12dp"
+            android:visibility="gone"
+            tools:visibility="visible"/>
 
     </LinearLayout>
 

--- a/src/org/thoughtcrime/securesms/components/ConversationItemFooter.java
+++ b/src/org/thoughtcrime/securesms/components/ConversationItemFooter.java
@@ -134,7 +134,7 @@ public class ConversationItemFooter extends LinearLayout {
                                          messageRecord.getExpiresIn());
         this.timerView.startAnimation();
 
-        if (messageRecord.getExpireStarted() + messageRecord.getExpiresIn() <= System.currentTimeMillis()) {
+        if (this.timerView.isExpired()) {
           ApplicationContext.getInstance(getContext()).getExpiringMessageManager().checkSchedule();
         }
       } else if (!messageRecord.isOutgoing() && !messageRecord.isMediaPending()) {

--- a/src/org/thoughtcrime/securesms/components/ExpirationTimerView.java
+++ b/src/org/thoughtcrime/securesms/components/ExpirationTimerView.java
@@ -59,6 +59,10 @@ public class ExpirationTimerView extends androidx.appcompat.widget.AppCompatImag
     setImageResource(frames[frame]);
   }
 
+  public boolean isExpired() {
+    return startedAt + expiresIn <= System.currentTimeMillis();
+  }
+
   public void startAnimation() {
     synchronized (this) {
       visible = true;

--- a/src/org/thoughtcrime/securesms/conversation/ConversationUpdateItem.java
+++ b/src/org/thoughtcrime/securesms/conversation/ConversationUpdateItem.java
@@ -166,7 +166,7 @@ public class ConversationUpdateItem extends LinearLayout
                                 messageRecord.getExpiresIn());
         timer.startAnimation();
 
-        if (messageRecord.getExpireStarted() + messageRecord.getExpiresIn() <= System.currentTimeMillis()) {
+        if (timer.isExpired()) {
           ApplicationContext.getInstance(getContext()).getExpiringMessageManager().checkSchedule();
         }
       } else if (!messageRecord.isOutgoing()) {

--- a/src/org/thoughtcrime/securesms/recipients/Recipient.java
+++ b/src/org/thoughtcrime/securesms/recipients/Recipient.java
@@ -339,6 +339,10 @@ public class Recipient {
     return expireMessages;
   }
 
+  public long getExpireMessagesInMillis() {
+    return getExpireMessages() * 1000L;
+  }
+
   public boolean hasSeenInviteReminder() {
     return seenInviteReminder;
   }


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
  * Samsung Galaxy S7 Edge, Android 6.0.1
  * Virtual device Intel Atom (x86), Android 9.0
  * Virtual device Intel Atom (x86), Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

It enables disappearing messages for call logs. Like existing disappearing messages, the expiration timer for messages also applies to call logs. Once disappearing messages is set for a particular chat, a timer icon appears on the righthand side of the call-log’s timestamp. When the timer expires, the call-log entry disappears.

Alice & Bob calls at 1:11am | Alice's handset a short while later
---|---
![Screenshot_1563102693.png](https://community.signalusers.org/uploads/db3609/original/2X/a/a67bf711ff2b8c71f9b49307cf39e247a0f4d394.png) | ![Screenshot_1563102966.png](https://community.signalusers.org/uploads/db3609/original/2X/e/e85b1f83dd87ee05d9da278391a1560c89dfb5c1.png)

Resolve #8923. Also, it fixes a possible bug: when you get a missed call, and you select “Mark as Read” in the notification popup, that action didn’t work properly for the call-log entries (not 100% sure about this, it happens during my testing).

This PR was discussed and tested in sigX+sigGesT. Link to forum:

https://community.signalusers.org/t/experiment-disappearing-call-logs/8464

I copy below the implementation details as it was presented there.

### Implementation details

Basically, the new code sets the EXPIRES_IN value within the database for each call-log item. The call logs are regular entries in the message store, so there is no need to modify the database schema – the EXPIRES_IN field is already there, just not getting utilized yet. Then, the code schedules the deletion of the call-log, if the expiration timer is non-zero.

The expiring timer code comes from another class “ConversationItemFooter”. The class where the call-logs are rendered (“ConversationUpdateItem”) manages the colors differently. I choose to not change anything more, and set the fill color of the timer icon the same way.

There is one subtle difference between disappearing-messages, and disappearing-call-logs. The expire-in value is a property of “DataMessage” in the protobuf schema. When you receive a regular message, this value (well, the minimum between this and your local expire-in value) is used to schedule when the message disappears. There is no such property for “CallMessage”, therefore, I always use the local expire-in value for call-logs.

For outgoing calls, it is not a problem. For incoming calls, it could be a problem – when the other party changes the disappearing-messages timer, sends the updated timer via sync-message, but we do not get that sync-message before receiving the incoming call via signal protocol. Not a big deal... and easy to fix, by extending “CallMessage” protobuf.

