### PR TITLE
Fixes #9173: remove blank config overrides

### DIFF
--- a/src/org/thoughtcrime/securesms/mms/IncomingLollipopMmsConnection.java
+++ b/src/org/thoughtcrime/securesms/mms/IncomingLollipopMmsConnection.java
@@ -26,6 +26,8 @@ import androidx.annotation.Nullable;
 
 import android.os.Bundle;
 import android.telephony.SmsManager;
+import android.text.TextUtils;
+
 import org.thoughtcrime.securesms.logging.Log;
 
 import com.google.android.mms.InvalidHeaderValueException;

--- a/src/org/thoughtcrime/securesms/mms/IncomingLollipopMmsConnection.java
+++ b/src/org/thoughtcrime/securesms/mms/IncomingLollipopMmsConnection.java
@@ -99,6 +99,14 @@ public class IncomingLollipopMmsConnection extends LollipopMmsConnection impleme
         }
       }
 
+      if (TextUtils.isEmpty(configOverrides.getString(SmsManager.MMS_CONFIG_USER_AGENT))) {
+        configOverrides.remove(SmsManager.MMS_CONFIG_USER_AGENT);
+      }
+
+      if (TextUtils.isEmpty(configOverrides.getString(SmsManager.MMS_CONFIG_UA_PROF_URL))) {
+        configOverrides.remove(SmsManager.MMS_CONFIG_UA_PROF_URL);
+      }
+      
       smsManager.downloadMultimediaMessage(getContext(),
                                            contentLocation,
                                            pointer.getUri(),


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * OnePlus One

- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
https://github.com/signalapp/Signal-Android/issues/9173
Some SIM cards include blank values for `uaProfUrl` and `userAgent`. 

Passing in these blank values along with the overrides causes a 412 precondition error when downloading MMS from AT&T. If these values happen to be blank, then they should be removed completely from the overrides, allowing the request to use the default `uaProfUrl` and `userAgent` for the system.
