### PR TITLE
Always convert HEIC images to JPEG

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/AttachmentCompressionJob.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/AttachmentCompressionJob.java
@@ -145,6 +145,10 @@ public final class AttachmentCompressionJob extends BaseJob {
         if (!constraints.isSatisfied(context, attachment)) {
           throw new UndeliverableMessageException("Size constraints could not be met on video!");
         }
+      } else if (MediaUtil.isHeic(attachment)) {
+        MediaStream converted = getResizedMedia(context, attachment, constraints);
+        attachmentDatabase.updateAttachmentData(attachment, converted, false);
+        attachmentDatabase.markAttachmentAsTransformed(attachmentId);
       } else if (constraints.isSatisfied(context, attachment)) {
         if (MediaUtil.isJpeg(attachment)) {
           MediaStream stripped = getResizedMedia(context, attachment, constraints);

--- a/app/src/main/java/org/thoughtcrime/securesms/util/MediaUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/MediaUtil.java
@@ -49,6 +49,7 @@ public class MediaUtil {
 
   public static final String IMAGE_PNG         = "image/png";
   public static final String IMAGE_JPEG        = "image/jpeg";
+  public static final String IMAGE_HEIC        = "image/heic";
   public static final String IMAGE_WEBP        = "image/webp";
   public static final String IMAGE_GIF         = "image/gif";
   public static final String AUDIO_AAC         = "audio/aac";
@@ -219,6 +220,10 @@ public class MediaUtil {
     return isJpegType(attachment.getContentType());
   }
 
+  public static boolean isHeic(Attachment attachment) {
+    return isHeicType(attachment.getContentType());
+  }
+
   public static boolean isImage(Attachment attachment) {
     return isImageType(attachment.getContentType());
   }
@@ -245,6 +250,10 @@ public class MediaUtil {
 
   public static boolean isJpegType(String contentType) {
     return !TextUtils.isEmpty(contentType) && contentType.trim().equals(IMAGE_JPEG);
+  }
+
+  public static boolean isHeicType(String contentType) {
+    return !TextUtils.isEmpty(contentType) && contentType.trim().equals(IMAGE_HEIC);
   }
 
   public static boolean isFile(Attachment attachment) {


### PR DESCRIPTION
## Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S10+, Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

This pr changes the behavior of sending HEIC images to always convert
them to JPEG. This conversion is required to support image inline
viewing accross different devices and operating systems. This follows
the same strategy as on IOS: https://github.com/signalapp/Signal-iOS/pull/2511

Fixes: https://github.com/signalapp/Signal-iOS/issues/4374 https://github.com/signalapp/Signal-Android/issues/9395