### PR TITLE
Don't send a read receipt when the recipient is blocked

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/SendReadReceiptJob.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/SendReadReceiptJob.java
@@ -97,7 +97,10 @@ public class SendReadReceiptJob extends BaseJob {
       return;
     }
 
-    Recipient                   recipient      = Recipient.resolved(recipientId);
+    Recipient recipient = Recipient.resolved(recipientId);
+    // Do not send a read receipt to whom is blocked by the user
+    if (recipient.isBlocked()) return;
+
     SignalServiceMessageSender  messageSender  = ApplicationDependencies.getSignalServiceMessageSender();
     SignalServiceAddress        remoteAddress  = RecipientUtil.toSignalServiceAddress(context, recipient);
     SignalServiceReceiptMessage receiptMessage = new SignalServiceReceiptMessage(SignalServiceReceiptMessage.Type.READ, messageIds, timestamp);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Essential PH-1, Android 10
 * Virtual device Pixel 2, API 28
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Check if the recipient was blocked before sending a read receipt, to prevent any cases including  what was described in the issue #9610 from happening.

Steps to verify:
1. Prepare two Signal users (A and B)
1. As A send a message to B
1. As B confirm the message has arrived, but don't open the conversation
1. As B tap on the A's profile picture to open the conversation settings
1. As B scroll down, and tap on "Block" to block A
1. As B go back to the conversations list
1. As B swipe right the conversation with A to archive it
1. As A see if the message has the checkmark checked

Behavior in the master @ [d955389c467147d40a95b8f1b3afb3917994482f]:
A receives the read receipt (checkmark checked)

Expected (tested) behavior after this PR
A doesn't receive the read receipt (checkmark remains unchecked)
