### PR TITLE
Fixes long clicking an item does not update the actionMode title

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/mediaoverview/ActionModeTitleData.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediaoverview/ActionModeTitleData.java
@@ -1,0 +1,26 @@
+package org.thoughtcrime.securesms.mediaoverview;
+
+/** A data class that carries information to construct a string to display on an action bar. */
+final class ActionModeTitleData {
+  private int     mediaCount;
+  private long    totalMediaSize;
+  private boolean showFileSize;
+
+  ActionModeTitleData(int mediaCount, long totalMediaSize, boolean showFileSize) {
+    this.mediaCount     = mediaCount;
+    this.totalMediaSize = totalMediaSize;
+    this.showFileSize   = showFileSize;
+  }
+
+  public int getMediaCount() {
+    return mediaCount;
+  }
+
+  public long getTotalMediaSize() {
+    return totalMediaSize;
+  }
+
+  public boolean isShowFileSize() {
+    return showFileSize;
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/mediaoverview/MediaOverviewPageViewModel.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediaoverview/MediaOverviewPageViewModel.java
@@ -1,0 +1,25 @@
+package org.thoughtcrime.securesms.mediaoverview;
+
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+import org.thoughtcrime.securesms.database.MediaDatabase.Sorting;
+import org.thoughtcrime.securesms.database.loaders.MediaLoader;
+
+public class MediaOverviewPageViewModel extends ViewModel {
+  private final MutableLiveData<ActionModeTitleData> actionModeTitleData = new MutableLiveData<>(
+      new ActionModeTitleData(0, 0, false));
+
+  public MutableLiveData<ActionModeTitleData> getActionModeTitleData() {
+    return actionModeTitleData;
+  }
+
+  public void updateActionModeTitle(int mediaCount, long selectedMediaSize, boolean isDetailLayout,
+                                    Sorting sortOrder, MediaLoader.MediaType mediaType)
+  {
+    boolean shouldShowTotalFileSize = isDetailLayout                             ||
+                                      mediaType != MediaLoader.MediaType.GALLERY ||
+                                      sortOrder   == Sorting.Largest;
+    actionModeTitleData.setValue(new ActionModeTitleData(mediaCount, selectedMediaSize, shouldShowTotalFileSize));
+  }
+}

--- a/app/src/test/java/org/thoughtcrime/securesms/mediaoverview/MediaOverviewPageViewModelTest.java
+++ b/app/src/test/java/org/thoughtcrime/securesms/mediaoverview/MediaOverviewPageViewModelTest.java
@@ -1,0 +1,92 @@
+package org.thoughtcrime.securesms.mediaoverview;
+
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.app.Application;
+import androidx.lifecycle.Lifecycle.Event;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.LifecycleRegistry;
+import androidx.lifecycle.Observer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import org.thoughtcrime.securesms.database.MediaDatabase.Sorting;
+import org.thoughtcrime.securesms.database.loaders.MediaLoader.MediaType;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE, application = Application.class)
+public final class MediaOverviewPageViewModelTest {
+  @Mock
+  private LifecycleOwner    lifecycleOwner;
+  private LifecycleRegistry lifecycleRegistry;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    lifecycleRegistry = new LifecycleRegistry(lifecycleOwner);
+    lifecycleRegistry.handleLifecycleEvent(Event.ON_CREATE);
+    lifecycleRegistry.handleLifecycleEvent(Event.ON_START);
+    when(lifecycleOwner.getLifecycle()).thenReturn(lifecycleRegistry);
+  }
+
+  @Test
+  public void update_actionModeTitle_triggers_observer_with_showFileSize() {
+    internal_updateActionModeTitle(Sorting.Largest, true, MediaType.ALL,
+        new ActionModeTitleData(100, 12345, true));
+  }
+
+  @Test
+  public void update_actionModeTitle_triggers_observer_with_fileSize_because_mediaType() {
+    internal_updateActionModeTitle(Sorting.Newest, false, MediaType.ALL,
+        new ActionModeTitleData(200, 12345, true));
+  }
+
+  @Test
+  public void update_actionModeTitle_triggers_observer_with_fileSize_because_detailLayout() {
+    internal_updateActionModeTitle(Sorting.Newest, true, MediaType.GALLERY,
+        new ActionModeTitleData(300, 12345, true));
+  }
+
+  @Test
+  public void update_actionModeTitle_triggers_observer_with_noFileSize() {
+    internal_updateActionModeTitle(Sorting.Newest, false, MediaType.GALLERY,
+        new ActionModeTitleData(400, 12345, false));
+  }
+
+  private void internal_updateActionModeTitle(Sorting sortOrder, boolean detailLayout, MediaType mediaType,
+                                              ActionModeTitleData expected) {
+    MediaOverviewPageViewModel viewModel   = new MediaOverviewPageViewModel();
+    Observer<ActionModeTitleData> observer = mock(Observer.class);
+    viewModel.getActionModeTitleData().observe(lifecycleOwner, observer);
+
+    reset(observer);
+    viewModel.updateActionModeTitle(expected.getMediaCount(), expected.getTotalMediaSize(),
+        detailLayout, sortOrder, mediaType);
+    verify(observer).onChanged(argThat(new ActionModeTitleDataMatcher(expected)));
+  }
+}
+
+final class ActionModeTitleDataMatcher implements ArgumentMatcher<ActionModeTitleData> {
+  private ActionModeTitleData expected;
+  ActionModeTitleDataMatcher(ActionModeTitleData expected) {
+    this.expected = expected;
+  }
+
+  @Override
+  public boolean matches(ActionModeTitleData actual) {
+    return expected.isShowFileSize()    == actual.isShowFileSize() &&
+           expected.getMediaCount()     == actual.getMediaCount() &&
+           expected.getTotalMediaSize() == actual.getTotalMediaSize();
+  }
+}


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Essential PH-1, Android 10
 * Virtual device Pixel 2 API 28
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Adds a call to trigger refreshing the actionMode title to onMediaLongClicked that fixes #9698.

It also moved a set of code from the fragment to the associated ViewModel so the decision around what to show in the action bar could be tested easier. By doing so the code that updates the action bar title is in one place now and whenever an event occurs that may want to update the state of the action bar, they should just call a ViewModel method without worrying about doing other things following a call to the method.

### Steps to verify
1. Go to Signal Settings
1. Storage
1. Review Storage
1. Long tap an item to enter the action mode
1. Long tap another item

Actual result at master@[d3c59585fd1d6ad90cd80a9ff8a0f33fa4004f4a]
Toolbar title doesn't update to reflect that we have two items selected.

Long tap to deselect an item does not update the toolbar title and action mode either.

Expected result after this PR
Toolbar title updates to indicate that 2 items are selected.

### Screenshots of the actual results at master@[d3c59585fd1d6ad90cd80a9ff8a0f33fa4004f4a]

![Screenshot_1600118573](https://user-images.githubusercontent.com/28482/93145942-9e195900-f6bb-11ea-94a3-9b31be238c9d.png)
![Screenshot_1600118592](https://user-images.githubusercontent.com/28482/93145943-9eb1ef80-f6bb-11ea-9b7e-fca5e6ae121c.png)


