### PR TITLE
Option for Signal install location (internal/external memory)

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
+          android:installLocation="auto"
           package="org.thoughtcrime.securesms">
 
     <uses-sdk tools:overrideLibrary="androidx.camera.core,androidx.camera.camera2"/>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] My contribution is fully baked and ready to be merged as is

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Following

https://developer.android.com/guide/topics/data/install-location.html

as originally pointed out at
https://community.signalusers.org/t/allow-installation-on-external-storage-location-sd-card/2638

Added option to allow the system to install Signal on the external storage.

Unfortunately, this feature request was closed automatically already twice.

My Signal database has reached some >7Gb size after which it is not possible to update the OS & apps without a
 
`backup Signal to SD -> uninstall Signal -> update -> install Signal again -> restore from SD backup`

sequence, which is very annoying.

I am aware of the issue
https://github.com/signalapp/Signal-Android/wiki/Data-loss-when-using-an-SD-Card-formatted-as-internal-memory
which I guess is likely caused by the official update overwriting the install option.

