### PR TITLE
Fix timestamp of missed call message

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationUpdateItem.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationUpdateItem.java
@@ -144,7 +144,7 @@ public class ConversationUpdateItem extends LinearLayout
     else                                     icon.setImageResource(R.drawable.ic_call_missed_grey600_24dp);
 
     body.setText(messageRecord.getDisplayBody(getContext()));
-    date.setText(DateUtils.getExtendedRelativeTimeSpanString(getContext(), locale, messageRecord.getDateReceived()));
+    date.setText(DateUtils.getExtendedRelativeTimeSpanString(getContext(), locale, messageRecord.getDateSent()));
 
     title.setVisibility(GONE);
     body.setVisibility(VISIBLE);

--- a/app/src/main/java/org/thoughtcrime/securesms/database/SmsDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/SmsDatabase.java
@@ -541,18 +541,18 @@ public class SmsDatabase extends MessagingDatabase {
   }
 
   public @NonNull Pair<Long, Long> insertReceivedCall(@NonNull RecipientId address) {
-    return insertCallLog(address, Types.INCOMING_CALL_TYPE, false);
+    return insertCallLog(address, Types.INCOMING_CALL_TYPE, false, System.currentTimeMillis());
   }
 
   public @NonNull Pair<Long, Long> insertOutgoingCall(@NonNull RecipientId address) {
-    return insertCallLog(address, Types.OUTGOING_CALL_TYPE, false);
+    return insertCallLog(address, Types.OUTGOING_CALL_TYPE, false, System.currentTimeMillis());
   }
 
-  public @NonNull Pair<Long, Long> insertMissedCall(@NonNull RecipientId address) {
-    return insertCallLog(address, Types.MISSED_CALL_TYPE, true);
+  public @NonNull Pair<Long, Long> insertMissedCall(@NonNull RecipientId address, long timestamp) {
+    return insertCallLog(address, Types.MISSED_CALL_TYPE, true, timestamp);
   }
 
-  private @NonNull Pair<Long, Long> insertCallLog(@NonNull RecipientId recipientId, long type, boolean unread) {
+  private @NonNull Pair<Long, Long> insertCallLog(@NonNull RecipientId recipientId, long type, boolean unread, long timestamp) {
     Recipient recipient = Recipient.resolved(recipientId);
     long      threadId  = DatabaseFactory.getThreadDatabase(context).getThreadIdFor(recipient);
 
@@ -560,7 +560,7 @@ public class SmsDatabase extends MessagingDatabase {
     values.put(RECIPIENT_ID, recipientId.serialize());
     values.put(ADDRESS_DEVICE_ID,  1);
     values.put(DATE_RECEIVED, System.currentTimeMillis());
-    values.put(DATE_SENT, System.currentTimeMillis());
+    values.put(DATE_SENT, timestamp);
     values.put(READ, unread ? 0 : 1);
     values.put(TYPE, type);
     values.put(THREAD_ID, threadId);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device, Android 8.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
The missed call info in the conversation always showed the date of when you received the call notification, instead of when that contact actually tried to call you. So when you were offline for some hours and someone tried to call you during that time, you could not know if your contact tried to call you some minutes or some hours ago.

Fixes #7647