### PR TITLE
Avoid unnecessary object allocation upon early receipt cache miss.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/EarlyReceiptCache.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/EarlyReceiptCache.java
@@ -6,6 +6,7 @@ import org.thoughtcrime.securesms.logging.Log;
 import org.thoughtcrime.securesms.recipients.RecipientId;
 import org.thoughtcrime.securesms.util.LRUCache;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -41,6 +42,6 @@ public class EarlyReceiptCache {
 
   public synchronized Map<RecipientId, Long> remove(long timestamp) {
     Map<RecipientId, Long> receipts = cache.remove(timestamp);
-    return receipts != null ? receipts : new HashMap<>();
+    return receipts != null ? receipts : Collections.emptyMap();
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/database/EarlyReceiptCache.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/EarlyReceiptCache.java
@@ -42,6 +42,6 @@ public class EarlyReceiptCache {
 
   public synchronized Map<RecipientId, Long> remove(long timestamp) {
     Map<RecipientId, Long> receipts = cache.remove(timestamp);
-    return receipts != null ? receipts : Collections.emptyMap();
+    return receipts != null ? Collections.unmodifiableMap(receipts) : Collections.emptyMap();
   }
 }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Pixel 3a, Android 9
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
The `Map<RecipientId, Long>` that is returned by `EarlyReceiptCache.remove(long)` is never written into, so it is safe to replace the `new HashMap` with an immutable, statically allocated, empty map.