### PR TITLE
Fix various fields to use built-in emoji

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiEditText.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiEditText.java
@@ -27,7 +27,7 @@ public class EmojiEditText extends AppCompatEditText {
   public EmojiEditText(Context context, AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
     if (!TextSecurePreferences.isSystemEmojiPreferred(getContext())) {
-      setFilters(appendEmojiFilter(this.getFilters()));
+      EmojiFilter.appendEmojiFilter(this);
     }
   }
 
@@ -43,20 +43,5 @@ public class EmojiEditText extends AppCompatEditText {
   public void invalidateDrawable(@NonNull Drawable drawable) {
     if (drawable instanceof EmojiDrawable) invalidate();
     else                                   super.invalidateDrawable(drawable);
-  }
-
-  private InputFilter[] appendEmojiFilter(@Nullable InputFilter[] originalFilters) {
-    InputFilter[] result;
-
-    if (originalFilters != null) {
-      result = new InputFilter[originalFilters.length + 1];
-      System.arraycopy(originalFilters, 0, result, 1, originalFilters.length);
-    } else {
-      result = new InputFilter[1];
-    }
-
-    result[0] = new EmojiFilter(this);
-
-    return result;
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiFilter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiFilter.java
@@ -6,6 +6,9 @@ import android.text.Spanned;
 import android.text.TextUtils;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 public class EmojiFilter implements InputFilter {
   private TextView view;
 
@@ -26,5 +29,20 @@ public class EmojiFilter implements InputFilter {
     }
 
     return emojified;
+  }
+
+  public static void appendEmojiFilter(@NonNull TextView textView) {
+    InputFilter[] result;
+    InputFilter[] originalFilters = textView.getFilters();
+    if (originalFilters != null) {
+      result = new InputFilter[originalFilters.length + 1];
+      System.arraycopy(originalFilters, 0, result, 1, originalFilters.length);
+    } else {
+      result = new InputFilter[1];
+    }
+
+    result[0] = new EmojiFilter(textView);
+
+    textView.setFilters(result);
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiSearchView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiSearchView.java
@@ -1,0 +1,39 @@
+package org.thoughtcrime.securesms.components.emoji;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.util.AttributeSet;
+import android.widget.EditText;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.components.DarkSearchView;
+import org.thoughtcrime.securesms.components.emoji.EmojiProvider.EmojiDrawable;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
+
+public class EmojiSearchView extends DarkSearchView {
+
+    public EmojiSearchView(@NonNull Context context) {
+        this(context, null);
+    }
+
+    public EmojiSearchView(@NonNull Context context, @Nullable AttributeSet attrs) {
+        this(context, attrs, R.attr.search_view_style);
+    }
+
+    public EmojiSearchView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        EditText searchText = findViewById(androidx.appcompat.R.id.search_src_text);
+        if (!TextSecurePreferences.isSystemEmojiPreferred(getContext())) {
+            EmojiFilter.appendEmojiFilter(searchText);
+        }
+    }
+
+    @Override
+    public void invalidateDrawable(@NonNull Drawable drawable) {
+        if (drawable instanceof EmojiDrawable) invalidate();
+        else                                   super.invalidateDrawable(drawable);
+    }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/contacts/ContactChip.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/contacts/ContactChip.java
@@ -16,6 +16,7 @@ import com.bumptech.glide.request.target.CustomTarget;
 import com.bumptech.glide.request.transition.Transition;
 import com.google.android.material.chip.Chip;
 
+import org.thoughtcrime.securesms.components.emoji.EmojiFilter;
 import org.thoughtcrime.securesms.contacts.avatars.ContactPhoto;
 import org.thoughtcrime.securesms.mms.GlideRequests;
 import org.thoughtcrime.securesms.recipients.Recipient;
@@ -26,14 +27,7 @@ public final class ContactChip extends Chip {
 
   public ContactChip(Context context) {
     super(context);
-  }
-
-  public ContactChip(Context context, AttributeSet attrs) {
-    super(context, attrs);
-  }
-
-  public ContactChip(Context context, AttributeSet attrs, int defStyleAttr) {
-    super(context, attrs, defStyleAttr);
+    EmojiFilter.appendEmojiFilter(this);
   }
 
   public void setContact(@NonNull SelectedContact contact) {

--- a/app/src/main/res/layout/contact_filter_toolbar.xml
+++ b/app/src/main/res/layout/contact_filter_toolbar.xml
@@ -11,7 +11,8 @@
                       android:layout_height="match_parent"
                       android:orientation="horizontal">
 
-            <EditText android:id="@+id/search_view"
+            <org.thoughtcrime.securesms.components.emoji.EmojiEditText
+                      android:id="@+id/search_view"
                       android:layout_height="wrap_content"
                       android:layout_width="0px"
                       android:layout_weight="1"

--- a/app/src/main/res/layout/conversation_item_received_multimedia.xml
+++ b/app/src/main/res/layout/conversation_item_received_multimedia.xml
@@ -77,7 +77,7 @@
                 android:visibility="gone"
                 tools:visibility="visible">
 
-                <TextView
+                <org.thoughtcrime.securesms.components.emoji.EmojiTextView
                     android:id="@+id/group_message_sender"
                     style="@style/Signal.Text.Preview"
                     android:layout_width="wrap_content"
@@ -90,7 +90,7 @@
                     tools:text="+14152222222"
                     tools:visibility="visible" />
 
-                <TextView
+                <org.thoughtcrime.securesms.components.emoji.EmojiTextView
                     android:id="@+id/group_message_sender_profile"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/layout/conversation_item_received_text_only.xml
+++ b/app/src/main/res/layout/conversation_item_received_text_only.xml
@@ -77,7 +77,7 @@
                 android:visibility="gone"
                 tools:visibility="visible">
 
-                <TextView
+                <org.thoughtcrime.securesms.components.emoji.EmojiTextView
                     android:id="@+id/group_message_sender"
                     style="@style/Signal.Text.Preview"
                     android:layout_width="wrap_content"
@@ -90,7 +90,7 @@
                     tools:text="+14152222222"
                     tools:visibility="visible" />
 
-                <TextView
+                <org.thoughtcrime.securesms.components.emoji.EmojiTextView
                     android:id="@+id/group_message_sender_profile"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/layout/conversation_item_update.xml
+++ b/app/src/main/res/layout/conversation_item_update.xml
@@ -47,7 +47,7 @@
         android:gravity="center"
         android:orientation="vertical">
 
-        <TextView
+        <org.thoughtcrime.securesms.components.emoji.EmojiTextView
             android:id="@+id/conversation_update_body"
             style="@style/Signal.Text.Preview"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/conversation_list_fragment.xml
+++ b/app/src/main/res/layout/conversation_list_fragment.xml
@@ -106,7 +106,7 @@
       app:layout_constraintTop_toBottomOf="@id/toolbar_barrier"
       tools:visibility="visible" />
 
-  <TextView
+  <org.thoughtcrime.securesms.components.emoji.EmojiTextView
       android:id="@+id/search_no_results"
       android:layout_width="0dp"
       android:layout_height="0dp"

--- a/app/src/main/res/layout/group_new_candidate_recipient_list_item.xml
+++ b/app/src/main/res/layout/group_new_candidate_recipient_list_item.xml
@@ -17,7 +17,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
+    <org.thoughtcrime.securesms.components.emoji.EmojiTextView
         android:id="@+id/recipient_name"
         android:layout_width="0dp"
         android:layout_height="0dp"

--- a/app/src/main/res/layout/group_recipient_list_item.xml
+++ b/app/src/main/res/layout/group_recipient_list_item.xml
@@ -17,7 +17,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
+    <org.thoughtcrime.securesms.components.emoji.EmojiTextView
         android:id="@+id/recipient_name"
         android:layout_width="0dp"
         android:layout_height="0dp"

--- a/app/src/main/res/layout/help_fragment.xml
+++ b/app/src/main/res/layout/help_fragment.xml
@@ -36,7 +36,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <EditText
+            <org.thoughtcrime.securesms.components.emoji.EmojiEditText
                 android:id="@+id/help_fragment_problem"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/invite_activity.xml
+++ b/app/src/main/res/layout/invite_activity.xml
@@ -43,7 +43,8 @@
                       android:layout_marginTop="18dp"
                       android:paddingStart="10dp"/>
 
-            <EditText android:id="@+id/invite_text"
+            <org.thoughtcrime.securesms.components.emoji.EmojiEditText
+                      android:id="@+id/invite_text"
                       android:layout_width="match_parent"
                       android:layout_height="wrap_content"
                       android:minLines="2"

--- a/app/src/main/res/layout/profile_create_fragment.xml
+++ b/app/src/main/res/layout/profile_create_fragment.xml
@@ -86,7 +86,7 @@
                     app:layout_constraintStart_toStartOf="@+id/avatar_background"
                     app:layout_constraintTop_toTopOf="@+id/avatar_background" />
 
-                <TextView
+                <org.thoughtcrime.securesms.components.emoji.EmojiTextView
                     android:id="@+id/name_preview"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -121,7 +121,7 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/name_preview">
 
-                    <EditText
+                    <org.thoughtcrime.securesms.components.emoji.EmojiEditText
                         android:id="@+id/given_name"
                         style="@style/Signal.Text.Body"
                         android:layout_width="match_parent"
@@ -136,7 +136,7 @@
                         android:inputType="textPersonName"
                         android:singleLine="true" />
 
-                    <EditText
+                    <org.thoughtcrime.securesms.components.emoji.EmojiEditText
                         android:id="@+id/family_name"
                         style="@style/Signal.Text.Body"
                         android:layout_width="match_parent"

--- a/app/src/main/res/menu/conversation.xml
+++ b/app/src/main/res/menu/conversation.xml
@@ -11,7 +11,7 @@
 
     <item android:title="@string/SearchToolbar_search"
           android:id="@+id/menu_search"
-          app:actionViewClass="org.thoughtcrime.securesms.components.DarkSearchView"
+          app:actionViewClass="org.thoughtcrime.securesms.components.emoji.EmojiSearchView"
           app:showAsAction="collapseActionView"/>
 
     <item android:title="@string/conversation__menu_add_shortcut"

--- a/app/src/main/res/menu/conversation_list_search.xml
+++ b/app/src/main/res/menu/conversation_list_search.xml
@@ -6,7 +6,7 @@
     <item
             android:id="@+id/action_filter_search"
             android:title=" "
-            app:actionViewClass="org.thoughtcrime.securesms.components.SearchView"
+            app:actionViewClass="org.thoughtcrime.securesms.components.emoji.EmojiSearchView"
             app:showAsAction="collapseActionView|always"
             tools:ignore="HardcodedText" />
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Honor 10 Lite, Android 10.0.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This PR fixes a bunch of places where currently system emoji are displayed (without the "Use system emoji" preference set):
- Conversations search box
- Messages search box
- Profile editing fragment
- Contact and profile names in received messages
- Contacts list when creating a new message/group
- Contact chips when creating a new group
- Contact filter box when creating a new message/group
- "Contact Us" help box
- Names in the conversation list
- Conversation search empty state message
- Names inside conversation updates

In most cases this was just a case of changing `TextView`s to `EmojiTextView`s and `EditText`s to `EmojiEditText`s, but I also added an emoji implementation of `SearchView` and modified `ContactChip` to support emoji.

One area that is not yet fixed is the automatically generated letter-based avatar images that can be seen in the conversations list. If for example a contact's second name is just an emoji, the emoji will be rendered in system style in the avatar.