### PR TITLE
Fixes #9662 - Don't refresh recent stickers instantly

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/stickers/StickerKeyboardPageFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/stickers/StickerKeyboardPageFragment.java
@@ -1,5 +1,6 @@
 package org.thoughtcrime.securesms.stickers;
 
+import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProviders;
 import android.content.res.Configuration;
 import android.graphics.Point;
@@ -23,6 +24,8 @@ import org.thoughtcrime.securesms.mms.GlideApp;
 import org.thoughtcrime.securesms.mms.GlideRequests;
 import org.thoughtcrime.securesms.stickers.StickerKeyboardPageAdapter.StickerKeyboardPageViewHolder;
 import org.whispersystems.libsignal.util.Pair;
+
+import java.util.List;
 
 /**
  * An individual page of stickers in the {@link StickerKeyboardProvider}.
@@ -125,10 +128,14 @@ public final class StickerKeyboardPageFragment extends Fragment implements Stick
     StickerKeyboardRepository repository = new StickerKeyboardRepository(DatabaseFactory.getStickerDatabase(requireContext()));
     viewModel = ViewModelProviders.of(this, new StickerKeyboardPageViewModel.Factory(requireActivity().getApplication(), repository)).get(StickerKeyboardPageViewModel.class);
 
-    viewModel.getStickers(packId).observe(getViewLifecycleOwner(), stickerRecords -> {
-      if (stickerRecords == null) return;
-
-      adapter.setStickers(stickerRecords, calculateStickerSize(getScreenWidth()));
+    viewModel.getStickers(packId).observe(getViewLifecycleOwner(), new Observer<List<StickerRecord>>() {
+      @Override
+      public void onChanged(List<StickerRecord> stickerRecords) {
+        if (stickerRecords == null) return;
+        adapter.setStickers(stickerRecords, calculateStickerSize(getScreenWidth()));
+        if(packId.equals(RECENT_PACK_ID))
+          viewModel.getStickers(packId).removeObserver(this);
+      }
     });
   }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Honor 10 Lite 10.0.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This PR stops the recent stickers fragment from observing changes to the recent stickers list after it is first loaded, which causes the stickers to move around while they are being sent. They will get updated next time the fragment is destroyed and recreated.