### PR TITLE
Shared links cleaner

### DIFF
--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -1070,6 +1070,8 @@ Vous avez reçu un message d’échange de clés pour une version de protocole i
   <string name="preferences__pressing_the_enter_key_will_send_text_messages">Appuyer sur la touche Entrée enverra les textos</string>
   <string name="preferences__send_link_previews">Envoyer des aperçus de liens</string>
   <string name="preferences__previews_are_supported_for">Les aperçus sont pris en charge pour les liens Imgur, Instagram, Pinterest, Reddit et YouTube</string>
+  <string name="preferences__clean_shared_links">Nettoyer les liens partagés</string>
+  <string name="preferences__clean_shared_links_description">Supprime les balises de pistage les plus courantes des liens que vous partagez à vos contacts dans Signal.</string>
   <string name="preferences__choose_identity">Choisir une identité</string>
   <string name="preferences__choose_your_contact_entry_from_the_contacts_list">Choisissez votre entrée de contact dans la liste des contacts.</string>
   <string name="preferences__change_passphrase">Changer la phrase de passe</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -1070,8 +1070,6 @@ Vous avez reçu un message d’échange de clés pour une version de protocole i
   <string name="preferences__pressing_the_enter_key_will_send_text_messages">Appuyer sur la touche Entrée enverra les textos</string>
   <string name="preferences__send_link_previews">Envoyer des aperçus de liens</string>
   <string name="preferences__previews_are_supported_for">Les aperçus sont pris en charge pour les liens Imgur, Instagram, Pinterest, Reddit et YouTube</string>
-  <string name="preferences__clean_shared_links">Nettoyer les liens partagés</string>
-  <string name="preferences__clean_shared_links_description">Supprime les balises de pistage les plus courantes des liens que vous partagez à vos contacts dans Signal.</string>
   <string name="preferences__choose_identity">Choisir une identité</string>
   <string name="preferences__choose_your_contact_entry_from_the_contacts_list">Choisissez votre entrée de contact dans la liste des contacts.</string>
   <string name="preferences__change_passphrase">Changer la phrase de passe</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1294,6 +1294,8 @@
     <string name="preferences__pressing_the_enter_key_will_send_text_messages">Pressing the Enter key will send text messages</string>
     <string name="preferences__send_link_previews">Send link previews</string>
     <string name="preferences__previews_are_supported_for">Previews are supported for Imgur, Instagram, Pinterest, Reddit, and YouTube links</string>
+    <string name="preferences__clean_shared_links">Clean up shared links</string>
+    <string name="preferences__clean_shared_links_description">Remove most common trackers from links you share to others in Signal.</string>
     <string name="preferences__choose_identity">Choose identity</string>
     <string name="preferences__choose_your_contact_entry_from_the_contacts_list">Choose your contact entry from the contacts list.</string>
     <string name="preferences__change_passphrase">Change passphrase</string>

--- a/res/xml/preferences_app_protection.xml
+++ b/res/xml/preferences_app_protection.xml
@@ -75,6 +75,12 @@
             android:summary="@string/preferences__previews_are_supported_for"
             android:title="@string/preferences__send_link_previews"/>
 
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="pref_clean_shared_links"
+            android:title="@string/preferences__clean_shared_links"
+            android:summary="@string/preferences__clean_shared_links_description"/>
+
         <Preference android:key="preference_category_blocked"
                     android:title="@string/preferences_app_protection__blocked_contacts" />
     </PreferenceCategory>

--- a/src/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/org/thoughtcrime/securesms/ShareActivity.java
@@ -51,6 +51,7 @@ import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicNoActionBarTheme;
 import org.thoughtcrime.securesms.util.DynamicTheme;
 import org.thoughtcrime.securesms.util.FileUtils;
+import org.thoughtcrime.securesms.util.LinkCleaner;
 import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.util.ViewUtil;
@@ -253,7 +254,13 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity
 
   private Intent getBaseShareIntent(final @NonNull Class<?> target) {
     final Intent           intent       = new Intent(this, target);
-    final String           textExtra    = getIntent().getStringExtra(Intent.EXTRA_TEXT);
+    final String           textExtra;
+    if (Intent.ACTION_SEND.equals(getIntent().getAction())
+        && "text/plain".equals(getIntent().getType())) {
+      textExtra = LinkCleaner.cleanText(getIntent().getStringExtra(Intent.EXTRA_TEXT));
+    } else {
+      textExtra = getIntent().getStringExtra(Intent.EXTRA_TEXT);
+    }
     final ArrayList<Media> mediaExtra   = getIntent().getParcelableArrayListExtra(ConversationActivity.MEDIA_EXTRA);
     final StickerLocator   stickerExtra = getIntent().getParcelableExtra(ConversationActivity.STICKER_EXTRA);
 

--- a/src/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/org/thoughtcrime/securesms/ShareActivity.java
@@ -255,7 +255,8 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity
   private Intent getBaseShareIntent(final @NonNull Class<?> target) {
     final Intent           intent       = new Intent(this, target);
     final String           textExtra;
-    if (Intent.ACTION_SEND.equals(getIntent().getAction())
+    if (TextSecurePreferences.isCleanSharedLinksEnabled(this)
+        && Intent.ACTION_SEND.equals(getIntent().getAction())
         && "text/plain".equals(getIntent().getType())) {
       textExtra = LinkCleaner.cleanText(getIntent().getStringExtra(Intent.EXTRA_TEXT));
     } else {

--- a/src/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
@@ -53,6 +53,7 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
     this.findPreference(TextSecurePreferences.READ_RECEIPTS_PREF).setOnPreferenceChangeListener(new ReadReceiptToggleListener());
     this.findPreference(TextSecurePreferences.TYPING_INDICATORS).setOnPreferenceChangeListener(new TypingIndicatorsToggleListener());
     this.findPreference(TextSecurePreferences.LINK_PREVIEWS).setOnPreferenceChangeListener(new LinkPreviewToggleListener());
+    this.findPreference(TextSecurePreferences.CLEAN_SHARED_LINKS).setOnPreferenceChangeListener(new cleanSharedLinksToggleListener());
     this.findPreference(PREFERENCE_CATEGORY_BLOCKED).setOnPreferenceClickListener(new BlockedContactsClickListener());
     this.findPreference(TextSecurePreferences.SHOW_UNIDENTIFIED_DELIVERY_INDICATORS).setOnPreferenceChangeListener(new ShowUnidentifiedDeliveryIndicatorsChangedListener());
     this.findPreference(TextSecurePreferences.UNIVERSAL_UNIDENTIFIED_ACCESS).setOnPreferenceChangeListener(new UniversalUnidentifiedAccessChangedListener());
@@ -207,6 +208,16 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
                                                                                         TextSecurePreferences.isTypingIndicatorsEnabled(requireContext()),
                                                                                         TextSecurePreferences.isShowUnidentifiedDeliveryIndicatorsEnabled(requireContext()),
                                                                                         enabled));
+
+      return true;
+    }
+  }
+
+  private class cleanSharedLinksToggleListener implements Preference.OnPreferenceChangeListener {
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+      boolean enabled = (boolean)newValue;
+      TextSecurePreferences.setCleanSharedLinksEnabled(getActivity(), enabled);
 
       return true;
     }

--- a/src/org/thoughtcrime/securesms/util/LinkCleaner.java
+++ b/src/org/thoughtcrime/securesms/util/LinkCleaner.java
@@ -1,0 +1,56 @@
+package org.thoughtcrime.securesms.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import android.util.Patterns;
+
+public class LinkCleaner {
+
+  private final static String CLEANING_REGEX = "(?i)(\\?|&)(utm_[a-z_]*|ocid|fbclid|igshid)=([^&]+)";
+
+  public static String cleanText(String text) {
+    Matcher linksMatcher = Patterns.WEB_URL.matcher(text);
+    String originalLink, cleanLink;
+    while (linksMatcher.find()) {
+      originalLink = linksMatcher.group();
+      cleanLink    = cleanLink(originalLink);
+      if (!originalLink.equals(cleanLink)) {
+        text = text.replace(originalLink, cleanLink);
+      }
+    }
+    return text;
+  }
+
+  private static String cleanLink(String link) {
+    Matcher regexMatcher = Pattern.compile(CLEANING_REGEX).matcher(link);
+    if (regexMatcher.find()) {
+      link = firstMatch(regexMatcher, link);
+      while (regexMatcher.find()) {
+        link = removeTracker(link, regexMatcher.group(0));
+      }
+      link = cleanUpEndResult(link);
+    }
+    return link;
+  }
+
+  private static String removeTracker(String link, String tracker) {
+    return link.replace(tracker, "");
+  }
+
+  private static String firstMatch(Matcher regexMatcher, String link) {
+    if (regexMatcher.group(1).equals("?")) {
+      return removeTracker(link, regexMatcher.group(0).substring(1));
+    } else {
+      return removeTracker(link, regexMatcher.group(0));
+    }
+  }
+
+  private static String cleanUpEndResult(String link) {
+    link = link.replace("?&", "?");
+    if (link.charAt(link.length() - 1) == '?') {
+      link = link.substring(0, link.length() - 1);
+    }
+    return link;
+  }
+}
+

--- a/src/org/thoughtcrime/securesms/util/LinkCleaner.java
+++ b/src/org/thoughtcrime/securesms/util/LinkCleaner.java
@@ -2,14 +2,14 @@ package org.thoughtcrime.securesms.util;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import android.util.Patterns;
+import androidx.core.util.PatternsCompat;
 
 public class LinkCleaner {
 
   private final static String CLEANING_REGEX = "(?i)(\\?|&)(utm_[a-z_]*|ocid|fbclid|igshid)=([^&]+)";
 
   public static String cleanText(String text) {
-    Matcher linksMatcher = Patterns.WEB_URL.matcher(text);
+    Matcher linksMatcher = PatternsCompat.WEB_URL.matcher(text);
     String originalLink, cleanLink;
     while (linksMatcher.find()) {
       originalLink = linksMatcher.group();
@@ -53,4 +53,3 @@ public class LinkCleaner {
     return link;
   }
 }
-

--- a/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -177,6 +177,8 @@ public class TextSecurePreferences {
 
   public static final String LINK_PREVIEWS = "pref_link_previews";
 
+  public static final String CLEAN_SHARED_LINKS = "pref_clean_shared_links";
+
   private static final String GIF_GRID_LAYOUT = "pref_gif_grid_layout";
 
   private static final String SEEN_STICKER_INTRO_TOOLTIP = "pref_seen_sticker_intro_tooltip";
@@ -380,6 +382,14 @@ public class TextSecurePreferences {
 
   public static boolean isLinkPreviewsEnabled(Context context) {
     return getBooleanPreference(context, LINK_PREVIEWS, true);
+  }
+
+  public static boolean isCleanSharedLinksEnabled(Context context) {
+    return getBooleanPreference(context, CLEAN_SHARED_LINKS, true);
+  }
+
+  public static void setCleanSharedLinksEnabled(Context context, boolean enabled) {
+    setBooleanPreference(context, CLEAN_SHARED_LINKS, enabled);
   }
 
   public static boolean isGifSearchInGridLayout(Context context) {

--- a/test/unitTest/java/org/thoughtcrime/securesms/util/LinkCleanerTest.java
+++ b/test/unitTest/java/org/thoughtcrime/securesms/util/LinkCleanerTest.java
@@ -1,0 +1,39 @@
+package org.thoughtcrime.securesms.util;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+
+public class LinkCleanerTest {
+
+  @Test
+  public void testCleanText_linkWithTrackersOnly() {
+    String dirtyLink = "https://www.this-test.org/index.php?fbclid=feA9DGOf842eEA_12d&utm_source=wonderland";
+    String cleanLink = "https://www.this-test.org/index.php";
+    assertEquals(cleanLink, LinkCleaner.cleanText(dirtyLink));
+  }
+
+  @Test
+  public void cleanText_linkWithoutTrackers() {
+    String link = "https://en.wikipedia.org/w/index.php?title=Special:UserLogin&returnto=Wikipedia";
+    assertEquals(link, LinkCleaner.cleanText(link));
+  }
+
+  @Test
+  public void cleanText_linkWithMixedContent() {
+    String dirtyLink = "https://www.random-forum.com/post.php?igshid=ex3T8Ann72_tE&id=123456&utm_media=social";
+    String cleanLink = "https://www.random-forum.com/post.php?id=123456";
+    assertEquals(cleanLink, LinkCleaner.cleanText(dirtyLink));
+  }
+
+  @Test
+  public void cleanText_longText() {
+    String dirtyText = "https://hello.world/projects/template.html?ocid=IwAR38aoZHqjWAbwzwrpcY7yLs" +
+        "http://i.am.a.clean/link.php?user=Foo&feature=bar" +
+        " Loremipsumhttps://instathing.com/image.htm?utm_campaign=buffer dolor sit amet.";
+    String cleanText = "https://hello.world/projects/template.html" +
+        "http://i.am.a.clean/link.php?user=Foo&feature=bar" +
+        " Loremipsumhttps://instathing.com/image.htm dolor sit amet.";
+    assertEquals(cleanText, LinkCleaner.cleanText(dirtyText));
+  }
+}


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Xiaomi Redmi Note 5, Android 9.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Contacts using Facebook, Instagram and other platforms always share links containing tracking parameters such as **fbclid** and **igshid**. This PR is about automatically removing said trackers when Signal receives text to share.

Since the development ideology of the project warns about implementing user-facing features, this PR includes 2 commits. The first one with the links cleaning feature always activated. And the second one adding a user-facing switch (in *Settings > Privacy*) to control this feature.

I tested it with both commits, by sharing:
- A link containing trackers only
- A link not containing trackers
- A link containing trackers and useful parameters
- A long text with several links containing trackers and useful parameters
- Image(s)

**Note:** it removes the following trackers: `utm_*`, `ocid`, `fbclid` and `igshid`.
