### PR TITLE
Fixing overflow menu button color on passphrase prompt

### DIFF
--- a/app/src/main/res/layout/prompt_passphrase_activity.xml
+++ b/app/src/main/res/layout/prompt_passphrase_activity.xml
@@ -26,7 +26,8 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
-            android:layout_marginTop="20dp">
+            android:layout_marginTop="20dp"
+            android:theme="@style/TextSecure.DarkActionBar">
 
         <ImageView
                 android:layout_width="wrap_content"
@@ -35,7 +36,6 @@
                 android:layout_gravity="center"/>
 
     </androidx.appcompat.widget.Toolbar>
-
 
     <LinearLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel XL, Android 10
 * Pixel 3XL, Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
The overflow menu button defaulted to a dark color when the device is using the light theme, despite the toolbar having a dark background color.

It now defaults to `@color/core_white` using the `TextSecure.DarkActionBar` theme.
