### PR TITLE
Fixes #9417 handle registration sms when already default sms app

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/registration/RegistrationNavigationActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/RegistrationNavigationActivity.java
@@ -77,13 +77,7 @@ public final class RegistrationNavigationActivity extends AppCompatActivity {
 
         switch (status.getStatusCode()) {
           case CommonStatusCodes.SUCCESS:
-            Optional<String> code = VerificationCodeParser.parse(context, (String) extras.get(SmsRetriever.EXTRA_SMS_MESSAGE));
-            if (code.isPresent()) {
-              Log.i(TAG, "Received verification code.");
-              handleVerificationCodeReceived(code.get());
-            } else {
-              Log.w(TAG, "Could not parse verification code.");
-            }
+            RegistrationSmsHandler.handleRegistrationSms(context, (String) extras.get(SmsRetriever.EXTRA_SMS_MESSAGE));
             break;
           case CommonStatusCodes.TIMEOUT:
             Log.w(TAG, "Hit a timeout waiting for the SMS to arrive.");
@@ -93,9 +87,5 @@ public final class RegistrationNavigationActivity extends AppCompatActivity {
         Log.w(TAG, "SmsRetrieverReceiver received the wrong action?");
       }
     }
-  }
-
-  private void handleVerificationCodeReceived(@NonNull String code) {
-    EventBus.getDefault().post(new ReceivedSmsEvent(code));
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/registration/RegistrationSmsHandler.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/RegistrationSmsHandler.java
@@ -1,0 +1,32 @@
+package org.thoughtcrime.securesms.registration;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import org.greenrobot.eventbus.EventBus;
+import org.thoughtcrime.securesms.logging.Log;
+import org.thoughtcrime.securesms.service.VerificationCodeParser;
+import org.whispersystems.libsignal.util.guava.Optional;
+
+/**
+ * Handle a received registration SMS.
+ * This SMS could have been received by either the RegistrationNavigationActivity or a SmsReceiveJob
+ */
+public class RegistrationSmsHandler {
+    private static final String TAG = Log.tag(RegistrationSmsHandler.class);
+
+    public static void handleRegistrationSms(Context context, String msgContent){
+        Optional<String> code = VerificationCodeParser.parse(context, msgContent);
+        if (code.isPresent()) {
+            Log.i(TAG, "Received verification code.");
+            handleVerificationCodeReceived(code.get());
+        } else {
+            Log.w(TAG, "Could not parse verification code.");
+        }
+    }
+
+    private static void handleVerificationCodeReceived(@NonNull String code) {
+        EventBus.getDefault().post(new ReceivedSmsEvent(code));
+    }
+}


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Oneplus One, Android 9

- [ ] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
The crash of #9417 was caused by the safeguard added in [this commit](https://github.com/signalapp/Signal-Android/commit/02865f99a9b8e84611c9d8db7ee31bff2ceceb63).
When verifying the account, the uuid is not set yet and this causes the app to crash when it tries to generate a notification for the received SMS, thus I disabled notifications for received SMS messages when we are are still verifying. Registering the account sets the uuid, but this requires the SMS to be received. Receiving this registration SMS was previously done in the `RegistrationNavigationActivity` using an `SmsRetriever` filtering on the `SMS_RETRIEVED_ACTION`. However, when Signal already is the default SMS app, I noticed that the `SmsRetriever` did not trigger, but that a `SmsReceiveJob` was registered. Thus, I factored out the functionality for processing a registration SMS, made the `SmsRetriever` use it and made the `SmsReceiveJob` use the function when it receives an SMS while registering.

I followed the steps to reproduce #9417 and verified that the app did not crash, registered and was able to exchange messages with other users. I then uninstalled the app, and registered as usual (with Signal not being the default SMS app). Now, I did receive the registration SMS, but the code was not filled in automatically. However, the auto-fill seems to only work when installing from the Playstore, so I'm not sure if the refactoring the `SmsReceiveJob` to handle registration SMS messages was neccesary.
