### PR TITLE
Memory leaks

### DIFF
--- a/src/org/thoughtcrime/securesms/util/task/InitializeSecurityAsyncTask.java
+++ b/src/org/thoughtcrime/securesms/util/task/InitializeSecurityAsyncTask.java
@@ -1,0 +1,86 @@
+package org.thoughtcrime.securesms.util.task;
+
+import android.content.Context;
+import android.os.AsyncTask;
+
+import org.thoughtcrime.securesms.contacts.sync.DirectoryHelper;
+import org.thoughtcrime.securesms.conversation.ConversationActivity;
+import org.thoughtcrime.securesms.database.RecipientDatabase;
+import org.thoughtcrime.securesms.logging.Log;
+import org.thoughtcrime.securesms.recipients.Recipient;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
+import org.thoughtcrime.securesms.util.Util;
+import org.thoughtcrime.securesms.util.concurrent.SettableFuture;
+
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+
+public class InitializeSecurityAsyncTask extends AsyncTask<Recipient, Void, boolean[]> {
+
+
+    private long threadId;
+
+    private boolean currentSecureText;
+
+    private boolean currentIsDefaultSms;
+
+    private SettableFuture<Boolean> future;
+
+    private WeakReference<Context> contextWeakReference;
+
+    private WeakReference<ConversationActivity> activityWeakReference;
+
+    private String tag;
+
+    public InitializeSecurityAsyncTask(long threadId, boolean currentSecureText, boolean currentIsDefaultSms, SettableFuture<Boolean> future, WeakReference<Context> contextWeakReference, WeakReference<ConversationActivity> activityWeakReference, String tag) {
+        this.threadId = threadId;
+        this.currentSecureText = currentSecureText;
+        this.currentIsDefaultSms = currentIsDefaultSms;
+        this.future = future;
+        this.contextWeakReference = contextWeakReference;
+        this.activityWeakReference = activityWeakReference;
+        this.tag = tag;
+    }
+
+    @Override
+    protected boolean[] doInBackground(Recipient... params) {
+        Context context = contextWeakReference.get();
+        Recipient recipient = params[0].resolve();
+        Log.i(tag, "Resolving registered state...");
+        RecipientDatabase.RegisteredState registeredState;
+
+        if (recipient.isPushGroup()) {
+            Log.i(tag, "Push group recipient...");
+            registeredState = RecipientDatabase.RegisteredState.REGISTERED;
+        } else {
+            Log.i(tag, "Checking through resolved recipient");
+            registeredState = recipient.resolve().getRegistered();
+        }
+
+        Log.i(tag, "Resolved registered state: " + registeredState);
+        boolean signalEnabled = TextSecurePreferences.isPushRegistered(context);
+
+        if (registeredState == RecipientDatabase.RegisteredState.UNKNOWN) {
+            try {
+                Log.i(tag, "Refreshing directory for user: " + recipient.getId().serialize());
+                registeredState = DirectoryHelper.refreshDirectoryFor(context, recipient, false);
+            } catch (IOException e) {
+                Log.w(tag, e);
+            }
+        }
+
+        Log.i(tag, "Returning registered state...");
+        return new boolean[]{registeredState == RecipientDatabase.RegisteredState.REGISTERED && signalEnabled,
+                Util.isDefaultSmsProvider(context)};
+    }
+
+    @Override
+    protected void onPostExecute(boolean[] result) {
+        if (result[0] != currentSecureText || result[1] != currentIsDefaultSms) {
+            Log.i(tag, "onPostExecute() handleSecurityChange: " + result[0] + " , " + result[1]);
+            activityWeakReference.get().handleSecurityChange(result[0], result[1]);
+        }
+        future.set(true);
+        activityWeakReference.get().onSecurityUpdated();
+    }
+}

--- a/src/org/thoughtcrime/securesms/util/task/InitializeSecurityAsyncTask.java
+++ b/src/org/thoughtcrime/securesms/util/task/InitializeSecurityAsyncTask.java
@@ -15,72 +15,75 @@ import org.thoughtcrime.securesms.util.concurrent.SettableFuture;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 
+/**
+* AsyncTask class to initialize the security of a conversation in background
+**/
 public class InitializeSecurityAsyncTask extends AsyncTask<Recipient, Void, boolean[]> {
 
 
-    private long threadId;
+  private long threadId;
 
-    private boolean currentSecureText;
+  private boolean currentSecureText;
 
-    private boolean currentIsDefaultSms;
+  private boolean currentIsDefaultSms;
 
-    private SettableFuture<Boolean> future;
+  private SettableFuture<Boolean> future;
 
-    private WeakReference<Context> contextWeakReference;
+  private WeakReference<Context> contextWeakReference;
 
-    private WeakReference<ConversationActivity> activityWeakReference;
+  private WeakReference<ConversationActivity> activityWeakReference;
 
-    private String tag;
+  private String tag;
 
-    public InitializeSecurityAsyncTask(long threadId, boolean currentSecureText, boolean currentIsDefaultSms, SettableFuture<Boolean> future, WeakReference<Context> contextWeakReference, WeakReference<ConversationActivity> activityWeakReference, String tag) {
-        this.threadId = threadId;
-        this.currentSecureText = currentSecureText;
-        this.currentIsDefaultSms = currentIsDefaultSms;
-        this.future = future;
-        this.contextWeakReference = contextWeakReference;
-        this.activityWeakReference = activityWeakReference;
-        this.tag = tag;
+  public InitializeSecurityAsyncTask(long threadId, boolean currentSecureText, boolean currentIsDefaultSms, SettableFuture<Boolean> future, WeakReference<Context> contextWeakReference, WeakReference<ConversationActivity> activityWeakReference, String tag) {
+    this.threadId = threadId;
+    this.currentSecureText = currentSecureText;
+    this.currentIsDefaultSms = currentIsDefaultSms;
+    this.future = future;
+    this.contextWeakReference = contextWeakReference;
+    this.activityWeakReference = activityWeakReference;
+    this.tag = tag;
+  }
+
+  @Override
+  protected boolean[] doInBackground(Recipient... params) {
+    Context context = contextWeakReference.get();
+    Recipient recipient = params[0].resolve();
+    Log.i(tag, "Resolving registered state...");
+    RecipientDatabase.RegisteredState registeredState;
+
+    if (recipient.isPushGroup()) {
+      Log.i(tag, "Push group recipient...");
+      registeredState = RecipientDatabase.RegisteredState.REGISTERED;
+    } else {
+      Log.i(tag, "Checking through resolved recipient");
+      registeredState = recipient.resolve().getRegistered();
     }
 
-    @Override
-    protected boolean[] doInBackground(Recipient... params) {
-        Context context = contextWeakReference.get();
-        Recipient recipient = params[0].resolve();
-        Log.i(tag, "Resolving registered state...");
-        RecipientDatabase.RegisteredState registeredState;
+    Log.i(tag, "Resolved registered state: " + registeredState);
+    boolean signalEnabled = TextSecurePreferences.isPushRegistered(context);
 
-        if (recipient.isPushGroup()) {
-            Log.i(tag, "Push group recipient...");
-            registeredState = RecipientDatabase.RegisteredState.REGISTERED;
-        } else {
-            Log.i(tag, "Checking through resolved recipient");
-            registeredState = recipient.resolve().getRegistered();
-        }
-
-        Log.i(tag, "Resolved registered state: " + registeredState);
-        boolean signalEnabled = TextSecurePreferences.isPushRegistered(context);
-
-        if (registeredState == RecipientDatabase.RegisteredState.UNKNOWN) {
-            try {
-                Log.i(tag, "Refreshing directory for user: " + recipient.getId().serialize());
-                registeredState = DirectoryHelper.refreshDirectoryFor(context, recipient, false);
-            } catch (IOException e) {
-                Log.w(tag, e);
-            }
-        }
-
-        Log.i(tag, "Returning registered state...");
-        return new boolean[]{registeredState == RecipientDatabase.RegisteredState.REGISTERED && signalEnabled,
-                Util.isDefaultSmsProvider(context)};
+    if (registeredState == RecipientDatabase.RegisteredState.UNKNOWN) {
+      try {
+        Log.i(tag, "Refreshing directory for user: " + recipient.getId().serialize());
+        registeredState = DirectoryHelper.refreshDirectoryFor(context, recipient, false);
+      } catch (IOException e) {
+        Log.w(tag, e);
+      }
     }
 
-    @Override
-    protected void onPostExecute(boolean[] result) {
-        if (result[0] != currentSecureText || result[1] != currentIsDefaultSms) {
-            Log.i(tag, "onPostExecute() handleSecurityChange: " + result[0] + " , " + result[1]);
-            activityWeakReference.get().handleSecurityChange(result[0], result[1]);
-        }
-        future.set(true);
-        activityWeakReference.get().onSecurityUpdated();
+    Log.i(tag, "Returning registered state...");
+    return new boolean[]{registeredState == RecipientDatabase.RegisteredState.REGISTERED && signalEnabled,
+        Util.isDefaultSmsProvider(context)};
+  }
+
+  @Override
+  protected void onPostExecute(boolean[] result) {
+    if (result[0] != currentSecureText || result[1] != currentIsDefaultSms) {
+      Log.i(tag, "onPostExecute() handleSecurityChange: " + result[0] + " , " + result[1]);
+      activityWeakReference.get().handleSecurityChange(result[0], result[1]);
     }
+    future.set(true);
+    activityWeakReference.get().onSecurityUpdated();
+  }
 }

--- a/src/org/thoughtcrime/securesms/util/task/SaveDraftAsyncTask.java
+++ b/src/org/thoughtcrime/securesms/util/task/SaveDraftAsyncTask.java
@@ -13,49 +13,52 @@ import org.thoughtcrime.securesms.util.concurrent.SettableFuture;
 
 import java.lang.ref.WeakReference;
 
+/**
+* AsyncTask class to save the message draft in background 
+**/
 public class SaveDraftAsyncTask extends AsyncTask<Long, Void, Long> {
 
-    private WeakReference<Context> contextWeakReference;
+  private WeakReference<Context> contextWeakReference;
 
-    private Recipient recipient;
+  private Recipient recipient;
 
-    private int thisDistributionType;
+  private int thisDistributionType;
 
-    private DraftDatabase.Drafts drafts;
+  private DraftDatabase.Drafts drafts;
 
-    private SettableFuture<Long> future;
+  private SettableFuture<Long> future;
 
-    public SaveDraftAsyncTask(WeakReference<Context> contextWeakReference, WeakReference<ConversationActivity> activityWeakReference, Recipient recipient, int thisDistributionType, DraftDatabase.Drafts drafts, SettableFuture<Long> future) {
-        this.contextWeakReference = contextWeakReference;
-        this.recipient = recipient;
-        this.thisDistributionType = thisDistributionType;
-        this.drafts = drafts;
-        this.future = future;
+  public SaveDraftAsyncTask(WeakReference<Context> contextWeakReference, WeakReference<ConversationActivity> activityWeakReference, Recipient recipient, int thisDistributionType, DraftDatabase.Drafts drafts, SettableFuture<Long> future) {
+    this.contextWeakReference = contextWeakReference;
+    this.recipient = recipient;
+    this.thisDistributionType = thisDistributionType;
+    this.drafts = drafts;
+    this.future = future;
+  }
+
+  @Override
+  protected Long doInBackground(Long... params) {
+    ThreadDatabase threadDatabase = DatabaseFactory.getThreadDatabase(contextWeakReference.get());
+    DraftDatabase draftDatabase = DatabaseFactory.getDraftDatabase(contextWeakReference.get());
+    long threadId = params[0];
+
+    if (drafts.size() > 0) {
+      if (threadId == -1)
+        threadId = threadDatabase.getThreadIdFor(recipient, thisDistributionType);
+
+      draftDatabase.insertDrafts(threadId, drafts);
+      threadDatabase.updateSnippet(threadId, drafts.getSnippet(contextWeakReference.get()),
+          drafts.getUriSnippet(),
+          System.currentTimeMillis(), MmsSmsColumns.Types.BASE_DRAFT_TYPE, true);
+    } else if (threadId > 0) {
+      threadDatabase.update(threadId, false);
     }
 
-    @Override
-    protected Long doInBackground(Long... params) {
-        ThreadDatabase threadDatabase = DatabaseFactory.getThreadDatabase(contextWeakReference.get());
-        DraftDatabase draftDatabase = DatabaseFactory.getDraftDatabase(contextWeakReference.get());
-        long threadId = params[0];
+    return threadId;
+  }
 
-        if (drafts.size() > 0) {
-            if (threadId == -1)
-                threadId = threadDatabase.getThreadIdFor(recipient, thisDistributionType);
-
-            draftDatabase.insertDrafts(threadId, drafts);
-            threadDatabase.updateSnippet(threadId, drafts.getSnippet(contextWeakReference.get()),
-                    drafts.getUriSnippet(),
-                    System.currentTimeMillis(), MmsSmsColumns.Types.BASE_DRAFT_TYPE, true);
-        } else if (threadId > 0) {
-            threadDatabase.update(threadId, false);
-        }
-
-        return threadId;
-    }
-
-    @Override
-    protected void onPostExecute(Long result) {
-        future.set(result);
-    }
+  @Override
+  protected void onPostExecute(Long result) {
+    future.set(result);
+  }
 }

--- a/src/org/thoughtcrime/securesms/util/task/SaveDraftAsyncTask.java
+++ b/src/org/thoughtcrime/securesms/util/task/SaveDraftAsyncTask.java
@@ -1,0 +1,61 @@
+package org.thoughtcrime.securesms.util.task;
+
+import android.content.Context;
+import android.os.AsyncTask;
+
+import org.thoughtcrime.securesms.conversation.ConversationActivity;
+import org.thoughtcrime.securesms.database.DatabaseFactory;
+import org.thoughtcrime.securesms.database.DraftDatabase;
+import org.thoughtcrime.securesms.database.MmsSmsColumns;
+import org.thoughtcrime.securesms.database.ThreadDatabase;
+import org.thoughtcrime.securesms.recipients.Recipient;
+import org.thoughtcrime.securesms.util.concurrent.SettableFuture;
+
+import java.lang.ref.WeakReference;
+
+public class SaveDraftAsyncTask extends AsyncTask<Long, Void, Long> {
+
+    private WeakReference<Context> contextWeakReference;
+
+    private Recipient recipient;
+
+    private int thisDistributionType;
+
+    private DraftDatabase.Drafts drafts;
+
+    private SettableFuture<Long> future;
+
+    public SaveDraftAsyncTask(WeakReference<Context> contextWeakReference, WeakReference<ConversationActivity> activityWeakReference, Recipient recipient, int thisDistributionType, DraftDatabase.Drafts drafts, SettableFuture<Long> future) {
+        this.contextWeakReference = contextWeakReference;
+        this.recipient = recipient;
+        this.thisDistributionType = thisDistributionType;
+        this.drafts = drafts;
+        this.future = future;
+    }
+
+    @Override
+    protected Long doInBackground(Long... params) {
+        ThreadDatabase threadDatabase = DatabaseFactory.getThreadDatabase(contextWeakReference.get());
+        DraftDatabase draftDatabase = DatabaseFactory.getDraftDatabase(contextWeakReference.get());
+        long threadId = params[0];
+
+        if (drafts.size() > 0) {
+            if (threadId == -1)
+                threadId = threadDatabase.getThreadIdFor(recipient, thisDistributionType);
+
+            draftDatabase.insertDrafts(threadId, drafts);
+            threadDatabase.updateSnippet(threadId, drafts.getSnippet(contextWeakReference.get()),
+                    drafts.getUriSnippet(),
+                    System.currentTimeMillis(), MmsSmsColumns.Types.BASE_DRAFT_TYPE, true);
+        } else if (threadId > 0) {
+            threadDatabase.update(threadId, false);
+        }
+
+        return threadId;
+    }
+
+    @Override
+    protected void onPostExecute(Long result) {
+        future.set(result);
+    }
+}


### PR DESCRIPTION
### First time contributor checklist
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * OnePlus 7 Pro Android 10 
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
As Described in #9220, there are memory leaks in the ConversationActivity. This PR aims to solve the ones that happen when opening and closing the activity. The AsyncTasks created in the initializeSecurity() and saveDraft() methods have implicit references to the activity. By moving the code of these AsyncTasks to separate classes and making weak references to the activity, these references are not created and the memory can be liberated. As seen in the memory profiling below, when the app is put in background, memory can be freed up.
![asdf](https://user-images.githubusercontent.com/18556257/69491709-be470580-0e66-11ea-9be8-102bc9ecbab4.png)
