### PR TITLE
Update time-based strings to be SI-compliant

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -327,7 +327,7 @@
 
     <!-- DateUtils -->
     <string name="DateUtils_just_now">Now</string>
-    <string name="DateUtils_minutes_ago">%dm</string>
+    <string name="DateUtils_minutes_ago">%d min</string>
     <string name="DateUtils_today">Today</string>
     <string name="DateUtils_yesterday">Yesterday</string>
 
@@ -1137,35 +1137,35 @@
         <item quantity="other">%d seconds</item>
     </plurals>
 
-    <string name="expiration_seconds_abbreviated">%ds</string>
+    <string name="expiration_seconds_abbreviated">%d s</string>
 
     <plurals name="expiration_minutes">
         <item quantity="one">%d minute</item>
         <item quantity="other">%d minutes</item>
     </plurals>
 
-    <string name="expiration_minutes_abbreviated">%dm</string>
+    <string name="expiration_minutes_abbreviated">%d min</string>
 
     <plurals name="expiration_hours">
         <item quantity="one">%d hour</item>
         <item quantity="other">%d hours</item>
     </plurals>
 
-    <string name="expiration_hours_abbreviated">%dh</string>
+    <string name="expiration_hours_abbreviated">%d h</string>
 
     <plurals name="expiration_days">
         <item quantity="one">%d day</item>
         <item quantity="other">%d days</item>
     </plurals>
 
-    <string name="expiration_days_abbreviated">%dd</string>
+    <string name="expiration_days_abbreviated">%d d</string>
 
     <plurals name="expiration_weeks">
         <item quantity="one">%d week</item>
         <item quantity="other">%d weeks</item>
     </plurals>
 
-    <string name="expiration_weeks_abbreviated">%dw</string>
+    <string name="expiration_weeks_abbreviated">%d wk</string>
 
     <!-- unverified safety numbers -->
     <string name="IdentityUtil_unverified_banner_one">Your safety number with %s has changed and is no longer verified</string>
@@ -1366,8 +1366,8 @@
 
     <!-- plurals.xml -->
     <plurals name="hours_ago">
-        <item quantity="one">%dh</item>
-        <item quantity="other">%dh</item>
+        <item quantity="one">%d h</item>
+        <item quantity="other">%d h</item>
     </plurals>
 
     <!-- preferences.xml -->


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Google Pixel 2 XL, Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
The units of second, minute, hour, and day are all SI units or are
associated with the SI, and therefore have symbols and not
abbreviations. The week is not an SI unit nor associated with it,
but is almost universally abbreviated as "wk". Finally, all units
should have a (non-breaking) space between the quantity and the
symbol/abbreviation. This commit addresses all these issues.