### PR TITLE
Don't cache locale in conversation

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListAdapter.java
@@ -141,7 +141,7 @@ class ConversationListAdapter extends PagedListAdapter<Conversation, RecyclerVie
 
       casted.getConversationListItem().bind(conversation.getThreadRecord(),
                                             glideRequests,
-                                            conversation.getLocale(),
+                                            Locale.getDefault(),
                                             typingSet,
                                             getBatchSelectionIds(),
                                             batchMode);

--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListDataSource.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListDataSource.java
@@ -20,7 +20,6 @@ import org.thoughtcrime.securesms.util.paging.SizeFixResult;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.concurrent.Executor;
 
 abstract class ConversationListDataSource extends PositionalDataSource<Conversation> {
@@ -60,14 +59,13 @@ abstract class ConversationListDataSource extends PositionalDataSource<Conversat
     long start = System.currentTimeMillis();
 
     List<Conversation> conversations  = new ArrayList<>(params.requestedLoadSize);
-    Locale             locale         = Locale.getDefault();
     int                totalCount     = getTotalCount();
     int                effectiveCount = params.requestedStartPosition;
 
     try (ThreadDatabase.Reader reader = threadDatabase.readerFor(getCursor(params.requestedStartPosition, params.requestedLoadSize))) {
       ThreadRecord record;
       while ((record = reader.getNext()) != null && effectiveCount < totalCount && !isInvalid()) {
-        conversations.add(new Conversation(record, locale));
+        conversations.add(new Conversation(record));
         effectiveCount++;
       }
     }
@@ -86,12 +84,11 @@ abstract class ConversationListDataSource extends PositionalDataSource<Conversat
     long start = System.currentTimeMillis();
 
     List<Conversation> conversations = new ArrayList<>(params.loadSize);
-    Locale             locale        = Locale.getDefault();
 
     try (ThreadDatabase.Reader reader = threadDatabase.readerFor(getCursor(params.startPosition, params.loadSize))) {
       ThreadRecord record;
       while ((record = reader.getNext()) != null && !isInvalid()) {
-        conversations.add(new Conversation(record, locale));
+        conversations.add(new Conversation(record));
       }
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/model/Conversation.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/model/Conversation.java
@@ -4,8 +4,6 @@ import androidx.annotation.NonNull;
 
 import org.thoughtcrime.securesms.database.model.ThreadRecord;
 
-import java.util.Objects;
-
 public class Conversation {
   private final ThreadRecord threadRecord;
 
@@ -27,6 +25,6 @@ public class Conversation {
 
   @Override
   public int hashCode() {
-    return Objects.hash(threadRecord);
+    return threadRecord.hashCode();
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/model/Conversation.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/model/Conversation.java
@@ -4,24 +4,17 @@ import androidx.annotation.NonNull;
 
 import org.thoughtcrime.securesms.database.model.ThreadRecord;
 
-import java.util.Locale;
 import java.util.Objects;
 
 public class Conversation {
   private final ThreadRecord threadRecord;
-  private final Locale       locale;
 
-  public Conversation(@NonNull ThreadRecord threadRecord, @NonNull Locale locale) {
+  public Conversation(@NonNull ThreadRecord threadRecord) {
     this.threadRecord = threadRecord;
-    this.locale       = locale;
   }
 
   public @NonNull ThreadRecord getThreadRecord() {
     return threadRecord;
-  }
-
-  public @NonNull Locale getLocale() {
-    return locale;
   }
 
   @Override
@@ -29,12 +22,11 @@ public class Conversation {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     Conversation that = (Conversation) o;
-    return threadRecord.equals(that.threadRecord) &&
-           locale.equals(that.locale);
+    return threadRecord.equals(that.threadRecord);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(threadRecord, locale);
+    return Objects.hash(threadRecord);
   }
 }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Pixel 2, Android 9 (API 28)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Found while debugging #9736. While PR #9750 fixes the issue, I found that the date text in each conversation thread in the list of MainActivity is not translated in the language that was just selected. 

The bug was due to the locale object cached in the list adapter which was set by `Locale.getDefault()` at the moment it was first created, and survives `activity.recreate()`.

### Steps to verify the fix
1. Prepare an account that has one or more conversation.
1. Launch Signal.
1. Tap on your profile picture to open Settings.
1. Tap on Appearance.
1. Tap on Language.
1. Tap on Japanese (or Chinese or any other language that is not the current one).
1. Either tap on the left arrow on the action bar or tap the back button on the device to go back to Settings.
1. Again, either tap on the left arrow on the action bar or tap the back button on the device to go back to the conversation list.

Behavior at master @ [dd717b60b8936d9e237ba78b654f99c0777c4f50]:

Date text is not translated to the language that was selected.

Behavior after the PR:

Every time you choose a language, the date text in each conversation thread in the list is translated in that language.

### Note
This change effectively makes `Conversation` class the same as `ThreadRecord` class. It seems the purpose of two classes are so different, and also to be compliant with making a PR as small as possible, I did not remove Conversation class.