### PR TITLE
Update Dockerfile to Ubuntu 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 RUN dpkg --add-architecture i386 && \
     apt-get update -y && \
     apt-get install -y software-properties-common && \
     apt-get update -y && \
-    apt-get install -y libc6:i386=2.26-0ubuntu2.1 libncurses5:i386=6.0+20160625-1ubuntu1 libstdc++6:i386=7.2.0-8ubuntu3.2 lib32z1=1:1.2.11.dfsg-0ubuntu2 wget openjdk-8-jdk=8u171-b11-0ubuntu0.17.10.1 git unzip opensc pcscd && \
+    apt-get install -y \
+        libc6:i386=2.27-3ubuntu1 \
+        libncurses5:i386=6.1-1ubuntu1.18.04 \
+        libstdc++6:i386=8.4.0-1ubuntu1~18.04 \
+        lib32z1=1:1.2.11.dfsg-0ubuntu2 \
+        openjdk-8-jdk=8u252-b09-1~18.04 \
+        wget git unzip opensc pcscd && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \
     apt-get clean


### PR DESCRIPTION
I couldn't rebuild the docker image, since the repositories for Ubuntu 17.10 have been disabled. 
This is fixed by updating to Ubuntu 18.04 and adjusting the versions of the installed packages as seen above.

I verified that i can reproduce Android Signal 4.59.10 (armeabi-v7a) and 4.59.11 (arm64-v8a) under this configurarion.

Fixes #8836

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these versions:
 * v4.59.10, v4.59.11
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
