### PR TITLE
Fix shared media title color and style

### DIFF
--- a/app/src/main/res/layout/recipient_preference_activity.xml
+++ b/app/src/main/res/layout/recipient_preference_activity.xml
@@ -76,8 +76,8 @@
                       android:text="@string/recipient_preference_activity__shared_media"
                       android:visibility="gone"
                       android:focusableInTouchMode="true"
-                      style="?android:attr/preferenceCategoryStyle"
-                      android:textColor="@color/core_ultramarine"/>
+                      android:textStyle="bold"
+                      android:textColor="?attr/colorAccent"/>
 
             <org.thoughtcrime.securesms.components.ThreadPhotoRailView
                     android:id="@+id/recent_photos"


### PR DESCRIPTION
### First time contributor checklist
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual device Pixel 3a, Android 10.0 (API 29)
- [ ] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

This will change _Shared media_ title color and style in conversation settings to match the rest of the sections like _Chat settings_ and fix the accessibility issues mentioned in the topic for _Beta feedback for the upcoming Android 4.58 release_ [[1](https://community.signalusers.org/t/beta-feedback-for-the-upcoming-android-4-58-release/12745/5?u=gtsiolis)][[2](https://community.signalusers.org/t/beta-feedback-for-the-upcoming-android-4-58-release/12745/9?u=gtsiolis)].

### Screenshots

| Before | After|
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/120486/78510538-81890480-779e-11ea-8f50-1c2564cc4d31.png)| ![image](https://user-images.githubusercontent.com/120486/78510541-851c8b80-779e-11ea-8789-3a6e9a170ca1.png) |
| ![image](https://user-images.githubusercontent.com/120486/78510552-96659800-779e-11ea-94d6-47f28c36c008.png) | ![image](https://user-images.githubusercontent.com/120486/78510557-9e253c80-779e-11ea-86a2-0f5a2d4b390d.png) |

### Pending issues

Although the fix mentioned in the [relevant discussion](https://community.signalusers.org/t/beta-feedback-for-the-upcoming-android-4-58-release/12745/7?u=gtsiolis) has been fixed for dialogs in https://github.com/signalapp/Signal-Android/commit/24528bf101d9655d486ba739f79e3fbbc5ee50c3 there are still plenty of instances of the `core_ultramarine` color used for links, titles, and more that are inaccessible when using the _Dark_ theme. /cc @greyson-signal