### PR TITLE
Fixes #9629 Remove five files' calls to GMS APIs for utility functions

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/RecipientDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/RecipientDatabase.java
@@ -10,7 +10,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.annimon.stream.Stream;
-import com.google.android.gms.common.util.ArrayUtils;
 
 import net.sqlcipher.database.SQLiteConstraintException;
 import net.sqlcipher.database.SQLiteDatabase;
@@ -150,14 +149,14 @@ public class RecipientDatabase extends Database {
 
   private static final String[] MENTION_SEARCH_PROJECTION  = new String[]{ID, removeWhitespace("COALESCE(" + nullIfEmpty(SYSTEM_DISPLAY_NAME) + ", " + nullIfEmpty(PROFILE_JOINED_NAME) + ", " + nullIfEmpty(PROFILE_GIVEN_NAME) + ", " + nullIfEmpty(USERNAME) + ", " + nullIfEmpty(PHONE) + ")") + " AS " + SORT_NAME};
 
-  private static final String[] RECIPIENT_FULL_PROJECTION = ArrayUtils.concat(
+  private static final String[] RECIPIENT_FULL_PROJECTION = Stream.of(
       new String[] { TABLE_NAME + "." + ID,
                      TABLE_NAME + "." + STORAGE_PROTO },
       TYPED_RECIPIENT_PROJECTION,
       new String[] {
         IdentityDatabase.TABLE_NAME + "." + IdentityDatabase.VERIFIED + " AS " + IDENTITY_STATUS,
         IdentityDatabase.TABLE_NAME + "." + IdentityDatabase.IDENTITY_KEY + " AS " + IDENTITY_KEY
-      });
+      }).flatMap(Stream::of).toArray(String[]::new);
 
   public static final String[] CREATE_INDEXS = new String[] {
       "CREATE INDEX IF NOT EXISTS recipient_dirty_index ON " + TABLE_NAME + " (" + DIRTY + ");",
@@ -1041,8 +1040,8 @@ public class RecipientDatabase extends Database {
                                                + " LEFT OUTER JOIN " + GroupDatabase.TABLE_NAME + " ON " + TABLE_NAME + "." + GROUP_ID + " = " + GroupDatabase.TABLE_NAME + "." + GroupDatabase.GROUP_ID;
     List<RecipientSettings> out   = new ArrayList<>();
 
-    String[] columns = ArrayUtils.concat(RECIPIENT_FULL_PROJECTION,
-      new String[]{GroupDatabase.TABLE_NAME + "." + GroupDatabase.V2_MASTER_KEY });
+    String[] columns = Stream.of(RECIPIENT_FULL_PROJECTION,
+      new String[]{GroupDatabase.TABLE_NAME + "." + GroupDatabase.V2_MASTER_KEY }).flatMap(Stream::of).toArray(String[]::new);
 
     try (Cursor cursor = db.query(table, columns, query, args, null, null, null)) {
       while (cursor != null && cursor.moveToNext()) {

--- a/app/src/main/java/org/thoughtcrime/securesms/profiles/edit/EditProfileFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/profiles/edit/EditProfileFragment.java
@@ -27,7 +27,6 @@ import androidx.navigation.Navigation;
 
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.dd.CircularProgressButton;
-import com.google.android.gms.common.util.IOUtils;
 
 import org.thoughtcrime.securesms.LoggingFragment;
 import org.thoughtcrime.securesms.R;
@@ -45,6 +44,7 @@ import org.thoughtcrime.securesms.registration.RegistrationUtil;
 import org.thoughtcrime.securesms.util.CommunicationActions;
 import org.thoughtcrime.securesms.util.FeatureFlags;
 import org.thoughtcrime.securesms.util.StringUtil;
+import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.concurrent.SimpleTask;
 import org.thoughtcrime.securesms.util.text.AfterTextChanged;
 import org.thoughtcrime.securesms.util.views.LearnMoreTextView;
@@ -174,7 +174,7 @@ public class EditProfileFragment extends LoggingFragment {
           Media       result = data.getParcelableExtra(AvatarSelectionActivity.EXTRA_MEDIA);
           InputStream stream = BlobProvider.getInstance().getStream(requireContext(), result.getUri());
 
-          return IOUtils.readInputStreamFully(stream);
+          return Util.readFully(stream);
         } catch (IOException ioException) {
           Log.w(TAG, ioException);
           return null;

--- a/app/src/main/java/org/thoughtcrime/securesms/stickers/StickerPackPreviewRepository.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/stickers/StickerPackPreviewRepository.java
@@ -6,7 +6,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.WorkerThread;
 
 import com.annimon.stream.Stream;
-import com.google.android.gms.common.util.Hex;
+import org.thoughtcrime.securesms.util.Hex;
 
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.StickerDatabase;
@@ -77,8 +77,8 @@ public final class StickerPackPreviewRepository {
   @WorkerThread
   private Optional<StickerManifestResult> getManifestRemote(@NonNull String packId, @NonNull String packKey) {
     try {
-      byte[]                       packIdBytes    = Hex.stringToBytes(packId);
-      byte[]                       packKeyBytes   = Hex.stringToBytes(packKey);
+      byte[]                       packIdBytes    = Hex.fromStringCondensed(packId);
+      byte[]                       packKeyBytes   = Hex.fromStringCondensed(packKey);
       SignalServiceStickerManifest remoteManifest = receiver.retrieveStickerManifest(packIdBytes, packKeyBytes);
       StickerManifest              localManifest  = new StickerManifest(packId,
                                                                         packKey,

--- a/app/src/main/java/org/thoughtcrime/securesms/stickers/StickerRemoteUriFetcher.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/stickers/StickerRemoteUriFetcher.java
@@ -5,7 +5,7 @@ import androidx.annotation.NonNull;
 import com.bumptech.glide.Priority;
 import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.data.DataFetcher;
-import com.google.android.gms.common.util.Hex;
+import org.thoughtcrime.securesms.util.Hex;
 
 import org.thoughtcrime.securesms.logging.Log;
 import org.whispersystems.libsignal.InvalidMessageException;
@@ -32,8 +32,8 @@ public final class StickerRemoteUriFetcher implements DataFetcher<InputStream> {
   @Override
   public void loadData(@NonNull Priority priority, @NonNull DataCallback<? super InputStream> callback) {
     try {
-      byte[]      packIdBytes  = Hex.stringToBytes(stickerUri.getPackId());
-      byte[]      packKeyBytes = Hex.stringToBytes(stickerUri.getPackKey());
+      byte[]      packIdBytes  = Hex.fromStringCondensed(stickerUri.getPackId());
+      byte[]      packKeyBytes = Hex.fromStringCondensed(stickerUri.getPackKey());
       InputStream stream       = receiver.retrieveSticker(packIdBytes, packKeyBytes, stickerUri.getStickerId());
 
       callback.onDataReady(stream);

--- a/app/src/main/java/org/thoughtcrime/securesms/stickers/StickerUrl.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/stickers/StickerUrl.java
@@ -5,7 +5,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import android.text.TextUtils;
 
-import com.google.android.gms.common.util.Hex;
+import org.thoughtcrime.securesms.util.Hex;
 
 import org.whispersystems.libsignal.util.Pair;
 import org.whispersystems.libsignal.util.guava.Optional;
@@ -70,7 +70,7 @@ public class StickerUrl {
 
   private static boolean isValidHex(String value) {
     try {
-      Hex.stringToBytes(value);
+      Hex.fromStringCondensed(value);
       return true;
     } catch (Exception e) {
       return false;

--- a/app/src/main/java/org/thoughtcrime/securesms/util/concurrent/SignalExecutors.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/concurrent/SignalExecutors.java
@@ -4,8 +4,6 @@ import android.os.HandlerThread;
 
 import androidx.annotation.NonNull;
 
-import com.google.android.gms.common.util.concurrent.NumberedThreadFactory;
-
 import org.thoughtcrime.securesms.util.LinkedBlockingLifoQueue;
 
 import java.util.Queue;


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S9+, LineageOS 17.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

As per issue #9629 Signal's source code contains references to proprietary `com.google.android.gms.common.util.*` functions. This replaces five of them with standard open-source equivalents from Signal's own utility functions and/or Java.

Additionally, one import of `com.google.android.gms.common.util.concurrent.NumberedThreadFactory` is removed as it duplicates code already declared in the same file.