### PR TITLE
Signal shows up as an option for sharing multiple files through another app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -159,6 +159,7 @@
 
         <intent-filter>
             <action android:name="android.intent.action.SEND" />
+            <action android:name="android.intent.action.SEND_MULTIPLE" />
             <category android:name="android.intent.category.DEFAULT"/>
             <data android:mimeType="audio/*" />
             <data android:mimeType="image/*" />


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Honor 20 Lite, Android 9
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
The ShareActivity now is also registered for the SEND_MULTIPLE action intent Through my gallery app now when selecting 2 or more files to share, Signal comes up as an option.
Fixes #9206 
