### PR TITLE
Fixes #9559: members dialog persists through activity pause

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/GroupMembersDialog.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/GroupMembersDialog.java
@@ -22,6 +22,7 @@ public final class GroupMembersDialog {
   private final Context   context;
   private final Recipient groupRecipient;
   private final Lifecycle lifecycle;
+  private AlertDialog dialog;
 
   public GroupMembersDialog(@NonNull Context context,
                             @NonNull Recipient groupRecipient,
@@ -37,14 +38,13 @@ public final class GroupMembersDialog {
       lifecycle,
       () -> DatabaseFactory.getGroupDatabase(context).getGroupMembers(groupRecipient.requireGroupId(), GroupDatabase.MemberSet.FULL_MEMBERS_INCLUDING_SELF),
       members -> {
-        AlertDialog dialog = new AlertDialog.Builder(context)
+        dialog = new AlertDialog.Builder(context)
                                             .setTitle(R.string.ConversationActivity_group_members)
                                             .setIconAttribute(R.attr.group_members_dialog_icon)
                                             .setCancelable(true)
                                             .setView(R.layout.dialog_group_members)
                                             .setPositiveButton(android.R.string.ok, null)
                                             .show();
-
         GroupMemberListView memberListView = dialog.findViewById(R.id.list_members);
 
         ArrayList<GroupMemberEntry.FullMember> pendingMembers = new ArrayList<>(members.size());
@@ -67,6 +67,11 @@ public final class GroupMembersDialog {
         memberListView.setMembers(pendingMembers);
       }
     );
+  }
+
+  public void dismiss() {
+    if(dialog.isShowing())
+      dialog.dismiss();
   }
 
   private void contactClick(@NonNull Recipient recipient) {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationActivity.java
@@ -322,6 +322,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   protected HidingLinearLayout       inlineAttachmentToggle;
   private   InputPanel               inputPanel;
   private   View                     panelParent;
+  private   GroupMembersDialog       groupMembersDialog;
 
   private LinkPreviewViewModel         linkPreviewViewModel;
   private ConversationSearchViewModel  searchViewModel;
@@ -504,6 +505,9 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     markLastSeen();
     AudioSlidePlayer.stopAll();
     EventBus.getDefault().unregister(this);
+
+    if(groupMembersDialog != null)
+      groupMembersDialog.dismiss();
   }
 
   @Override
@@ -1192,7 +1196,8 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void handleDisplayGroupRecipients() {
-    new GroupMembersDialog(this, getRecipient(), getLifecycle()).display();
+    groupMembersDialog = new GroupMembersDialog(this, getRecipient(), getLifecycle());
+    groupMembersDialog.display();
   }
 
   private void handleAddToContacts() {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Honor 10 Lite, Android 9
 * Virtual Pixel 3a, Android 9
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This PR adds a dismiss method to the `GroupMembersDialog` class and calls this method in `ConversationActivity`'s `onPause`, so that the dialog does not persist when the app is opened separately through sharing as described in the original issue.