### PR TITLE
Use Galois/Counter Mode 

### DIFF
--- a/src/org/thoughtcrime/securesms/crypto/ClassicDecryptingPartInputStream.java
+++ b/src/org/thoughtcrime/securesms/crypto/ClassicDecryptingPartInputStream.java
@@ -59,7 +59,7 @@ public class ClassicDecryptingPartInputStream {
       byte[]          ivBytes    = new byte[IV_LENGTH];
       readFully(fileStream, ivBytes);
 
-      Cipher          cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+      Cipher          cipher = Cipher.getInstance("AES/GCM/NoPadding");
       IvParameterSpec iv     = new IvParameterSpec(ivBytes);
       cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(attachmentSecret.getClassicCipherKey(), "AES"), iv);
 

--- a/src/org/thoughtcrime/securesms/crypto/MasterCipher.java
+++ b/src/org/thoughtcrime/securesms/crypto/MasterCipher.java
@@ -65,8 +65,8 @@ public class MasterCipher {
   public MasterCipher(MasterSecret masterSecret) {
     try {
       this.masterSecret = masterSecret;		
-      this.encryptingCipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
-      this.decryptingCipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+      this.encryptingCipher = Cipher.getInstance("AES/GCM/NoPadding");
+      this.decryptingCipher = Cipher.getInstance("AES/GCM/NoPadding");
       this.hmac             = Mac.getInstance("HmacSHA1");
     } catch (NoSuchPaddingException | NoSuchAlgorithmException nspe) {
       throw new AssertionError(nspe);

--- a/src/org/thoughtcrime/securesms/logging/LogFile.java
+++ b/src/org/thoughtcrime/securesms/logging/LogFile.java
@@ -43,7 +43,7 @@ class LogFile {
       this.outputStream = new BufferedOutputStream(new FileOutputStream(file, true));
 
       try {
-        this.cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        this.cipher =  Cipher.getInstance("AES/CBC/PKCS5Padding");
       } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
         throw new AssertionError(e);
       }
@@ -94,7 +94,7 @@ class LogFile {
       this.inputStream = new BufferedInputStream(new FileInputStream(file));
 
       try {
-        this.cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        this.cipher =  Cipher.getInstance("AES/GCM/NoPadding");
       } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
         throw new AssertionError(e);
       }


### PR DESCRIPTION

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
After analyzing the code with sonarqube, sonar detects that the Advanced Encryption Standard (AES) encryption algorithm can be used with various modes. Some combinations are not secured:

Electronic Codebook (ECB) mode: Under a given key, any given plaintext block always gets encrypted to the same ciphertext block. Thus, it does not hide data patterns well. In some senses, it doesn't provide serious message confidentiality, and it is not recommended for use in cryptographic protocols at all.
Cipher Block Chaining (CBC) with PKCS#5 padding (or PKCS#7) is susceptible to padding oracle attacks.
In both cases, Galois/Counter Mode (GCM) with no padding should be preferred.