### PR TITLE
Fixes #9465 Fix crash when importing vcf after exporting it

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/contactshare/SharedContactRepository.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/contactshare/SharedContactRepository.java
@@ -125,7 +125,11 @@ public class SharedContactRepository {
       List<Phone> phoneNumbers = new ArrayList<>(vPhones.size());
       for (ezvcard.property.Telephone vEmail : vPhones) {
         String label = !vEmail.getTypes().isEmpty() ? getCleanedVcardType(vEmail.getTypes().get(0).getValue()) : null;
-        phoneNumbers.add(new Phone(vEmail.getText(), phoneTypeFromVcardType(label), label));
+
+        //Phone number is stored in the uri field in v4.0 only. In other versions, it is in the text field.
+        String phoneNrFromText = vEmail.getText();
+        String extractedPhoneNumber = phoneNrFromText == null ? vEmail.getUri().getNumber() : phoneNrFromText;
+        phoneNumbers.add(new Phone(extractedPhoneNumber, phoneTypeFromVcardType(label), label));
       }
 
       List<Email> emails = new ArrayList<>(vEmails.size());


### PR DESCRIPTION
Fixes #9465

### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Oneplus One, Android 9.0
 * Xiaomi Mi A2, Android 10
 * Oneplus 5, Android 10

- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This pull request fixes #9465. When sending a contact from a vcf file, a null value was loaded into the phone number field of the created contact, which caused Signal to crash when opening the app again. In versions before 4.0 of vcard, the telephone number was stored in the `text` field of the Telephone object of the used library. However, in version 4.0 of vcard, this number is stored in the `uri` field of the Telephone object (see [this Telephone object definition](https://github.com/mangstadt/ez-vcard/blob/master/src/main/java/ezvcard/property/Telephone.java)). This pull request modifies Signal from only checking the `text` field to first checking if this field is null and using the `uri` field if it is. 

As far as I have been able to see, there is currently no chance that the `text` and `uri` field both contain (potentially conflicting) information, as the Telephone constructor sets only one field and the setters of the fields clear the other one.
