### PR TITLE
Append instead of prepend location description to user message

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/mms/OutgoingMediaMessage.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/OutgoingMediaMessage.java
@@ -154,12 +154,13 @@ public class OutgoingMediaMessage {
   }
 
   private static String buildMessage(SlideDeck slideDeck, String message) {
-    if (!TextUtils.isEmpty(message) && !TextUtils.isEmpty(slideDeck.getBody())) {
-      return slideDeck.getBody() + "\n\n" + message;
+    String body = slideDeck.getBody();
+    if (!TextUtils.isEmpty(message) && !TextUtils.isEmpty(body)) {
+      return message + "\n\n" + body;
     } else if (!TextUtils.isEmpty(message)) {
       return message;
     } else {
-      return slideDeck.getBody();
+      return body;
     }
   }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
When sharing a location the location description is added as text. The user can add an additional text that is currently appended to the location description.
With this change the user message comes first and the location description is appended, which makes the message easier to read. It also allows to display the user text as preview in the conversation list instead of just a difficult to understand part of the location description.

Example with this change applied:
> Please quickly pick me up here
>
> 1600 Amphitheatre Pkwy, Mountain View,
> CA 94043, USA https://maps.google.com...