### PR TITLE
Improve Visibility of Backup Location

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/backup/BackupDialog.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/BackupDialog.java
@@ -17,9 +17,11 @@ import androidx.appcompat.app.AlertDialog;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.SwitchPreferenceCompat;
+import org.thoughtcrime.securesms.database.NoExternalStorageException;
 import org.thoughtcrime.securesms.registration.fragments.RestoreBackupFragment;
 import org.thoughtcrime.securesms.service.LocalBackupListener;
 import org.thoughtcrime.securesms.util.BackupUtil;
+import org.thoughtcrime.securesms.util.StorageUtil;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.text.AfterTextChanged;
@@ -45,6 +47,15 @@ public class BackupDialog {
           LocalBackupListener.schedule(context);
 
           preference.setChecked(true);
+          String summaryText = context.getString(R.string.preferences_chats__backup_chats_to_external_storage);
+          try {
+            String location = String.format(
+                    context.getString(R.string.preferences_chats__backup_chats_storage_location),
+                    StorageUtil.getBackupDirectory().toString()
+            );
+            summaryText += "\n" + location;
+          } catch (NoExternalStorageException e) {}
+          preference.setSummary(summaryText);
           created.dismiss();
         } else {
           Toast.makeText(context, R.string.BackupDialog_please_acknowledge_your_understanding_by_marking_the_confirmation_check_box, Toast.LENGTH_LONG).show();
@@ -85,6 +96,7 @@ public class BackupDialog {
                      TextSecurePreferences.setBackupEnabled(context, false);
                      BackupUtil.deleteAllBackups();
                      preference.setChecked(false);
+                     preference.setSummary(context.getString(R.string.preferences_chats__backup_chats_to_external_storage));
                    })
                    .create()
                    .show();

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -152,7 +152,7 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
                  .request(Manifest.permission.WRITE_EXTERNAL_STORAGE)
                  .ifNecessary()
                  .onAllGranted(() -> {
-                   Log.i(TAG, "Queing backup...");
+                   Log.i(TAG, "Queueing backup...");
                    ApplicationDependencies.getJobManager().add(new LocalBackupJob());
                  })
                  .withPermanentDenialDialog(getString(R.string.ChatsPreferenceFragment_signal_requires_external_storage_permission_in_order_to_create_backups))

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -18,12 +18,14 @@ import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.backup.BackupDialog;
 import org.thoughtcrime.securesms.backup.FullBackupBase.BackupEvent;
 import org.thoughtcrime.securesms.components.SwitchPreferenceCompat;
+import org.thoughtcrime.securesms.database.NoExternalStorageException;
 import org.thoughtcrime.securesms.dependencies.ApplicationDependencies;
 import org.thoughtcrime.securesms.jobs.LocalBackupJob;
 import org.thoughtcrime.securesms.logging.Log;
 import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.preferences.widgets.ProgressPreference;
 import org.thoughtcrime.securesms.util.BackupUtil;
+import org.thoughtcrime.securesms.util.StorageUtil;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 
 import java.util.ArrayList;
@@ -69,7 +71,8 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
     super.onResume();
     ((ApplicationPreferencesActivity)getActivity()).getSupportActionBar().setTitle(R.string.preferences__chats);
     setMediaDownloadSummaries();
-    setBackupSummary();
+    setBackupEnableSummary();
+    setBackupCreateSummary();
   }
 
   @Override
@@ -94,11 +97,26 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
     } else if (event.getType() == BackupEvent.Type.FINISHED) {
       preference.setEnabled(true);
       preference.setProgressVisible(false);
-      setBackupSummary();
+      setBackupCreateSummary();
     }
   }
 
-  private void setBackupSummary() {
+  private void setBackupEnableSummary() {
+    Preference pref = findPreference(TextSecurePreferences.BACKUP_ENABLED);
+    String summaryText = getString(R.string.preferences_chats__backup_chats_to_external_storage);
+    if (((SwitchPreferenceCompat)pref).isChecked()) {
+      try {
+        String location = String.format(
+                getString(R.string.preferences_chats__backup_chats_storage_location),
+                StorageUtil.getBackupDirectory().toString()
+        );
+        summaryText += "\n" + location;
+      } catch (NoExternalStorageException ignored) {}
+    }
+    pref.setSummary(summaryText);
+  }
+
+  private void setBackupCreateSummary() {
     findPreference(TextSecurePreferences.BACKUP_NOW)
         .setSummary(String.format(getString(R.string.ChatsPreferenceFragment_last_backup_s), BackupUtil.getLastBackupTime(getContext(), Locale.US)));
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -149,6 +149,7 @@ public class TextSecurePreferences {
   private static final String ENCRYPTED_BACKUP_PASSPHRASE = "pref_encrypted_backup_passphrase";
   private static final String BACKUP_TIME                 = "pref_backup_next_time";
   public  static final String BACKUP_NOW                  = "pref_backup_create";
+  public  static final String BACKUP_VIEW_FOLDER          = "pref_backup_show_folder";
   public  static final String BACKUP_PASSPHRASE_VERIFY    = "pref_backup_passphrase_verify";
 
   public static final String SCREEN_LOCK         = "pref_android_screen_lock";

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1931,6 +1931,7 @@
     <string name="registration_activity__register">Register</string>
     <string name="preferences_chats__chat_backups">Chat backups</string>
     <string name="preferences_chats__backup_chats_to_external_storage">Backup chats to external storage</string>
+    <string name="preferences_chats__backup_chats_storage_location">Location: %s</string>
     <string name="preferences_chats__create_backup">Create backup</string>
     <string name="preferences_chats__verify_backup_passphrase">Verify backup passphrase</string>
     <string name="preferences_chats__test_your_backup_passphrase_and_verify_that_it_matches">Test your backup passphrase and verify that it matches</string>
@@ -1958,6 +1959,7 @@
     <string name="ChatsPreferenceFragment_signal_requires_external_storage_permission_in_order_to_create_backups">Signal requires external storage permission in order to create backups, but it has been permanently denied. Please continue to app settings, select \"Permissions\" and enable \"Storage\".</string>
     <string name="ChatsPreferenceFragment_last_backup_s">Last backup: %s</string>
     <string name="ChatsPreferenceFragment_in_progress">In progress</string>
+    <string name="ChatsPreferenceFragment_unable_to_show_folder">Unable to show backup folder</string>
     <string name="LocalBackupJob_creating_backup">Creating backup…</string>
     <string name="ProgressPreference_d_messages_so_far">%d messages so far</string>
     <string name="RegistrationActivity_please_enter_the_verification_code_sent_to_s">Please enter the verification code sent to %s.</string>

--- a/app/src/main/res/xml/preferences_chats.xml
+++ b/app/src/main/res/xml/preferences_chats.xml
@@ -76,6 +76,14 @@
                 tools:summary="Last backup: 3 days ago"/>
 
         <androidx.preference.Preference
+                android:key="pref_backup_show_folder"
+                android:title="Show backup folder"
+                android:persistent="false"
+                android:dependency="pref_backup_enabled"
+                android:summary="Open your backup folder in an external file browser"
+            />
+
+        <androidx.preference.Preference
                 android:key="pref_backup_passphrase_verify"
                 android:title="@string/preferences_chats__verify_backup_passphrase"
                 android:persistent="false"

--- a/app/src/main/res/xml/preferences_chats.xml
+++ b/app/src/main/res/xml/preferences_chats.xml
@@ -66,7 +66,7 @@
                 android:defaultValue="false"
                 android:key="pref_backup_enabled"
                 android:title="@string/preferences_chats__chat_backups"
-                android:summary="@string/preferences_chats__backup_chats_to_external_storage" />
+                android:summary="" />
 
         <org.thoughtcrime.securesms.preferences.widgets.ProgressPreference
                 android:key="pref_backup_create"


### PR DESCRIPTION
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * LG V20, Android 8.0.0
 * Virtual Nexus 5X, Android 10
- [ ] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

The goals of this PR were to
1. At a minimum, integrate the path for the backup location into the signal app itself so that searching for the signal support page is not necessary in order to find and move the backup file somewhere.
2. Add a button in the backup settings that takes you to the `Signal/Backup` folder in your file manager of choice so you can easily copy it to another location/etc.

(1.) is addressed through f939b4e, but (2.) is much more work-in-progress on e18005f. 
From what I can tell, there doesn't appear to be a well standardized intent for simply opening a directory in another app with no intention of actually choosing a file/etc. Other solutions from [here](https://stackoverflow.com/questions/17165972/android-how-to-open-a-specific-folder-via-intent-and-show-its-content-in-a-file) and [here](http://www.openintents.org/action/android-intent-action-view/file-directory) were tried without any being a solution I'm super happy with. 
As such, I'd appreciate any input on (2.) that anyone may have, but if no better solution is found, I would be perfectly fine just merging the first two commits as long as showing a file path to the user isn't considered too advanced/power user.

Screenshots:
Backups Enabled:
![2020-03-08-155214_532x458_scrot](https://user-images.githubusercontent.com/8922497/76172581-80f55200-618f-11ea-8cf4-0b667a8c908e.png)
Backups Disabled:
![2020-03-08-155610_527x431_scrot](https://user-images.githubusercontent.com/8922497/76172655-0a0c8900-6190-11ea-8227-f8d499eb4116.png)
