### PR TITLE
Fixes #9421

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.java
@@ -487,7 +487,7 @@ public class WebRtcCallService extends Service implements CallManager.Observer,
     boolean muted     = intent.getBooleanExtra(EXTRA_MUTE, false);
     microphoneEnabled = !muted;
 
-    if (activePeer == null) {
+    if (activePeer == null || activePeer.getState().equals(CallState.DIALING)) {
       Log.w(TAG, "handleSetMuteAudio(): Ignoring for inactive call.");
       return;
     }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Huawei G7-L01, Android 5.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixes #9421

When you start a (voice or video) call and press the 'mute' button while the call is still in the dialing state (i.e. the other person did not pick up yet), the call would terminate, leaving the following exception in the log:

```
2020-03-11 15:20:46.174 21343-22075/org.thoughtcrime.securesms W/WebRtcCallService: Enabling audio failed: 
    org.signal.ringrtc.CallException: Expecting non-none option value in: active_connection, var: active_connection caused by java exception:
    unknown -- unable to decode exception
        at org.signal.ringrtc.CallManager.ringrtcGetActiveConnection(Native Method)
        at org.signal.ringrtc.CallManager.setAudioEnable(CallManager.java:472)
        at org.thoughtcrime.securesms.service.WebRtcCallService.handleSetMuteAudio(WebRtcCallService.java:496)
        at org.thoughtcrime.securesms.service.WebRtcCallService.lambda$onStartCommand$0$WebRtcCallService(WebRtcCallService.java:207)
        at org.thoughtcrime.securesms.service.-$$Lambda$WebRtcCallService$2o0hr8cm8pH2Kvr7bOsjjdU-c4A.run(Unknown Source:4)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:764)
```

This fix adds to the null check, and ensures the function returns if the `activePeer.callState` is equal to `DIALING`: During dialing. This prevents the crash.