### PR TITLE
Fix status bar height in RecipientPreferenceActivity for phones with notches

### DIFF
--- a/res/layout/recipient_preference_activity.xml
+++ b/res/layout/recipient_preference_activity.xml
@@ -6,6 +6,7 @@
         android:layout_height="match_parent"
         android:layout_marginStart="0dp"
         android:layout_marginEnd="0dp"
+        android:fitsSystemWindows="true"
         android:background="@color/transparent"
         xmlns:tools="http://schemas.android.com/tools">
 
@@ -13,18 +14,21 @@
             android:id="@+id/app_bar_layout"
             android:layout_width="match_parent"
             android:layout_height="300dp"
+            android:fitsSystemWindows="true"
             android:background="@color/transparent">
 
         <com.google.android.material.appbar.CollapsingToolbarLayout
                 android:id="@+id/collapsing_toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:fitsSystemWindows="true"
                 android:background="@color/transparent"
                 app:layout_scrollFlags="scroll|exitUntilCollapsed">
 
             <ImageView android:id="@+id/avatar"
                        android:layout_width="match_parent"
                        android:layout_height="match_parent"
+                       android:fitsSystemWindows="true"
                        android:transitionName="avatar"
                        app:layout_collapseMode="parallax"
                        app:layout_collapseParallaxMultiplier="0.7"/>
@@ -48,7 +52,6 @@
                     android:layout_height="?attr/actionBarSize"
                     android:theme="@style/TextSecure.LightActionBar"
                     android:background="@color/transparent"
-                    android:layout_marginTop="24dp"
                     app:layout_collapseMode="pin" >
 
             </androidx.appcompat.widget.Toolbar>

--- a/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
+++ b/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
@@ -223,6 +223,7 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
     this.avatar.setBackgroundColor(recipient.getColor().toActionBarColor(this));
     this.toolbarLayout.setTitle(recipient.toShortString());
     this.toolbarLayout.setContentScrimColor(recipient.getColor().toActionBarColor(this));
+    this.toolbarLayout.setStatusBarScrimColor(recipient.getColor().toActionBarColor(this));
   }
 
   @Override


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 3XL, Android 9
 * Virtual Pixel 3, Android SDK 28
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
The RecipientPreferenceActivity had a hard-coded value for the height of
the status bar, which resulted in a clipped toolbar on phones with notches
(due to the increased status bar height). This margin has been re-implemented
using the proper "fitsSystemWindows" attribute, which was designed for this
purpose.

This also has the side effect of dropping the top scrim to below the status bar,
which as far as I can tell, was the intended location for it in the first place.

I did not find any open issues for this bug. 

Note: The status bar color is set to the contact's action bar color
(`recipient.getColor().toActionBarColor(this)`), as a dark scrim
is drawn over it. If the status bar was set to the correct color (`recipient.getColor().toStatusBarColor(this)`), then the final result
would be too dark. This is how it was styled previously.

### Pictures

#### Before
![before-notch1](https://user-images.githubusercontent.com/6509035/64072831-105aff00-cc5b-11e9-806f-d1fb01e472d2.png)
![before-notch2](https://user-images.githubusercontent.com/6509035/64072832-105aff00-cc5b-11e9-8ae3-2aa7205c606f.png)

#### After
![after-notch1](https://user-images.githubusercontent.com/6509035/64072834-13ee8600-cc5b-11e9-8338-15e813f70d4f.png)
![after-notch2](https://user-images.githubusercontent.com/6509035/64072835-14871c80-cc5b-11e9-83ac-7ccb555ea305.png)
