### PR TITLE
Make draggable the local view on video calls

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/webrtc/WebRtcCallScreen.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/webrtc/WebRtcCallScreen.java
@@ -17,11 +17,14 @@
 
 package org.thoughtcrime.securesms.components.webrtc;
 
+import android.content.ClipData;
+import android.content.ClipDescription;
 import android.content.Context;
 import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.method.LinkMovementMethod;
 import android.util.AttributeSet;
+import android.view.DragEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -216,6 +219,38 @@ public class WebRtcCallScreen extends FrameLayout implements RecipientForeverObs
     localRenderer.setVisibility(cameraState.isEnabled() ? VISIBLE : INVISIBLE);
   }
 
+  private void setViewDraggable(@NonNull View draggableView, @NonNull View draggableViewLayout) {
+    draggableView.setOnLongClickListener(new OnLongClickListener() {
+
+               public boolean onLongClick(View v) {
+                 ClipData.Item item = new ClipData.Item((String) v.getTag());
+                 ClipData dragData = new ClipData(
+                         (String) v.getTag(),
+                         new String[] { ClipDescription.MIMETYPE_TEXT_PLAIN },
+                         item);
+                 return v.startDrag(dragData,
+                         new DragShadowBuilder(draggableView),
+                         null,
+                         0
+                 );
+               }
+
+             }
+    );
+    draggableViewLayout.setOnDragListener(new OnDragListener() {
+      @Override
+      public boolean onDrag(View view, DragEvent dragEvent) {
+        if (
+                dragEvent.getAction() != DragEvent.ACTION_DRAG_ENDED
+        ){
+          draggableView.setX(dragEvent.getX()-draggableView.getWidth()/2);
+          draggableView.setY(dragEvent.getY()-draggableView.getHeight()/2);
+        }
+        return true;
+      }
+    });
+  }
+
   public void setRemoteVideoEnabled(boolean enabled) {
     if (enabled && this.remoteRenderLayout.isHidden()) {
       this.photo.setVisibility(View.INVISIBLE);
@@ -357,6 +392,8 @@ public class WebRtcCallScreen extends FrameLayout implements RecipientForeverObs
 
       localRenderLayout.addView(localRenderer);
       remoteRenderLayout.addView(remoteRenderer);
+
+      setViewDraggable(localRenderer, localRenderLayout);
 
       this.localRenderer = localRenderer;
     }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Xiaomi mi A3
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

This PR allows users to move around the thumbnail of user's camera in the video call screen. 

For example, if a contacted person points its camera so that it appear behind the user's camera thumbnail, the user can move away the thumbnail without telling its contact to center his/her camera.
