### PR TITLE
Fix PassphrasePromptActivity status bar height

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -280,7 +280,6 @@
 
     <activity android:name=".PassphrasePromptActivity"
               android:launchMode="singleTask"
-              android:theme="@style/TextSecure.LightIntroTheme"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
     <activity android:name=".NewConversationActivity"

--- a/res/layout/prompt_passphrase_activity.xml
+++ b/res/layout/prompt_passphrase_activity.xml
@@ -25,8 +25,7 @@
     <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:layout_marginTop="20dp">
+            android:layout_height="?attr/actionBarSize">
 
         <ImageView
                 android:layout_width="wrap_content"

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -74,6 +74,7 @@
         <item name="windowNoTitle">true</item>
         <item name="windowActionModeOverlay">true</item>
         <item name="colorAccent">@color/signal_primary</item>
+        <item name="colorPrimaryDark">@color/textsecure_primary_dark</item>
 
         <item name="android:textColorHint">#cc000000</item>
         <item name="centered_app_title_color">#55000000</item>

--- a/src/org/thoughtcrime/securesms/PassphrasePromptActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphrasePromptActivity.java
@@ -92,8 +92,6 @@ public class PassphrasePromptActivity extends PassphraseActivity {
     Log.i(TAG, "onCreate()");
     dynamicTheme.onCreate(this);
     dynamicLanguage.onCreate(this);
-    getWindow().addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
-    getWindow().addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
     super.onCreate(savedInstanceState);
 
     setContentView(R.layout.prompt_passphrase_activity);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 3XL, Android 9
 * Virtual Pixel 3, Android SDK 28
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
The height of the status bar in PassphrasePromptActivity was set to a
hard-coded value that was too small for both notchless and notched
phones. This caused the toolbar to clip into the status bar. This PR 
fixes the issue by replacing the transparent nav and status bars with
opaque fixed ones. This has the added benefit of a more attractively
colored status bar.

If the transparency was set so that the nav bar matches the theme better, then the nav bar color can be changed manually to a white variant (as of API 27). 

This change has been tested on both light and dark themes.

Fixes #8653

### Screenshots

#### Before
![before-notchless](https://user-images.githubusercontent.com/6509035/64074778-6b015480-cc75-11e9-9d62-da4bdd7dea91.png)
![before-notch](https://user-images.githubusercontent.com/6509035/64074782-6ccb1800-cc75-11e9-98fd-d486b1de5b6c.png)

#### After
![after-notchless](https://user-images.githubusercontent.com/6509035/64074784-718fcc00-cc75-11e9-9e59-b4c3ca82ada7.png)
![after-notch](https://user-images.githubusercontent.com/6509035/64074785-72c0f900-cc75-11e9-9fad-8abb43c51bbb.png)
