### PR TITLE
Add Xiaomi Mi A2 to echo cancellation blacklist

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -303,6 +303,7 @@ public class ApplicationContext extends MultiDexApplication implements DefaultLi
         add("Moto G4");
         add("TA-1053");
         add("Mi A1");
+        add("Mi A2");
         add("E5823"); // Sony z5 compact
         add("Redmi Note 5");
         add("FP2"); // Fairphone FP2


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Xiaomi Mi A2
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Currently echo cancellation on the Xiaomi Mi A2 does not work for me and other users (see https://github.com/signalapp/Signal-Android/issues/7635#issuecomment-552225012). This pull request adds the device to the hardware echo cancellation blacklist.
