### PR TITLE
Fix text alignment when forwarding audio message

### DIFF
--- a/app/src/main/res/layout/conversation_item_sent.xml
+++ b/app/src/main/res/layout/conversation_item_sent.xml
@@ -159,6 +159,7 @@
                 android:clipChildren="false"
                 android:clipToPadding="false"
                 android:gravity="end"
+                android:layout_gravity="end"
                 app:footer_icon_color="?attr/conversation_item_sent_icon_color"
                 app:footer_text_color="?attr/conversation_item_sent_text_secondary_color" />
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Xiaomi Mi A2, Android 10
 * Oneplus 5, Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixes #9445
When forwarding an audio message and attaching a long text, the text may become wider than the voice message (which takes up a hard-coded 210dp). The footer, in this case, aligned with the right side of the audio player, instead of with the right side of the message bubble. By making the contents of the footer have their `gravity` set to `end`, the footer always ends up in the bottom right corner of the message bubble, independent of the message length.
