### PR TITLE
Fixes how the date time appears in the restore backup screen

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/RestoreBackupFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/RestoreBackupFragment.java
@@ -126,7 +126,7 @@ public final class RestoreBackupFragment extends BaseRegistrationFragment {
                   .navigate(RestoreBackupFragmentDirections.actionNoBackupFound());
       } else {
         restoreBackupSize.setText(getString(R.string.RegistrationActivity_backup_size_s, Util.getPrettyFileSize(backup.getSize())));
-        restoreBackupTime.setText(getString(R.string.RegistrationActivity_backup_timestamp_s, DateUtils.getExtendedRelativeTimeSpanString(requireContext(), Locale.US, backup.getTimestamp())));
+        restoreBackupTime.setText(getString(R.string.RegistrationActivity_backup_timestamp_s, DateUtils.getExtendedRelativeTimeSpanString(requireContext(), Locale.getDefault(), backup.getTimestamp())));
 
         restoreButton.setOnClickListener((v) -> handleRestore(v.getContext(), backup));
       }


### PR DESCRIPTION

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x ] I have tested my contribution on these devices:
 * Essential PH-1, Android 10
 * Virtual device Pixel2 API28
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Use the locale of the device to display when the backup that is about to be restored was taken at.

I am aware that there is a discussion on how the date time should be formatted in #9403, but this PR does not address the proposal in there. This PR just fixes the locale of the date time displays in the restore backup screen.