### PR TITLE
Replaced a hardcoded string with an existing string id

### DIFF
--- a/app/src/main/res/layout/fragment_registration_enter_phone_number.xml
+++ b/app/src/main/res/layout/fragment_registration_enter_phone_number.xml
@@ -63,7 +63,7 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="3"
                 app:labeledEditText_background="@color/white"
-                app:labeledEditText_label="Phone Number"
+                app:labeledEditText_label="@string/RegistrationActivity_phone_number_description"
                 app:labeledEditText_textLayout="@layout/phone_text" />
         </LinearLayout>
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual Device Pixel2 API 28 on ADB
 * Essential PH-1, Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Replaced a hardcoded string with an existing string id that is very similar to the hardcoded one.

I am aware that this pull request may not be what the team and the issue author ultimately want to implement by the following arguments:

1. The author states in the issue that the label may be redundant because the edit text below the label has the same text as the placeholder (aka hint).
2. The original, hardcoded string was `Phone Number` but this pull request will replace it with `Phone number` (lowercase `n`) for users of English locale (other locale users will now see this in their language).

The reasons I did this in this way are:

1. Removing a label seems to me a big decision that I am in no place to make.
1. But showing something in a different language from what are in other places could make the app look broken or immature to some users which I would not like them to see.
1. Adding another string to translate just for the upper/lower casing may not justify the effort by translators. And late translations would result in the same situation I worried in the above bullet point.

But please do let me know if I should have done it in a different way. I am willing to make the change to this PR. I also don't feel bad at all if this PR is closed without being merged because of a different point of view.