### PR TITLE
Respect local camera aspect ratio in calls.

### DIFF
--- a/src/org/thoughtcrime/securesms/components/webrtc/WebRtcCallScreen.java
+++ b/src/org/thoughtcrime/securesms/components/webrtc/WebRtcCallScreen.java
@@ -49,6 +49,7 @@ import org.thoughtcrime.securesms.ringrtc.CameraState;
 import org.thoughtcrime.securesms.util.FeatureFlags;
 import org.thoughtcrime.securesms.util.VerifySpan;
 import org.thoughtcrime.securesms.util.ViewUtil;
+import org.webrtc.RendererCommon;
 import org.webrtc.SurfaceViewRenderer;
 import org.whispersystems.libsignal.IdentityKey;
 
@@ -204,6 +205,7 @@ public class WebRtcCallScreen extends FrameLayout implements RecipientForeverObs
     this.controls.setCameraFlipButtonEnabled(cameraState.getActiveDirection() == CameraState.Direction.BACK);
 
     localRenderer.setMirror(cameraState.getActiveDirection() == CameraState.Direction.FRONT);
+    localRenderer.setScalingType(RendererCommon.ScalingType.SCALE_ASPECT_FIT);
 
     this.localRenderer = localRenderer;
 
@@ -344,7 +346,6 @@ public class WebRtcCallScreen extends FrameLayout implements RecipientForeverObs
       }
 
       localRenderLayout.setPosition(7, 70, 25, 25);
-      localRenderLayout.setSquare(true);
       remoteRenderLayout.setPosition(0, 0, 100, 100);
 
       localRenderer.setLayoutParams(new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S9 (SM-G960U), Android 9 (Dec 1 2019 Patch)
 * Virtual Pixel 3, Android 9 (API 28)
 * Virtual Nexus 5X, Android 7.0 (API 24)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This removes the restriction on the video preview that forces it into a square aspect ratio.  The preview is currently cropped instead of fitting the camera's aspect ratio.
These few lines will remove the square box and set the aspect ratio of the preview layout renderer to fit the aspect ratio of the camera.