### PR TITLE
Added a choice between Google Map types

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/location/SignalMapView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/location/SignalMapView.java
@@ -18,6 +18,8 @@ import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.model.MarkerOptions;
 
 import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.dependencies.ApplicationDependencies;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.util.ViewUtil;
 import org.thoughtcrime.securesms.util.concurrent.ListenableFuture;
 import org.thoughtcrime.securesms.util.concurrent.SettableFuture;
@@ -52,6 +54,15 @@ public class SignalMapView extends LinearLayout {
     this.textView  = ViewUtil.findById(this, R.id.address_view);
   }
 
+  public void setGoogleMapType(GoogleMap googleMap) {
+    String mapType = TextSecurePreferences.getGoogleMapType(ApplicationDependencies.getApplication());
+    if (mapType.equals("normal")) { googleMap.setMapType(GoogleMap.MAP_TYPE_NORMAL); }
+    else if (mapType.equals("hybrid")) { googleMap.setMapType(GoogleMap.MAP_TYPE_HYBRID); }
+    else if (mapType.equals("satellite")) { googleMap.setMapType(GoogleMap.MAP_TYPE_SATELLITE); }
+    else if (mapType.equals("terrain")) { googleMap.setMapType(GoogleMap.MAP_TYPE_TERRAIN); }
+    else if (mapType.equals("none")) { googleMap.setMapType(GoogleMap.MAP_TYPE_NONE); }
+  }
+
   public ListenableFuture<Bitmap> display(final SignalPlace place) {
     final SettableFuture<Bitmap> future = new SettableFuture<>();
 
@@ -67,7 +78,7 @@ public class SignalMapView extends LinearLayout {
         googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(place.getLatLong(), 13));
         googleMap.addMarker(new MarkerOptions().position(place.getLatLong()));
         googleMap.setBuildingsEnabled(true);
-        googleMap.setMapType(GoogleMap.MAP_TYPE_NORMAL);
+        setGoogleMapType(googleMap);
         googleMap.getUiSettings().setAllGesturesEnabled(false);
         googleMap.setOnMapLoadedCallback(new GoogleMap.OnMapLoadedCallback() {
           @Override

--- a/app/src/main/java/org/thoughtcrime/securesms/maps/PlacePickerActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/maps/PlacePickerActivity.java
@@ -74,7 +74,7 @@ public final class PlacePickerActivity extends AppCompatActivity {
     View fab         = findViewById(R.id.place_chosen_button);
 
     Button btnMapTypeNormal = findViewById(R.id.btnMapTypeNormal);
-    Button btnMapTypeSattelite = findViewById(R.id.btnMapTypeSattelite);
+    Button btnMapTypeSatellite = findViewById(R.id.btnMapTypeSatellite);
     Button btnMapTypeTerrain = findViewById(R.id.btnMapTypeTerrain);
 
     fab.setOnClickListener(v -> finishWithAddress());
@@ -86,7 +86,7 @@ public final class PlacePickerActivity extends AppCompatActivity {
       }
     });
 
-    btnMapTypeSattelite.setOnClickListener(new View.OnClickListener() {
+    btnMapTypeSatellite.setOnClickListener(new View.OnClickListener() {
       @Override public void onClick(@NonNull View v) {
         googleMap.setMapType(GoogleMap.MAP_TYPE_SATELLITE);
         TextSecurePreferences.setGoogleMapType(getApplicationContext(), "satellite");

--- a/app/src/main/java/org/thoughtcrime/securesms/maps/PlacePickerActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/maps/PlacePickerActivity.java
@@ -12,6 +12,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 import android.view.animation.OvershootInterpolator;
+import android.widget.Button;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -72,8 +73,32 @@ public final class PlacePickerActivity extends AppCompatActivity {
     View markerImage = findViewById(R.id.marker_image_view);
     View fab         = findViewById(R.id.place_chosen_button);
 
+    Button btnMapTypeNormal = findViewById(R.id.btnMapTypeNormal);
+    Button btnMapTypeSattelite = findViewById(R.id.btnMapTypeSattelite);
+    Button btnMapTypeTerrain = findViewById(R.id.btnMapTypeTerrain);
+
     fab.setOnClickListener(v -> finishWithAddress());
 
+    btnMapTypeNormal.setOnClickListener(new View.OnClickListener() {
+      @Override public void onClick(@NonNull View v) {
+        googleMap.setMapType(GoogleMap.MAP_TYPE_NORMAL);
+        TextSecurePreferences.setGoogleMapType(getApplicationContext(), "normal");
+      }
+    });
+
+    btnMapTypeSattelite.setOnClickListener(new View.OnClickListener() {
+      @Override public void onClick(@NonNull View v) {
+        googleMap.setMapType(GoogleMap.MAP_TYPE_SATELLITE);
+        TextSecurePreferences.setGoogleMapType(getApplicationContext(), "satellite");
+      }
+    });
+
+    btnMapTypeTerrain.setOnClickListener(new View.OnClickListener() {
+      @Override public void onClick(@NonNull View v) {
+        googleMap.setMapType(GoogleMap.MAP_TYPE_TERRAIN);
+        TextSecurePreferences.setGoogleMapType(getApplicationContext(), "terrain");
+      }
+    });
 
     if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)   == PackageManager.PERMISSION_GRANTED ||
         ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED)

--- a/app/src/main/java/org/thoughtcrime/securesms/maps/PlacePickerActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/maps/PlacePickerActivity.java
@@ -25,6 +25,7 @@ import com.google.android.gms.maps.model.LatLng;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.logging.Log;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
 
 import java.io.IOException;
 import java.util.List;
@@ -127,8 +128,18 @@ public final class PlacePickerActivity extends AppCompatActivity {
 
   private void setMap(GoogleMap googleMap) {
     this.googleMap = googleMap;
+    setGoogleMapType(googleMap);
 
     moveMapToInitialIfPossible();
+  }
+
+  private void setGoogleMapType(GoogleMap googleMap) {
+    String mapType = TextSecurePreferences.getGoogleMapType(getApplicationContext());
+    if (mapType.equals("normal")) { googleMap.setMapType(GoogleMap.MAP_TYPE_NORMAL); }
+    else if (mapType.equals("hybrid")) { googleMap.setMapType(GoogleMap.MAP_TYPE_HYBRID); }
+    else if (mapType.equals("satellite")) { googleMap.setMapType(GoogleMap.MAP_TYPE_SATELLITE); }
+    else if (mapType.equals("terrain")) { googleMap.setMapType(GoogleMap.MAP_TYPE_TERRAIN); }
+    else if (mapType.equals("none")) { googleMap.setMapType(GoogleMap.MAP_TYPE_NONE); }
   }
 
   private void moveMapToInitialIfPossible() {

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -53,8 +53,11 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
         .setOnPreferenceClickListener(new BackupCreateListener());
     findPreference(TextSecurePreferences.BACKUP_PASSPHRASE_VERIFY)
         .setOnPreferenceClickListener(new BackupVerifyListener());
+    findPreference(TextSecurePreferences.GOOGLE_MAP_TYPE)
+        .setOnPreferenceChangeListener(new ListSummaryListener());
 
     initializeListSummary((ListPreference) findPreference(TextSecurePreferences.MESSAGE_BODY_TEXT_SIZE_PREF));
+    initializeListSummary((ListPreference) findPreference(TextSecurePreferences.GOOGLE_MAP_TYPE));
 
     EventBus.getDefault().register(this);
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -213,6 +213,12 @@ public class TextSecurePreferences {
 
   private static final String ARGON2_TESTED = "argon2_tested";
 
+  public static final String GOOGLE_MAP_TYPE = "pref_google_map_type";
+
+  public static String getGoogleMapType(Context context) {
+    return getStringPreference(context, GOOGLE_MAP_TYPE, "normal");
+  }
+
   public static boolean isScreenLockEnabled(@NonNull Context context) {
     return getBooleanPreference(context, SCREEN_LOCK, false);
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -219,6 +219,10 @@ public class TextSecurePreferences {
     return getStringPreference(context, GOOGLE_MAP_TYPE, "normal");
   }
 
+  public static void setGoogleMapType(Context context, String value) {
+    setStringPreference(context, GOOGLE_MAP_TYPE, value);
+  }
+
   public static boolean isScreenLockEnabled(@NonNull Context context) {
     return getBooleanPreference(context, SCREEN_LOCK, false);
   }

--- a/app/src/main/res/layout/activity_place_picker.xml
+++ b/app/src/main/res/layout/activity_place_picker.xml
@@ -36,7 +36,7 @@
             android:text="@string/preferences__map_normal" />
 
         <Button
-            android:id="@+id/btnMapTypeSattelite"
+            android:id="@+id/btnMapTypeSatellite"
             style="?android:attr/buttonBarButtonStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_place_picker.xml
+++ b/app/src/main/res/layout/activity_place_picker.xml
@@ -19,6 +19,37 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.0" />
 
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="140dp"
+        android:adjustViewBounds="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintVertical_bias="0.0">
+
+        <Button
+            android:id="@+id/btnMapTypeNormal"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/preferences__map_normal" />
+
+        <Button
+            android:id="@+id/btnMapTypeSattelite"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/preferences__map_satellite" />
+
+        <Button
+            android:id="@+id/btnMapTypeTerrain"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/preferences__map_terrain" />
+    </LinearLayout>
+
     <ImageView
         android:id="@+id/marker_shadow_image_view"
         android:layout_width="wrap_content"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -157,6 +157,22 @@
       <item>dark</item>
   </string-array>
 
+  <string-array name="pref_map_type_entries">
+    <item>@string/preferences__map_normal</item>
+    <item>@string/preferences__map_hybrid</item>
+    <item>@string/preferences__map_satellite</item>
+    <item>@string/preferences__map_terrain</item>
+    <item>@string/preferences__map_none</item>
+  </string-array>
+
+  <string-array name="pref_map_type_values" translatable="false">
+    <item>normal</item>
+    <item>hybrid</item>
+    <item>satellite</item>
+    <item>terrain</item>
+    <item>none</item>
+  </string-array>
+
   <string-array name="pref_led_color_entries">
     <item>@string/preferences__green</item>
     <item>@string/preferences__red</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1626,6 +1626,13 @@
     <string name="preferences_communication__sealed_sender_allow_from_anyone">Allow from anyone</string>
     <string name="preferences_communication__sealed_sender_allow_from_anyone_description">Enable sealed sender for incoming messages from non-contacts and people with whom you have not shared your profile.</string>
     <string name="preferences_communication__sealed_sender_learn_more">Learn more</string>
+    <string name="preferences_chats__google_map_type">Location</string>
+    <string name="preferences__map_type">Map type</string>
+    <string name="preferences__map_normal">Normal</string>
+    <string name="preferences__map_hybrid">Hybrid</string>
+    <string name="preferences__map_satellite">Satellite</string>
+    <string name="preferences__map_terrain">Terrain</string>
+    <string name="preferences__map_none">None</string>
 
     <!-- **************************************** -->
     <!-- menus -->

--- a/app/src/main/res/xml/preferences_chats.xml
+++ b/app/src/main/res/xml/preferences_chats.xml
@@ -84,4 +84,15 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory android:layout="@layout/preference_divider"/>
+
+    <PreferenceCategory android:title="@string/preferences_chats__google_map_type">
+        <org.thoughtcrime.securesms.preferences.widgets.SignalListPreference
+            android:key="pref_google_map_type"
+            android:defaultValue="normal"
+            android:title="@string/preferences__map_type"
+            android:entries="@array/pref_map_type_entries"
+            android:entryValues="@array/pref_map_type_values" />
+    </PreferenceCategory>
+
 </PreferenceScreen>


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Z3 Compact, Android 6.0.1
 * Sony M4 Aqua Android 5.0

- [x] My contribution is fully baked and ready to be merged as is
----------

### Description
<!--
Currently, when sharing a location, only Google Maps in "noral" mode is used, which uses a street map.With this update an option is added to select all options, like satellite view, to share.
-->

![Signal-maptype](https://user-images.githubusercontent.com/8427572/77248747-1be43680-6c3c-11ea-9b2e-63f8b7c06bb0.png)

![Screenshot_20200322-125505](https://user-images.githubusercontent.com/8427572/77248787-7e3d3700-6c3c-11ea-91ad-27ccbe8de71b.png)
