### PR TITLE
Fixes #8560 - Add Vcard support to received messages

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/SharedContactView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/SharedContactView.java
@@ -225,6 +225,10 @@ public class SharedContactView extends LinearLayout implements RecipientForeverO
     }
   }
 
+  public Contact getContact() {
+    return this.contact;
+  }
+
   public interface EventListener {
     void onAddToContactsClicked(@NonNull Contact contact);
     void onInviteClicked(@NonNull List<Recipient> choices);

--- a/app/src/main/java/org/thoughtcrime/securesms/components/SharedContactView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/SharedContactView.java
@@ -225,10 +225,6 @@ public class SharedContactView extends LinearLayout implements RecipientForeverO
     }
   }
 
-  public Contact getContact() {
-    return this.contact;
-  }
-
   public interface EventListener {
     void onAddToContactsClicked(@NonNull Contact contact);
     void onInviteClicked(@NonNull List<Recipient> choices);

--- a/app/src/main/java/org/thoughtcrime/securesms/contactshare/VCardUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/contactshare/VCardUtil.java
@@ -1,0 +1,158 @@
+package org.thoughtcrime.securesms.contactshare;
+
+import android.provider.ContactsContract;
+import android.text.TextUtils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.thoughtcrime.securesms.logging.Log;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import ezvcard.Ezvcard;
+import ezvcard.VCard;
+
+public class VCardUtil {
+
+    private static final String TAG = VCardUtil.class.getSimpleName();
+
+    public static List<Contact> parseContacts(@NonNull String vCardData) {
+        List<VCard> vContacts = Ezvcard.parse(vCardData).all();
+        List<Contact> contacts = new LinkedList<>();
+        for (VCard vCard: vContacts){
+            contacts.add(getContactFromVcard(vCard));
+        }
+        return contacts;
+    }
+
+    static @Nullable Contact getContactFromVcard(@NonNull VCard vcard) {
+        ezvcard.property.StructuredName  vName            = vcard.getStructuredName();
+        List<ezvcard.property.Telephone> vPhones          = vcard.getTelephoneNumbers();
+        List<ezvcard.property.Email>     vEmails          = vcard.getEmails();
+        List<ezvcard.property.Address>   vPostalAddresses = vcard.getAddresses();
+
+        String organization = vcard.getOrganization() != null && !vcard.getOrganization().getValues().isEmpty() ? vcard.getOrganization().getValues().get(0) : null;
+        String displayName  = vcard.getFormattedName() != null ? vcard.getFormattedName().getValue() : null;
+
+        if (displayName == null && vName != null) {
+            displayName = vName.getGiven();
+        }
+
+        if (displayName == null && vcard.getOrganization() != null) {
+            displayName = organization;
+        }
+
+        if (displayName == null) {
+            Log.w(TAG, "Failed to parse the vcard: No valid name.");
+            return null;
+        }
+
+        Contact.Name name = new Contact.Name(displayName,
+                vName != null ? vName.getGiven() : null,
+                vName != null ? vName.getFamily() : null,
+                vName != null && !vName.getPrefixes().isEmpty() ? vName.getPrefixes().get(0) : null,
+                vName != null && !vName.getSuffixes().isEmpty() ? vName.getSuffixes().get(0) : null,
+                null);
+
+
+        List<Contact.Phone> phoneNumbers = new ArrayList<>(vPhones.size());
+        for (ezvcard.property.Telephone vEmail : vPhones) {
+            String label = !vEmail.getTypes().isEmpty() ? getCleanedVcardType(vEmail.getTypes().get(0).getValue()) : null;
+
+            // Phone number is stored in the uri field in v4.0 only. In other versions, it is in the text field.
+            String phoneNumberFromText  = vEmail.getText();
+            String extractedPhoneNumber = phoneNumberFromText == null ? vEmail.getUri().getNumber() : phoneNumberFromText;
+            phoneNumbers.add(new Contact.Phone(extractedPhoneNumber, phoneTypeFromVcardType(label), label));
+        }
+
+        List<Contact.Email> emails = new ArrayList<>(vEmails.size());
+        for (ezvcard.property.Email vEmail : vEmails) {
+            String label = !vEmail.getTypes().isEmpty() ? getCleanedVcardType(vEmail.getTypes().get(0).getValue()) : null;
+            emails.add(new Contact.Email(vEmail.getValue(), emailTypeFromVcardType(label), label));
+        }
+
+        List<Contact.PostalAddress> postalAddresses = new ArrayList<>(vPostalAddresses.size());
+        for (ezvcard.property.Address vPostalAddress : vPostalAddresses) {
+            String label = !vPostalAddress.getTypes().isEmpty() ? getCleanedVcardType(vPostalAddress.getTypes().get(0).getValue()) : null;
+            postalAddresses.add(new Contact.PostalAddress(postalAddressTypeFromVcardType(label),
+                    label,
+                    vPostalAddress.getStreetAddress(),
+                    vPostalAddress.getPoBox(),
+                    null,
+                    vPostalAddress.getLocality(),
+                    vPostalAddress.getRegion(),
+                    vPostalAddress.getPostalCode(),
+                    vPostalAddress.getCountry()));
+        }
+
+        return new Contact(name, organization, phoneNumbers, emails, postalAddresses, null);
+    }
+
+    static Contact.Phone.Type phoneTypeFromContactType(int type) {
+        switch (type) {
+            case ContactsContract.CommonDataKinds.Phone.TYPE_HOME:
+                return Contact.Phone.Type.HOME;
+            case ContactsContract.CommonDataKinds.Phone.TYPE_MOBILE:
+                return Contact.Phone.Type.MOBILE;
+            case ContactsContract.CommonDataKinds.Phone.TYPE_WORK:
+                return Contact.Phone.Type.WORK;
+        }
+        return Contact.Phone.Type.CUSTOM;
+    }
+
+    private static Contact.Phone.Type phoneTypeFromVcardType(@Nullable String type) {
+        if      ("home".equalsIgnoreCase(type)) return Contact.Phone.Type.HOME;
+        else if ("cell".equalsIgnoreCase(type)) return Contact.Phone.Type.MOBILE;
+        else if ("work".equalsIgnoreCase(type)) return Contact.Phone.Type.WORK;
+        else                                    return Contact.Phone.Type.CUSTOM;
+    }
+
+    static Contact.Email.Type emailTypeFromContactType(int type) {
+        switch (type) {
+            case ContactsContract.CommonDataKinds.Email.TYPE_HOME:
+                return Contact.Email.Type.HOME;
+            case ContactsContract.CommonDataKinds.Email.TYPE_MOBILE:
+                return Contact.Email.Type.MOBILE;
+            case ContactsContract.CommonDataKinds.Email.TYPE_WORK:
+                return Contact.Email.Type.WORK;
+        }
+        return Contact.Email.Type.CUSTOM;
+    }
+
+    private static Contact.Email.Type emailTypeFromVcardType(@Nullable String type) {
+        if      ("home".equalsIgnoreCase(type)) return Contact.Email.Type.HOME;
+        else if ("cell".equalsIgnoreCase(type)) return Contact.Email.Type.MOBILE;
+        else if ("work".equalsIgnoreCase(type)) return Contact.Email.Type.WORK;
+        else                                    return Contact.Email.Type.CUSTOM;
+    }
+
+    static Contact.PostalAddress.Type postalAddressTypeFromContactType(int type) {
+        switch (type) {
+            case ContactsContract.CommonDataKinds.StructuredPostal.TYPE_HOME:
+                return Contact.PostalAddress.Type.HOME;
+            case ContactsContract.CommonDataKinds.StructuredPostal.TYPE_WORK:
+                return Contact.PostalAddress.Type.WORK;
+        }
+        return Contact.PostalAddress.Type.CUSTOM;
+    }
+
+    private static Contact.PostalAddress.Type postalAddressTypeFromVcardType(@Nullable String type) {
+        if      ("home".equalsIgnoreCase(type)) return Contact.PostalAddress.Type.HOME;
+        else if ("work".equalsIgnoreCase(type)) return Contact.PostalAddress.Type.WORK;
+        else                                    return Contact.PostalAddress.Type.CUSTOM;
+    }
+
+    private static String getCleanedVcardType(@Nullable String type) {
+        if (TextUtils.isEmpty(type)) return "";
+
+        if (type.startsWith("x-") && type.length() > 2) {
+            return type.substring(2);
+        }
+
+        return type;
+    }
+
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/contactshare/VCardUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/contactshare/VCardUtil.java
@@ -15,7 +15,9 @@ import java.util.List;
 import ezvcard.Ezvcard;
 import ezvcard.VCard;
 
-public class VCardUtil {
+public final class VCardUtil {
+
+    private VCardUtil(){}
 
     private static final String TAG = VCardUtil.class.getSimpleName();
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
@@ -336,6 +336,15 @@ public class ConversationItem extends LinearLayout implements BindableConversati
       }
     }
 
+    if (hasSharedContact(messageRecord)) {
+      int contactWidth = sharedContactStub.get().getMeasuredWidth();
+      int availableWidth = getAvailableMessageBubbleWidth(sharedContactStub.get());
+      if (contactWidth != availableWidth) {
+        sharedContactStub.get().getLayoutParams().width = availableWidth;
+        needsMeasure = true;
+      }
+    }
+
     ConversationItemFooter activeFooter   = getActiveFooter(messageRecord);
     int                    availableWidth = getAvailableMessageBubbleWidth(footer);
 
@@ -671,7 +680,6 @@ public class ConversationItem extends LinearLayout implements BindableConversati
       sharedContactStub.get().setOnLongClickListener(passthroughClickListener);
 
       setSharedContactCorners(messageRecord, previousRecord, nextRecord, isGroupThread);
-      setSharedContactWidth(messageRecord);
 
       ViewUtil.updateLayoutParams(bodyText, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
       ViewUtil.updateLayoutParamsIfNonNull(groupSenderHolder, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
@@ -902,13 +910,6 @@ public class ConversationItem extends LinearLayout implements BindableConversati
           sharedContactStub.get().setClusteredIncomingStyle();
       }
     }
-  }
-
-  private void setSharedContactWidth(@NonNull MessageRecord current) {
-    if (!TextUtils.isEmpty(current.getDisplayBody(getContext()))){
-      sharedContactStub.get().getLayoutParams().width = ViewGroup.LayoutParams.MATCH_PARENT;;
-    }
-
   }
 
   private void setLinkPreviewCorners(@NonNull MessageRecord current, @NonNull Optional<MessageRecord> previous, @NonNull Optional<MessageRecord> next, boolean isGroupThread, boolean bigImage) {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
@@ -902,7 +902,6 @@ public class ConversationItem extends LinearLayout implements BindableConversati
           sharedContactStub.get().setClusteredIncomingStyle();
       }
     }
-
   }
 
   private void setSharedContactWidth(@NonNull MessageRecord current) {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
@@ -1341,7 +1341,7 @@ public class ConversationItem extends LinearLayout implements BindableConversati
     @Override
     public void onClick(View view) {
       if (eventListener != null && batchSelected.isEmpty() && messageRecord.isMms() && !((MmsMessageRecord) messageRecord).getSharedContacts().isEmpty()) {
-        eventListener.onSharedContactDetailsClicked(((SharedContactView) view).getContact(), ((SharedContactView) view).getAvatarView());
+        eventListener.onSharedContactDetailsClicked(((MmsMessageRecord) messageRecord).getSharedContacts().get(0), sharedContactStub.get().getAvatarView());
       } else {
         passthroughClickListener.onClick(view);
       }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
@@ -337,8 +337,9 @@ public class ConversationItem extends LinearLayout implements BindableConversati
     }
 
     if (hasSharedContact(messageRecord)) {
-      int contactWidth = sharedContactStub.get().getMeasuredWidth();
+      int contactWidth   = sharedContactStub.get().getMeasuredWidth();
       int availableWidth = getAvailableMessageBubbleWidth(sharedContactStub.get());
+
       if (contactWidth != availableWidth) {
         sharedContactStub.get().getLayoutParams().width = availableWidth;
         needsMeasure = true;

--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/MmsDownloadJob.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/MmsDownloadJob.java
@@ -13,6 +13,9 @@ import com.google.android.mms.pdu_alt.RetrieveConf;
 
 import org.thoughtcrime.securesms.attachments.Attachment;
 import org.thoughtcrime.securesms.attachments.UriAttachment;
+import org.thoughtcrime.securesms.contactshare.Contact;
+import org.thoughtcrime.securesms.contactshare.ContactUtil;
+import org.thoughtcrime.securesms.contactshare.VCardUtil;
 import org.thoughtcrime.securesms.database.AttachmentDatabase;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.MessageDatabase;
@@ -33,6 +36,7 @@ import org.thoughtcrime.securesms.providers.BlobProvider;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.RecipientId;
 import org.thoughtcrime.securesms.service.KeyCachingService;
+import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.util.Util;
 import org.whispersystems.libsignal.util.guava.Optional;
@@ -189,6 +193,7 @@ public class MmsDownloadJob extends BaseJob {
     Set<RecipientId>  members     = new HashSet<>();
     String            body        = null;
     List<Attachment>  attachments = new LinkedList<>();
+    List<Contact>     sharedContacts = new LinkedList<>();
 
     RecipientId from = null;
 
@@ -223,14 +228,18 @@ public class MmsDownloadJob extends BaseJob {
         PduPart part = media.getPart(i);
 
         if (part.getData() != null) {
-          Uri    uri  = BlobProvider.getInstance().forData(part.getData()).createForSingleUseInMemory();
-          String name = null;
+          if (Util.toIsoString(part.getContentType()).toLowerCase().equals(MediaUtil.VCARD)){
+            sharedContacts.addAll(VCardUtil.parseContacts(new String(part.getData())));
+          } else {
+            Uri    uri  = BlobProvider.getInstance().forData(part.getData()).createForSingleUseInMemory();
+            String name = null;
 
-          if (part.getName() != null) name = Util.toIsoString(part.getName());
+            if (part.getName() != null) name = Util.toIsoString(part.getName());
 
-          attachments.add(new UriAttachment(uri, Util.toIsoString(part.getContentType()),
-                                            AttachmentDatabase.TRANSFER_PROGRESS_DONE,
-                                            part.getData().length, name, false, false, false, null, null, null, null, null));
+            attachments.add(new UriAttachment(uri, Util.toIsoString(part.getContentType()),
+                    AttachmentDatabase.TRANSFER_PROGRESS_DONE,
+                    part.getData().length, name, false, false, false, null, null, null, null, null));
+          }
         }
       }
     }
@@ -240,7 +249,7 @@ public class MmsDownloadJob extends BaseJob {
       group = Optional.of(DatabaseFactory.getGroupDatabase(context).getOrCreateMmsGroupForMembers(recipients));
     }
 
-    IncomingMediaMessage   message      = new IncomingMediaMessage(from, group, body, retrieved.getDate() * 1000L, -1, attachments, subscriptionId, 0, false, false, false);
+    IncomingMediaMessage   message      = new IncomingMediaMessage(from, group, body, retrieved.getDate() * 1000L, -1, attachments, subscriptionId, 0, false, false, false, Optional.of(sharedContacts));
     Optional<InsertResult> insertResult = database.insertMessageInbox(message, contentLocation, threadId);
 
     if (insertResult.isPresent()) {

--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/MmsDownloadJob.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/MmsDownloadJob.java
@@ -237,8 +237,8 @@ public class MmsDownloadJob extends BaseJob {
             if (part.getName() != null) name = Util.toIsoString(part.getName());
 
             attachments.add(new UriAttachment(uri, Util.toIsoString(part.getContentType()),
-                    AttachmentDatabase.TRANSFER_PROGRESS_DONE,
-                    part.getData().length, name, false, false, false, null, null, null, null, null));
+                            AttachmentDatabase.TRANSFER_PROGRESS_DONE,
+                            part.getData().length, name, false, false, false, null, null, null, null, null));
           }
         }
       }

--- a/app/src/main/java/org/thoughtcrime/securesms/mms/IncomingMediaMessage.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/IncomingMediaMessage.java
@@ -48,7 +48,8 @@ public class IncomingMediaMessage {
                               long expiresIn,
                               boolean expirationUpdate,
                               boolean viewOnce,
-                              boolean unidentified)
+                              boolean unidentified,
+                              Optional<List<Contact>> sharedContacts)
   {
     this.from             = from;
     this.groupId          = groupId.orNull();
@@ -64,6 +65,8 @@ public class IncomingMediaMessage {
     this.unidentified     = unidentified;
 
     this.attachments.addAll(attachments);
+    this.sharedContacts.addAll(sharedContacts.or(Collections.emptyList()));
+
   }
 
   public IncomingMediaMessage(@NonNull RecipientId from,

--- a/app/src/main/java/org/thoughtcrime/securesms/mms/PartParser.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/PartParser.java
@@ -9,17 +9,20 @@ import org.thoughtcrime.securesms.logging.Log;
 import org.thoughtcrime.securesms.util.Util;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+import java.util.List;
 
 
 public class PartParser {
 
-  private static final String TAG = Log.tag(PartParser.class);
+  private static final String       TAG            = Log.tag(PartParser.class);
+  private static final List<String> DOCUMENT_TYPES = Arrays.asList("text/vcard", "text/x-vcard");
 
   public static String getMessageText(PduBody body) {
     String bodyText = null;
 
     for (int i=0;i<body.getPartsNum();i++) {
-      if (ContentType.isTextType(Util.toIsoString(body.getPart(i).getContentType()))) {
+      if (isText(body.getPart(i)) && !isDocument(body.getPart(i))) {
         String partText;
 
         try {
@@ -49,7 +52,7 @@ public class PartParser {
     PduBody stripped = new PduBody();
 
     for (int i=0;i<body.getPartsNum();i++) {
-      if (isDisplayableMedia(body.getPart(i))) {
+      if (isDisplayableMedia(body.getPart(i)) || isDocument(body.getPart(i))) {
         stripped.addPart(body.getPart(i));
       }
     }
@@ -61,7 +64,7 @@ public class PartParser {
     int partCount = 0;
 
     for (int i=0;i<body.getPartsNum();i++) {
-      if (isDisplayableMedia(body.getPart(i))) {
+      if (isDisplayableMedia(body.getPart(i)) || isDocument(body.getPart(i))) {
         partCount++;
       }
     }
@@ -87,5 +90,9 @@ public class PartParser {
 
   public static boolean isDisplayableMedia(PduPart part) {
     return isImage(part) || isAudio(part) || isVideo(part);
+  }
+
+  public static boolean isDocument(PduPart part) {
+    return DOCUMENT_TYPES.contains(Util.toIsoString(part.getContentType()).toLowerCase());
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/mms/Slide.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/Slide.java
@@ -210,7 +210,10 @@ public abstract class Slide {
     Optional<String> fileName = getFileName();
 
     if (fileName.isPresent()) {
-      return Optional.of(getFileType(fileName));
+      String fileType = getFileType(fileName);
+      if (!fileType.isEmpty()){
+        return Optional.of(fileType);
+      }
     }
 
     return Optional.fromNullable(MediaUtil.getExtension(context, getUri()));

--- a/app/src/main/java/org/thoughtcrime/securesms/mms/Slide.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/Slide.java
@@ -211,7 +211,7 @@ public abstract class Slide {
 
     if (fileName.isPresent()) {
       String fileType = getFileType(fileName);
-      if (!fileType.isEmpty()){
+      if (!fileType.isEmpty()) {
         return Optional.of(fileType);
       }
     }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S8, Android 8.0.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixes #8560 

This PR allows received vcards to be easily imported into contacts.  It accomplishes this by parsing vcards into shared contact objects before storing the message.

Before:
![vcard_before](https://user-images.githubusercontent.com/5505389/83099731-224bc000-a07c-11ea-90fb-423cbaeb2769.png)


After:
![Screenshot_20200529-091211_Signal](https://user-images.githubusercontent.com/5505389/83263620-e6ece680-a18c-11ea-937a-bb32edbe33d2.jpg)

### Future PRs:
* Add support for displaying multiple shared contacts at once


