### PR TITLE
Stop calling deprecated method to update context in newer OS

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/dynamiclanguage/DynamicLanguageContextWrapper.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/dynamiclanguage/DynamicLanguageContextWrapper.java
@@ -20,9 +20,7 @@ public final class DynamicLanguageContextWrapper {
     final Configuration config    = resources.getConfiguration();
     final Configuration newConfig = copyWithNewLocale(config, newLocale);
 
-    resources.updateConfiguration(newConfig, resources.getDisplayMetrics());
-
-    return context;
+    return context.createConfigurationContext(newConfig);
   }
 
   private static Configuration copyWithNewLocale(Configuration config, Locale locale) {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Pixel 2, Android 28
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Steps to verify the fix
1. Prepare a device that has API 28 or newer.
1. Launch Signal.
1. Tap on your profile picture to open Settings.
1. Tap on Appearance.
1. Tap on Language.
1. Tap on Japanese (or Chinese or any other language that is not the current one).
1. Either tap on the left arrow on the action bar or tap the back button on the device to go back to Settings.
1. Again, either tap on the left arrow on the action bar or tap the back button on the device to go back to the conversation list.
1. Tap on the magnifier icon on the action bar.
1. If you see the hint in the edit text translated in the language you choose at the step above, repeat from the step 3 one more time.
  * I saw sometimes the bug reproduces at the first iteration, but most of the times I see this bug reproduces after the second iteration.

Actual behavior of the master @[dd717b60b8936d9e237ba78b654f99c0777c4f50]:

In most cases, after the second iteration, the hint text in the edit text field is not translated in the current language that you choose.

Expected behavior after this PR:

Every time you choose a language, the hint text in the edit text field is translated in that language.