### PR TITLE
Fixes #8986 . Fix backup timestamp language

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -100,7 +100,7 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
 
   private void setBackupSummary() {
     findPreference(TextSecurePreferences.BACKUP_NOW)
-        .setSummary(String.format(getString(R.string.ChatsPreferenceFragment_last_backup_s), BackupUtil.getLastBackupTime(getContext(), Locale.US)));
+        .setSummary(String.format(getString(R.string.ChatsPreferenceFragment_last_backup_s), BackupUtil.getLastBackupTime(getContext(), getResources().getConfiguration().locale)));
   }
 
   private void setMediaDownloadSummaries() {

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -100,7 +100,7 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
 
   private void setBackupSummary() {
     findPreference(TextSecurePreferences.BACKUP_NOW)
-        .setSummary(String.format(getString(R.string.ChatsPreferenceFragment_last_backup_s), BackupUtil.getLastBackupTime(getContext(), getResources().getConfiguration().locale)));
+        .setSummary(String.format(getString(R.string.ChatsPreferenceFragment_last_backup_s), BackupUtil.getLastBackupTime(getContext(), Locale.getDefault())));
   }
 
   private void setMediaDownloadSummaries() {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Redmi Note 7, Android 9.0
 * Virtual Pixel 2, Android 9.0
 * Virtual Pixel 3, Android 9.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

The backup timestamp is now written in the app default language, instead of always being in English. 
Before : (Signal is in French, but timestamp is in English)
![before](https://user-images.githubusercontent.com/35769770/80921281-c3917000-8d75-11ea-8766-76ee07c952d2.png)
After : 
![after2](https://user-images.githubusercontent.com/35769770/80921519-33542a80-8d77-11ea-9bef-d7434e24b4f3.png)

