### PR TITLE
Fix passphrase screen status bar

### DIFF
--- a/app/src/main/res/layout/prompt_passphrase_activity.xml
+++ b/app/src/main/res/layout/prompt_passphrase_activity.xml
@@ -22,19 +22,27 @@
 
     </FrameLayout>
 
-    <androidx.appcompat.widget.Toolbar
-            android:id="@+id/toolbar"
+    <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:layout_marginTop="20dp">
+            android:layout_height="wrap_content"
+            android:fitsSystemWindows="true">
 
-        <ImageView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:src="@drawable/icon_transparent"
-                android:layout_gravity="center"/>
+        <androidx.appcompat.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:fitsSystemWindows="true"
+                android:layout_height="?attr/actionBarSize">
 
-    </androidx.appcompat.widget.Toolbar>
+            <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/icon_transparent"
+                    android:layout_marginTop="8dp"
+                    android:layout_gravity="center"/>
+
+        </androidx.appcompat.widget.Toolbar>
+
+    </FrameLayout>
 
 
     <LinearLayout


### PR DESCRIPTION
Dynamically set padding for the toolbar. Fixes #8653

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device Google Pixel 3 XL, Android 10.0
 * Device Samsung Galaxy S10+, Android 9.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
The top margin height of the toolbar was hardcoded resulting in toolbar being behind statusbar or clipped by the notch on some of the devices like Pixel 3 XL. This commit leverages the fitsSystemWindows to dynamically set padding for the toolbar.