### PR TITLE
stay awake while playing voice message

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
@@ -15,7 +15,6 @@ import android.os.PowerManager.WakeLock;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import android.util.Pair;
-import android.view.WindowManager;
 import android.widget.Toast;
 
 import com.google.android.exoplayer2.C;
@@ -57,7 +56,7 @@ public class AudioSlidePlayer implements SensorEventListener {
   private final @NonNull  AudioManager      audioManager;
   private final @NonNull  SensorManager     sensorManager;
   private final @NonNull  Sensor            proximitySensor;
-  private @Nullable WakeLock          wakeLock;
+  private       @Nullable WakeLock          wakeLock;
 
   private @NonNull  WeakReference<Listener> listener;
   private @Nullable SimpleExoPlayer         mediaPlayer;


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Google Pixel 3a, Android 10
 * Huawei <device name>, Android 7.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

Keep the screen on while playing voice messages. Before, the user had to frequently touch the screen during long messages when the screen timeout is set to a low value. Behavior when phone is moved to ear is kept as before.


Fixes #8462 (sorry, did not include it in first commit)
