### PR TITLE
Optimization of runtime in generateWaveForm

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -304,7 +304,7 @@ dependencies {
 
     implementation 'org.signal:argon2:13.1@aar'
 
-    implementation 'org.signal:ringrtc-android:2.1.0'
+    implementation 'org.signal:ringrtc-android:2.1.1'
 
     implementation "me.leolin:ShortcutBadger:1.1.16"
     implementation 'se.emilsjolander:stickylistheaders:2.7.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,8 +80,8 @@ protobuf {
     }
 }
 
-def canonicalVersionCode = 659
-def canonicalVersionName = "4.64.2"
+def canonicalVersionCode = 660
+def canonicalVersionName = "4.64.3"
 
 def postFixSize = 10
 def abiPostFix = ['universal'   : 0,

--- a/app/src/main/java/org/thoughtcrime/securesms/audio/AudioWaveForm.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/audio/AudioWaveForm.java
@@ -157,83 +157,75 @@ public final class AudioWaveForm {
       codec.configure(format, null, null, 0);
       codec.start();
 
-      ByteBuffer[] codecInputBuffers  = codec.getInputBuffers();
-      ByteBuffer[] codecOutputBuffers = codec.getOutputBuffers();
-
       extractor.selectTrack(0);
 
-      long                  kTimeOutUs      = 5000;
+      final long            TIMEOUT_US      = 5000;
       MediaCodec.BufferInfo info            = new MediaCodec.BufferInfo();
       boolean               sawInputEOS     = false;
       boolean               sawOutputEOS    = false;
       int                   noOutputCounter = 0;
 
+      final long            BAR_FACTOR      = totalDurationUs / (BAR_COUNT * SAMPLES_PER_BAR);
+      long                  barTimer        = 0;
+
+      int                   barIndex;
+      int                   sampleSize;
+      long                  presentationTimeUs;
+      long                  total;
+      short                 aShort;
+      int                   inputBufferId;
+      int                   outputBufferId;
+      ByteBuffer            codecInputBuffer;
+      ByteBuffer            codecOutputBuffer;
+
       while (!sawOutputEOS && noOutputCounter < 50) {
         noOutputCounter++;
         if (!sawInputEOS) {
-          int inputBufIndex = codec.dequeueInputBuffer(kTimeOutUs);
-          if (inputBufIndex >= 0) {
-            ByteBuffer dstBuf             = codecInputBuffers[inputBufIndex];
-            int        sampleSize         = extractor.readSampleData(dstBuf, 0);
-            long       presentationTimeUs = 0;
-
-            if (sampleSize < 0) {
-              sawInputEOS = true;
-              sampleSize  = 0;
+          inputBufferId = codec.dequeueInputBuffer(TIMEOUT_US);
+          if (inputBufferId >= 0) {
+            codecInputBuffer = codec.getInputBuffer(inputBufferId);
+            extractor.seekTo(barTimer, MediaExtractor.SEEK_TO_NEXT_SYNC);
+            barTimer  += BAR_FACTOR;
+            sampleSize = extractor.readSampleData(codecInputBuffer, 0);
+            if (sampleSize < 0 || barTimer > totalDurationUs) {
+              sawInputEOS        = true;
+              sampleSize         = 0;
+              presentationTimeUs = 0;
             } else {
               presentationTimeUs = extractor.getSampleTime();
             }
 
             codec.queueInputBuffer(
-              inputBufIndex,
+              inputBufferId,
               0,
               sampleSize,
               presentationTimeUs,
               sawInputEOS ? MediaCodec.BUFFER_FLAG_END_OF_STREAM : 0);
-
-            if (!sawInputEOS) {
-              int barSampleIndex = (int) (SAMPLES_PER_BAR * (wave.length * extractor.getSampleTime()) / totalDurationUs);
-              sawInputEOS = !extractor.advance();
-              int nextBarSampleIndex = (int) (SAMPLES_PER_BAR * (wave.length * extractor.getSampleTime()) / totalDurationUs);
-              while (!sawInputEOS && nextBarSampleIndex == barSampleIndex) {
-                sawInputEOS = !extractor.advance();
-                if (!sawInputEOS) {
-                  nextBarSampleIndex = (int) (SAMPLES_PER_BAR * (wave.length * extractor.getSampleTime()) / totalDurationUs);
-                }
-              }
-            }
           }
         }
-
-        int outputBufferIndex;
-        do {
-          outputBufferIndex = codec.dequeueOutputBuffer(info, kTimeOutUs);
-          if (outputBufferIndex >= 0) {
-            if (info.size > 0) {
-              noOutputCounter = 0;
-            }
-
-            ByteBuffer buf = codecOutputBuffers[outputBufferIndex];
-            int barIndex = (int) ((wave.length * info.presentationTimeUs) / totalDurationUs);
-            long total = 0;
-            for (int i = 0; i < info.size; i += 2 * 4) {
-              short aShort = buf.getShort(i);
-              total += Math.abs(aShort);
-            }
-            if (barIndex >= 0 && barIndex < wave.length) {
-              wave[barIndex] += total;
-              waveSamples[barIndex] += info.size / 2;
-            }
-            codec.releaseOutputBuffer(outputBufferIndex, false);
-            if ((info.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
-              sawOutputEOS = true;
-            }
-          } else if (outputBufferIndex == MediaCodec.INFO_OUTPUT_BUFFERS_CHANGED) {
-            codecOutputBuffers = codec.getOutputBuffers();
-          } else if (outputBufferIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
-            Log.d(TAG, "output format has changed to " + codec.getOutputFormat());
+        outputBufferId = codec.dequeueOutputBuffer(info, TIMEOUT_US);
+        if (outputBufferId >= 0) {
+          if (info.size > 0) {
+            noOutputCounter = 0;
           }
-        } while (outputBufferIndex >= 0);
+          codecOutputBuffer = codec.getOutputBuffer(outputBufferId);
+          barIndex = (int) ((wave.length * info.presentationTimeUs) / totalDurationUs);
+          total = 0;
+          for (int i = 0; i < info.size; i += 2 * 4) {
+            aShort = codecOutputBuffer.getShort(i);
+            total += Math.abs(aShort);
+          }
+          if (barIndex >= 0 && barIndex < wave.length) {
+            wave[barIndex] += total;
+            waveSamples[barIndex] += info.size;
+          }
+          if (info.flags == MediaCodec.BUFFER_FLAG_END_OF_STREAM) {
+            sawOutputEOS = true;
+          }
+          codec.releaseOutputBuffer(outputBufferId, false);
+        } else if (outputBufferId == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
+          Log.d(TAG, "output format has changed to " + codec.getOutputFormat());
+        }
       }
 
       codec.stop();

--- a/app/src/main/java/org/thoughtcrime/securesms/database/MmsDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/MmsDatabase.java
@@ -599,11 +599,13 @@ public class MmsDatabase extends MessagingDatabase {
 
     db.beginTransaction();
     try {
+      String query = ID + " = ? AND (" + EXPIRE_STARTED + " = 0 OR " + EXPIRE_STARTED + " > ?)";
+
       for (long id : ids) {
         ContentValues contentValues = new ContentValues();
         contentValues.put(EXPIRE_STARTED, startedAtTimestamp);
 
-        db.update(TABLE_NAME, contentValues, ID_WHERE, new String[]{String.valueOf(id)});
+        db.update(TABLE_NAME, contentValues, query, new String[]{String.valueOf(id), String.valueOf(startedAtTimestamp)});
 
         if (threadId < 0) {
           threadId = getThreadIdForMessage(id);

--- a/app/src/main/java/org/thoughtcrime/securesms/database/RecipientDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/RecipientDatabase.java
@@ -170,6 +170,10 @@ public class RecipientDatabase extends Database {
     public static VibrateState fromId(int id) {
       return values()[id];
     }
+
+    public static VibrateState fromBoolean(boolean enabled) {
+      return enabled ? ENABLED : DISABLED;
+    }
   }
 
   public enum RegisteredState {

--- a/app/src/main/java/org/thoughtcrime/securesms/database/SmsDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/SmsDatabase.java
@@ -366,11 +366,13 @@ public class SmsDatabase extends MessagingDatabase {
 
     db.beginTransaction();
     try {
+      String query = ID + " = ? AND (" + EXPIRE_STARTED + " = 0 OR " + EXPIRE_STARTED + " > ?)";
+
       for (long id : ids) {
         ContentValues contentValues = new ContentValues();
         contentValues.put(EXPIRE_STARTED, startedAtTimestamp);
 
-        db.update(TABLE_NAME, contentValues, ID_WHERE, new String[]{String.valueOf(id)});
+        db.update(TABLE_NAME, contentValues, query, new String[]{String.valueOf(id), String.valueOf(startedAtTimestamp)});
 
         if (threadId < 0) {
           threadId = getThreadIdForMessage(id);

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/ui/managegroup/ManageGroupActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/ui/managegroup/ManageGroupActivity.java
@@ -44,7 +44,7 @@ public class ManageGroupActivity extends PassphraseRequiredActionBarActivity {
   @Override
   protected void onCreate(Bundle savedInstanceState, boolean ready) {
     super.onCreate(savedInstanceState, ready);
-    getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
+    getWindow().getDecorView().setSystemUiVisibility(getWindow().getDecorView().getSystemUiVisibility() | View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
     setContentView(R.layout.group_manage_activity);
     if (savedInstanceState == null) {
       getSupportFragmentManager().beginTransaction()

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/NotificationChannels.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/NotificationChannels.java
@@ -509,8 +509,8 @@ public class NotificationChannels {
     copy.setGroup(original.getGroup());
     copy.setSound(original.getSound(), original.getAudioAttributes());
     copy.setBypassDnd(original.canBypassDnd());
-    copy.enableVibration(original.shouldVibrate());
     copy.setVibrationPattern(original.getVibrationPattern());
+    copy.enableVibration(original.shouldVibrate());
     copy.setLockscreenVisibility(original.getLockscreenVisibility());
     copy.setShowBadge(original.canShowBadge());
     copy.setLightColor(original.getLightColor());

--- a/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/managerecipient/ManageRecipientActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/managerecipient/ManageRecipientActivity.java
@@ -55,7 +55,7 @@ public class ManageRecipientActivity extends PassphraseRequiredActionBarActivity
   @Override
   protected void onCreate(Bundle savedInstanceState, boolean ready) {
     super.onCreate(savedInstanceState, ready);
-    getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
+    getWindow().getDecorView().setSystemUiVisibility(getWindow().getDecorView().getSystemUiVisibility() | View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
     setContentView(R.layout.recipient_manage_activity);
     if (savedInstanceState == null) {
       getSupportFragmentManager().beginTransaction()

--- a/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/notifications/CustomNotificationsRepository.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/notifications/CustomNotificationsRepository.java
@@ -30,10 +30,9 @@ class CustomNotificationsRepository {
       Recipient         recipient         = getRecipient();
       RecipientDatabase recipientDatabase = DatabaseFactory.getRecipientDatabase(context);
 
-      if (NotificationChannels.supported()) {
+      if (NotificationChannels.supported() && recipient.getNotificationChannel() != null) {
         recipientDatabase.setMessageRingtone(recipient.getId(), NotificationChannels.getMessageRingtone(context, recipient));
-        recipientDatabase.setMessageVibrate(recipient.getId(), NotificationChannels.getMessageVibrate(context, recipient) ? RecipientDatabase.VibrateState.ENABLED
-                                                                                                                          : RecipientDatabase.VibrateState.DISABLED);
+        recipientDatabase.setMessageVibrate(recipient.getId(), RecipientDatabase.VibrateState.fromBoolean(NotificationChannels.getMessageVibrate(context, recipient)));
 
         NotificationChannels.ensureCustomChannelConsistency(context);
       }

--- a/app/src/main/res/layout/custom_notifications_dialog_fragment.xml
+++ b/app/src/main/res/layout/custom_notifications_dialog_fragment.xml
@@ -107,7 +107,7 @@
     </LinearLayout>
 
     <LinearLayout
-        android:id="@+id/custom_notifications_vibrate_row"
+        android:id="@+id/custom_notifications_message_vibrate_row"
         android:layout_width="match_parent"
         android:layout_height="48dp"
         android:background="?selectableItemBackground"
@@ -121,7 +121,7 @@
         app:layout_constraintTop_toBottomOf="@id/custom_notifications_sound_row">
 
         <TextView
-            android:id="@+id/custom_notifications_vibrate_label"
+            android:id="@+id/custom_notifications_message_vibrate_label"
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_gravity="center"
@@ -131,6 +131,17 @@
             android:text="@string/CustomNotificationsDialogFragment__vibrate"
             android:textAlignment="viewStart"
             android:textAppearance="@style/TextAppearance.Signal.Body2" />
+
+        <TextView
+            android:id="@+id/custom_notifications_message_vibrate_selector"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:clickable="false"
+            android:textColor="?attr/colorAccent"
+            android:visibility="gone"
+            tools:text="Default"
+            tools:visibility="visible" />
 
         <androidx.appcompat.widget.SwitchCompat
             android:id="@+id/custom_notifications_vibrate_switch"
@@ -154,7 +165,7 @@
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/custom_notifications_vibrate_row"
+        app:layout_constraintTop_toBottomOf="@id/custom_notifications_message_vibrate_row"
         tools:visibility="visible" />
 
     <LinearLayout
@@ -221,7 +232,7 @@
             android:textAppearance="@style/TextAppearance.Signal.Body2" />
 
         <TextView
-            android:id="@+id/custom_notifications_call_vibrate_selection"
+            android:id="@+id/custom_notifications_call_vibrate_selectior"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -318,7 +318,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">يمكنك السحب إلى اليسار فوق أي رسالة للرد بسرعة</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">ملفات الوسائط المرسلة كمشاهدة لمرة واحدة تحذف تلقائيا بعد ارسالها</string>
   <string name="ConversationFragment_you_already_viewed_this_message">سبق وأن شاهدت هذه الرسالة</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">تستطيع إضافه ملاحظات لنفسك فى هذه المحادثه . وسيتم مزامنتها مع باقى الأجهزه المتصله بنفس الحساب.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">لا يوجد متصفح مثبّت في جهازك.</string>
   <!--ConversationListFragment-->
@@ -2115,8 +2114,6 @@
   <string name="recipient_preferences__about">حول</string>
   <string name="Recipient_unknown">مجهول</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">رسالة</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">اتصال</string> -->
   <string name="RecipientBottomSheet_block">حظر</string>
   <string name="RecipientBottomSheet_unblock">رفع الحظر</string>
   <string name="RecipientBottomSheet_add_to_contacts">أضف إلى جهات الاتصال</string>
@@ -2126,6 +2123,7 @@
   <string name="RecipientBottomSheet_make_group_admin">اجعلهـ/ـا إداريـ/ـة للمجموعة</string>
   <string name="RecipientBottomSheet_remove_as_admin">أزل من كونه إداريًا</string>
   <string name="RecipientBottomSheet_remove_from_group">أزل من المجموعة</string>
+  <string name="RecipientBottomSheet_message_description">رسالة</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">أأزيل %1$s من كونه إداريًا في المجموعة؟</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">سيستطيع %1$s تعديل خصائص وأعضاء هذه المجموعة</string>
   <string name="RecipientBottomSheet_remove_s_from_s">أأزيل %1$s من \"%2$s\"؟</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -276,7 +276,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">দ্রুত উত্তর দেওয়ার জন্য আপনি কোনও বার্তায় বাম দিকে সোয়াইপ করতে পারেন</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">একবার দেখার যোগ্য বহির্গামী মিডিয়া ফাইলগুলি প্রেরণের পরে সেগুলি স্বয়ংক্রিয়ভাবে মুছে ফেলা হবে</string>
   <string name="ConversationFragment_you_already_viewed_this_message">আপনি ইতিমধ্যে এই বার্তাটি দেখেছেন</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">আপনি এই কথোপকথনে নিজের জন্য নোট যুক্ত করতে পারেন। যদি আপনার অ্যাকাউন্টে কোনও ডিভাইস যুক্ত থাকলে তবে নতুন নোটগুলি সিঙ্ক হবে।</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">আপনার ডিভাইসে কোন ব্রাউজার ইন্সটল করা নেই।</string>
   <!--ConversationListFragment-->
@@ -1906,8 +1905,6 @@
   <string name="recipient_preferences__about">সম্বন্ধে</string>
   <string name="Recipient_unknown">অজানা</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">বার্তা</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">কল করুন</string> -->
   <string name="RecipientBottomSheet_block">অবরূদ্ধ</string>
   <string name="RecipientBottomSheet_unblock">মূক্ত করুন</string>
   <string name="RecipientBottomSheet_add_to_contacts">পরিচিতি তালিকায় যোগ করুন</string>
@@ -1915,6 +1912,7 @@
   <string name="RecipientBottomSheet_make_group_admin">গ্রুপ এডমিন বানান</string>
   <string name="RecipientBottomSheet_remove_as_admin">গ্রুপ এডমিন থেকে সরান</string>
   <string name="RecipientBottomSheet_remove_from_group">গ্রুপ থেকে সরান</string>
+  <string name="RecipientBottomSheet_message_description">বার্তা</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">%1$s কে গ্রুপ এডমিন থেকে সরাবেন?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s গ্রুপ এবং এর সদস্য সম্পাদনা করতে সমর্থ হবে</string>
   <string name="RecipientBottomSheet_remove_s_from_s">%1$s কে %2$s থেকে সরান</string>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -288,7 +288,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Na svaku poruku možete brzo odgovoriti tako što ćete je povući ulijevo</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Jednokratne multimedijske datoteke automatski će se izbrisati nakon što su poslane</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Već ste vidjeli ovu poruku</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">U ovoj konverzaciji možete dodati bilješke za sebe. Ako Signal koristite na više uređaja, ove će bilješke biti sinhronizovane među njima.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Preglednik nije instaliran na Vašem uređaju.</string>
   <!--ConversationListFragment-->
@@ -2012,8 +2011,6 @@
   <string name="recipient_preferences__about">O kontaktu</string>
   <string name="Recipient_unknown">Nepoznato</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Poruka</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Nazovi</string> -->
   <string name="RecipientBottomSheet_block">Blokiraj</string>
   <string name="RecipientBottomSheet_unblock">Deblokiraj</string>
   <string name="RecipientBottomSheet_add_to_contacts">Dodajte među kontakte</string>
@@ -2023,6 +2020,7 @@
   <string name="RecipientBottomSheet_make_group_admin">Odredi administratora grupe</string>
   <string name="RecipientBottomSheet_remove_as_admin">Ukloni administratorske ovlasti</string>
   <string name="RecipientBottomSheet_remove_from_group">Udalji iz grupe</string>
+  <string name="RecipientBottomSheet_message_description">Poruka</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">Smijeniti %1$s kao administratora grupe?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s će moći uređivati ovu grupu i njene članove</string>
   <string name="RecipientBottomSheet_remove_s_from_s">Udaljiti %1$s iz \"%2$s\"?</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -278,7 +278,7 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Podeu lliscar cap a l’esquerra en qualsevol missatge per respondre ràpidament.</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Els fitxers multimèdia d\'una sola visualització se suprimeixen automàticament un cop enviats.</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Ja heu vist aquest missatge.</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Podeu afegir notes per a vosaltres mateixos en aquesta conversa. Si hi ha algun dispositiu enllaçat, s\'hi sincronitzaran les notes noves.</string>
+  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Podeu afegir notes per a vosaltres mateixos en aquesta conversa.\nSi el compte té dispositius enllaçats, s\'hi sincronitzaran les notes noves.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">No hi ha cap navegador instal·lat al dispositiu.</string>
   <!--ConversationListFragment-->
@@ -456,6 +456,7 @@
   <string name="GroupManagement_choose_who_can_change_the_group_name_and_photo">Trieu qui pot canviar el nom i la imatge del grup.</string>
   <!--ManageRecipientActivity-->
   <string name="ManageRecipientActivity_disappearing_messages">Missatges efímers</string>
+  <string name="ManageRecipientActivity_chat_color">Color del xat</string>
   <string name="ManageRecipientActivity_block">Bloca</string>
   <string name="ManageRecipientActivity_unblock">Desbloca</string>
   <string name="ManageRecipientActivity_view_safety_number">Mostra el número de seguretat</string>
@@ -465,9 +466,18 @@
   <string name="ManageRecipientActivity_off">Inactiu</string>
   <string name="ManageRecipientActivity_on">Actiu</string>
   <string name="ManageRecipientActivity_add_to_a_group">Afegeix-lo a un grup</string>
+  <string name="ManageRecipientActivity_view_all_groups">Mostra tots els grups</string>
   <string name="ManageRecipientActivity_see_all">Mostra-ho tot</string>
+  <string name="ManageRecipientActivity_no_groups_in_common">No hi ha grups en comú.</string>
+  <plurals name="ManageRecipientActivity_d_groups_in_common">
+    <item quantity="one">%d grup en comú</item>
+    <item quantity="other">%d grups en comú</item>
+  </plurals>
   <string name="ManageRecipientActivity_edit_name_and_picture">Editeu el nom i la imatge</string>
   <string name="ManageRecipientActivity_message_description">Missatge</string>
+  <string name="ManageRecipientActivity_voice_call_description">Trucada de veu</string>
+  <string name="ManageRecipientActivity_insecure_voice_call_description">Trucada de veu no segura</string>
+  <string name="ManageRecipientActivity_video_call_description">Trucada de vídeo</string>
   <plurals name="GroupMemberList_invited">
     <item quantity="one">%1$s ha convidat 1 persona</item>
     <item quantity="other">%1$s ha convidat %2$d persones</item>
@@ -843,6 +853,7 @@ especificat (%s) no és vàlid.</string>
   <string name="RegistrationActivity_more_information">Més informació</string>
   <string name="RegistrationActivity_less_information">Menys informació</string>
   <string name="RegistrationActivity_signal_needs_access_to_your_contacts_and_media_in_order_to_connect_with_friends">El Signal necessita accés als contactes i als continguts multimèdia per tal de connectar amb amistats, intercanviar-hi missatges i fer trucades amb seguretat.</string>
+  <string name="RegistrationActivity_rate_limited_to_service">Heu fet massa intents per registrar aquest número. Si us plau, torneu-ho a provar més tard.</string>
   <string name="RegistrationActivity_unable_to_connect_to_service">No es pot connectar al servei. Si us plau, comproveu la connexió de xarxa i torneu-ho a provar.</string>
   <string name="RegistrationActivity_to_easily_verify_your_phone_number_signal_can_automatically_detect_your_verification_code">Per verificar fàcilment el número de telèfon, el Signal pot detectar automàticament el codi de verificació si permeteu que vegi els missatges d\'SMS.</string>
   <plurals name="RegistrationActivity_debug_log_hint">
@@ -1396,6 +1407,12 @@ S\'ha rebut un missatge d\'intercanvi de claus per a una versió del protocol no
   <string name="message_details_header__disappears">Desapareix</string>
   <string name="message_details_header__via">Per</string>
   <!--message_details_recipient_header-->
+  <string name="message_details_recipient_header__pending_send">Pendent</string>
+  <string name="message_details_recipient_header__sent_to">Enviat a</string>
+  <string name="message_details_recipient_header__sent_from">Enviat per</string>
+  <string name="message_details_recipient_header__delivered_to">Lliurat a</string>
+  <string name="message_details_recipient_header__read_by">Llegit per</string>
+  <string name="message_details_recipient_header__not_sent">No enviat</string>
   <!--message_Details_recipient-->
   <string name="message_details_recipient__failed_to_send">No s\'ha pogut enviar.</string>
   <string name="message_details_recipient__new_safety_number">Número de seguretat nou</string>
@@ -1952,8 +1969,6 @@ S\'ha rebut un missatge d\'intercanvi de claus per a una versió del protocol no
   <string name="recipient_preferences__about">Quant a</string>
   <string name="Recipient_unknown">Desconegut</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Missatge</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Truca</string> -->
   <string name="RecipientBottomSheet_block">Bloca</string>
   <string name="RecipientBottomSheet_unblock">Desbloca</string>
   <string name="RecipientBottomSheet_add_to_contacts">Afegeix als contactes</string>
@@ -1963,6 +1978,10 @@ S\'ha rebut un missatge d\'intercanvi de claus per a una versió del protocol no
   <string name="RecipientBottomSheet_make_group_admin">Fes adminstrador/a del grup</string>
   <string name="RecipientBottomSheet_remove_as_admin">Suprimeix com a administrador/a</string>
   <string name="RecipientBottomSheet_remove_from_group">Suprimeix del grup</string>
+  <string name="RecipientBottomSheet_message_description">Missatge</string>
+  <string name="RecipientBottomSheet_voice_call_description">Trucada de veu</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">Trucada de veu no segura</string>
+  <string name="RecipientBottomSheet_video_call_description">Trucada de vídeo</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">Voleu suprimir %1$s com a administrador/a del grup?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s podrà editar aquest grup i els seus membres.</string>
   <string name="RecipientBottomSheet_remove_s_from_s">Voleu suprimir %1$s de \"%2$s\"?</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -298,7 +298,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Chcete-li rychle odpovědět, přejeďte prstem na zprávě do leva</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Odchozí soubory médií pro jednorázové zobrazení jsou po odeslání automaticky odstraněny</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Tuto zprávu jste už zobrazili</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">V této konverzaci můžete přidávat poznámky pro sebe. Pokud má váš účet nějaká propojená zařízení, budou se nové poznámky synchronizovat.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Nemáte na vašem zařízení nainstalován žádný prohlížeč.</string>
   <!--ConversationListFragment-->
@@ -2084,8 +2083,6 @@ Obdržen požadavek na výměnu klíčů pro neplatnou verzi protokolu.
   <string name="recipient_preferences__about">Info</string>
   <string name="Recipient_unknown">Neznámý</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Zpráva</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Volat</string> -->
   <string name="RecipientBottomSheet_block">Blokovat</string>
   <string name="RecipientBottomSheet_unblock">Odblokovat</string>
   <string name="RecipientBottomSheet_add_to_contacts">Přidat do kontaktů</string>
@@ -2095,6 +2092,10 @@ Obdržen požadavek na výměnu klíčů pro neplatnou verzi protokolu.
   <string name="RecipientBottomSheet_make_group_admin">Nastavit správce skupiny</string>
   <string name="RecipientBottomSheet_remove_as_admin">Odebrat jako správce</string>
   <string name="RecipientBottomSheet_remove_from_group">Odebrat ze skupiny</string>
+  <string name="RecipientBottomSheet_message_description">Zpráva</string>
+  <string name="RecipientBottomSheet_voice_call_description">Hlasový hovor</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">Nezabezpečený hlasový hovor</string>
+  <string name="RecipientBottomSheet_video_call_description">Videohovor</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">Odebrat %1$s jako správce skupiny?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s bude schopen upravovat tuto skupinu a její členy</string>
   <string name="RecipientBottomSheet_remove_s_from_s">Odebrat %1$s z \"%2$s\"?</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -300,7 +300,6 @@ Send neges heb ei ddiogelu?</string>
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Gallwch lusgo i\'r chwith ar unrhyw neges i ateb yn sydyn</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Mae ffeiliau cyfrwng gweld unwaith a anfonwyd yn cael eu tynnu ar ôl eu hanfon</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Rydych eisoes wedi gweld y neges hon</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Gallwch ychwanegu nodiadau i chi\'ch hun yn y sgwrs hon. Os oes gan eich cyfrif unrhyw ddyfeisiau cysylltiedig, bydd nodiadau newydd yn cael eu cydweddu.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Nid oes porwr wedi\'i osod ar eich dyfais.</string>
   <!--ConversationListFragment-->
@@ -2068,8 +2067,6 @@ Send neges heb ei ddiogelu?</string>
   <string name="recipient_preferences__about">Ynghylch</string>
   <string name="Recipient_unknown">Anhysbys</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Neges</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Galw</string> -->
   <string name="RecipientBottomSheet_block">Rhwystro</string>
   <string name="RecipientBottomSheet_unblock">Dadrwystro</string>
   <string name="RecipientBottomSheet_add_to_contacts">Ychwanegu at gysylltiadau</string>
@@ -2079,6 +2076,7 @@ Send neges heb ei ddiogelu?</string>
   <string name="RecipientBottomSheet_make_group_admin">Creu gweinyddwr grŵp</string>
   <string name="RecipientBottomSheet_remove_as_admin">Tynnu fel gweinyddwr</string>
   <string name="RecipientBottomSheet_remove_from_group">Tynnu o\'r grŵp</string>
+  <string name="RecipientBottomSheet_message_description">Neges</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">Tynnu %1$s fel gweinyddwr grŵp?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">Bydd %1$s yn gallu golygu\'r grŵp hwn a\'i aelodau</string>
   <string name="RecipientBottomSheet_remove_s_from_s">Tynnu %1$s o \"%2$s\"?</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -279,7 +279,7 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Du kan swipe til venstre på enhver besked, for at svare hurtigt</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Udgående mediebeskeder der kun vises én gang, bliver automatisk fjernet efter de er sendt</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Beskeden er allerede læst</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Du kan tilføje egne notater i samtalen. Hvis din konto har forbundne enheder, vil notaterne blive synkroniseret</string>
+  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Du kan tilføje egne notater i samtalen.\nHvis din konto har forbundne enheder, vil notaterne blive synkroniseret.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Ingen browser installeret på enheden</string>
   <!--ConversationListFragment-->
@@ -1976,8 +1976,6 @@ Der er %d dage tilbage</string>
   <string name="recipient_preferences__about">Om</string>
   <string name="Recipient_unknown">Ukendt</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Besked</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Ring op </string> -->
   <string name="RecipientBottomSheet_block">Blokér</string>
   <string name="RecipientBottomSheet_unblock">Fjern blokering</string>
   <string name="RecipientBottomSheet_add_to_contacts">Tilføj til kontakter</string>
@@ -1987,6 +1985,10 @@ Der er %d dage tilbage</string>
   <string name="RecipientBottomSheet_make_group_admin">Gør til gruppeadministrator</string>
   <string name="RecipientBottomSheet_remove_as_admin">Fjern som administrator</string>
   <string name="RecipientBottomSheet_remove_from_group">Fjern fra gruppe</string>
+  <string name="RecipientBottomSheet_message_description">Besked</string>
+  <string name="RecipientBottomSheet_voice_call_description">Taleopkald</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">Ukrypteret taleopkald</string>
+  <string name="RecipientBottomSheet_video_call_description">Videoopkald</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">Fjern %1$s som gruppeadministrator?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s vil være i stand til at redigere gruppen og dens medlemmer</string>
   <string name="RecipientBottomSheet_remove_s_from_s">Fjern %1$s fra \"%2$s\"?</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -278,7 +278,7 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Zum schnellen Antworten kannst du auf jeder Nachricht nach links wischen</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Versendete einmalig anzeigbare Mediendateien werden nach dem Senden automatisch entfernt</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Du hast diese Nachricht bereits angezeigt</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Du kannst in dieser Unterhaltung an dich selbst gerichtete Notizen hinzufügen. Falls dein Benutzerkonto gekoppelte Geräte besitzt, werden neue Notizen synchronisiert.</string>
+  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Du kannst in dieser Unterhaltung an dich selbst gerichtete Notizen hinzufügen.\nFalls dein Benutzerkonto gekoppelte Geräte besitzt, werden neue Notizen synchronisiert.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Auf deinem Gerät ist derzeit kein Browser installiert.</string>
   <!--ConversationListFragment-->
@@ -1964,8 +1964,6 @@ Schlüsselaustausch-Nachricht für eine ungültige Protokollversion empfangen</s
   <string name="recipient_preferences__about">Info</string>
   <string name="Recipient_unknown">Unbekannt</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Nachricht</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Anrufen</string> -->
   <string name="RecipientBottomSheet_block">Blockieren</string>
   <string name="RecipientBottomSheet_unblock">Freigeben</string>
   <string name="RecipientBottomSheet_add_to_contacts">Zu Kontakten hinzufügen</string>
@@ -1975,6 +1973,10 @@ Schlüsselaustausch-Nachricht für eine ungültige Protokollversion empfangen</s
   <string name="RecipientBottomSheet_make_group_admin">Zum Gruppenadmin machen</string>
   <string name="RecipientBottomSheet_remove_as_admin">Als Admin entfernen</string>
   <string name="RecipientBottomSheet_remove_from_group">Aus Gruppe entfernen</string>
+  <string name="RecipientBottomSheet_message_description">Nachricht</string>
+  <string name="RecipientBottomSheet_voice_call_description">Sprachanruf</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">Unverschlüsselter Sprachanruf</string>
+  <string name="RecipientBottomSheet_video_call_description">Videoanruf</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">%1$s als Gruppenadmin entfernen?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s wird diese Gruppe und deren Mitglieder bearbeiten können</string>
   <string name="RecipientBottomSheet_remove_s_from_s">%1$s aus »%2$s« entfernen?</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -278,7 +278,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Μπορείς να σύρεις οποιοδήποτε μήνυμα προς τα αριστερά για γρήγορη απάντηση</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Τα εξερχόμενα πολυμέσα μιας μόνο προβολής αφαιρούνται αυτόματα αφού αποσταλθούν</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Έχεις ήδη δει αυτό το μήνυμα</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Μπορείς να προσθέσεις σημειώσεις για δική σου χρήση σε αυτήν τη συνομιλία. Εάν ο λογαριασμός σου είναι συνδεμένος με άλλες συσκευές, οι νέες σημειώσεις θα συγχρονίζονται.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Δεν υπάρχει εγκατεστημένο πρόγραμμα περιήγησης στη συσκευή σου.</string>
   <!--ConversationListFragment-->
@@ -1971,8 +1970,6 @@
   <string name="recipient_preferences__about">Πληροφορίες</string>
   <string name="Recipient_unknown">Άγνωστο</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Μήνυμα</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Κλήση</string> -->
   <string name="RecipientBottomSheet_block">Φραγή</string>
   <string name="RecipientBottomSheet_unblock">Κατάργηση φραγής</string>
   <string name="RecipientBottomSheet_add_to_contacts">Προσθήκη στις επαφές</string>
@@ -1982,6 +1979,10 @@
   <string name="RecipientBottomSheet_make_group_admin">Ορισμός ως διαχειριστή/τρια ομάδας</string>
   <string name="RecipientBottomSheet_remove_as_admin">Αφαίρεση διαχειριστή/τριας</string>
   <string name="RecipientBottomSheet_remove_from_group">Αφαίρεση απ\' την ομάδα</string>
+  <string name="RecipientBottomSheet_message_description">Μήνυμα</string>
+  <string name="RecipientBottomSheet_voice_call_description">Βιντεοκλήση</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">Μη ασφαλής κλήση φωνής</string>
+  <string name="RecipientBottomSheet_video_call_description">Βιντεοκλήση</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">Αφαίρεση των δικαιωμάτων διαχείρισης της ομάδας από τον/την %1$s;</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">Ο/Η %1$s θα μπορεί να επεξεργάζεται αυτή την ομάδα και τα μέλη της.</string>
   <string name="RecipientBottomSheet_remove_s_from_s">Αφαίρεση του/της %1$s από \"%2$s\";</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -278,7 +278,7 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Vi povas ŝovumi maldekstren iun mesaĝon por rapide respondi</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Nurunufoje videblaj elirantaj aŭdvidaĵoj estas aŭtomate forigitaj post ilia sendado</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Vi jam vidis tiun mesaĝon</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Vi povas aldoni notojn al vi mem en tiu interparolo. Se via konto estas ligita al aliaj aparatoj, novaj notoj sinkroniĝos.</string>
+  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Vi povas aldoni notojn al vi mem en tiu interparolo.\nSe via konto estas ligita al aliaj aparatoj, novaj notoj sinkroniĝos.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Ne estas foliumilo instalata sur via aparato.</string>
   <!--ConversationListFragment-->
@@ -456,6 +456,7 @@
   <string name="GroupManagement_choose_who_can_change_the_group_name_and_photo">Elekti tiun, kiu povas ŝanĝi la nomon kaj la foton de la grupo</string>
   <!--ManageRecipientActivity-->
   <string name="ManageRecipientActivity_disappearing_messages">Memviŝontaj mesaĝoj</string>
+  <string name="ManageRecipientActivity_chat_color">Koloro de interparolo</string>
   <string name="ManageRecipientActivity_block">Bloki</string>
   <string name="ManageRecipientActivity_unblock">Malbloki</string>
   <string name="ManageRecipientActivity_view_safety_number">Montri sekurigan numeron</string>
@@ -465,9 +466,18 @@
   <string name="ManageRecipientActivity_off">Malŝaltita</string>
   <string name="ManageRecipientActivity_on">Ŝaltita</string>
   <string name="ManageRecipientActivity_add_to_a_group">Aldoni al grupo</string>
+  <string name="ManageRecipientActivity_view_all_groups">Vidi ĉiujn grupojn</string>
   <string name="ManageRecipientActivity_see_all">Vidu ĉiujn</string>
+  <string name="ManageRecipientActivity_no_groups_in_common">Neniu komuna grupo</string>
+  <plurals name="ManageRecipientActivity_d_groups_in_common">
+    <item quantity="one">%d komuna grupo</item>
+    <item quantity="other">%d komunaj grupoj</item>
+  </plurals>
   <string name="ManageRecipientActivity_edit_name_and_picture">Modifi nomon kaj bildon</string>
   <string name="ManageRecipientActivity_message_description">Mesaĝo</string>
+  <string name="ManageRecipientActivity_voice_call_description">Voĉ-alvoko</string>
+  <string name="ManageRecipientActivity_insecure_voice_call_description">Nesekura voĉ-alvoko</string>
+  <string name="ManageRecipientActivity_video_call_description">Vid-alvoko</string>
   <plurals name="GroupMemberList_invited">
     <item quantity="one">%1$s invitis 1 homon</item>
     <item quantity="other">%1$s invitis %2$d homojn</item>
@@ -847,6 +857,7 @@
   <string name="RegistrationActivity_more_information">Plia informo</string>
   <string name="RegistrationActivity_less_information">Malplia informo</string>
   <string name="RegistrationActivity_signal_needs_access_to_your_contacts_and_media_in_order_to_connect_with_friends">Signal bezonas aliri al viaj kontaktoj kaj aŭdvidaĵoj por konekti kun amikoj, interŝanĝi mesaĝojn, kaj fari sekurajn alvokojn.</string>
+  <string name="RegistrationActivity_rate_limited_to_service">Vi tro faris neĝustajn provojn por registri tiun numeron. Reprovu poste.</string>
   <string name="RegistrationActivity_unable_to_connect_to_service">Konekto al servo ne eblas. Bv. kontroli retkonekton, kaj provi denove.</string>
   <string name="RegistrationActivity_to_easily_verify_your_phone_number_signal_can_automatically_detect_your_verification_code">Por facile kontroli vian telefonnumeron, Signal povas aŭtomate depreni la validigan kodon, se vi permesas al Signal aliri al viaj SMS-mesaĝoj.</string>
   <plurals name="RegistrationActivity_debug_log_hint">
@@ -1401,6 +1412,12 @@ Ricevis mesaĝon pri interŝanĝo de ŝlosiloj por nevalida protokola versio.
   <string name="message_details_header__disappears">Malaperos je</string>
   <string name="message_details_header__via">Per</string>
   <!--message_details_recipient_header-->
+  <string name="message_details_recipient_header__pending_send">Pritraktota</string>
+  <string name="message_details_recipient_header__sent_to">Sendita al</string>
+  <string name="message_details_recipient_header__sent_from">Sendita el</string>
+  <string name="message_details_recipient_header__delivered_to">Liverita al</string>
+  <string name="message_details_recipient_header__read_by">Legita de</string>
+  <string name="message_details_recipient_header__not_sent">Ne sendita</string>
   <!--message_Details_recipient-->
   <string name="message_details_recipient__failed_to_send">Malsukcesa sendo</string>
   <string name="message_details_recipient__new_safety_number">Nova sekuriga numero</string>
@@ -1931,7 +1948,7 @@ Ricevis mesaĝon pri interŝanĝo de ŝlosiloj por nevalida protokola versio.
   <string name="RegistrationActivity_incorrect_registration_lock_pin">Neĝusta PIN de bloko de registriĝo</string>
   <string name="RegistrationActivity_too_many_attempts">Tro da provoj</string>
   <string name="RegistrationActivity_you_have_made_too_many_incorrect_registration_lock_pin_attempts_please_try_again_in_a_day">Vi tro faris neĝustajn provojn kun via persona identiga numero de bloko de registriĝo. Bv. reprovi post unu tago.</string>
-  <string name="RegistrationActivity_you_have_made_too_many_attempts_please_try_again_later">Vi tro faris neĝustajn provojn. Reprovi poste.</string>
+  <string name="RegistrationActivity_you_have_made_too_many_attempts_please_try_again_later">Vi tro faris neĝustajn provojn. Reprovu poste.</string>
   <string name="RegistrationActivity_error_connecting_to_service">Eraro dum konekto al servo</string>
   <string name="RegistrationActivity_oh_no">Ho, ne!</string>
   <string name="RegistrationActivity_registration_of_this_phone_number_will_be_possible_without_your_registration_lock_pin_after_seven_days_have_passed">Registriĝo de tiu ĉi telefonnumero eblos, sen via PIN de bloko de registriĝo, 7 tagojn post la lasta Signal-a aktiveco de tiu ĉi telefonnumero. Restas %d tagoj.</string>
@@ -1957,8 +1974,6 @@ Ricevis mesaĝon pri interŝanĝo de ŝlosiloj por nevalida protokola versio.
   <string name="recipient_preferences__about">Pri</string>
   <string name="Recipient_unknown">Nekonata</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Mesaĝo</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Alvoko</string> -->
   <string name="RecipientBottomSheet_block">Bloki</string>
   <string name="RecipientBottomSheet_unblock">Malbloki</string>
   <string name="RecipientBottomSheet_add_to_contacts">Aldoni al kontaktoj</string>
@@ -1968,6 +1983,10 @@ Ricevis mesaĝon pri interŝanĝo de ŝlosiloj por nevalida protokola versio.
   <string name="RecipientBottomSheet_make_group_admin">Estigi grupadministranton</string>
   <string name="RecipientBottomSheet_remove_as_admin">Forigi kiel administranton</string>
   <string name="RecipientBottomSheet_remove_from_group">Forigi el la grupo</string>
+  <string name="RecipientBottomSheet_message_description">Mesaĝo</string>
+  <string name="RecipientBottomSheet_voice_call_description">Voĉ-alvoko</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">Nesekura voĉ-alvoko</string>
+  <string name="RecipientBottomSheet_video_call_description">Vid-alvoko</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">Forigi %1$s kiel grupadministranton?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s povos modifi tiun grupon kaj ties anojn</string>
   <string name="RecipientBottomSheet_remove_s_from_s">Ĉu forigi %1$s el „%2$s“?</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -278,7 +278,7 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Puedes deslizar hacia la izquierda sobre cualquier mensaje para responder rápidamente</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Los medios que envías para ver solo una vez se eliminan automáticamente tras enviar.</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Ya has visto este mensaje</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">En este chat puedes añadir notas, mensajes personales, contraseñas …. Si tu cuenta tiene dispositivos enlazados, las notas se sincronizarán.</string>
+  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">En este chat puedes añadir notas que sólo tú puedes ver.\nSi tu cuenta tiene dispositivos enlazados, las nuevas notas se sincronizarán.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">No hay ningún navegador instalado</string>
   <!--ConversationListFragment-->
@@ -1976,8 +1976,6 @@ Se recibió un mensaje de intercambio de claves para una versión no válida del
   <string name="recipient_preferences__about">Acerca de</string>
   <string name="Recipient_unknown">Desconocido</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Mensaje</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Llamar</string> -->
   <string name="RecipientBottomSheet_block">Bloquear</string>
   <string name="RecipientBottomSheet_unblock">Desbloquear</string>
   <string name="RecipientBottomSheet_add_to_contacts">Añadir a contactos</string>
@@ -1987,6 +1985,10 @@ Se recibió un mensaje de intercambio de claves para una versión no válida del
   <string name="RecipientBottomSheet_make_group_admin">Promover a admin</string>
   <string name="RecipientBottomSheet_remove_as_admin">Retirar permisos de admin</string>
   <string name="RecipientBottomSheet_remove_from_group">Expulsar del grupo</string>
+  <string name="RecipientBottomSheet_message_description">Mensaje</string>
+  <string name="RecipientBottomSheet_voice_call_description">Llamada de voz</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">Llamada no segura</string>
+  <string name="RecipientBottomSheet_video_call_description">Vídeollamada</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">¿Retirar los permisos de admin a %1$s?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s podrá editar los detalles de este grupo y modificar la lista de participantes</string>
   <string name="RecipientBottomSheet_remove_s_from_s">¿Expulsar a %1$s de «%2$s»?</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -277,7 +277,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Sa saad kiiresti vastamiseks mistahes sõnumil vasakule viibata</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Väljuvad korra vaatamise meediafailid eemaldatakse pärast nende saatmist automaatselt</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Sa juba vaatasid seda sõnumit</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Selles vestluses saate enda jaoks märkmeid lisada. Kui su kontol on lingitud seadmeid, sünkroonitakse uued märkmed.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Sinu seadmesse pole installitud brauserit.</string>
   <!--ConversationListFragment-->
@@ -1968,8 +1967,6 @@
   <string name="recipient_preferences__about">Teave</string>
   <string name="Recipient_unknown">Tundmatu</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Sõnum</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Helista</string> -->
   <string name="RecipientBottomSheet_block">Blokeeri</string>
   <string name="RecipientBottomSheet_unblock">Eemalda blokeering</string>
   <string name="RecipientBottomSheet_add_to_contacts">Lisa kontaktidesse</string>
@@ -1979,6 +1976,10 @@
   <string name="RecipientBottomSheet_make_group_admin">Tee grupi administraatoriks</string>
   <string name="RecipientBottomSheet_remove_as_admin">Eemaldada administraatoriõigused</string>
   <string name="RecipientBottomSheet_remove_from_group">Eemalda grupist</string>
+  <string name="RecipientBottomSheet_message_description">Sõnum</string>
+  <string name="RecipientBottomSheet_voice_call_description">Häälkõne</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">Ebaturvaline häälkõne</string>
+  <string name="RecipientBottomSheet_video_call_description">Videokõne</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">Kas eemaldada %1$s grupi administraatorite hulgast?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s saab muuta seda gruppi ja selle liikmeid </string>
   <string name="RecipientBottomSheet_remove_s_from_s">Kas eemaldada %1$s grupist \"%2$s\"?</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -65,7 +65,7 @@
   <string name="AttachmentKeyboard_give_access">Eman baimena</string>
   <!--AttachmentManager-->
   <string name="AttachmentManager_cant_open_media_selection">Ez da euskarria aukeratzeko aplikaziorik aurkitu.</string>
-  <string name="AttachmentManager_signal_requires_the_external_storage_permission_in_order_to_attach_photos_videos_or_audio">Signal aplikazioak Gordailu baimena behar du argazkiak, bideoak edo audioak bidaltzeko baina ukatu egin diozu. Joan aplikazioaren ezarpenetara, aukeratu \"Baimenak\" eta aktibatu \"Gordailua\".</string>
+  <string name="AttachmentManager_signal_requires_the_external_storage_permission_in_order_to_attach_photos_videos_or_audio">Signal aplikazioak Gordailurako baimena behar du argazkiak, bideoak edo audioak bidaltzeko baina ukatu egin diozu. Joan aplikazioaren ezarpenetara, aukeratu \"Baimenak\" eta aktibatu \"Gordailua\".</string>
   <string name="AttachmentManager_signal_requires_contacts_permission_in_order_to_attach_contact_information">Signal aplikazioak Kontaktuen baimena behar du kontaktuak atzitu ahal izateko baina ukatu egin diozu. Joan aplikazioaren ezarpenetara, aukeratu \"Baimenak\" eta aktibatu \"Kontaktuak\".</string>
   <string name="AttachmentManager_signal_requires_location_information_in_order_to_attach_a_location">Signal aplikazioak baimena behar du kokalekuak bidali ahal izateko baina ukatu egin diozu. Joan aplikazioaren ezarpenetara, aukeratu \"Baimenak\" eta aktibatu \"Kokalekua\".</string>
   <string name="AttachmentManager_signal_requires_the_camera_permission_in_order_to_take_photos_but_it_has_been_permanently_denied">Signal aplikazioak Kamera baimena behar du argazkiak egiteko baina ukatu egin diozu. Joan aplikazioaren ezarpenetara, aukeratu \"Baimenak\" eta aktibatu \"Kamara\".</string>
@@ -87,7 +87,7 @@
   <string name="BlockUnblockDialog_unblock_s">Desblokeatu %1$s?</string>
   <string name="BlockUnblockDialog_unblock">Desblokeatu</string>
   <string name="BlockUnblockDialog_block">Blokeatu</string>
-  <string name="BlockUnblockDialog_block_and_leave">Blokeatu eta utzi</string>
+  <string name="BlockUnblockDialog_block_and_leave">Blokeatu eta Irten</string>
   <string name="BlockUnblockDialog_block_and_delete">Blokeatu eta ezabatu</string>
   <!--BucketedThreadMedia-->
   <string name="BucketedThreadMedia_Today">Gaur</string>
@@ -278,7 +278,7 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Azkar erantzuteko, irristatu hatza ezkerretara edozein mezuren gainean </string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Bakarri behin ikustekoak diren multimedia fitxategiak automatikoki ezabatuko dira behin bidalita</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Mezu hau ikusia duzu</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Zuretzako oharrak gehitu ditzakezu solasaldi honetan. Zure kontuak lotutako gailurik badauka, ohar berriak sinkronizatuko dira.</string>
+  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Zuretzako oharrak gehitu ditzakezu solasaldi honetan.\nZure kontuak lotutako gailurik badauka, ohar berriak sinkronizatuko dira.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Ez dago nabigatzaile instalaturik zure gailuan.</string>
   <!--ConversationListFragment-->
@@ -357,7 +357,7 @@
   <string name="DozeReminder_optimize_for_missing_play_services">Optimizatu Google Play-ren zerbitzuetarko</string>
   <string name="DozeReminder_this_device_does_not_support_play_services_tap_to_disable_system_battery">Gailu honek ez dauka Play Services erabiltzerik. Signal ezgaituta dagoenean, sistemaren bateria optimizazioek galarazten diote mezuak jasotzea. Ukitu sistemaren bateria optimizazioak ezgaitzeko.</string>
   <!--ShareActivity-->
-  <string name="ShareActivity_share_with">Norekin konpartitu</string>
+  <string name="ShareActivity_share_with">Honekin partekatu:</string>
   <string name="ShareActivity_multiple_attachments_are_only_supported">Eranskin anitzak bakarrik irudi eta bideoetan onartzen dira</string>
   <!--GcmBroadcastReceiver-->
   <string name="GcmBroadcastReceiver_retrieving_a_message">Mezu bat berreskuratzen…</string>
@@ -456,6 +456,7 @@
   <string name="GroupManagement_choose_who_can_change_the_group_name_and_photo">Aukeratu taldearen izena eta argazkia aldatu dezakeena</string>
   <!--ManageRecipientActivity-->
   <string name="ManageRecipientActivity_disappearing_messages">Mezuen desagerpena</string>
+  <string name="ManageRecipientActivity_chat_color">Txat-aren kolorea</string>
   <string name="ManageRecipientActivity_block">Blokeatu</string>
   <string name="ManageRecipientActivity_unblock">Desblokeatu</string>
   <string name="ManageRecipientActivity_view_safety_number">Erakutsi segurtasun zenbakia </string>
@@ -465,9 +466,18 @@
   <string name="ManageRecipientActivity_off">Desaktibatuta</string>
   <string name="ManageRecipientActivity_on">Aktibatuta</string>
   <string name="ManageRecipientActivity_add_to_a_group">Gehitu taldera</string>
+  <string name="ManageRecipientActivity_view_all_groups">Ikusi talde guztiak</string>
   <string name="ManageRecipientActivity_see_all">Ikusi denak</string>
+  <string name="ManageRecipientActivity_no_groups_in_common">Ez duzue talderik komunean</string>
+  <plurals name="ManageRecipientActivity_d_groups_in_common">
+    <item quantity="one">Talde %d komunean</item>
+    <item quantity="other">%d talde komunean</item>
+  </plurals>
   <string name="ManageRecipientActivity_edit_name_and_picture">Editatu izena eta irudia</string>
   <string name="ManageRecipientActivity_message_description">Mezua</string>
+  <string name="ManageRecipientActivity_voice_call_description">Ahots deia</string>
+  <string name="ManageRecipientActivity_insecure_voice_call_description">Ahots dei ez segurua</string>
+  <string name="ManageRecipientActivity_video_call_description">Bideo deia</string>
   <plurals name="GroupMemberList_invited">
     <item quantity="one">%1$s erabiltzaileak pertsona 1 gonbidatu du</item>
     <item quantity="other">%1$s erabiltzaileak %2$d pertsona gonbidatu ditu</item>
@@ -544,7 +554,7 @@
   </plurals>
   <plurals name="MediaOverviewActivity_Media_delete_confirm_message">
     <item quantity="one">Honek hautatutako artxiboa betiko ezabatuko du. Elementu honekin lotutako edozein testu ere ezabatuko da.</item>
-    <item quantity="other">Honek hautatutako %1$d artxiboak betiko ezabatuko ditu. Elementu honekin lotutako edozein testu ere ezabatuko da.</item>
+    <item quantity="other">Ekintza honek hautatutako %1$d artxiboak betiko ezabatuko ditu. Elementu honekin lotutako edozein testu ere ezabatuko da.</item>
   </plurals>
   <string name="MediaOverviewActivity_Media_delete_progress_title">Ezabatzen</string>
   <string name="MediaOverviewActivity_Media_delete_progress_message">Mezuak ezabatzen…</string>
@@ -576,7 +586,7 @@
   <string name="MediaOverviewActivity_sent_by_you_to_s">Zuk %1$s (r)i bidalia</string>
   <!--Megaphones-->
   <string name="Megaphones_introducing_reactions">Erreakzioak Aurkezten</string>
-  <string name="Megaphones_tap_and_hold_any_message_to_quicky_share_how_you_feel">Ukitu eta eutsi edozein mezutan, berehala partzekatzeko nola sentitzen zaren.</string>
+  <string name="Megaphones_tap_and_hold_any_message_to_quicky_share_how_you_feel">Ukitu eta eutsi edozein mezutan nola sentitzen zaren berehala partzekatzeko.</string>
   <string name="Megaphones_remind_me_later">Gogorarazi iezadazu beranduago</string>
   <string name="Megaphones_verify_your_signal_pin">Zure Signal PINa egiaztatu</string>
   <string name="Megaphones_well_occasionally_ask_you_to_verify_your_pin">Noizean behin eskatuko dizugu zure PINa egiaztatzeko, gogora dezazun.</string>
@@ -691,10 +701,10 @@
   <string name="MessageRecord_s_changed_who_can_edit_group_membership_to_s">%1$s erabiltzaileak aldatu du taldearen kidetza aldatu dezakeen pertsona. Orain \"%2$s\" da.</string>
   <!--End of GV2 specific update messages-->
   <string name="MessageRecord_your_safety_number_with_s_has_changed">Zure segurtasun zenbakia %s aldatu da.</string>
-  <string name="MessageRecord_you_marked_your_safety_number_with_s_verified">%srekin duzun segurtasun zenbakia egiaztatu da</string>
-  <string name="MessageRecord_you_marked_your_safety_number_with_s_verified_from_another_device">%srekin duzun segurtasun zenbakia egiaztatutzat markatu duzu beste gailu batetik</string>
-  <string name="MessageRecord_you_marked_your_safety_number_with_s_unverified">%srekin duzun segurtasun zenbakia ez egiaztatutzat markatu duzu</string>
-  <string name="MessageRecord_you_marked_your_safety_number_with_s_unverified_from_another_device">%srekin duzun segurtasun zenbakia ez egiaztatutzat markatu duzu beste gailu batetik </string>
+  <string name="MessageRecord_you_marked_your_safety_number_with_s_verified">%s erabiltzailearekin duzun segurtasun zenbakia egiaztatu da</string>
+  <string name="MessageRecord_you_marked_your_safety_number_with_s_verified_from_another_device">%s erabiltzailearekin duzun segurtasun zenbakia egiaztatutzat markatu duzu beste gailu batetik</string>
+  <string name="MessageRecord_you_marked_your_safety_number_with_s_unverified">%s erabiltzailearekin duzun segurtasun zenbakia ez egiaztatutzat markatu duzu</string>
+  <string name="MessageRecord_you_marked_your_safety_number_with_s_unverified_from_another_device">%s erabiltzailearekin duzun segurtasun zenbakia ez egiaztatutzat markatu duzu beste gailu batetik </string>
   <!--MessageRequestBottomView-->
   <string name="MessageRequestBottomView_accept">Onartu</string>
   <string name="MessageRequestBottomView_delete">Ezabatu</string>
@@ -764,7 +774,7 @@
   <string name="PlayServicesProblemFragment_the_version_of_google_play_services_you_have_installed_is_not_functioning">Instalatutako Google Play Services bertsioa ez dabil ongi.  Berrinstalatu Google Play Services eta saiatu berriro mesedez.</string>
   <!--PinRestoreEntryFragment-->
   <string name="PinRestoreEntryFragment_incorrect_pin">PIN okerra</string>
-  <string name="PinRestoreEntryFragment_skip_pin_entry"> Saltatu nahi duzu PIN-a sartzeko urratsa?</string>
+  <string name="PinRestoreEntryFragment_skip_pin_entry">Saltatu nahi duzu PIN-a sartzeko urratsa?</string>
   <string name="PinRestoreEntryFragment_need_help">Laguntza behar duzu?</string>
   <string name="PinRestoreEntryFragment_your_pin_is_a_d_digit_code">Zure PIN-a %1$d zenbaki baino gehiago duen kode bat da; zenbakiduna edo alfanumerikoa izan dateke. Zure PIN-a ezin baduzu gogoratu, berri bat sortu dezakezu. Zure kontua erregistratu eta erabili dezakezu, baina gordetako ezarpen batzuk galduko dituzu; esate baterako, zure profilaren informazioa.</string>
   <string name="PinRestoreEntryFragment_if_you_cant_remember_your_pin">Zure PIN-a ezin baduzu gogoratu, berri bat sortu dezakezu. Zure kontua erregistratu eta erabili dezakezu, baina gordetako ezarpen batzuk galduko dituzu; esate baterako, zure profilaren informazioa.</string>
@@ -802,7 +812,7 @@
   <string name="RecipientPreferenceActivity_unblock">Desblokeatu</string>
   <string name="RecipientPreferenceActivity_enabled">Aktibatuta</string>
   <string name="RecipientPreferenceActivity_disabled">Desaktibatuta</string>
-  <string name="RecipientPreferenceActivity_available_once_a_message_has_been_sent_or_received">Erabilgarri mezu bat bidalitakoan edo jasotakoan.</string>
+  <string name="RecipientPreferenceActivity_available_once_a_message_has_been_sent_or_received">Eskuragarri izango da mezu bat bidalitakoan edo jasotakoan.</string>
   <!--RecipientProvider-->
   <string name="RecipientProvider_unnamed_group">Izenik gabeko taldea</string>
   <!--RedPhone-->
@@ -826,7 +836,7 @@
   <string name="WebRtcCallView__signal_voice_call">Signal ahots deia…</string>
   <string name="WebRtcCallView__signal_video_call">Signal bideo deia…</string>
   <!--RegistrationActivity-->
-  <string name="RegistrationActivity_select_your_country">Zure herrialdea aukeratu</string>
+  <string name="RegistrationActivity_select_your_country">Aukeratu zure herrialdea</string>
   <string name="RegistrationActivity_you_must_specify_your_country_code">Zure herrialdearen 
 kodea zehaztu behar duzu
 </string>
@@ -847,6 +857,7 @@ zenbakia (%s) baliogabea da.
   <string name="RegistrationActivity_more_information">Informazio gehiago</string>
   <string name="RegistrationActivity_less_information">Informazio gutxiago</string>
   <string name="RegistrationActivity_signal_needs_access_to_your_contacts_and_media_in_order_to_connect_with_friends">Signalek zure kontaktu eta mediara sartzeko baimena behar du zure lagunekin kontaktuan jarri, mezuak bidali eta dei seguruak egiteko</string>
+  <string name="RegistrationActivity_rate_limited_to_service">Zenbakia erregistratzeko saiakera gehiegi egin dituzu. Mesedez, saia zaitez beranduago.</string>
   <string name="RegistrationActivity_unable_to_connect_to_service">Ezin da zerbitzura konektatu. Egiaztatu sarearen ezarpenak eta saiatu berriz.</string>
   <string name="RegistrationActivity_to_easily_verify_your_phone_number_signal_can_automatically_detect_your_verification_code">Zure telefono zenbakia erraz egiaztatzeko, Signalek automatikoki irakur dezake egiaztapen kodea SMS mezuak ikusteko baimena ematen badiozu.</string>
   <plurals name="RegistrationActivity_debug_log_hint">
@@ -1064,7 +1075,7 @@ Gakoaren elkar-trukeraro mezua jaso da protokoloaren bertsio baliogabe baterako.
   <string name="MessageNotifier_message_delivery_failed">Mezuaren banaketak huts egin du.</string>
   <string name="MessageNotifier_failed_to_deliver_message">Mezuaren banaketak huts egin du.</string>
   <string name="MessageNotifier_error_delivering_message">Errorea mezua banatzen.</string>
-  <string name="MessageNotifier_mark_all_as_read">Denak irrakurritako gisa markatu</string>
+  <string name="MessageNotifier_mark_all_as_read">Markatu denak irrakurritako gisa</string>
   <string name="MessageNotifier_mark_read">Markatu irakurritako gisa</string>
   <string name="MessageNotifier_media_message">Multimedia mezua</string>
   <string name="MessageNotifier_sticker">Eranskailua</string>
@@ -1220,14 +1231,14 @@ Gakoaren elkar-trukeraro mezua jaso da protokoloaren bertsio baliogabe baterako.
   <string name="conversation_activity__emoji_toggle_description">Emoji teklatua aktibatu/desaktibatu</string>
   <string name="conversation_activity__attachment_thumbnail">Eranskinerako koadro txikia</string>
   <string name="conversation_activity__quick_attachment_drawer_toggle_camera_description">Gaitu/ezgaitu kamara arinaren eranskinen tiradera</string>
-  <string name="conversation_activity__quick_attachment_drawer_record_and_send_audio_description">Audio eranskina grabatu eta bidali</string>
+  <string name="conversation_activity__quick_attachment_drawer_record_and_send_audio_description">Grabatu eta bidali audio eranskina</string>
   <string name="conversation_activity__quick_attachment_drawer_lock_record_description">Finkatu audio atxikimenduen grabaketa audio mezu luzeak grabatzeko</string>
   <string name="conversation_activity__enable_signal_for_sms">Aktibatu Signal SMSetarako</string>
   <!--conversation_input_panel-->
   <string name="conversation_input_panel__slide_to_cancel">Korritu alde batera ezeztatzeko</string>
   <string name="conversation_input_panel__cancel">Utzi</string>
   <!--conversation_item-->
-  <string name="conversation_item__mms_image_description">Media mezua</string>
+  <string name="conversation_item__mms_image_description">Medio mezua</string>
   <string name="conversation_item__secure_message_description">Mezu segurua</string>
   <!--conversation_item_sent-->
   <string name="conversation_item_sent__send_failed_indicator_description">Bidalketak huts egin du</string>
@@ -1243,7 +1254,7 @@ Gakoaren elkar-trukeraro mezua jaso da protokoloaren bertsio baliogabe baterako.
   <string name="QuoteView_audio">Audioa</string>
   <string name="QuoteView_video">Bideoa</string>
   <string name="QuoteView_photo">Argazkia</string>
-  <string name="QuoteView_view_once_media">Behi ikusteko multimedia</string>
+  <string name="QuoteView_view_once_media">Behin ikusteko medioa</string>
   <string name="QuoteView_sticker">Eranskailua</string>
   <string name="QuoteView_document">Dokumentua</string>
   <string name="QuoteView_you">Zu</string>
@@ -1294,13 +1305,13 @@ Gakoaren elkar-trukeraro mezua jaso da protokoloaren bertsio baliogabe baterako.
   </plurals>
   <string name="expiration_weeks_abbreviated">%da</string>
   <!--unverified safety numbers-->
-  <string name="IdentityUtil_unverified_banner_one">%srekin duzun segurtasun zenbakia aldatu da eta egiaztatu gabe dago</string>
+  <string name="IdentityUtil_unverified_banner_one">%s erabiltzailearekin duzun segurtasun zenbakia aldatu da eta egiaztatu gabe dago</string>
   <string name="IdentityUtil_unverified_banner_two">%1$seta %2$serabiltzaileekin duzun segurtasun zenbakiak egiaztatu gabe daude</string>
   <string name="IdentityUtil_unverified_banner_many">%1$s, %2$s eta %3$s erabiltzaileekin duzun segurtasun zenbakiak egiaztatu gabe daude</string>
   <string name="IdentityUtil_unverified_dialog_one">%1$s erabiltzailearekin duzun segurtasun zenbakia egiaztatu gabe dago. Agian norbait zure komunikazioa atzematen saiatzen ari da edo %1$s erabiltzaileak Signal berrinstalatu du.</string>
   <string name="IdentityUtil_unverified_dialog_two">%1$s eta %2$s erabiltzaileekin duzun segurtasun zenbakiak egiaztatu gabe daude. Agian norbait zure komunikazioa atzematen saiatzen ari da edo aipatutako erabiltzaileok Signal berrinstalatu dute.</string>
   <string name="IdentityUtil_unverified_dialog_many">%1$s, %2$s, eta %3$serabiltzaileekin duzun segurtasun zenbakiak egiaztatu gabe daude. Agian norbait zure komunikazioa atzematen saiatzen ari da edo aipatutako erabiltzaileok Signal berrinstalatu dute.</string>
-  <string name="IdentityUtil_untrusted_dialog_one">%srekin duzun segurtasun mezua aldatu berri da.</string>
+  <string name="IdentityUtil_untrusted_dialog_one">%s erabiltzailearekin duzun segurtasun mezua aldatu berri da.</string>
   <string name="IdentityUtil_untrusted_dialog_two">%1$s eta %2$serabiltzaileekin duzun segurtasun zenbakiak aldatu berri dira.</string>
   <string name="IdentityUtil_untrusted_dialog_many">%1$s, %2$s eta %3$s erabiltzaileekin duzun segurtasun zenbakiak aldatu berri dira.</string>
   <plurals name="identity_others">
@@ -1359,7 +1370,7 @@ Inportatu \'SMSBackup and Restorekin\' bateragarria den enkriptatu gabeko babesk
   <string name="prompt_passphrase_activity__unlock">Desblokeatu</string>
   <!--prompt_mms_activity-->
   <string name="prompt_mms_activity__signal_requires_mms_settings_to_deliver_media_and_group_messages">Signalek MMS ezarpenak behar ditu media eta taldeko mezuak banatu ahal izateko zure hari-gabeko hornitzailearen bitartez. Zure gailuak ez dauka informazio hau eskuragarri. Hau batzuetan gertatzen da blokeatuta dauden eta beste konfigurazio murrizgarriak dituzten gailuetan.</string>
-  <string name="prompt_mms_activity__to_send_media_and_group_messages_tap_ok">Media eta taldeko mezuak bidaltzeko, ukitu \'Ados\' eta osatu behar diren ezarpenak. Zure hornitzailearentzako ezarpenak normalean topa daitezke zure hornitzailearen APNa bilatuz. Bakarrik behin egin beharko duzu hau.</string>
+  <string name="prompt_mms_activity__to_send_media_and_group_messages_tap_ok">Medio eta talde mezuak bidaltzeko, ukitu \'Ados\' eta osatu behar diren ezarpenak. Zure hornitzailearentzako ezarpenak normalean topa daitezke zure hornitzailearen APNa bilatuz. Bakarrik behin egin beharko duzu hau.</string>
   <!--profile_create_activity-->
   <string name="CreateProfileActivity_first_name_required">Izena (beharrezkoa)</string>
   <string name="CreateProfileActivity_last_name_optional">Abizena (aukerazkoa)</string>
@@ -1375,12 +1386,12 @@ Inportatu \'SMSBackup and Restorekin\' bateragarria den enkriptatu gabeko babesk
   <string name="redphone_call_card__signal_call">Signal deia</string>
   <!--registration_activity-->
   <string name="registration_activity__phone_number">TELEFONO ZENBAKIA</string>
-  <string name="registration_activity__registration_will_transmit_some_contact_information_to_the_server_temporariliy">Signalek komunikatzea erraz bihurtzen du, zure telefono zenbaki eta helbide-liburua erabiliz. Zurekin harremanetan nola jarri dakiten lagunek eta kontaktuek modu errazean egin ahal izango dute Signalen bitartez.\n\nErregistratzeak kontakturako informazioa igortzen du zerbitzarira. Ez da gordetzen.</string>
+  <string name="registration_activity__registration_will_transmit_some_contact_information_to_the_server_temporariliy">Signalek komunikatzea erraz bihurtzen du, zure telefono zenbaki eta helbide-liburua erabiliz. Zurekin harremanetan nola jarri dakiten lagunek eta kontaktuek modu errazean egin ahal izango dute Signalen bitartez.\n\nErregistratzeak kontaktuei buruzko zenbait datu igortzen du zerbitzarira. Aipatutako datuak ez dira gordeko.</string>
   <string name="registration_activity__verify_your_number">Zure zenbakia egiaztatzen</string>
   <string name="registration_activity__please_enter_your_mobile_number_to_receive_a_verification_code_carrier_rates_may_apply">Idatzi zure telefono zenbakia egiaztatze-kode bat lortzeko. Telefono-konpainiaren arabera kostua izan dezake mezu honek.</string>
   <!--recipients_panel-->
   <string name="recipients_panel__to"><small>Izen edo zenbaki bat sartu</small></string>
-  <string name="recipients_panel__add_members">Kideak gehitu</string>
+  <string name="recipients_panel__add_members">Gehitu kideak</string>
   <!--unknown_sender_view-->
   <string name="unknown_sender_view__the_sender_is_not_in_your_contact_list">Bidaltzailea ez dago zure kontaktu-zerrendan</string>
   <string name="unknown_sender_view__block">BLOKEATU</string>
@@ -1403,6 +1414,12 @@ Inportatu \'SMSBackup and Restorekin\' bateragarria den enkriptatu gabeko babesk
   <string name="message_details_header__disappears">Desagertzen da</string>
   <string name="message_details_header__via">Honen bidez</string>
   <!--message_details_recipient_header-->
+  <string name="message_details_recipient_header__pending_send">Falta dira</string>
+  <string name="message_details_recipient_header__sent_to">Honi bidalia</string>
+  <string name="message_details_recipient_header__sent_from">Honengandik bidalia</string>
+  <string name="message_details_recipient_header__delivered_to">Honi banatua</string>
+  <string name="message_details_recipient_header__read_by">Honek irakurria</string>
+  <string name="message_details_recipient_header__not_sent">Ez bidalia</string>
   <!--message_Details_recipient-->
   <string name="message_details_recipient__failed_to_send">Bidalketak huts egin du</string>
   <string name="message_details_recipient__new_safety_number">Segurtasun zenbaki berria</string>
@@ -1443,7 +1460,7 @@ Inportatu \'SMSBackup and Restorekin\' bateragarria den enkriptatu gabeko babesk
   <string name="HelpFragment__please_be_as_descriptive_as_possible">Mesedez, deskriba ezazu arazoa ahalik eta ondoen ulertzen laguntzeko.</string>
   <string name="HelpFragment__no_email_app_found">Ez da e-posta aplikaziorik aurkitu.</string>
   <!--ReactWithAnyEmojiBottomSheetDialogFragment-->
-  <string name="ReactWithAnyEmojiBottomSheetDialogFragment__recently_used">Duela gutxi erabilia</string>
+  <string name="ReactWithAnyEmojiBottomSheetDialogFragment__recently_used">Arestian erabilia</string>
   <string name="ReactWithAnyEmojiBottomSheetDialogFragment__smileys_and_people">Emojiak &amp; Jendea</string>
   <string name="ReactWithAnyEmojiBottomSheetDialogFragment__nature">Natura</string>
   <string name="ReactWithAnyEmojiBottomSheetDialogFragment__food">Janaria</string>
@@ -1496,7 +1513,7 @@ Inportatu \'SMSBackup and Restorekin\' bateragarria den enkriptatu gabeko babesk
   <string name="preferences__previews_are_supported_for">Aurrebistak honako zerbitzuekin funtzionatzen du: Imgur, Instagram, Reddit eta YouTube</string>
   <string name="preferences__choose_identity">Aukeratu nortasuna</string>
   <string name="preferences__choose_your_contact_entry_from_the_contacts_list">Hautatu zure kontaktua kontaktuen zerrendatik.</string>
-  <string name="preferences__change_passphrase">Pasahitza aldatu</string>
+  <string name="preferences__change_passphrase">Aldatu pasahitza</string>
   <string name="preferences__change_your_passphrase">Aldatu zure pasahitza</string>
   <string name="preferences__enable_passphrase">Gaitu pasahitza blokeo-pantailan</string>
   <string name="preferences__lock_signal_and_message_notifications_with_a_passphrase">Blokeatu pantaila eta jakinarazpenak pasahitz batekin</string>
@@ -1548,19 +1565,19 @@ Inportatu \'SMSBackup and Restorekin\' bateragarria den enkriptatu gabeko babesk
   <string name="preferences__chats">Txatak eta multimedia</string>
   <string name="preferences__storage">Biltegia</string>
   <string name="preferences__conversation_length_limit">Solasaldiaren luzera muga</string>
-  <string name="preferences__trim_all_conversations_now">Solasaldi guztien luzera murriztu orain</string>
+  <string name="preferences__trim_all_conversations_now">Murriztu solasaldi guztien luzera orain</string>
   <string name="preferences__scan_through_all_conversations_and_enforce_conversation_length_limits">Eskaneatu solasaldi guztiak eta betearazi luzera mugak.</string>
   <string name="preferences__linked_devices">Lotutako gailuak</string>
   <string name="preferences__light_theme">Argia</string>
   <string name="preferences__dark_theme">Iluna</string>
   <string name="preferences__appearance">Itxura</string>
   <string name="preferences__theme">Gaia</string>
-  <string name="preferences__system_default">Sistemaren lehenetsia</string>
+  <string name="preferences__system_default">Sisteman lehenetsia</string>
   <string name="preferences__default">Lehenetsia</string>
   <string name="preferences__language">Hizkuntza</string>
   <string name="preferences__signal_messages_and_calls">Signal mezu eta deiak</string>
   <string name="preferences__free_private_messages_and_calls">Mezu eta dei pribatu doanak Signal erabiltzaileri.</string>
-  <string name="preferences__submit_debug_log">Arazketaren log-a bidali</string>
+  <string name="preferences__submit_debug_log">Arazketaren informazioa bidali</string>
   <string name="preferences__support_wifi_calling">\'WiFi Calling\' bateragarritasunerako modua</string>
   <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Aktibatu zure gailuak WiFi bidezko SMS/MMS banaketa erabiltzen badu (bakarrik aktibatu \'WiFi Calling\' aktibatuta badago zure gailuan).</string>
   <string name="preferences__incognito_keyboard">Ezkutuko teklatua</string>
@@ -1601,7 +1618,7 @@ Inportatu \'SMSBackup and Restorekin\' bateragarria den enkriptatu gabeko babesk
   <string name="preferences_notifications__priority">Lehentasuna</string>
   <string name="preferences_communication__category_sealed_sender">Igorle Zigilatuta</string>
   <string name="preferences_communication__sealed_sender_display_indicators">Erakutsi adierazpenak</string>
-  <string name="preferences_communication__sealed_sender_display_indicators_description">\"Igorle zigilatuta\" aukera erabiliz bidali diren mezuetan egoera-ikono bat erakutsi \"mezuaren xehetasunak\" aukeratzen duzunean .</string>
+  <string name="preferences_communication__sealed_sender_display_indicators_description">\"Igorle zigilatuta\" aukera erabiliz bidali diren mezuetan, \"mezuaren xehetasunak\" hautatzen duzunean,  egoera-ikono bat erakutsi.</string>
   <string name="preferences_communication__sealed_sender_allow_from_anyone">Edozeinengandik onartu</string>
   <string name="preferences_communication__sealed_sender_allow_from_anyone_description">Nahiz eta zure kontaktuetan ez egon eta beraiekin zure profila ez partekatu, gaitu igorle zigilatuta horrelako erabiltzaileek bidaltzen dituzten mezuetarako.</string>
   <string name="preferences_communication__sealed_sender_learn_more">Gehiago jakin</string>
@@ -1621,7 +1638,7 @@ Inportatu \'SMSBackup and Restorekin\' bateragarria den enkriptatu gabeko babesk
   <string name="conversation_context__menu_copy_text">Testua kopiatu</string>
   <string name="conversation_context__menu_delete_message">Mezua ezabatu</string>
   <string name="conversation_context__menu_forward_message">Birbidali mezua</string>
-  <string name="conversation_context__menu_resend_message">Mezua berbidali</string>
+  <string name="conversation_context__menu_resend_message">Berriro bidali mezua</string>
   <string name="conversation_context__menu_reply_to_message">Erantzun mezuari</string>
   <!--conversation_context_reacction-->
   <string name="conversation_context__reaction_multi_select">Hautapen anitza</string>
@@ -1931,7 +1948,7 @@ Inportatu \'SMSBackup and Restorekin\' bateragarria den enkriptatu gabeko babesk
   <string name="RegistrationActivity_you_must_enter_your_registration_lock_PIN">Erregistratzea blokeatzeko zure PINa sartu behar duzu</string>
   <string name="RegistrationActivity_your_pin_has_at_least_d_digits_or_characters">Zure PINak gutxienez %d zenbaki edo karaktere dauzka</string>
   <string name="RegistrationActivity_incorrect_registration_lock_pin">Erregistratzea blokeatzeko PINa okerra da</string>
-  <string name="RegistrationActivity_too_many_attempts">Saio gehiegi</string>
+  <string name="RegistrationActivity_too_many_attempts">Saikera gehiegi</string>
   <string name="RegistrationActivity_you_have_made_too_many_incorrect_registration_lock_pin_attempts_please_try_again_in_a_day">Erregistratzea blokeatzeko PINarekin okerreko saiakera gehiegi egin dituzu. Saiatu berriro egun bat barru.</string>
   <string name="RegistrationActivity_you_have_made_too_many_attempts_please_try_again_later">Saiakera asko egin dituzu. Mesedez, saia zaitez berriro beranduago.</string>
   <string name="RegistrationActivity_error_connecting_to_service">Errorea zerbitzura konektatzean</string>
@@ -1959,8 +1976,6 @@ Inportatu \'SMSBackup and Restorekin\' bateragarria den enkriptatu gabeko babesk
   <string name="recipient_preferences__about">Honi buruz</string>
   <string name="Recipient_unknown">Ezezaguna</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Mezua</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Deitu</string> -->
   <string name="RecipientBottomSheet_block">Blokeatu</string>
   <string name="RecipientBottomSheet_unblock">Desblokeatu</string>
   <string name="RecipientBottomSheet_add_to_contacts">Kontaktuetara gehitu</string>
@@ -1970,6 +1985,10 @@ Inportatu \'SMSBackup and Restorekin\' bateragarria den enkriptatu gabeko babesk
   <string name="RecipientBottomSheet_make_group_admin">Bilakatu talde administratzailea</string>
   <string name="RecipientBottomSheet_remove_as_admin">Administratzaile gisa ezabatu</string>
   <string name="RecipientBottomSheet_remove_from_group">Ezabatu taldetik</string>
+  <string name="RecipientBottomSheet_message_description">Mezua</string>
+  <string name="RecipientBottomSheet_voice_call_description">Ahots deia</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">Ahots dei ez segurua</string>
+  <string name="RecipientBottomSheet_video_call_description">Bideo deia</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">%1$s erabiltzailea talde administratzaile gisa ezabatu nahi duzu?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s erabiltzailea talde hau eta bere kideak editatzeko gai izango da</string>
   <string name="RecipientBottomSheet_remove_s_from_s">%1$s erabiltzailea \"%2$s\"-tik ezabatu?</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -174,7 +174,7 @@
   <string name="ConversationItem_this_message_was_deleted">این پیام حذف شد</string>
   <!--ConversationActivity-->
   <string name="ConversationActivity_reset_secure_session_question">تنظیم مجدد نشست امن؟</string>
-  <string name="ConversationActivity_this_may_help_if_youre_having_encryption_problems">اگر در این مکالمه با مشکلات رمزگذاری روبرو هستید این کار ممکن است کمک کند. پیام‌های شما باقی خواهند ماند.</string>
+  <string name="ConversationActivity_this_may_help_if_youre_having_encryption_problems">اگر در این مکالمه با مشکلات رمزگذاری روبرو هستید این گزینه ممکن است کمک کند. پیام‌های شما حفظ خواهند شد.</string>
   <string name="ConversationActivity_reset">تنظیم مجدد</string>
   <string name="ConversationActivity_add_attachment">افزودن پیوست</string>
   <string name="ConversationActivity_select_contact_info">انتخاب اطلاعات مخاطب</string>
@@ -243,7 +243,7 @@
   </plurals>
   <plurals name="ConversationFragment_this_will_permanently_delete_all_n_selected_messages">
     <item quantity="one">این گزینه باعث حذف شدن دائمی پیام انتخاب شده می‌شود.</item>
-    <item quantity="other">این گزینه باعث حذف دائمی تمامی %1$d پیام انتخاب شده می‌شود.</item>
+    <item quantity="other">این گزینه باعث حذف دائمی هر %1$d پیام انتخاب شده می‌شود.</item>
   </plurals>
   <string name="ConversationFragment_save_to_sd_card">در حافظه ذخیره شود؟</string>
   <plurals name="ConversationFragment_saving_n_media_to_storage_warning">
@@ -289,7 +289,7 @@
   </plurals>
   <plurals name="ConversationListFragment_this_will_permanently_delete_all_n_selected_conversations">
     <item quantity="one">این گزینه باعث حذف دائمی مکالمهٔ انتخاب شده می‌شود.</item>
-    <item quantity="other">این گزینه باعث حذف دائمی تمامی %1$d مکالمهٔ انتخاب شده می‌شود.</item>
+    <item quantity="other">این گزینه باعث حذف دائمی هر %1$d مکالمهٔ انتخاب شده می‌شود.</item>
   </plurals>
   <string name="ConversationListFragment_deleting">در حال حذف</string>
   <string name="ConversationListFragment_deleting_selected_conversations">حذف مکالمه‌های انتخاب شده…</string>
@@ -638,8 +638,8 @@
   <string name="MessageRecord_called_s">با %s تماس گرفته شد</string>
   <string name="MessageRecord_missed_call_from">تماس از دست رفته از %s</string>
   <string name="MessageRecord_s_joined_signal">%s در Signal است!</string>
-  <string name="MessageRecord_you_disabled_disappearing_messages">شما پیام های ناپدید شونده را غیر فعال کردید.</string>
-  <string name="MessageRecord_s_disabled_disappearing_messages">%1$s پیام های ناپدید شونده را غیرفعال کرد.</string>
+  <string name="MessageRecord_you_disabled_disappearing_messages">شما پیام‌های ناپدید شونده را غیر فعال کردید.</string>
+  <string name="MessageRecord_s_disabled_disappearing_messages">%1$s پیام‌های ناپدید شونده را غیرفعال کرد.</string>
   <string name="MessageRecord_you_set_disappearing_message_time_to_s">شما زمان سنج پیام های ناپدید شونده را روی %1$s تنظیم کردید.</string>
   <string name="MessageRecord_s_set_disappearing_message_time_to_s">%1$s زمان سنج پیام های ناپدید شونده را روی %2$s قرار داد.</string>
   <!--GV2 specific-->
@@ -756,8 +756,8 @@
   <string name="DeviceActivity_signal_needs_the_camera_permission_in_order_to_scan_a_qr_code">Signal جهت اسکن کردن کد QR نیاز به دسترسی به دوربین دارد، اما این دسترسی داده نشده است. لطفاً به بخش مدیریت برنامه‌ها در تنظیمات تلفن همراه خود رفته، در بخش «مجوزها» گزینهٔ «دوربین» را فعال کنید.</string>
   <string name="DeviceActivity_unable_to_scan_a_qr_code_without_the_camera_permission">امکان اسکن کردن کد QR بدون مجوز دوربین وجود ندارد</string>
   <!--ExpirationDialog-->
-  <string name="ExpirationDialog_disappearing_messages">پیام های ناپدید شونده</string>
-  <string name="ExpirationDialog_your_messages_will_not_expire">پیام های شما انقضا نخواهند یافت.</string>
+  <string name="ExpirationDialog_disappearing_messages">پیام‌های ناپدید شونده</string>
+  <string name="ExpirationDialog_your_messages_will_not_expire">پیام‌های شما ناپدید نخواهند شد.</string>
   <string name="ExpirationDialog_your_messages_will_disappear_s_after_they_have_been_seen">پیام های ارسال شده و دریافت شده در مکالمه %s بعد از دیده شدن ناپدید خواهند شد.</string>
   <!--PassphrasePromptActivity-->
   <string name="PassphrasePromptActivity_enter_passphrase">گذرواژه را وارد کنید</string>
@@ -893,7 +893,7 @@
   <string name="SearchFragment_no_results">هیچ نتیجه ای برای \'%s\' یافت نشد</string>
   <string name="SearchFragment_header_conversations">مکالمه ها</string>
   <string name="SearchFragment_header_contacts">مخاطبان</string>
-  <string name="SearchFragment_header_messages">پیام ها</string>
+  <string name="SearchFragment_header_messages">پیام‌ها</string>
   <!--SharedContactDetailsActivity-->
   <string name="SharedContactDetailsActivity_add_to_contacts">افزودن به مخاطبان</string>
   <string name="SharedContactDetailsActivity_invite_to_signal">دعوت به Signal</string>
@@ -932,7 +932,7 @@
   <string name="StickerManagementAdapter_stickers_you_received">استیکر هایی که دریافت کردید</string>
   <string name="StickerManagementAdapter_signal_artist_series">سری های هنرمند Signal</string>
   <string name="StickerManagementAdapter_no_stickers_installed">هیچ استیکری نصب نشده است</string>
-  <string name="StickerManagementAdapter_stickers_from_incoming_messages_will_appear_here">استیکر هایی که از پیام های ورودی دریافت می شوند اینجا نمایش داده خواهند شد</string>
+  <string name="StickerManagementAdapter_stickers_from_incoming_messages_will_appear_here">استیکرهایی که از پیام‌های ورودی دریافت می‌شوند اینجا نمایش داده خواهند شد</string>
   <string name="StickerManagementAdapter_untitled">بدون نام</string>
   <string name="StickerManagementAdapter_unknown">ناشناخته</string>
   <!--StickerPackPreviewActivity-->
@@ -977,7 +977,7 @@
   <string name="ThreadRecord_view_once_media">رسانهٔ یکبار مصرف</string>
   <string name="ThreadRecord_this_message_was_deleted">این پیام حذف شد</string>
   <string name="ThreadRecord_s_is_on_signal">%s به Signal پیوست!</string>
-  <string name="ThreadRecord_disappearing_messages_disabled">پیام های ناپدید شونده غیر فعال شدند</string>
+  <string name="ThreadRecord_disappearing_messages_disabled">پیام‌های ناپدید شونده غیرفعال شدند</string>
   <string name="ThreadRecord_disappearing_message_time_updated_to_s">زمان پیام ناپدید شونده  روی %s تنظیم شد</string>
   <string name="ThreadRecord_safety_number_changed">شمارهٔ امنیتی تغییر یافت</string>
   <string name="ThreadRecord_your_safety_number_with_s_has_changed">شمارهٔ امنیتی شما با %s تغییر یافت.</string>
@@ -1046,10 +1046,10 @@
   <!--OutdatedBuildReminder-->
   <string name="OutdatedBuildReminder_no_web_browser_installed">هیچ مرورگر اینترنتی نصب نشده است!</string>
   <!--ApplicationMigrationService-->
-  <string name="ApplicationMigrationService_import_in_progress">درون برد در حال انجام</string>
-  <string name="ApplicationMigrationService_importing_text_messages">درون برد پیام های متنی</string>
-  <string name="ApplicationMigrationService_import_complete">درون برد کامل شد</string>
-  <string name="ApplicationMigrationService_system_database_import_is_complete">درون برد پایگاه داده سیستم کامل شد.</string>
+  <string name="ApplicationMigrationService_import_in_progress">در حال وارد کردن</string>
+  <string name="ApplicationMigrationService_importing_text_messages">در حال وارد کردن پیام‌های متنی</string>
+  <string name="ApplicationMigrationService_import_complete">وارد کردن به پایان رسید</string>
+  <string name="ApplicationMigrationService_system_database_import_is_complete">وارد کردن پایگاه دادهٔ سیستم به پایان رسید.</string>
   <!--KeyCachingService-->
   <string name="KeyCachingService_signal_passphrase_cached">برای باز کردن لمس کنید.</string>
   <string name="KeyCachingService_signal_passphrase_cached_with_lock">برای باز کردن لمس کرده، یا برای بستن قفل را لمس کنید.</string>
@@ -1102,7 +1102,7 @@
   <string name="NotificationChannel_locked_status">وضعیت قفل</string>
   <string name="NotificationChannel_app_updates">به‌روزرسانی‌های برنامه</string>
   <string name="NotificationChannel_other">سایر</string>
-  <string name="NotificationChannel_group_messages">پیام ها</string>
+  <string name="NotificationChannel_group_messages">پیام‌ها</string>
   <string name="NotificationChannel_missing_display_name">ناشناخته</string>
   <!--ProfileEditNameFragment-->
   <string name="ProfileEditNameFragment_successfully_set_profile_name">نام پروفایل با موفقیت تنظیم شد.</string>
@@ -1335,13 +1335,13 @@
   <string name="log_submit_activity__please_review_this_log_from_my_app">لطفاً این گزارش از برنامه من را بازبینی کنید: %1$s</string>
   <string name="log_submit_activity__network_failure">خطای شبکه. لطفاً دوباره تلاش کنید.</string>
   <!--database_migration_activity-->
-  <string name="database_migration_activity__would_you_like_to_import_your_existing_text_messages">آیا مایل به درون برد پیام های متنی موجود خود به پایگاه داده رمزگذاری شده Signal می باشید؟</string>
+  <string name="database_migration_activity__would_you_like_to_import_your_existing_text_messages">آیا مایل به وارد کردن پیام‌های متنی موجود خود به پایگاه داده رمزگذاری شدهٔ Signal هستید؟</string>
   <string name="database_migration_activity__the_default_system_database_will_not_be_modified">پایگاه دادهٔ پيش‌‌فرض سيستم به هيچ شکلی تغییر نخواهد کرد.</string>
   <string name="database_migration_activity__skip">پرش</string>
-  <string name="database_migration_activity__import">درون برد</string>
-  <string name="database_migration_activity__this_could_take_a_moment_please_be_patient">ممکن است مدتی زمان ببرد. لطفاً صبور باشید، پس از انجام درون برد شما را آگاه خواهیم کرد.</string>
-  <string name="database_migration_activity__importing">درون برد</string>
-  <string name="import_fragment__import_system_sms_database">درون برد پایگاه داده پیامک سیستم</string>
+  <string name="database_migration_activity__import">وارد کردن</string>
+  <string name="database_migration_activity__this_could_take_a_moment_please_be_patient">ممکن است مدتی زمان ببرد. لطفاً صبور باشید، هنگامی که فرایند وارد کردن به پایان برسد به شما اطلاع می‌دهیم.</string>
+  <string name="database_migration_activity__importing">وارد کردن</string>
+  <string name="import_fragment__import_system_sms_database">وارد کردن پایگاه داده پیامک سیستم</string>
   <string name="import_fragment__import_the_database_from_the_default_system">وارد کردن پایگاه داده از برنامهٔ پیام‌رسان پیش‌فرض سیستم</string>
   <string name="import_fragment__import_plaintext_backup">وارد کردن پشتیبان متن ساده</string>
   <string name="import_fragment__import_a_plaintext_backup_file">وارد کردن یک فایل پشتیبان متن ساده. سازگار با «پشتیبان پیامک و بازگردانی.»</string>
@@ -1365,7 +1365,7 @@
   <!--prompt_passphrase_activity-->
   <string name="prompt_passphrase_activity__unlock">باز کردن قفل</string>
   <!--prompt_mms_activity-->
-  <string name="prompt_mms_activity__signal_requires_mms_settings_to_deliver_media_and_group_messages">Signal برای ارسال پیام‌ها به تنظیمات فراپیام یا فراپیام اپراتور وایرلس شما نیاز دارد. دستگاه شما این اطلاعات را در دسترس قرار نمی‌دهد، این مورد معمولاً برای دستگاه‌های قفل شده و پیکربندی‌های محدود شده رخ می‌دهد.</string>
+  <string name="prompt_mms_activity__signal_requires_mms_settings_to_deliver_media_and_group_messages">Signal برای تحویل رسانه‌ها و پیام‌های گروهی از طریق اپراتور همراه شما به تنظیمات فراپیام نیاز دارد. دستگاه شما این اطلاعات را در دسترس قرار نمی‌دهد، این مشکل معمولاً برای دستگاه‌های قفل شده و پیکربندی‌های محدود شده رخ می‌دهد.</string>
   <string name="prompt_mms_activity__to_send_media_and_group_messages_tap_ok">برای ارسال رسانه و پیام‌های گروهی، روی \'قبول\' ضربه بزنید و تنظیمات خواسته شده را کامل کنید. تنظیمات فراپیام برای اپراتور شما معمولاً با جستجو برای \'APN اپراتور شما\' یافت می‌شود. شما فقط یکبار نیاز به انجام این کار دارید.</string>
   <!--profile_create_activity-->
   <string name="CreateProfileActivity_first_name_required">نام (اجباری)</string>
@@ -1467,7 +1467,7 @@
   <string name="ReactWithAnyEmojiBottomSheetDialogFragment__flags">پرچم‌ها</string>
   <string name="ReactWithAnyEmojiBottomSheetDialogFragment__emoticons">شکلک‌ها</string>
   <!--arrays.xml-->
-  <string name="arrays__import_export">درون برد</string>
+  <string name="arrays__import_export">وارد کردن</string>
   <string name="arrays__use_default">استفاده از پیش‌فرض سیستم</string>
   <string name="arrays__use_custom">استفاده از سفارشی</string>
   <string name="arrays__mute_for_one_hour">بی‌صدا به مدت ۱ ساعت</string>
@@ -1501,10 +1501,10 @@
   <string name="preferences__sms_mms">پیامک و فراپیام</string>
   <string name="preferences__pref_all_sms_title">دریافت تمام پیامک ها</string>
   <string name="preferences__pref_all_mms_title">دریافت تمامی فراپیام ها</string>
-  <string name="preferences__use_signal_for_viewing_and_storing_all_incoming_text_messages">استفاده از Signal برای همه پیام های متنی دریافتی</string>
-  <string name="preferences__use_signal_for_viewing_and_storing_all_incoming_multimedia_messages">استفاده از Signal برای تمام فراپیام های دریافتی</string>
+  <string name="preferences__use_signal_for_viewing_and_storing_all_incoming_text_messages">استفاده از Signal برای همهٔ پیام‌های متنی دریافتی</string>
+  <string name="preferences__use_signal_for_viewing_and_storing_all_incoming_multimedia_messages">استفاده از Signal برای همهٔ پیام‌های چندرسانه‌ای دریافتی</string>
   <string name="preferences__pref_enter_sends_title">ارسال با کلید Enter</string>
-  <string name="preferences__pressing_the_enter_key_will_send_text_messages">پیام‌ ها با زدن کلید Enter ارسال خواهند شد</string>
+  <string name="preferences__pressing_the_enter_key_will_send_text_messages">پیام‌ها با زدن کلید Enter ارسال خواهند شد</string>
   <string name="preferences__send_link_previews">ارسال پیش‌نمایش‌های پیوند</string>
   <string name="preferences__previews_are_supported_for">پیش‌نمایش‌ها برای پیوند‌های Imgur ،Reddit Pinterest ،Instagram و Youtube پشتیبانی می‌شوند</string>
   <string name="preferences__choose_identity">انتخاب هویت</string>
@@ -1556,7 +1556,7 @@
   <string name="preferences__mmsc_password">رمز عبور MMSC</string>
   <string name="preferences__sms_delivery_reports">گزارش‌های تحویل پیامک</string>
   <string name="preferences__request_a_delivery_report_for_each_sms_message_you_send">درخواست گزارش تحویل برای هر پیامک ارسالی از جانب شما</string>
-  <string name="preferences__automatically_delete_older_messages_once_a_conversation_exceeds_a_specified_length">حذف خودکار پیام های قدیمی زمانی که یک مکالمه از طول مشخص شده بیشتر شد</string>
+  <string name="preferences__automatically_delete_older_messages_once_a_conversation_exceeds_a_specified_length">حذف خودکار پیام‌های قدیمی زمانی که یک مکالمه از طول مشخص شده بیشتر می‌شود</string>
   <string name="preferences__delete_old_messages">حذف پیام‌های قدیمی</string>
   <string name="preferences__chats">گفتگوها و رسانه‌ها</string>
   <string name="preferences__storage">حافظه</string>
@@ -1616,7 +1616,7 @@
   <string name="preferences_communication__sealed_sender_display_indicators">نمایش نشانگرها</string>
   <string name="preferences_communication__sealed_sender_display_indicators_description">نمایش نگارک وضعیت در حالتی که شما «جزئیات پیام» را بر روی پیام‌‌هایی که با استفاده از فرستندهٔ ناشناس تحویل داده شده بودند انتخاب می‌کنید.</string>
   <string name="preferences_communication__sealed_sender_allow_from_anyone">اجازه به همه</string>
-  <string name="preferences_communication__sealed_sender_allow_from_anyone_description">فعال‌سازی فرستندهٔ ناشناس برای پیام‌های دریافتی از غیر-مخاطبان و کسانی که پروفایل خود را با آن‌ها به اشتراک نگذاشته‌اید.</string>
+  <string name="preferences_communication__sealed_sender_allow_from_anyone_description">فعال‌سازی فرستندهٔ ناشناس برای پیام‌های دریافتی از غیرمخاطبان و کسانی که پروفایل خود را با آن‌ها به اشتراک نگذاشته‌اید.</string>
   <string name="preferences_communication__sealed_sender_learn_more">بیشتر یاد بگیرید</string>
   <!--****************************************-->
   <!--menus-->
@@ -1972,8 +1972,6 @@
   <string name="recipient_preferences__about">درباره</string>
   <string name="Recipient_unknown">ناشناخته</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">پیام</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">تماس</string> -->
   <string name="RecipientBottomSheet_block">مسدود کردن</string>
   <string name="RecipientBottomSheet_unblock">رفع مسدودیت</string>
   <string name="RecipientBottomSheet_add_to_contacts">افزودن به مخاطبان</string>
@@ -1983,6 +1981,10 @@
   <string name="RecipientBottomSheet_make_group_admin">ارتقا به مدیر گروه</string>
   <string name="RecipientBottomSheet_remove_as_admin">حذف بعنوان مدیر</string>
   <string name="RecipientBottomSheet_remove_from_group">حذف از گروه</string>
+  <string name="RecipientBottomSheet_message_description">پیام</string>
+  <string name="RecipientBottomSheet_voice_call_description">تماس صوتی</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">تماس صوتی ناامن</string>
+  <string name="RecipientBottomSheet_video_call_description">تماس تصویری</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">آیا می‌خواهید %1$s را بعنوان مدیر حذف کنید؟</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s قادر خواهد بود که این گروه‌ و اعضایش را ویرایش کند</string>
   <string name="RecipientBottomSheet_remove_s_from_s">آیا می‌خواهید %1$s را از «%2$s» حذف کنید؟</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -278,7 +278,7 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Voit pyyhkäistä vasemmalle missä tahansa viestissä vastataksesi nopeasti</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Lähtevät kerran katsottavat mediatiedostot poistetaan automaattisesti lähettämisen jälkeen</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Olet jo katsonut tämän viestin</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Voit lisätä itsellesi muistiinpanoja tähän keskusteluun. Jos tililläsi on linkitettyjä laitteita, uudet muistiinpanot synkronoidaan.</string>
+  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Voit lisätä itsellesi muistiinpanoja tähän keskusteluun.\nJos tililläsi on linkitettyjä laitteita, uudet muistiinpanot synkronoidaan.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Laitteessasi ei ole verkkoselainta asennettuna.</string>
   <!--ConversationListFragment-->
@@ -853,6 +853,7 @@ puhelinnumero</string>
   <string name="RegistrationActivity_more_information">Näytä lisää</string>
   <string name="RegistrationActivity_less_information">Näytä vähemmän</string>
   <string name="RegistrationActivity_signal_needs_access_to_your_contacts_and_media_in_order_to_connect_with_friends">Signal tarvitsee lupaa käyttää yhteystietojasi ja mediaa, jotta voit olla yhteydessä ystäviisi, viestitellä ja soitella turvallisesti.</string>
+  <string name="RegistrationActivity_rate_limited_to_service">Olet yrittänyt rekisteröidä tätä numeroa liian monta kertaa. Yritä myöhemmin uudelleen.</string>
   <string name="RegistrationActivity_unable_to_connect_to_service">Yhteyttä ei voitu muodostaa palveluun. Tarkista verkkoyhteytesi ja yritä uudelleen.</string>
   <string name="RegistrationActivity_to_easily_verify_your_phone_number_signal_can_automatically_detect_your_verification_code">Jotta voit helposti vahvistaa puhelinnumerosi, Signal voi automaattisesti lukea saamasi vahvistustekstiviestin, jos annat Signalille luvan lukea tesktiviestejäsi.</string>
   <plurals name="RegistrationActivity_debug_log_hint">
@@ -1407,6 +1408,11 @@ Vastaanotetiin avaintenvaihtoviesti, joka kuuluu väärälle protokollaversiolle
   <string name="message_details_header__via">Tyyppi</string>
   <!--message_details_recipient_header-->
   <string name="message_details_recipient_header__pending_send">Käsiteltävänä</string>
+  <string name="message_details_recipient_header__sent_to">Lähetetty käyttäjälle</string>
+  <string name="message_details_recipient_header__sent_from">Lähetetty käyttäjältä</string>
+  <string name="message_details_recipient_header__delivered_to">Toimitettu käyttäjälle</string>
+  <string name="message_details_recipient_header__read_by">Lukenut</string>
+  <string name="message_details_recipient_header__not_sent">Ei lähetetty</string>
   <!--message_Details_recipient-->
   <string name="message_details_recipient__failed_to_send">Lähetys epäonnistui</string>
   <string name="message_details_recipient__new_safety_number">Uusi turvanumero</string>
@@ -1963,8 +1969,6 @@ Vastaanotetiin avaintenvaihtoviesti, joka kuuluu väärälle protokollaversiolle
   <string name="recipient_preferences__about">Tiedot</string>
   <string name="Recipient_unknown">Tuntematon</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Viesti</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Soita</string> -->
   <string name="RecipientBottomSheet_block">Estä</string>
   <string name="RecipientBottomSheet_unblock">Poista esto</string>
   <string name="RecipientBottomSheet_add_to_contacts">Lisää yhteystietoihin</string>
@@ -1974,6 +1978,10 @@ Vastaanotetiin avaintenvaihtoviesti, joka kuuluu väärälle protokollaversiolle
   <string name="RecipientBottomSheet_make_group_admin">Nimitä ryhmän ylläpitäjäksi</string>
   <string name="RecipientBottomSheet_remove_as_admin">Poista ylläpitäjän oikeudet</string>
   <string name="RecipientBottomSheet_remove_from_group">Poista ryhmästä</string>
+  <string name="RecipientBottomSheet_message_description">Viesti</string>
+  <string name="RecipientBottomSheet_voice_call_description">Äänipuhelu</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">Salaamaton äänipuhelu</string>
+  <string name="RecipientBottomSheet_video_call_description">Videopuhelu</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">Poista %1$s ryhmän ylläpitäjistä?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s voi tulevaisuudessa muokata ryhmää ja sen jäseniä</string>
   <string name="RecipientBottomSheet_remove_s_from_s">Poista %1$s ryhmästä \"%2$s\"?</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -277,7 +277,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Vous pouvez faire glisser un message vers la gauche pour y répondre rapidement</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Les fichiers multimédias éphémères sortants sont supprimés automatiquement après l’envoi</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Vous avez déjà visualisé ce message</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Vous pouvez ajouter des notes à votre intention dans cette conversation. Si des appareils sont reliés à votre compte, les nouvelles notes seront synchronisées.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Aucun navigateur n’est installé sur votre appareil.</string>
   <!--ConversationListFragment-->
@@ -1936,8 +1935,6 @@
   <string name="recipient_preferences__about">À propos</string>
   <string name="Recipient_unknown">Inconnu</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Message</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Appeler</string> -->
   <string name="RecipientBottomSheet_block">Bloquer</string>
   <string name="RecipientBottomSheet_unblock">Débloquer</string>
   <string name="RecipientBottomSheet_add_to_contacts">Ajouter aux contacts</string>
@@ -1945,6 +1942,7 @@
   <string name="RecipientBottomSheet_make_group_admin">Nommer administrateur du groupe</string>
   <string name="RecipientBottomSheet_remove_as_admin">Supprimer en tant qu’administrateur</string>
   <string name="RecipientBottomSheet_remove_from_group">Supprimer du groupe</string>
+  <string name="RecipientBottomSheet_message_description">Message</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">Supprimer %1$s en tant qu’administrateur du groupe ?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s pourra modifier ce groupe et ses membres</string>
   <string name="RecipientBottomSheet_remove_s_from_s">Supprimer %1$s de « %2$s » ?</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -270,7 +270,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Podes pasar o dedo cara á esquerda sobre calquera mensaxe para responder rapidamente</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Os ficheiros multimedia de un só visionado elimínanse automáticamente tras o envío</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Xa viches esta mensaxe</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Podes engadir notas para ti mesmo nesta conversa. Se a conta ten dispositivos ligados, as notas tamén se sincronizan.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Non hai ningún navegador instalado no teu dispositivo.</string>
   <!--ConversationListFragment-->
@@ -1688,12 +1687,11 @@
   <string name="recipient_preferences__about">Acerca de</string>
   <string name="Recipient_unknown">Descoñecido</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Mensaxe</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Chamar</string> -->
   <string name="RecipientBottomSheet_block">Bloquear</string>
   <string name="RecipientBottomSheet_unblock">Desbloquear</string>
   <string name="RecipientBottomSheet_add_to_contacts">Engadir a contactos</string>
   <string name="RecipientBottomSheet_view_safety_number">Ver número de seguranza</string>
+  <string name="RecipientBottomSheet_message_description">Mensaxe</string>
   <string name="RecipientBottomSheet_remove">Eliminar</string>
   <string name="RecipientBottomSheet_copied_to_clipboard">Copiado ao portapapeis</string>
   <!--EOF-->

--- a/app/src/main/res/values-gu/strings.xml
+++ b/app/src/main/res/values-gu/strings.xml
@@ -255,7 +255,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">ઝડપથી જવાબ આપવા માટે તમે કોઈપણ મેસેજ ની ડાબી બાજુ સ્વાઇપ કરી શકો છો</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">આઉટગોઇંગ વ્યૂ-એકવાર મીડિયા ફાઇલો મોકલ્યા પછી આપમેળે દૂર થાય છે</string>
   <string name="ConversationFragment_you_already_viewed_this_message">તમે આ મેસેજ પહેલેથી જોયો છે</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">તમે આ વાતચીતમાં તમારા માટે નોંધો ઉમેરી શકો છો. જો તમારા એકાઉન્ટમાં કોઈ લિંક થયેલ ડિવાઇસ છે, તો નવી નોટ્સ સમન્વયિત કરવામાં આવશે.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">તમારા ડિવાઇસ પર કોઈ બ્રાઉઝર ઇન્સ્ટોલ કરેલું નથી.</string>
   <!--ConversationListFragment-->
@@ -1646,12 +1645,11 @@
   <string name="recipient_preferences__about">વિષે</string>
   <string name="Recipient_unknown">અજાણ્યું</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">મેસેજ</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">કૉલ</string> -->
   <string name="RecipientBottomSheet_block">અવરોધિત કરો</string>
   <string name="RecipientBottomSheet_unblock">અનાવરોધિત કરો</string>
   <string name="RecipientBottomSheet_add_to_contacts">સંપર્કોમાં ઉમેરો </string>
   <string name="RecipientBottomSheet_view_safety_number">સલામતી નંબર જુઓ</string>
+  <string name="RecipientBottomSheet_message_description">મેસેજ</string>
   <string name="RecipientBottomSheet_remove">દૂર કરો</string>
   <string name="RecipientBottomSheet_copied_to_clipboard">ક્લિપબોર્ડ પર કૉપી કરેલું</string>
   <string name="GroupRecipientListItem_admin">એડમિન</string>

--- a/app/src/main/res/values-ha/strings.xml
+++ b/app/src/main/res/values-ha/strings.xml
@@ -255,7 +255,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Zaka/ki iya doke ta gefen hagu domin amsa ko wanne sako da wuri.</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Idan midiya na ciki saitin view-once da zaran anturasu za\'a cire.</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Ka/kin riga ka/kin karanta wannan sakon.</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Zak/ki iya rubutawa kanka/Kanji Karin bayani a wannan hirar. Idan asusunka/ki a hade yake da wani na\'ura, za\'a tantance sabbobin rkarin bayani. </string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Ba burauza a wannan na\'urar</string>
   <!--ConversationListFragment-->
@@ -1650,12 +1649,11 @@
   <string name="recipient_preferences__about">Game da</string>
   <string name="Recipient_unknown">Ba suna</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Sako</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Kira</string> -->
   <string name="RecipientBottomSheet_block">Toshe</string>
   <string name="RecipientBottomSheet_unblock">Bude</string>
   <string name="RecipientBottomSheet_add_to_contacts">Sa a lambobin sadarwa</string>
   <string name="RecipientBottomSheet_view_safety_number">Kalli lambar tsari</string>
+  <string name="RecipientBottomSheet_message_description">Sako</string>
   <string name="RecipientBottomSheet_remove">Cire</string>
   <string name="RecipientBottomSheet_copied_to_clipboard">An kwafa zuwa allon rubutu</string>
   <string name="GroupRecipientListItem_admin">Mai gudanarwa</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -257,7 +257,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">आप जल्दी से उत्तर देने के लिए किसी भी मेसेज पर बाईं ओर स्वाइप कर सकते हैं</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">आउटगोइंग व्यू-एक बार मीडिया फ़ाइलों को उनके भेजे जाने के बाद स्वचालित रूप से हटा दिया जाता है</string>
   <string name="ConversationFragment_you_already_viewed_this_message">आपने यह मेसेज पहले ही देख लिया है</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">आप इस संवाद में अपने लिये नोट्स लिख सकते हैं। अगर आपके खाते से लिंक और डिवाइस हैं तो उनसे नयेे नोट्स सिंक हो जाएँगे।</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">आपके डिवाइस पर कोई ब्राउज़र इंस्टॉल नहीं है।</string>
   <!--ConversationListFragment-->
@@ -1648,12 +1647,11 @@
   <string name="recipient_preferences__about">हमारे बारे में</string>
   <string name="Recipient_unknown">अनजान</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">मेसेज</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">कॉल</string> -->
   <string name="RecipientBottomSheet_block">ब्लॉक</string>
   <string name="RecipientBottomSheet_unblock">अनब्लॉक करें</string>
   <string name="RecipientBottomSheet_add_to_contacts">संपर्क के खाते में जोड़ दे</string>
   <string name="RecipientBottomSheet_view_safety_number">सुरक्षा नंबर देखें</string>
+  <string name="RecipientBottomSheet_message_description">मेसेज</string>
   <string name="RecipientBottomSheet_remove">हटा दें </string>
   <string name="RecipientBottomSheet_copied_to_clipboard">क्लिपबोर्ड पर कॉपी किया गया है</string>
   <string name="GroupRecipientListItem_admin">एडमिन</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -286,7 +286,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Možete prelaziti prstom ulijevo na bilo koju poruku kako biste brzo odgovorili</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Odlazne datoteke pogledaj-jednom medija su automatski uklonjene nakon što su poslane.</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Već ste pogledali ovu poruku.</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Možete dodavati bilješke za sebe u ovom razgovoru. Ako Vaš račun ima povezane uređaju, nove bilješke će se sinkronizirati između njih.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Preglednik nije instaliran na vašem uređaju.</string>
   <!--ConversationListFragment-->
@@ -1642,8 +1641,6 @@ Uvezi nekriptiranu kopiju. Kompatibilno s \'SMSBackup And Restore\'.</string>
   <string name="recipient_preferences__about">O aplikaciji</string>
   <string name="Recipient_unknown">Nepoznato</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Poruka</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Poziv</string> -->
   <string name="RecipientBottomSheet_block">Blokiraj</string>
   <string name="RecipientBottomSheet_unblock">Deblokiraj</string>
   <string name="RecipientBottomSheet_add_to_contacts">Dodaj u kontakte</string>
@@ -1651,6 +1648,7 @@ Uvezi nekriptiranu kopiju. Kompatibilno s \'SMSBackup And Restore\'.</string>
   <string name="RecipientBottomSheet_make_group_admin">Postavi za administratora</string>
   <string name="RecipientBottomSheet_remove_as_admin">Ukloni administratorske ovlasti</string>
   <string name="RecipientBottomSheet_remove_from_group">Ukloni iz grupe</string>
+  <string name="RecipientBottomSheet_message_description">Poruka</string>
   <string name="RecipientBottomSheet_remove">Ukloni</string>
   <string name="RecipientBottomSheet_copied_to_clipboard">Kopirano u međuspremnik</string>
   <string name="GroupRecipientListItem_admin">Administrator</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -279,7 +279,7 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Az üzenetet balra húzva gyorsan válaszolhatsz rá</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">A kimenő egyszer megjelenő médiafájlokat automatikusan töröljük feladásukat követően</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Ezt az üzenetet egyszer már megtekintetted</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Ebben a beszélgetésben magadnak hagyhatsz jegyzeteket, Ha a fiókodat más, társított eszközökkel is használod, a jegyzetek azokra is átszinkronizálásra kerülnek.</string>
+  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Ehhez a beszélgetéshez privát jegyzeteket fűzhetsz.\nHa társítottál más eszközöket is fiókodhoz, akkor az új jegyzetek a szinkronizálás révén ott is elérhetőek lesznek.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Nincs böngésző telepítve a készülékedre.</string>
   <!--ConversationListFragment-->
@@ -1978,8 +1978,6 @@ Kulcs-csere üzenet érkezett érvénytelen protokoll verzióhoz.
   <string name="recipient_preferences__about">Névjegy</string>
   <string name="Recipient_unknown">Ismeretlen</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Üzenet</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Hívás</string> -->
   <string name="RecipientBottomSheet_block">Letiltás</string>
   <string name="RecipientBottomSheet_unblock">Tiltás feloldása</string>
   <string name="RecipientBottomSheet_add_to_contacts">Hozzáadás a névjegyzékhez</string>
@@ -1989,6 +1987,10 @@ Kulcs-csere üzenet érkezett érvénytelen protokoll verzióhoz.
   <string name="RecipientBottomSheet_make_group_admin">Csoportadmin jogosultság megadása</string>
   <string name="RecipientBottomSheet_remove_as_admin">Admin jogosultság elvétele</string>
   <string name="RecipientBottomSheet_remove_from_group">Eltávolítás a csoportból</string>
+  <string name="RecipientBottomSheet_message_description">Üzenet</string>
+  <string name="RecipientBottomSheet_voice_call_description">Hanghívás</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">Titkosítatlan hanghívás</string>
+  <string name="RecipientBottomSheet_video_call_description">Videóhívás</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">Eltávolítod %1$s-t a csoport adminjai közül?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s szerkesztheti a csoportot és annak tagjait</string>
   <string name="RecipientBottomSheet_remove_s_from_s">Eltávolítod %1$s-t innen: \"%2$s\"?</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -266,7 +266,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Anda dapat geser ke kiri pada pesan manapun untuk membalasnya dengan cepat</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Berkas media satu-tayangan yang keluar secara otomatis dihapus setelah terkirim</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Anda telah melihat pesan ini</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Anda dapat menambahkan catatan pribadi dalam percakapan. Jika akun Anda memiliki perangkat terhubung, catatan akan tersinkronisasi.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Tidak ada peramban yang terpasang pada perangkat Anda.</string>
   <!--ConversationListFragment-->
@@ -1832,8 +1831,6 @@ Menerima pesan pertukaran kunci untuk versi protokol yang tidak valid.
   <string name="recipient_preferences__about">Tentang</string>
   <string name="Recipient_unknown">Tidak dikenal</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Pesan</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Panggil</string> -->
   <string name="RecipientBottomSheet_block">Blokir</string>
   <string name="RecipientBottomSheet_unblock">Buka blokir</string>
   <string name="RecipientBottomSheet_add_to_contacts">Tambah ke kontak</string>
@@ -1841,6 +1838,7 @@ Menerima pesan pertukaran kunci untuk versi protokol yang tidak valid.
   <string name="RecipientBottomSheet_make_group_admin">Jadikan admin grup</string>
   <string name="RecipientBottomSheet_remove_as_admin">Cabut dari admin</string>
   <string name="RecipientBottomSheet_remove_from_group">Keluarkan dari grup</string>
+  <string name="RecipientBottomSheet_message_description">Pesan</string>
   <string name="RecipientBottomSheet_remove">Hapus</string>
   <string name="RecipientBottomSheet_copied_to_clipboard">Disalin ke papan klip</string>
   <string name="GroupRecipientListItem_admin">Admin</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -278,7 +278,7 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Puoi scorrere verso sinistra su qualsiasi messaggio per rispondere rapidamente</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">I file multimediali visualizzabili una volta in uscita sono automaticamente rimossi dopo l\'invio</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Hai già visualizzato questo messaggio</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Puoi aggiungere note per te stesso in questa conversazione. Se il tuo account ha dei dispositivi collegati, le nuove note verranno sincronizzate.</string>
+  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Puoi aggiungere note per te stesso in questa conversazione.\nSe il tuo account ha dei dispositivi collegati, le nuove note verranno sincronizzate.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Sul tuo dispositivo non ci sono browser installati.</string>
   <!--ConversationListFragment-->
@@ -1975,8 +1975,6 @@
   <string name="recipient_preferences__about">A riguardo</string>
   <string name="Recipient_unknown">Sconosciuto</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Invia messaggio</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Chiama</string> -->
   <string name="RecipientBottomSheet_block">Blocca</string>
   <string name="RecipientBottomSheet_unblock">Sblocca</string>
   <string name="RecipientBottomSheet_add_to_contacts">Aggiungi ai contatti</string>
@@ -1986,6 +1984,10 @@
   <string name="RecipientBottomSheet_make_group_admin">Rendi amministratore del gruppo</string>
   <string name="RecipientBottomSheet_remove_as_admin">Rimuovi come amministratore</string>
   <string name="RecipientBottomSheet_remove_from_group">Rimuovi dal gruppo</string>
+  <string name="RecipientBottomSheet_message_description">Invia messaggio</string>
+  <string name="RecipientBottomSheet_voice_call_description">Chiamata vocale</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">Chiamata vocale non sicura</string>
+  <string name="RecipientBottomSheet_video_call_description">Videochiamata</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">Rimuovere %1$s come amministratore del gruppo?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s potrà modificare questo gruppo e i suoi membri</string>
   <string name="RecipientBottomSheet_remove_s_from_s">Rimuovere %1$s da \"%2$s\"?</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -298,7 +298,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">אתה יכול להחליק שמאלה על הודעה כלשהי כדי להשיב בזריזות</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">קבצי מדיה יוצאים לצפייה חד־פעמית מוסרים באופן אוטומטי לאחר שהם נשלחים</string>
   <string name="ConversationFragment_you_already_viewed_this_message">צפית כבר בהודעה זו</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">אתה יכול להוסיף הערות לעצמך בשיחה זו. אם לחשבון שלך יש מכשירים מקושרים כלשהם, הערות חדשות יסונכרנו.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">אין דפדפן מותקן במכשיר שלך.</string>
   <!--ConversationListFragment-->
@@ -2066,8 +2065,6 @@
   <string name="recipient_preferences__about">אודות</string>
   <string name="Recipient_unknown">בלתי ידוע</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">הודעה</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">התקשרו</string> -->
   <string name="RecipientBottomSheet_block">חסמו</string>
   <string name="RecipientBottomSheet_unblock">בטלו חסימה</string>
   <string name="RecipientBottomSheet_add_to_contacts">הוסיפו לאנשי הקשר</string>
@@ -2077,6 +2074,7 @@
   <string name="RecipientBottomSheet_make_group_admin">הפכו למנהל קבוצה</string>
   <string name="RecipientBottomSheet_remove_as_admin">הסירו תפקיד מנהל</string>
   <string name="RecipientBottomSheet_remove_from_group">הסירו מהקבוצה</string>
+  <string name="RecipientBottomSheet_message_description">הודעה</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">להסיר את %1$s מתפקיד מנהל קבוצה?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s יוכל לערוך קבוצה זו ואת חברי הקבוצה שלה</string>
   <string name="RecipientBottomSheet_remove_s_from_s">להסיר את %1$s מ-\"%2$s\"?</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -268,7 +268,7 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">メッセージを左にスワイプすると素早く返信できます</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">消える (一度しか見れないファイル) メディアファイルは、送信されたら自動的に削除されます。</string>
   <string name="ConversationFragment_you_already_viewed_this_message">このメッセージは閲覧済みです</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">この会話に自分用のメモを追加できます。リンクした別の端末にも同期されます。</string>
+  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">この会話に自分用のメモを追加できます。.\nリンクした別の端末にも同期されます。</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">ブラウザがインストールされていません</string>
   <!--ConversationListFragment-->
@@ -437,6 +437,7 @@
   <string name="GroupManagement_choose_who_can_change_the_group_name_and_photo">グループ名と写真を変更できるメンバーを選択</string>
   <!--ManageRecipientActivity-->
   <string name="ManageRecipientActivity_disappearing_messages">消えるメッセージ</string>
+  <string name="ManageRecipientActivity_chat_color">チャットの色</string>
   <string name="ManageRecipientActivity_block">ブロック</string>
   <string name="ManageRecipientActivity_unblock">ブロック解除</string>
   <string name="ManageRecipientActivity_view_safety_number">安全番号を表示</string>
@@ -446,9 +447,13 @@
   <string name="ManageRecipientActivity_off">オフ</string>
   <string name="ManageRecipientActivity_on">オン</string>
   <string name="ManageRecipientActivity_add_to_a_group">グループへ追加</string>
+  <string name="ManageRecipientActivity_view_all_groups">すべてのグループを表示</string>
   <string name="ManageRecipientActivity_see_all">すべて表示</string>
   <string name="ManageRecipientActivity_edit_name_and_picture">名前と写真の編集</string>
   <string name="ManageRecipientActivity_message_description">メッセージ</string>
+  <string name="ManageRecipientActivity_voice_call_description">音声通話</string>
+  <string name="ManageRecipientActivity_insecure_voice_call_description">保護されていない音声通話</string>
+  <string name="ManageRecipientActivity_video_call_description">ビデオ通話</string>
   <plurals name="GroupMemberList_invited">
     <item quantity="other">%1$s は%2$d人招待しました</item>
   </plurals>
@@ -1346,6 +1351,7 @@
   <string name="message_details_header__disappears">消える</string>
   <string name="message_details_header__via">経由</string>
   <!--message_details_recipient_header-->
+  <string name="message_details_recipient_header__pending_send">保留中</string>
   <!--message_Details_recipient-->
   <string name="message_details_recipient__failed_to_send">送信に失敗しました</string>
   <string name="message_details_recipient__new_safety_number">新しい安全番号</string>
@@ -1893,8 +1899,6 @@
   <string name="recipient_preferences__about">コンタクト情報</string>
   <string name="Recipient_unknown">不明</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">メッセージ</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">通話</string> -->
   <string name="RecipientBottomSheet_block">ブロック</string>
   <string name="RecipientBottomSheet_unblock">ブロック解除</string>
   <string name="RecipientBottomSheet_add_to_contacts">連絡先に追加</string>
@@ -1904,6 +1908,10 @@
   <string name="RecipientBottomSheet_make_group_admin">グループ管理者を作成</string>
   <string name="RecipientBottomSheet_remove_as_admin">管理者から削除</string>
   <string name="RecipientBottomSheet_remove_from_group">グループから削除</string>
+  <string name="RecipientBottomSheet_message_description">メッセージ</string>
+  <string name="RecipientBottomSheet_voice_call_description">音声通話</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">保護されていない音声電話</string>
+  <string name="RecipientBottomSheet_video_call_description">ビデオ通話</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">グループ管理者から %1$s を削除しますか?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$sがこのグループの設定やメンバーを編集できるようになります</string>
   <string name="RecipientBottomSheet_remove_s_from_s">%2$s から %1$s を削除しますか?</string>

--- a/app/src/main/res/values-jv/strings.xml
+++ b/app/src/main/res/values-jv/strings.xml
@@ -245,7 +245,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Sampeyan saged nggeser saben pesen ngiwa kangge mangsuli sacara gelis</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">File media ingkang saged ditingali sepisan mawon bakal dibrusak sacara otomatis saksampune dikirimaken</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Sampeyan sampun maos pesen niki</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Sampeyan saged minggahaken catetan kangge sampeyan piyambak ing obrolan niki. Menawi akun sampeyan dipuntautaken datheng pirantos benten, catetan enggal bakal disinkronasiaken.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Mboten enten browser ingkang dipunpasang ing pirantos sampeyan.</string>
   <!--ConversationListFragment-->
@@ -1626,12 +1625,11 @@
   <string name="recipient_preferences__about">Babagan</string>
   <string name="Recipient_unknown">Mboten kasumarepan</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Pesen</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Telepon</string> -->
   <string name="RecipientBottomSheet_block">Blokir</string>
   <string name="RecipientBottomSheet_unblock">Uculaken blokiranipun</string>
   <string name="RecipientBottomSheet_add_to_contacts">Minggahaken dhateng kontak</string>
   <string name="RecipientBottomSheet_view_safety_number">Tingali nomer keamanan</string>
+  <string name="RecipientBottomSheet_message_description">Pesen</string>
   <string name="RecipientBottomSheet_remove">Icali</string>
   <string name="RecipientBottomSheet_copied_to_clipboard">Dipunsalin dhateng clipboard</string>
   <string name="GroupRecipientListItem_admin">Admin</string>

--- a/app/src/main/res/values-km/strings.xml
+++ b/app/src/main/res/values-km/strings.xml
@@ -267,7 +267,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">អ្នកអាចអូសទៅឆ្វេងលើសារណាមួយ ដើម្បីឆ្លើយតបរហ័ស</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">ឯកសារមេឌាមើល-ម្តង ដែលផ្ញើចេញ ត្រូវលុបចោលដោយស្វ័យប្រវត្តិបន្ទាប់ពីបានផ្ញើចេញ</string>
   <string name="ConversationFragment_you_already_viewed_this_message">អ្នកបានបើកមើលសារនេះ</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">អ្នកនៅតែអាចបន្ថែមកំណត់ត្រាសម្រាប់ខ្លួនអ្នកក្នុងការសន្ទនានេះ។ បើគណនីរបស់អ្នក មានឧបករណ៍ច្រើនបានតភ្ជាប់ កំណត់ត្រាថ្មីនឹងត្រូវធ្វើសមកាលកម្មផងដែរ។</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">ពំុមានកម្មវិធីរុករកបានដំឡើងនៅលើឧបករណ៍របស់អ្នកទេ។</string>
   <!--ConversationListFragment-->
@@ -1884,8 +1883,6 @@
   <string name="recipient_preferences__about">អំពី</string>
   <string name="Recipient_unknown">មិនស្គាល់</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">សារ</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">ហៅចេញ</string> -->
   <string name="RecipientBottomSheet_block">រារាំង</string>
   <string name="RecipientBottomSheet_unblock">បើកវិញ</string>
   <string name="RecipientBottomSheet_add_to_contacts">បន្ថែមទៅបញ្ជីទំនាក់ទំនង</string>
@@ -1893,6 +1890,7 @@
   <string name="RecipientBottomSheet_make_group_admin">កំណត់អ្នកគ្រប់គ្រងក្រុម</string>
   <string name="RecipientBottomSheet_remove_as_admin">លុបអ្នកគ្រប់គ្រង</string>
   <string name="RecipientBottomSheet_remove_from_group">លុបចេញពីក្រុម</string>
+  <string name="RecipientBottomSheet_message_description">សារ</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">លុប %1$s ពីអ្នកគ្រប់គ្រងក្រុម?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s នឹងមិនអាចកែប្រែក្រុមនេះ និងសមាជិកទេ</string>
   <string name="RecipientBottomSheet_remove_s_from_s">លុប %1$s ពី \"%2$s\"?</string>

--- a/app/src/main/res/values-kn/strings.xml
+++ b/app/src/main/res/values-kn/strings.xml
@@ -266,7 +266,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">ತ್ವರಿತವಾಗಿ ಪ್ರತ್ಯುತ್ತರಿಸುವುದಕ್ಕೆ ನೀವು ಯಾವುದೇ ಸಂದೇಶದ ಮೇಲೆ ಎಡಕ್ಕೆ ಸ್ವೈಪ್ ಮಾಡಬಹುದು</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">ಹೊರಹೋಗುವ ವ್ಯೂ ಒನ್ಸ್ ಮೀಡಿಯಾ ಫೈಲ್‌ಗಳನ್ನು ಕಳುಹಿಸಿದ ನಂತರ ಅವುಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ತೆಗೆದುಹಾಕಲಾಗುತ್ತದೆ</string>
   <string name="ConversationFragment_you_already_viewed_this_message">ನೀವು ಈಗಾಗಲೇ ಈ ಸಂದೇಶವನ್ನು ವೀಕ್ಷಿಸಿದ್ದೀರಿ</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">ಈ ಸಂಭಾಷಣೆಯಲ್ಲಿ ನೀವು ಸ್ವತಃ ನಿಮಗಾಗಿ ಟಿಪ್ಪಣಿಗಳನ್ನು ಸೇರಿಸಬಹುದು. ನಿಮ್ಮ ಖಾತೆಯನ್ನು ಯಾವುದೇ ಸಾಧನಗಳಲ್ಲಿ ಲಿಂಕ್ ಮಾಡಿದ್ದಲ್ಲಿ, ಹೊಸ ಟಿಪ್ಪಣಿಗಳನ್ನು ಸಿಂಕ್ ಮಾಡಲಾಗುವುದು.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">ನಿಮ್ಮ ಸಾಧನ ಯಾವುದೇ ಬ್ರೌಸರ್ ಅನ್ನು ಸ್ಥಾಪಿಸಲಾಗಿಲ್ಲ.</string>
   <!--ConversationListFragment-->
@@ -1730,12 +1729,11 @@
   <string name="recipient_preferences__about">ಬಗ್ಗೆ</string>
   <string name="Recipient_unknown">ತಿಳಿದಿಲ್ಲ</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">ಸಂದೇಶ</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">ಕರೆ ಮಾಡಿ</string> -->
   <string name="RecipientBottomSheet_block">ನಿರ್ಬಂಧಿಸಿ</string>
   <string name="RecipientBottomSheet_unblock">ನಿರ್ಬಂಧ ತೆಗೆಯಿರಿ</string>
   <string name="RecipientBottomSheet_add_to_contacts">ಸಂಪರ್ಕಗಳಿಗೆ ಸೇರಿಸು</string>
   <string name="RecipientBottomSheet_view_safety_number">ಸುರಕ್ಷತಾ ಸಂಖ್ಯೆ ನೋಡಿ</string>
+  <string name="RecipientBottomSheet_message_description">ಸಂದೇಶ</string>
   <string name="RecipientBottomSheet_remove">ತೆಗೆದುಹಾಕಿ</string>
   <string name="RecipientBottomSheet_copied_to_clipboard">ಕ್ಲಿಪ್‌‌ಬೋರ್ಡಿಗೆ ನಕಲು ಮಾಡಲಾಗಿದೆ</string>
   <string name="GroupRecipientListItem_admin">ಅಡ್ಮಿನ್‌‌</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -256,7 +256,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">메시지를 왼쪽으로 쓸어서 빨리 답장할 수 있습니다.</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">한 번 볼 수 있는 미디어 파일은 전송 후 자동으로 삭제됩니다.</string>
   <string name="ConversationFragment_you_already_viewed_this_message">메시지를 이미 읽었습니다.</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">이 대화에서 당신은 당신에게 노트를 적을 수 있습니다. 만약 아무 기기나 당신의 계정과 연동되어 있다면, 새 노트는 동기화될 것 입니다.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">기기에 설치된 브라우저가 없습니다.</string>
   <!--ConversationListFragment-->
@@ -1700,12 +1699,11 @@
   <string name="recipient_preferences__about">정보</string>
   <string name="Recipient_unknown">알 수 없음</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">메시지</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">전화</string> -->
   <string name="RecipientBottomSheet_block">차단</string>
   <string name="RecipientBottomSheet_unblock">차단 해제</string>
   <string name="RecipientBottomSheet_add_to_contacts">연락처에 추가</string>
   <string name="RecipientBottomSheet_view_safety_number">안전 번호 보기</string>
+  <string name="RecipientBottomSheet_message_description">메시지</string>
   <string name="RecipientBottomSheet_remove">삭제</string>
   <string name="RecipientBottomSheet_copied_to_clipboard">클립보드로 복사됨</string>
   <string name="GroupRecipientListItem_admin">관리자</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -298,7 +298,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Norėdami greitai atsakyti į žinutę, galite perbraukti ją į kairę</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Išsiunčiami vienkartinės peržiūros medijos failai, juos išsiuntus, yra automatiškai pašalinami</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Jūs jau žiūrėjote šią žinutę</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Šiame pokalbyje galite rašyti sau pastabas. Jeigu yra su paskyra susietų įrenginių, naujos pastabos bus sinchronizuotos.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Jūsų įrenginyje nėra įdiegtos naršyklės.</string>
   <!--ConversationListFragment-->
@@ -2066,8 +2065,6 @@
   <string name="recipient_preferences__about">Apie</string>
   <string name="Recipient_unknown">Nežinoma</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Žinutė</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Skambinti</string> -->
   <string name="RecipientBottomSheet_block">Užblokuoti</string>
   <string name="RecipientBottomSheet_unblock">Atblokuoti</string>
   <string name="RecipientBottomSheet_add_to_contacts">Įtraukti į adresatus</string>
@@ -2077,6 +2074,7 @@
   <string name="RecipientBottomSheet_make_group_admin">Paskirti grupės administratoriumi</string>
   <string name="RecipientBottomSheet_remove_as_admin">Pašalinti iš administratorių</string>
   <string name="RecipientBottomSheet_remove_from_group">Šalinti iš grupės</string>
+  <string name="RecipientBottomSheet_message_description">Žinutė</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">Pašalinti %1$s iš grupės administratorių?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s galės taisyti šią grupę ir jos narių sąrašą</string>
   <string name="RecipientBottomSheet_remove_s_from_s">Šalinti %1$s iš \"%2$s\"?</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -286,7 +286,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Variet vilkt pa kreisi, lai ātri atbildētu uz jebkuru ziņu</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Izejošie vienreiz-skatāmie multivides faili pēc nosūtīšanas tiek automātiski dzēsti</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Jūs jau skatījāt šo ziņu</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Šajā sarunā varat pievienot piezīmes priekš sevis. Ja jūsu kontam ir saistītās ierīces, jaunās piezīmes tiks sinhronizētas.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Jūsu ierīcē nav uzstādīts pārlūks.</string>
   <!--ConversationListFragment-->
@@ -1905,8 +1904,6 @@ Saņemts nederīgas protokola versijas atslēgas apmaiņas ziņojums.
   <string name="recipient_preferences__about">Par</string>
   <string name="Recipient_unknown">Nezināms</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Sūtīt/ziņa</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Zvanīt</string> -->
   <string name="RecipientBottomSheet_block">Bloķēt</string>
   <string name="RecipientBottomSheet_unblock">Atbloķēt</string>
   <string name="RecipientBottomSheet_add_to_contacts">Pievienot kontaktiem</string>
@@ -1914,6 +1911,7 @@ Saņemts nederīgas protokola versijas atslēgas apmaiņas ziņojums.
   <string name="RecipientBottomSheet_make_group_admin">Izveidot grupas aministratoru</string>
   <string name="RecipientBottomSheet_remove_as_admin">Noņemt grupas administratoru</string>
   <string name="RecipientBottomSheet_remove_from_group">Noņemt no grupas</string>
+  <string name="RecipientBottomSheet_message_description">Ziņa</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">Noņemt %1$sgrupas administratora tiesības?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s varēs labot grupu un tās dalībniekus</string>
   <string name="RecipientBottomSheet_remove_s_from_s">Noņemt %1$s no \" %2$s \"?</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -278,7 +278,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">വേഗത്തിൽ മറുപടി നൽകാൻ ഏത് സന്ദേശത്തിലും നിങ്ങൾക്ക് ഇടത്തേക്ക് സ്വൈപ്പുചെയ്യാനാകും</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">അയയ്ക്കുന്ന താൽക്കാലിക മീഡിയ ഫയലുകൾ അയച്ചതിനുശേഷം അവ സ്വയമേവ നീക്കംചെയ്യപ്പെടും</string>
   <string name="ConversationFragment_you_already_viewed_this_message">നിങ്ങൾ ഇതിനകം ഈ സന്ദേശം കണ്ടു</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">ഈ സംഭാഷണത്തിൽ‌ നിങ്ങൾ‌ക്കായി കുറിപ്പുകൾ‌ ചേർ‌ക്കാൻ‌ കഴിയും. നിങ്ങളുടെ അക്കൗണ്ടിൽ ലിങ്കുചെയ്‌ത ഉപകരണങ്ങളുണ്ടെങ്കിൽ, പുതിയ കുറിപ്പുകൾ സമന്വയിപ്പിക്കും.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">നിങ്ങളുടെ ഉപകരണത്തിൽ ഒരു ബ്രൌസർ ഇൻസ്റ്റാൾ ചെയ്തിട്ടില്ല.</string>
   <!--ConversationListFragment-->
@@ -456,6 +455,7 @@
   <string name="GroupManagement_choose_who_can_change_the_group_name_and_photo">ഗ്രൂപ്പിന്റെ പേരും ഫോട്ടോയും ആർക്കൊക്കെ മാറ്റാൻ കഴിയുമെന്ന് തിരഞ്ഞെടുക്കുക</string>
   <!--ManageRecipientActivity-->
   <string name="ManageRecipientActivity_disappearing_messages">അപ്രത്യക്ഷമാകുന്ന സന്ദേശങ്ങൾ</string>
+  <string name="ManageRecipientActivity_chat_color">ചാറ്റ് നിറം</string>
   <string name="ManageRecipientActivity_block">ബ്ലോക്ക്</string>
   <string name="ManageRecipientActivity_unblock">തടഞ്ഞത് മാറ്റുക</string>
   <string name="ManageRecipientActivity_view_safety_number">സുരക്ഷാ നമ്പർ കാണുക</string>
@@ -465,9 +465,13 @@
   <string name="ManageRecipientActivity_off">ഓഫ്</string>
   <string name="ManageRecipientActivity_on">ഓൺ</string>
   <string name="ManageRecipientActivity_add_to_a_group">ഒരു ഗ്രൂപ്പിലേക്ക് ചേർക്കുക</string>
+  <string name="ManageRecipientActivity_view_all_groups">എല്ലാ ഗ്രൂപ്പുകളും കാണുക</string>
   <string name="ManageRecipientActivity_see_all">എല്ലാം കാണുക</string>
   <string name="ManageRecipientActivity_edit_name_and_picture">പേരും ചിത്രവും എഡിറ്റുചെയ്യുക</string>
   <string name="ManageRecipientActivity_message_description">സന്ദേശം</string>
+  <string name="ManageRecipientActivity_voice_call_description">വോയ്സ് കോൾ</string>
+  <string name="ManageRecipientActivity_insecure_voice_call_description">സുരക്ഷിതമല്ലാത്ത വോയ്‌സ് കോൾ</string>
+  <string name="ManageRecipientActivity_video_call_description">വീഡിയോ കോൾ</string>
   <plurals name="GroupMemberList_invited">
     <item quantity="one">%1$s 1 പേരെ ക്ഷണിച്ചു</item>
     <item quantity="other">%1$s %2$d ആളുകളെ ക്ഷണിച്ചു</item>
@@ -841,6 +845,7 @@
   <string name="RegistrationActivity_more_information">കൂടുതൽ വിവരങ്ങൾ</string>
   <string name="RegistrationActivity_less_information">കുറഞ്ഞ വിവരങ്ങൾ</string>
   <string name="RegistrationActivity_signal_needs_access_to_your_contacts_and_media_in_order_to_connect_with_friends">ചങ്ങാതിമാരുമായി ബന്ധപ്പെടുന്നതിനും സന്ദേശങ്ങൾ കൈമാറുന്നതിനും സുരക്ഷിത കോളുകൾ ചെയ്യുന്നതിനും Signal-ന് നിങ്ങളുടെ കോൺ‌ടാക്റ്റുകളിലേക്കും മീഡിയയിലേക്കും ആക്‌സസ് ആവശ്യമാണ്</string>
+  <string name="RegistrationActivity_rate_limited_to_service">ഈ നമ്പർ രജിസ്റ്റർ ചെയ്യുന്നതിന് നിങ്ങൾ വളരെയധികം ശ്രമങ്ങൾ നടത്തി. പിന്നീട് വീണ്ടും ശ്രമിക്കുക.</string>
   <string name="RegistrationActivity_unable_to_connect_to_service">സേവനത്തിലേക്ക് കണക്റ്റുചെയ്യാനായില്ല. നെറ്റ്‌വർക്ക് കണക്ഷൻ പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക.</string>
   <string name="RegistrationActivity_to_easily_verify_your_phone_number_signal_can_automatically_detect_your_verification_code">നിങ്ങളുടെ ഫോൺ നമ്പർ എളുപ്പത്തിൽ സ്ഥിരീകരിക്കുന്നതിന്, SMS സന്ദേശങ്ങൾ കാണാൻ Signal-നെ അനുവദിക്കുകയാണെങ്കിൽ Signal-ന് നിങ്ങളുടെ സ്ഥിരീകരണ കോഡ് സ്വപ്രേരിതമായി കണ്ടെത്താനാകും.</string>
   <plurals name="RegistrationActivity_debug_log_hint">
@@ -1395,6 +1400,9 @@ grūpp ap‌ḍē</string>
   <string name="message_details_header__disappears">അപ്രത്യക്ഷമാകുന്നു</string>
   <string name="message_details_header__via">വഴി</string>
   <!--message_details_recipient_header-->
+  <string name="message_details_recipient_header__sent_from">അയച്ചത്</string>
+  <string name="message_details_recipient_header__read_by">വായിച്ചത്</string>
+  <string name="message_details_recipient_header__not_sent">അയച്ചില്ല</string>
   <!--message_Details_recipient-->
   <string name="message_details_recipient__failed_to_send">അയയ്‌ക്കുന്നതിൽ പരാജയപ്പെട്ടു</string>
   <string name="message_details_recipient__new_safety_number">പുതിയ സുരക്ഷാ നമ്പർ </string>
@@ -1952,8 +1960,6 @@ grūpp ap‌ḍē</string>
   <string name="recipient_preferences__about">കുറിച്ച്</string>
   <string name="Recipient_unknown">അജ്ഞാതം</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">സന്ദേശം</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">കോൾ ചെയ്യുക</string> -->
   <string name="RecipientBottomSheet_block">ബ്ലോക്ക്</string>
   <string name="RecipientBottomSheet_unblock">തടഞ്ഞത് മാറ്റുക</string>
   <string name="RecipientBottomSheet_add_to_contacts">കോൺ‌ടാക്റ്റുകളിലേക്ക് ചേർക്കുക</string>
@@ -1963,6 +1969,10 @@ grūpp ap‌ḍē</string>
   <string name="RecipientBottomSheet_make_group_admin">ഗ്രൂപ്പ് അഡ്‌മിൻ ആക്കുക</string>
   <string name="RecipientBottomSheet_remove_as_admin">അഡ്മിനായി നീക്കംചെയ്യുക</string>
   <string name="RecipientBottomSheet_remove_from_group">ഗ്രൂപ്പിൽ നിന്ന് നീക്കംചെയ്യുക</string>
+  <string name="RecipientBottomSheet_message_description">സന്ദേശം</string>
+  <string name="RecipientBottomSheet_voice_call_description">വോയ്സ് കോൾ</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">സുരക്ഷിതമല്ലാത്ത വോയ്‌സ് കോൾ</string>
+  <string name="RecipientBottomSheet_video_call_description">വീഡിയോ കോൾ</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">%1$s-നെ അഡ്മിൻ സ്ഥാനത്ത് നിന്ന് ഒഴിവാക്കണോ?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">ഈ ഗ്രൂപ്പിനെയും അതിന്റെ അംഗങ്ങളെയും എഡിറ്റുചെയ്യാൻ %1$s-ന് കഴിയും</string>
   <string name="RecipientBottomSheet_remove_s_from_s">\"%2$s\" യിൽ നിന്ന് %1$s-നെ നീക്കംചെയ്യണോ?</string>

--- a/app/src/main/res/values-mr/strings.xml
+++ b/app/src/main/res/values-mr/strings.xml
@@ -276,7 +276,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">जलद प्रतिसाद देण्यासाठी आपण कुठल्याही संदेशावर डावीकडे स्वाइप करू शकता</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">पाठविल्यानंतर बाहेर जाणाऱ्या एकदा-बघा मिडिया फाईल स्वयंचलितपणे काढल्या जातील</string>
   <string name="ConversationFragment_you_already_viewed_this_message">आपण आधीच हा संदेश पाहिला आहे</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">या संभाषणामध्ये आपण स्वतःसाठी टिपा जोडू शकता. जर आपल्या खात्यामध्ये लिंक केलेले डिव्हाईस असतील, तर नवीन टिपा संकलित केल्या जातील. </string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">आपल्या डिव्हाईसवर कुठलेही ब्राऊझर स्थापन केलेले नाही.</string>
   <!--ConversationListFragment-->
@@ -1705,12 +1704,11 @@
   <string name="recipient_preferences__about">याबद्दल</string>
   <string name="Recipient_unknown">अज्ञात</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">संदेश</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">कॉल करा</string> -->
   <string name="RecipientBottomSheet_block">अवरोधित करा</string>
   <string name="RecipientBottomSheet_unblock">अनब्लॉक करा</string>
   <string name="RecipientBottomSheet_add_to_contacts">संपर्कात जोडा</string>
   <string name="RecipientBottomSheet_view_safety_number">सुरक्षितता नंबर बघा</string>
+  <string name="RecipientBottomSheet_message_description">संदेश</string>
   <string name="RecipientBottomSheet_remove">काढा</string>
   <string name="RecipientBottomSheet_copied_to_clipboard">क्लिपबोर्ड वर कॉपी केले</string>
   <string name="GroupRecipientListItem_admin">प्रशासक</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -268,7 +268,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Du kan sveipe til venstre på meldinger for å svare raskt</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Utgående visningsmediefiler blir automatisk fjernet etter at de er sendt</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Du har allerede sett denne meldingen</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Du kan legge til notater for deg selv i denne samtalen. Hvis kontoen din har koblede enheter, blir nye notater synkronisert.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Denne enheten har ingen nettleser installert.</string>
   <!--ConversationListFragment-->
@@ -1721,12 +1720,11 @@ Mottok nøkkelutvekslingsmelding for ugyldig protokollversion.</string>
   <string name="recipient_preferences__about">Om</string>
   <string name="Recipient_unknown">Ukjent</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Melding</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Ring</string> -->
   <string name="RecipientBottomSheet_block">Blokker</string>
   <string name="RecipientBottomSheet_unblock">Skru av blokkering</string>
   <string name="RecipientBottomSheet_add_to_contacts">Legg til i kontakter</string>
   <string name="RecipientBottomSheet_view_safety_number">Vis sikkerhetsnummer</string>
+  <string name="RecipientBottomSheet_message_description">Melding</string>
   <string name="RecipientBottomSheet_remove">Fjern</string>
   <string name="RecipientBottomSheet_copied_to_clipboard">Kopiert til utklippstavle</string>
   <string name="GroupRecipientListItem_admin">Administrator</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -278,7 +278,7 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Je kunt elk bericht naar links vegen om snel een reactie te schijven</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Uitgaande eenmaligeweergave-media worden onmiddellijk gewist zodra ze zijn verzonden. Je kunt je eigen media dus niet terugzien. – Gebruik eenmaligeweergave-berichten niet ter beveiliging, want Signal kan niet garanderen dat een bericht op het apparaat van een ander daadwerkelijk wordt gewist.</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Je hebt dit eenmaligeweergave-bericht al weergegeven</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Je kunt in dit gesprek notities voor jezelf achterlaten. Als je gebruik maakt van gekoppelde apparaten dan zullen notities worden gesynchroniseerd.</string>
+  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Je kunt in dit speciale gesprek notities voor jezelf achterlaten.\nAls je de Signal app op een ander apparaat gekoppeld hebt, dan worden alle notities van na het moment van koppelen gesynchroniseerd. Je kunt dus notities toevoegen en teruglezen vanaf al je gekoppelde apparaten.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Er is geen browser op je apparaat geïnstalleerd.</string>
   <!--ConversationListFragment-->
@@ -1979,8 +1979,6 @@ Signal zal nu toestemming vragen om je contactenlijst te lezen, om na te gaan wi
   <string name="recipient_preferences__about">Over</string>
   <string name="Recipient_unknown">Onbekend</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Bericht</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Bellen</string> -->
   <string name="RecipientBottomSheet_block">Blokkeren</string>
   <string name="RecipientBottomSheet_unblock">Deblokkeren</string>
   <string name="RecipientBottomSheet_add_to_contacts">Aan contactenlijst toevoegen</string>
@@ -1990,6 +1988,10 @@ Signal zal nu toestemming vragen om je contactenlijst te lezen, om na te gaan wi
   <string name="RecipientBottomSheet_make_group_admin">Groepsbeheerder maken</string>
   <string name="RecipientBottomSheet_remove_as_admin">Beheerdersbevoegdheden intrekken</string>
   <string name="RecipientBottomSheet_remove_from_group">Van de groep verwijderen</string>
+  <string name="RecipientBottomSheet_message_description">Bericht</string>
+  <string name="RecipientBottomSheet_voice_call_description">Spraakoproep</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">Onbeveiligde spraakoproep</string>
+  <string name="RecipientBottomSheet_video_call_description">Video-oproep</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">De beheerdersbevoegdheden van %1$s intrekken?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s zal dit groepsgesprek en de deelnemers kunnen aanpassen</string>
   <string name="RecipientBottomSheet_remove_s_from_s">%1$s verwijderen van “%2$s”?</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -278,7 +278,8 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Du kan sveipa til venstre på ei melding for å svara raskt</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Utgåande éi-visnings-mediefiler blir automatisk fjerna etter dei er sende.</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Du har allereie sett denne meldinga</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Du kan legga til notat til deg sjølv i denne samtalen. Viss kontoen din har tilkopla einingar, så blir dei nye notata synkronisert.</string>
+  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Du kan legga til notat til deg sjølv i denne samtalen.
+Viss kontoen din har lenka einingar, så vil nye notat bli synkroniserte.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Denne eininga har ingen nettlesar installert.</string>
   <!--ConversationListFragment-->
@@ -456,6 +457,7 @@
   <string name="GroupManagement_choose_who_can_change_the_group_name_and_photo">Vel kven som kan endra gruppenamnet og bildet</string>
   <!--ManageRecipientActivity-->
   <string name="ManageRecipientActivity_disappearing_messages">Forsvinnande meldingar</string>
+  <string name="ManageRecipientActivity_chat_color">Samtalefarge</string>
   <string name="ManageRecipientActivity_block">Blokker</string>
   <string name="ManageRecipientActivity_unblock">Fjern blokkering</string>
   <string name="ManageRecipientActivity_view_safety_number">Vis tryggingsnummer</string>
@@ -465,9 +467,18 @@
   <string name="ManageRecipientActivity_off">Av</string>
   <string name="ManageRecipientActivity_on">På</string>
   <string name="ManageRecipientActivity_add_to_a_group">Legg til i ei gruppe</string>
+  <string name="ManageRecipientActivity_view_all_groups">Vis alle grupper</string>
   <string name="ManageRecipientActivity_see_all">Vis alle</string>
+  <string name="ManageRecipientActivity_no_groups_in_common">Inga grupper felles</string>
+  <plurals name="ManageRecipientActivity_d_groups_in_common">
+    <item quantity="one">%d gruppe felles</item>
+    <item quantity="other">%d grupper felles</item>
+  </plurals>
   <string name="ManageRecipientActivity_edit_name_and_picture">Endra namn og bilde</string>
   <string name="ManageRecipientActivity_message_description">Melding</string>
+  <string name="ManageRecipientActivity_voice_call_description">Lydsamtale</string>
+  <string name="ManageRecipientActivity_insecure_voice_call_description">Usikra lydsamtale</string>
+  <string name="ManageRecipientActivity_video_call_description">Videosamtale</string>
   <plurals name="GroupMemberList_invited">
     <item quantity="one">%1$s inviterte person</item>
     <item quantity="other">%1$s inviterte %2$d personar</item>
@@ -847,6 +858,7 @@ Viss du ikkje er ein avansert brukar, ikkje køyrer ein sjølvinstallert Android
   <string name="RegistrationActivity_more_information">Meir informasjon</string>
   <string name="RegistrationActivity_less_information">Mindre informasjon</string>
   <string name="RegistrationActivity_signal_needs_access_to_your_contacts_and_media_in_order_to_connect_with_friends">Signal treng tilgang til kontaktane dine og media for å ta kontakt med vennar, utveksla meldingar og oppretta trygge samtalar</string>
+  <string name="RegistrationActivity_rate_limited_to_service">Du har prøvd for mange gongar å registrera dette nummeret. Prøv igjen seinare.</string>
   <string name="RegistrationActivity_unable_to_connect_to_service">Kan ikkje kopla til tenesta. Sjekk nettverkstilkoplinga og prøv igjen.</string>
   <string name="RegistrationActivity_to_easily_verify_your_phone_number_signal_can_automatically_detect_your_verification_code">Signal kan automatisk oppdaga stadfestingskoden for å enkelt stadfesta telefonnummeret ditt, viss du gir Signal tilgang til å lesa SMS-meldingar.</string>
   <plurals name="RegistrationActivity_debug_log_hint">
@@ -1403,6 +1415,12 @@ Ved registrering sender me litt kontaktinformasjon til tenaren. Informasjonen ve
   <string name="message_details_header__disappears">Forsvinn</string>
   <string name="message_details_header__via">Via</string>
   <!--message_details_recipient_header-->
+  <string name="message_details_recipient_header__pending_send">På vent</string>
+  <string name="message_details_recipient_header__sent_to">Sendt</string>
+  <string name="message_details_recipient_header__sent_from">Sendt frå</string>
+  <string name="message_details_recipient_header__delivered_to">Levert til</string>
+  <string name="message_details_recipient_header__read_by">Lesen av</string>
+  <string name="message_details_recipient_header__not_sent">Ikkje sendt</string>
   <!--message_Details_recipient-->
   <string name="message_details_recipient__failed_to_send">Sending mislukkast</string>
   <string name="message_details_recipient__new_safety_number">Nytt tryggingsnummer</string>
@@ -1961,8 +1979,6 @@ Du er à jour!</string>
   <string name="recipient_preferences__about">Om</string>
   <string name="Recipient_unknown">Ukjend</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Melding</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Ring</string> -->
   <string name="RecipientBottomSheet_block">Blokker</string>
   <string name="RecipientBottomSheet_unblock">Fjern blokkering</string>
   <string name="RecipientBottomSheet_add_to_contacts">Legg til i kontaktar</string>
@@ -1972,6 +1988,10 @@ Du er à jour!</string>
   <string name="RecipientBottomSheet_make_group_admin">Gjer til gruppeadministrator</string>
   <string name="RecipientBottomSheet_remove_as_admin">Fjern som administrator</string>
   <string name="RecipientBottomSheet_remove_from_group">Fjern frå gruppa</string>
+  <string name="RecipientBottomSheet_message_description">Melding</string>
+  <string name="RecipientBottomSheet_voice_call_description">Lydsamtale</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">Usikra lydsamtale</string>
+  <string name="RecipientBottomSheet_video_call_description">Videosamtale</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">Fjern %1$s som gruppeadministrator?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s vil kunna endra denne gruppa og medlemmane i ho</string>
   <string name="RecipientBottomSheet_remove_s_from_s">Fjern %1$s frå «%2$s»?</string>

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -258,7 +258,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">فوری جواب دین لئی تسیں کسے وی سنیہے تے کھبے پاسے سوائپ کرسکدے او</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">باہر جان آلیاں اک واری ویکھیاں جان آلیاں میڈیا فائلاں گھلن توں بعد آپوں آپ مٹ جاندیاں نیں</string>
   <string name="ConversationFragment_you_already_viewed_this_message">تسیں ایہہ سنیہا پہلاں ای ویکھ چکے او</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">تساں ایس گل وات اچ اپنے لئے نوٹس شامل کر سکدے او۔ جے تساں دے اکاؤنٹ اچ کوئی لنک کیتے آلے ہون، تے نویں نوٹس نوں ہم آہنگ کیا جاوے گا۔</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">تہاڈے آلے تے کوئی براؤزر نصب نئیں اے۔</string>
   <!--ConversationListFragment-->
@@ -1694,12 +1693,11 @@
   <string name="recipient_preferences__about">متعلق</string>
   <string name="Recipient_unknown">نامعلوم</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message"> سنیہا</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">کال کرو</string> -->
   <string name="RecipientBottomSheet_block">بلاک کرو</string>
   <string name="RecipientBottomSheet_unblock">ان بلاک کرو</string>
   <string name="RecipientBottomSheet_add_to_contacts">رابطیاں اچ شامل کرو</string>
   <string name="RecipientBottomSheet_view_safety_number">سیفٹی نمبر ویکھو</string>
+  <string name="RecipientBottomSheet_message_description"> سنیہا</string>
   <string name="RecipientBottomSheet_remove">ہٹاؤ</string>
   <string name="RecipientBottomSheet_copied_to_clipboard">کلپ بورڈ تے کاپی کیتا</string>
   <string name="GroupRecipientListItem_admin">ایڈمن</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -258,7 +258,6 @@
   <string name="ConversationFragment_failed_to_open_message">ਸੁਨੇਹਾ ਖੋਲ੍ਹਣ ਵਿੱਚ ਅਸਫਲ</string>
   <string name="ConversationFragment_you_can_swipe_to_the_right_reply">ਤੁਰੰਤ ਜਵਾਬ ਦੇਣ ਲਈ ਤੁਸੀਂ ਕਿਸੇ ਵੀ ਸੁਨੇਹੇ ਤੇ ਸੱਜੇ ਪਾਸੇ ਸਵਾਈਪ ਕਰ ਸਕਦੇ ਹੋ</string>
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">ਜਲਦੀ ਜਵਾਬ ਦੇਣ ਲਈ ਤੁਸੀਂ ਕਿਸੇ ਵੀ ਸੁਨੇਹੇ ਤੇ ਖੱਬੇ ਪਾਸੇ ਸਵਾਈਪ ਕਰ ਸਕਦੇ ਹੋ</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">ਤੁਸੀਂ ਇਸ ਵਾਰਤਾਲਾਪ ਵਿੱਚ ਖੁਦ ਲਈ ਨੋਟ ਸ਼ਾਮਲ ਕਰ ਸਕਦੇ ਹੋ. ਜੇਕਰ ਤੁਹਾਡੇ ਖਾਤੇ ਦੇ ਨਾਲ ਲਿੰਕ ਕੀਤੇ ਹੋਏ ਕਈ ਡਿਵਾਈਸ ਹਨ, ਤਾਂ ਨਵੇਂ ਨੋਟ ਸਿੰਕ ਹੋ ਜਾਣਗੇ.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">ਤੁਹਾਡੇ ਫੋਨ ਤੇ ਕੋਈ ਬਰਾਊਜ਼ਰ ਨਹੀਂ ਹੈ </string>
   <!--ConversationListFragment-->
@@ -1606,12 +1605,11 @@
   <string name="recipient_preferences__about">ਇਸ ਬਾਰੇ</string>
   <string name="Recipient_unknown">ਅਣਜਾਣ</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">ਸੁਨੇਹਾ</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">ਕਾਲ</string> -->
   <string name="RecipientBottomSheet_block">ਬਲਾਕ</string>
   <string name="RecipientBottomSheet_unblock">ਅਨਬਲੌਕ</string>
   <string name="RecipientBottomSheet_add_to_contacts">ਸੰਪਰਕਾਂ ਵਿੱਚ ਸ਼ਾਮਲ ਕਰੋ</string>
   <string name="RecipientBottomSheet_view_safety_number">ਸੁਰੱਖਿਆ ਨੰਬਰ ਵੇਖੋ</string>
+  <string name="RecipientBottomSheet_message_description">ਸੁਨੇਹਾ</string>
   <string name="RecipientBottomSheet_remove">ਹਟਾਓ </string>
   <string name="RecipientBottomSheet_copied_to_clipboard">ਕਲਿਪਬੋਰਡ ਤੇ ਕਾਪੀ ਕੀਤਾ ਗਿਆ</string>
   <string name="GroupRecipientListItem_admin">ਐਡਮਿਨ</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -298,7 +298,7 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Możesz przesunąć wiadomość w lewo, by szybko odpowiedzieć.</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Wychodzące wiadomości jednorazowe są automatycznie usuwane po wysłaniu</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Już widziałeś(aś) tę wiadomość</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">W tej konwersacji możesz dodawać swoje notatki. Jeśli z Twoim kontem są połączone jakieś urządzenia, nowe notatki zostaną zsynchronizowane.</string>
+  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">W tej konwersacji możesz dodawać swoje notatki.\nJeśli z Twoim kontem są połączone jakieś urządzenia, nowe notatki zostaną zsynchronizowane.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Twoje urządzenie nie ma zainstalowanej przeglądarki.</string>
   <!--ConversationListFragment-->
@@ -1497,7 +1497,7 @@ Otrzymano wiadomość wymiany klucz dla niepoprawnej wersji protokołu.</string>
   <string name="message_details_header__disappears">Wygasa</string>
   <string name="message_details_header__via">Przez</string>
   <!--message_details_recipient_header-->
-  <string name="message_details_recipient_header__pending_send">Oczekujące</string>
+  <string name="message_details_recipient_header__pending_send">Oczekujący</string>
   <string name="message_details_recipient_header__sent_to">Wysłano do</string>
   <string name="message_details_recipient_header__sent_from">Wysłano przez</string>
   <string name="message_details_recipient_header__delivered_to">Dostarczono do</string>
@@ -2077,8 +2077,6 @@ Otrzymano wiadomość wymiany klucz dla niepoprawnej wersji protokołu.</string>
   <string name="recipient_preferences__about">O mnie</string>
   <string name="Recipient_unknown">Nieznany</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Wiadomość</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Zadzwoń</string> -->
   <string name="RecipientBottomSheet_block">Zablokuj</string>
   <string name="RecipientBottomSheet_unblock">Odblokuj</string>
   <string name="RecipientBottomSheet_add_to_contacts">Dodaj do kontaktów</string>
@@ -2088,6 +2086,10 @@ Otrzymano wiadomość wymiany klucz dla niepoprawnej wersji protokołu.</string>
   <string name="RecipientBottomSheet_make_group_admin">Mianuj administratorem grupy</string>
   <string name="RecipientBottomSheet_remove_as_admin">Usuń administratora</string>
   <string name="RecipientBottomSheet_remove_from_group">Usuń z grupy</string>
+  <string name="RecipientBottomSheet_message_description">Wiadomość</string>
+  <string name="RecipientBottomSheet_voice_call_description">Połączenie głosowe</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">Niezaszyfrowane połączenie głosowe</string>
+  <string name="RecipientBottomSheet_video_call_description">Połączenie wideo</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">Usunąć %1$s, jako administratora grupy?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s będzie w stanie edytować tę grupę i jej członków</string>
   <string name="RecipientBottomSheet_remove_s_from_s">Usunąć %1$s z \"%2$s\"?</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -267,7 +267,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Você pode deslizar para a esquerda em qualquer mensagem para responder rapidamente</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Os arquivos de mídia efêmeros são removidos automaticamente após serem enviados</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Você já visualizou esta mensagem</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Você mesmo pode adicionar anotações nessa conversa. Se sua conta estiver ligada a algum dispositivo, as novas anotações serão sincronizadas. </string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Não há nenhum navegador instalado no seu dispositivo.</string>
   <!--ConversationListFragment-->
@@ -1754,12 +1753,11 @@
   <string name="recipient_preferences__about">Sobre</string>
   <string name="Recipient_unknown">Desconhecido</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Mensagem</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Ligar</string> -->
   <string name="RecipientBottomSheet_block">Bloquear</string>
   <string name="RecipientBottomSheet_unblock">Desbloquear</string>
   <string name="RecipientBottomSheet_add_to_contacts">Adicionar aos contatos</string>
   <string name="RecipientBottomSheet_view_safety_number">Ver número de segurança</string>
+  <string name="RecipientBottomSheet_message_description">Mensagem</string>
   <string name="RecipientBottomSheet_remove">Remover</string>
   <string name="RecipientBottomSheet_copied_to_clipboard">Copiado para a área de transferência</string>
   <string name="GroupRecipientListItem_admin">Admin</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -278,7 +278,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Pode deslizar qualquer mensagem para a esquerda para responder rapidamente</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Os ficheiros multimédia de visualização única são removidos automaticamente depois de terem sido enviados</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Já viu esta mensagem</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Pode adicionar notas para si próprio(a) com esta conversa. Se a sua conta tiver dispositivos ligados, as novas notas serão sincronizadas.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Não existe nenhum navegador instalado no seu dispositivo.</string>
   <!--ConversationListFragment-->
@@ -1954,8 +1953,6 @@ Mensagem de troca de chaves inválida para esta versão do protocolo.
   <string name="recipient_preferences__about">Sobre</string>
   <string name="Recipient_unknown">Desconhecido</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Mensagem</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Telefonar</string> -->
   <string name="RecipientBottomSheet_block">Bloquear</string>
   <string name="RecipientBottomSheet_unblock">Desbloquear</string>
   <string name="RecipientBottomSheet_add_to_contacts">Adicionar aos contactos</string>
@@ -1965,6 +1962,7 @@ Mensagem de troca de chaves inválida para esta versão do protocolo.
   <string name="RecipientBottomSheet_make_group_admin">Tornar administrador de grupo</string>
   <string name="RecipientBottomSheet_remove_as_admin">Remover como administrador</string>
   <string name="RecipientBottomSheet_remove_from_group">Remover do grupo</string>
+  <string name="RecipientBottomSheet_message_description">Mensagem</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">Remover %1$s de administrador de grupo?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s será capaz de editar este grupo e os seus membros</string>
   <string name="RecipientBottomSheet_remove_s_from_s">Remover %1$s de \"%2$s\"?</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -288,7 +288,7 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Puteți glisa la stânga pe orice mesaj pentru a răspunde rapid</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Fișierele trimise de tip media vizibile o singură dată sunt eliminate automat după ce sunt trimise</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Ați văzut deja acest mesaj</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Puteți adăuga note pentru dvs. în această conversație. Dacă contul dvs. are dispozitive asociate, notele noi vor fi sincronizate.</string>
+  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Puteți adăuga notiţe pentru dvs. în această conversație.\nDacă contul dvs. are dispozitive asociate, notiţele noi vor fi sincronizate.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Nu aveți nici un browser instalat pe dispozitivul dvs.</string>
   <!--ConversationListFragment-->
@@ -475,6 +475,7 @@
   <string name="GroupManagement_choose_who_can_change_the_group_name_and_photo">Alegeți cine poate schimba numele grupului si poza</string>
   <!--ManageRecipientActivity-->
   <string name="ManageRecipientActivity_disappearing_messages">Dispariție mesaje</string>
+  <string name="ManageRecipientActivity_chat_color">Culoare conversaţie</string>
   <string name="ManageRecipientActivity_block">Blochează</string>
   <string name="ManageRecipientActivity_unblock">Deblochează</string>
   <string name="ManageRecipientActivity_view_safety_number">Afișează numărul de siguranță</string>
@@ -484,9 +485,19 @@
   <string name="ManageRecipientActivity_off">Dezactivate</string>
   <string name="ManageRecipientActivity_on">Activate</string>
   <string name="ManageRecipientActivity_add_to_a_group">Adaugaţi la un grup</string>
+  <string name="ManageRecipientActivity_view_all_groups">Vizualizați toate grupurile</string>
   <string name="ManageRecipientActivity_see_all">Vezi tot</string>
+  <string name="ManageRecipientActivity_no_groups_in_common">Nu există grupuri în comun</string>
+  <plurals name="ManageRecipientActivity_d_groups_in_common">
+    <item quantity="one">%d grup în comun</item>
+    <item quantity="few">%d grupuri în comun</item>
+    <item quantity="other">%d grupuri în comun</item>
+  </plurals>
   <string name="ManageRecipientActivity_edit_name_and_picture">Editare nume și poză</string>
   <string name="ManageRecipientActivity_message_description">Mesaj</string>
+  <string name="ManageRecipientActivity_voice_call_description">Apel vocal</string>
+  <string name="ManageRecipientActivity_insecure_voice_call_description">Apel vocal nesecurizat</string>
+  <string name="ManageRecipientActivity_video_call_description">Apel video</string>
   <plurals name="GroupMemberList_invited">
     <item quantity="one">%1$s a invitat o persoană</item>
     <item quantity="few"> %1$s a invitat %2$d persoane</item>
@@ -879,6 +890,7 @@ furnizat (%s) este invalid.</string>
   <string name="RegistrationActivity_more_information">Mai multe detalii</string>
   <string name="RegistrationActivity_less_information">Mai puține detalii</string>
   <string name="RegistrationActivity_signal_needs_access_to_your_contacts_and_media_in_order_to_connect_with_friends">Signal are nevoie de acces la contactele tale și media pentru a putea facilita comunicarea cu prietenii tăi, schimba mesaje și pentru a efectua apeluri securizate</string>
+  <string name="RegistrationActivity_rate_limited_to_service">Ați făcut prea multe încercări de înregistrare a acestui număr. Vă rugăm să încercați din nou mai târziu.</string>
   <string name="RegistrationActivity_unable_to_connect_to_service">Nu s-a putut realiza conexiunea la serviciu. Te rog verifică conexiunea la rețea și încearcă din nou.</string>
   <string name="RegistrationActivity_to_easily_verify_your_phone_number_signal_can_automatically_detect_your_verification_code">Pentru a putea verifica cât mai ușor numărul tău de telefon, Signal poate detecta automat codul de verificare dacă îi permiți aplicației Signal să citească mesajele SMS.</string>
   <plurals name="RegistrationActivity_debug_log_hint">
@@ -1443,6 +1455,12 @@ Am primit mesajul conform căruia schimbul de chei a avut loc pentru o versiune 
   <string name="message_details_header__disappears">Dispare</string>
   <string name="message_details_header__via">Prin</string>
   <!--message_details_recipient_header-->
+  <string name="message_details_recipient_header__pending_send">În curs</string>
+  <string name="message_details_recipient_header__sent_to">Trimis la</string>
+  <string name="message_details_recipient_header__sent_from">Trimis de</string>
+  <string name="message_details_recipient_header__delivered_to">Livrat la</string>
+  <string name="message_details_recipient_header__read_by">Citit de</string>
+  <string name="message_details_recipient_header__not_sent">Nu a fost trimis</string>
   <!--message_Details_recipient-->
   <string name="message_details_recipient__failed_to_send">Expediere eşuată</string>
   <string name="message_details_recipient__new_safety_number">Număr de siguranță nou</string>
@@ -2009,8 +2027,6 @@ Am primit mesajul conform căruia schimbul de chei a avut loc pentru o versiune 
   <string name="recipient_preferences__about">Despre</string>
   <string name="Recipient_unknown">Necunoscut</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Mesaj</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Apelează</string> -->
   <string name="RecipientBottomSheet_block">Blochează</string>
   <string name="RecipientBottomSheet_unblock">Deblochează</string>
   <string name="RecipientBottomSheet_add_to_contacts">Adăugați la contacte</string>
@@ -2020,6 +2036,10 @@ Am primit mesajul conform căruia schimbul de chei a avut loc pentru o versiune 
   <string name="RecipientBottomSheet_make_group_admin">Faceți administrator de grup</string>
   <string name="RecipientBottomSheet_remove_as_admin">Eliminați ca administrator</string>
   <string name="RecipientBottomSheet_remove_from_group">Eliminați din grup</string>
+  <string name="RecipientBottomSheet_message_description">Mesaj</string>
+  <string name="RecipientBottomSheet_voice_call_description">Apel vocal</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">Apel vocal nesecurizat</string>
+  <string name="RecipientBottomSheet_video_call_description">Apel video</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">Eliminați pe %1$s ca și admin de grup?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s va putea edita acest grup și membrii acestuia</string>
   <string name="RecipientBottomSheet_remove_s_from_s">Eliminați pe %1$s din \"%2$s\"?</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -298,7 +298,7 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Вы можете провести влево по любому сообщению, чтобы быстро ответить</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Исходящие одноразовые медиа-файлы автоматически удаляются после того, как они были отправлены</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Вы уже просмотрели это сообщение</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Вы можете добавлять заметки для себя в этом разговоре. Если у вашей учётной записи есть привязанные устройства, то новые заметки будут синхронизированы.</string>
+  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Вы можете добавлять заметки для себя в этом разговоре.\nЕсли у вашей учётной записи есть привязанные устройства, то новые заметки будут синхронизированы.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">На вашем устройстве не установлен браузер.</string>
   <!--ConversationListFragment-->
@@ -2078,8 +2078,6 @@
   <string name="recipient_preferences__about">О собеседнике</string>
   <string name="Recipient_unknown">Неизвестный</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Написать сообщение</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Позвонить</string> -->
   <string name="RecipientBottomSheet_block">Заблокировать</string>
   <string name="RecipientBottomSheet_unblock">Разблокировать</string>
   <string name="RecipientBottomSheet_add_to_contacts">Добавить в контакты</string>
@@ -2089,6 +2087,10 @@
   <string name="RecipientBottomSheet_make_group_admin">Сделать администратором группы</string>
   <string name="RecipientBottomSheet_remove_as_admin">Удалить как администратора</string>
   <string name="RecipientBottomSheet_remove_from_group">Удалить из группы</string>
+  <string name="RecipientBottomSheet_message_description">Написать сообщение</string>
+  <string name="RecipientBottomSheet_voice_call_description">Начать аудиозвонок</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">Начать незащищённый аудиозвонок</string>
+  <string name="RecipientBottomSheet_video_call_description">Начать видеозвонок</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">Удалить %1$s как администратора группы?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s сможет редактировать эту группу и её участников</string>
   <string name="RecipientBottomSheet_remove_s_from_s">Удалить %1$s из «%2$s»?</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -293,7 +293,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Pre rýchlu odpoveď môžete na akejkoľvek správe prejsť prstom doľava</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Odchádzajúce mediálne súbory na jedno zobrazenie sa po odoslaní automaticky odstránia</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Túto správu ste si už zobrazili</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">V tejto konverzácii si môžete pridávať poznámky. Ak máte vo vašom účte nejaké pripojené zariadenia, nové poznámky sa budú synchronizovať.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Nemáte nainštalovaný žiadny prehliadač.</string>
   <!--ConversationListFragment-->
@@ -1966,12 +1965,11 @@ Bola prijatá správa výmeny kľúčov s neplatnou verziou protokolu.
   <string name="recipient_preferences__about">Informácie</string>
   <string name="Recipient_unknown">Neznáme</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Správa</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Zavolať</string> -->
   <string name="RecipientBottomSheet_block">Blokovať</string>
   <string name="RecipientBottomSheet_unblock">Odblokovať</string>
   <string name="RecipientBottomSheet_add_to_contacts">Pridať medzi kontakty</string>
   <string name="RecipientBottomSheet_view_safety_number">Zobraziť bezpečnostné číslo</string>
+  <string name="RecipientBottomSheet_message_description">Správa</string>
   <string name="RecipientBottomSheet_remove">Odstrániť</string>
   <string name="RecipientBottomSheet_copied_to_clipboard">Skopírované do schránky</string>
   <string name="GroupRecipientListItem_admin">Admin</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -298,7 +298,7 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Za hiter odgovor na sporočilo podrsajte na levo</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Poslane medijske datoteke za enkraten ogled so avtomatično odstranjene s seznama </string>
   <string name="ConversationFragment_you_already_viewed_this_message">To sporočilo ste že videli</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">V tem pogovoru lahko shranjujete lastne zabeležke. Če je vaš račun povezan s še kakšno napravo, se bodo zabeležke prenesle tudi tja.</string>
+  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">V tem pogovoru lahko shranjujete lastne zabeležke.\nČe je vaš račun povezan s še kakšno napravo, se bodo zabeležke prenesle tudi tja.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Na svoji napravi nimate nameščenega spletnega brskalnika.</string>
   <!--ConversationListFragment-->
@@ -469,7 +469,7 @@
   <string name="ManageGroupActivity_until_s">Do %1$s</string>
   <string name="ManageGroupActivity_off">Izklopljena</string>
   <string name="ManageGroupActivity_on">Vklopljena</string>
-  <string name="ManageGroupActivity_add_members">Dodajanje članov/ic</string>
+  <string name="ManageGroupActivity_add_members">Dodaj člane/ice</string>
   <string name="ManageGroupActivity_view_all_members">Poglej vse člane</string>
   <string name="ManageGroupActivity_see_all">Prikaz vseh</string>
   <string name="ManageGroupActivity_none">Brez</string>
@@ -497,8 +497,8 @@
   <string name="ManageRecipientActivity_chat_color">Barva pogovora</string>
   <string name="ManageRecipientActivity_block">Blokiraj</string>
   <string name="ManageRecipientActivity_unblock">Odblokiraj</string>
-  <string name="ManageRecipientActivity_view_safety_number">Preglej varnostno število</string>
-  <string name="ManageRecipientActivity_mute_notifications">Izklop obvestil</string>
+  <string name="ManageRecipientActivity_view_safety_number">Pregled varnostnega števila</string>
+  <string name="ManageRecipientActivity_mute_notifications">Izklopi obvestila</string>
   <string name="ManageRecipientActivity_custom_notifications">Obvestila po meri</string>
   <string name="ManageRecipientActivity_until_s">Do %1$s</string>
   <string name="ManageRecipientActivity_off">Izklopljena</string>
@@ -1110,7 +1110,7 @@ Prejeto sporočilo za izmenjavo ključev za napačno različico protokola.</stri
   <string name="MmsMessageRecord_bad_encrypted_mms_message">Napačno šifrirano sporočilo MMS</string>
   <string name="MmsMessageRecord_mms_message_encrypted_for_non_existing_session">Sporočilo MMS je bilo šifrirano za neobstoječo sejo</string>
   <!--MuteDialog-->
-  <string name="MuteDialog_mute_notifications">Izklopi obvestila</string>
+  <string name="MuteDialog_mute_notifications">Izklop obvestil</string>
   <!--OutdatedBuildReminder-->
   <string name="OutdatedBuildReminder_no_web_browser_installed">Spletni brskalnik ni nameščen!</string>
   <!--ApplicationMigrationService-->
@@ -1514,7 +1514,7 @@ Prejeto sporočilo za izmenjavo ključev za napačno različico protokola.</stri
   <string name="AndroidManifest__media_preview">Ogled medija</string>
   <string name="AndroidManifest__message_details">Podrobnosti sporočila</string>
   <string name="AndroidManifest__linked_devices">Povezane naprave</string>
-  <string name="AndroidManifest__invite_friends">Povabi prijatelje</string>
+  <string name="AndroidManifest__invite_friends">Povabite prijatelje</string>
   <string name="AndroidManifest_archived_conversations">Arhivirani pogovori</string>
   <string name="AndroidManifest_remove_photo">Odstrani fotografijo</string>
   <!--Message Requests Megaphone-->
@@ -1755,7 +1755,7 @@ Prejeto sporočilo za izmenjavo ključev za napačno različico protokola.</stri
   <string name="conversation_list_fragment__open_camera_description">Odpri kamero</string>
   <string name="conversation_list_fragment__give_your_inbox_something_to_write_home_about_get_started_by_messaging_a_friend">Vaš poštni nabiralnik je lačen nove pošte. ;-) Začnite s sporočilom prijatelju!</string>
   <!--conversation_secure_verified-->
-  <string name="conversation_secure_verified__menu_reset_secure_session">Ponastavi varno sejo</string>
+  <string name="conversation_secure_verified__menu_reset_secure_session">Ponastavitev varne seje</string>
   <!--conversation_muted-->
   <string name="conversation_muted__unmute">Prekliči utišanje</string>
   <!--conversation_unmuted-->
@@ -1767,7 +1767,7 @@ Prejeto sporočilo za izmenjavo ključev za napačno različico protokola.</stri
   <string name="conversation__menu_leave_group">Zapusti skupino</string>
   <string name="conversation__menu_view_all_media">Vsa multimedijska sporočila</string>
   <string name="conversation__menu_conversation_settings">Nastavitve pogovora</string>
-  <string name="conversation__menu_add_shortcut">Dodaj na domači zaslon</string>
+  <string name="conversation__menu_add_shortcut">Dodajanje na domači zaslon</string>
   <string name="conversation__menu_pending_members">Čakajoči/e člani/ce</string>
   <!--conversation_popup-->
   <string name="conversation_popup__menu_expand_popup">Razširi pojavno okno</string>
@@ -1783,7 +1783,7 @@ Prejeto sporočilo za izmenjavo ključev za napačno različico protokola.</stri
   <string name="text_secure_normal__menu_settings">Nastavitve</string>
   <string name="text_secure_normal__menu_clear_passphrase">Zakleni</string>
   <string name="text_secure_normal__mark_all_as_read">Označi vse kot prebrano</string>
-  <string name="text_secure_normal__invite_friends">Povabi prijatelje</string>
+  <string name="text_secure_normal__invite_friends">Vabilo prijateljem</string>
   <string name="text_secure_normal__help">Pomoč</string>
   <!--verify_display_fragment-->
   <string name="verify_display_fragment_context_menu__copy_to_clipboard">Kopiraj v odložišče</string>
@@ -2076,17 +2076,19 @@ Prejeto sporočilo za izmenjavo ključev za napačno različico protokola.</stri
   <string name="recipient_preferences__about">Več</string>
   <string name="Recipient_unknown">Neznano</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Sporočilo</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Kliči</string> -->
   <string name="RecipientBottomSheet_block">Blokiraj</string>
   <string name="RecipientBottomSheet_unblock">Odblokiraj</string>
   <string name="RecipientBottomSheet_add_to_contacts">Dodaj k stikom</string>
   <string name="RecipientBottomSheet_add_to_a_group">Dodaj v skupino</string>
   <string name="RecipientBottomSheet_add_to_another_group">Dodaj v drugo skupino</string>
-  <string name="RecipientBottomSheet_view_safety_number">Preglej varnostno število</string>
+  <string name="RecipientBottomSheet_view_safety_number">Pregled varnostnega števila</string>
   <string name="RecipientBottomSheet_make_group_admin">Določi za skrbnika skupine</string>
   <string name="RecipientBottomSheet_remove_as_admin">Odstrani kot skrbnika</string>
   <string name="RecipientBottomSheet_remove_from_group">Odstrani iz skupine</string>
+  <string name="RecipientBottomSheet_message_description">Sporočilo</string>
+  <string name="RecipientBottomSheet_voice_call_description">Zvočni klic</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">Nezavarovan zvočni klic</string>
+  <string name="RecipientBottomSheet_video_call_description">Video klic</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">Odstranim uporabnika/co %1$s kot skrbnika/co skupine?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">Uporabnik/ca %1$s bo lahko urejal/a skupino in njeno članstvo</string>
   <string name="RecipientBottomSheet_remove_s_from_s">Odtsranim uporabnika/co %1$s iz skupine \"%2$s\"?</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -278,7 +278,7 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Për t’u përgjigjur shpejt e shpejt, mund të fërkoni ekranin për majtas</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Kartela media për parje vetëm një herë, që duhen dërguar, hiqen automatikisht pasi të jenë dërguar.</string>
   <string name="ConversationFragment_you_already_viewed_this_message">E patë tashmë këtë mesazh</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Në këtë bisedë mund të shtoni shënime për veten. Nëse llogaria juaj ka ndonjë pajisje të lidhur, shënimet e reja do të njëkohësohen.</string>
+  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Në këtë bisedë mund të shtoni shënime për veten.\nNëse llogaria juaj ka ndonjë pajisje të lidhur, shënimet e reja do të njëkohësohen.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Në pajisjen tuaj s\’ka shfletues të instaluar.</string>
   <!--ConversationListFragment-->
@@ -456,6 +456,7 @@
   <string name="GroupManagement_choose_who_can_change_the_group_name_and_photo">Zgjidhni cilët mund të ndryshojnë emrin dhe foton e grupit</string>
   <!--ManageRecipientActivity-->
   <string name="ManageRecipientActivity_disappearing_messages">Zhdukje mesazhesh</string>
+  <string name="ManageRecipientActivity_chat_color">Ngjyrë fjalosjeje</string>
   <string name="ManageRecipientActivity_block">Bllokoje</string>
   <string name="ManageRecipientActivity_unblock">Zhbllokoje</string>
   <string name="ManageRecipientActivity_view_safety_number">Shihni numër sigurie</string>
@@ -465,9 +466,18 @@
   <string name="ManageRecipientActivity_off">Off</string>
   <string name="ManageRecipientActivity_on">On</string>
   <string name="ManageRecipientActivity_add_to_a_group">Shtoje te grup</string>
+  <string name="ManageRecipientActivity_view_all_groups">Shihni krejt grupet</string>
   <string name="ManageRecipientActivity_see_all">Shihini krejt</string>
+  <string name="ManageRecipientActivity_no_groups_in_common">S’ka grupe të përbashkët.</string>
+  <plurals name="ManageRecipientActivity_d_groups_in_common">
+    <item quantity="one">%d grup i përbashkët</item>
+    <item quantity="other">%d grupe të përbashkët</item>
+  </plurals>
   <string name="ManageRecipientActivity_edit_name_and_picture">Përpunoni emër dhe foto</string>
   <string name="ManageRecipientActivity_message_description">Mesazh</string>
+  <string name="ManageRecipientActivity_voice_call_description">Thirrje zanore</string>
+  <string name="ManageRecipientActivity_insecure_voice_call_description">Thirrje zanore jo e sigurt</string>
+  <string name="ManageRecipientActivity_video_call_description">Thirrje video</string>
   <plurals name="GroupMemberList_invited">
     <item quantity="one">%1$s ftoi 1 person</item>
     <item quantity="other">%1$s ftoi %2$d vetë</item>
@@ -845,6 +855,7 @@
   <string name="RegistrationActivity_more_information">Më tepër të dhëna</string>
   <string name="RegistrationActivity_less_information">Më pak të dhëna</string>
   <string name="RegistrationActivity_signal_needs_access_to_your_contacts_and_media_in_order_to_connect_with_friends">Që të mund të lidheni me shokët, të shkëmbeni mesazhe dhe të bëni thirje të siguruara, Signal-i lyp hyrje te kontaktet dhe mediat tuaja</string>
+  <string name="RegistrationActivity_rate_limited_to_service">Keni bërë shumë përpjekje për të regjistruar këtë numër. Ju lutemi, riprovoni më vonë.</string>
   <string name="RegistrationActivity_unable_to_connect_to_service">S\’arrihet të bëhet lidhja te shërbimi. Ju lutemi, kontrolloni lidhjen me rrjetin dhe riprovoni.</string>
   <string name="RegistrationActivity_to_easily_verify_your_phone_number_signal_can_automatically_detect_your_verification_code">Që të verifikohet lehtësisht numri juaj i telefonit, Signal-i mund të zbulojë vetvetiu kodin tuaj të verifikimit, nëse e lejoni Signal-in të shohë mesazhe SMS.</string>
   <plurals name="RegistrationActivity_debug_log_hint">
@@ -1398,6 +1409,12 @@
   <string name="message_details_header__disappears">Zhduket më</string>
   <string name="message_details_header__via">Përmes</string>
   <!--message_details_recipient_header-->
+  <string name="message_details_recipient_header__pending_send">Pezull</string>
+  <string name="message_details_recipient_header__sent_to">Dërguar te</string>
+  <string name="message_details_recipient_header__sent_from">Dërguar nga</string>
+  <string name="message_details_recipient_header__delivered_to">Dorëzuar te</string>
+  <string name="message_details_recipient_header__read_by">Lexuar nga</string>
+  <string name="message_details_recipient_header__not_sent">S’u dërgua</string>
   <!--message_Details_recipient-->
   <string name="message_details_recipient__failed_to_send">Dështoi dërgimi</string>
   <string name="message_details_recipient__new_safety_number">Numër i ri sigurie</string>
@@ -1956,8 +1973,6 @@ spastrohet dhe krejt lënda do të fshihet.</item>
   <string name="recipient_preferences__about">Mbi</string>
   <string name="Recipient_unknown">I panjohur</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Mesazh</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Thirrje</string> -->
   <string name="RecipientBottomSheet_block">Bllokoje</string>
   <string name="RecipientBottomSheet_unblock">Zhbllokoje</string>
   <string name="RecipientBottomSheet_add_to_contacts">Shtoje te kontaktet</string>
@@ -1967,6 +1982,10 @@ spastrohet dhe krejt lënda do të fshihet.</item>
   <string name="RecipientBottomSheet_make_group_admin">Bëje përgjegjës grupi</string>
   <string name="RecipientBottomSheet_remove_as_admin">Hiqe nga përgjegjës</string>
   <string name="RecipientBottomSheet_remove_from_group">Hiqe nga grup</string>
+  <string name="RecipientBottomSheet_message_description">Mesazh</string>
+  <string name="RecipientBottomSheet_voice_call_description">Thirrje zanore</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">Thirrje zanore jo e sigurt</string>
+  <string name="RecipientBottomSheet_video_call_description">Thirrje video</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">Të hiqet %1$s nga përgjegjës grupi?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s do të jetë në gjendje të përpunojë këtë grup dhe anëtarët e tij</string>
   <string name="RecipientBottomSheet_remove_s_from_s">Të hiqet %1$s nga \"%2$s\"?</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -278,7 +278,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Du kan dra åt vänster på ett meddelande för att snabbt svara</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Filer för utgående visa-en-gång media tas bort automatiskt efter att de har skickats</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Du har redan sett det här meddelandet</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Du kan lägga till anteckningar för dig själv i den här konversationen. Om ditt konto har några länkade enheter kommer nya anteckningar att synkroniseras.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Det finns ingen webbläsare installerad på din enhet.</string>
   <!--ConversationListFragment-->
@@ -1969,8 +1968,6 @@ Tog emot meddelande för nyckelutbyte för ogiltig protokollversion.</string>
   <string name="recipient_preferences__about">Om</string>
   <string name="Recipient_unknown">Okänt</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Meddelande</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Ring</string> -->
   <string name="RecipientBottomSheet_block">Blockera</string>
   <string name="RecipientBottomSheet_unblock">Sluta blockera</string>
   <string name="RecipientBottomSheet_add_to_contacts">Lägg till som kontakt</string>
@@ -1980,6 +1977,10 @@ Tog emot meddelande för nyckelutbyte för ogiltig protokollversion.</string>
   <string name="RecipientBottomSheet_make_group_admin">Gör till gruppadminstratör</string>
   <string name="RecipientBottomSheet_remove_as_admin">Ta bort som administratör</string>
   <string name="RecipientBottomSheet_remove_from_group">Ta bort från grupp</string>
+  <string name="RecipientBottomSheet_message_description">Meddelande</string>
+  <string name="RecipientBottomSheet_voice_call_description">Röstsamtal</string>
+  <string name="RecipientBottomSheet_insecure_voice_call_description">Osäkert röstsamtal</string>
+  <string name="RecipientBottomSheet_video_call_description">Videosamtal</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">Ta bort %1$s som gruppadministratör?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s kommer att kunna redigera denna grupp och dess medlemmar</string>
   <string name="RecipientBottomSheet_remove_s_from_s">Ta bort %1$s från \"%2$s\"?</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -259,7 +259,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Unaweza kusongeza kidole kwa upande wa kushoto kwa ujumbe wowote ili kujibu haraka</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Faili zako za mtazamo mmoja zinazotumwa zinaondolewa punde tu zinapotumwa</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Umeshautazama ujumbe huu</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Unaweza kujiongezea maelezo katika mazungumzo haya. Iwapo akaunti yako ina vifaa vyovyote vilivyounganishwa, maelezo mapya yatalandanishwa.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Hakuna kivinjari kilichosakinishwa kwenye kifaa chako.</string>
   <!--ConversationListFragment-->
@@ -1694,12 +1693,11 @@ Funga ufikiaji wa Signal na ufungaji wa Android au alama za vidole</string>
   <string name="recipient_preferences__about">Kuhusu</string>
   <string name="Recipient_unknown">Isiyojulikana</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Ujumbe</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Simu</string> -->
   <string name="RecipientBottomSheet_block">Zuia</string>
   <string name="RecipientBottomSheet_unblock">Fungua</string>
   <string name="RecipientBottomSheet_add_to_contacts">Ongeza kwa wawasiliani</string>
   <string name="RecipientBottomSheet_view_safety_number">Tazama nambari ya usalama</string>
+  <string name="RecipientBottomSheet_message_description">Ujumbe</string>
   <string name="RecipientBottomSheet_remove">Ondoa</string>
   <string name="RecipientBottomSheet_copied_to_clipboard">Imenakiliwa kwenye bodi ya kunakili</string>
   <string name="GroupRecipientListItem_admin">Msimamizi</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -264,7 +264,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">விரைவாக பதிலளிக்க, எந்த செய்தியிலும் இடதுபுறமாக ஸ்வைப் செய்யலாம்</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">வெளிச்செல்லும் காண்க-ஒருமுறை கோப்புகள் அனுப்பப்பட்ட பின் தானாகவே அகற்றப்படும்</string>
   <string name="ConversationFragment_you_already_viewed_this_message">நீங்கள் ஏற்கனவே இந்த செய்தியைப் பார்த்தீர்கள்</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">நீங்கள் இந்த உரையாடலில் உங்களுக்காக குறிப்புகளைச் சேர்க்கலாம். என்றால் உங்கள் கணக்கு ஏதேனும் உள்ளது இணைக்கப்பட்டுள்ளது சாதனங்கள், புதிய குறிப்புகள் ஒத்திசைக்கப்படும்.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">உங்கள் சாதனத்தில் எந்த உலாவியும் நிறுவப்படவில்லை.</string>
   <!--ConversationListFragment-->
@@ -1682,12 +1681,11 @@
   <string name="recipient_preferences__about">அறிமுகம்</string>
   <string name="Recipient_unknown">தெரியாத</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">செய்தி</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">அழைப்பு</string> -->
   <string name="RecipientBottomSheet_block">தடு </string>
   <string name="RecipientBottomSheet_unblock">தடைநீக்கு </string>
   <string name="RecipientBottomSheet_add_to_contacts">தொடர்புகளுடன் சேர்க்க</string>
   <string name="RecipientBottomSheet_view_safety_number">பாதுகாப்பு எண்ணைக் காண்பி</string>
+  <string name="RecipientBottomSheet_message_description">செய்தி</string>
   <string name="RecipientBottomSheet_remove">நீக்கு</string>
   <string name="RecipientBottomSheet_copied_to_clipboard">கிளிப்போர்டுக்கு நகலெடுக்கப்பட்டது</string>
   <string name="GroupRecipientListItem_admin">நிர்வாகம்</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -277,7 +277,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">త్వరగా సమాధానం ఇవ్వడానికి మీరు ఏదైనా సందేశంలో ఎడమ వైపుకు స్వైప్ చేయవచ్చు</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">అవుట్గోయింగ్  ఒకసారి-దృశ్యం  మీడియా ఫైల్స్ పంపిన తర్వాత స్వయంచాలకంగా తొలగించబడతాయి</string>
   <string name="ConversationFragment_you_already_viewed_this_message">మీరు ఇప్పటికే ఈ సందేశాన్ని చూశారు</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">ఈ సంభాషణలో మీరు మీ కోసం గమనికలను జోడించవచ్చు. మీ ఖాతాకు ఏదైనా లింక్ చేసిన పరికరాలు ఉంటే, క్రొత్త గమనికలు సమకాలీకరించబడతాయి.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">మీ పరికరంలో ఎటువంటి బ్రౌజర్ ఇన్స్టాల్ అయి లేదు</string>
   <!--ConversationListFragment-->
@@ -1767,12 +1766,11 @@
   <string name="recipient_preferences__about">గురించి</string>
   <string name="Recipient_unknown">తెలియని</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">సందేశం</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">కాల్</string> -->
   <string name="RecipientBottomSheet_block">నిరోధించు</string>
   <string name="RecipientBottomSheet_unblock">అనుమతించు</string>
   <string name="RecipientBottomSheet_add_to_contacts">పరిచయాలకు జోడించండి</string>
   <string name="RecipientBottomSheet_view_safety_number">భద్రతా సంఖ్యను వీక్షించండి</string>
+  <string name="RecipientBottomSheet_message_description">సందేశం</string>
   <string name="RecipientBottomSheet_remove">తొలగించు</string>
   <string name="RecipientBottomSheet_copied_to_clipboard">క్లిప్బోర్డ్కు కాపీ చేయబడింది</string>
   <string name="GroupRecipientListItem_admin">అడ్మిన్</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -264,7 +264,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">คุณสามารถปัดด้านซ้ายเพื่อตอบข้อความอย่างรวดเร็ว</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">ไฟล์สื่อที่ดูได้ครั้งเดียวที่กำลังถูกส่งออกไปจะถูกลบอัตโนมัติหลังจากส่งไปแล้ว</string>
   <string name="ConversationFragment_you_already_viewed_this_message">คุณเห็นข้อความนี้แล้ว</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">คุณสามารถเพิ่มบันทึกสำหรับตัวคุณเองในการสนทนานี้ ถ้าบัญชีของคุณมีอุปกรณ์ที่เชื่อมโยงอยู่ บันทึกใหม่ทุกอันจะถูกปรับประสานถึงกัน</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">ไม่มีเบราว์เซอร์ติดตั้งอยู่ในอุปกรณ์ของคุณ</string>
   <!--ConversationListFragment-->
@@ -1848,8 +1847,6 @@
   <string name="recipient_preferences__about">เกี่ยวกับ</string>
   <string name="Recipient_unknown">ไม่ทราบ</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">ข้อความ</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">โทร</string> -->
   <string name="RecipientBottomSheet_block">ปิดกั้น</string>
   <string name="RecipientBottomSheet_unblock">เลิกปิดกั้น</string>
   <string name="RecipientBottomSheet_add_to_contacts">เพิ่มลงในรายชื่อผู้ติดต่อ</string>
@@ -1857,6 +1854,7 @@
   <string name="RecipientBottomSheet_make_group_admin">ตั้งเป็นผู้ดูแลกลุ่ม</string>
   <string name="RecipientBottomSheet_remove_as_admin">ลบจากการเป็นผู้ดูแล</string>
   <string name="RecipientBottomSheet_remove_from_group">ลบจากลุ่ม</string>
+  <string name="RecipientBottomSheet_message_description">ข้อความ</string>
   <string name="RecipientBottomSheet_remove_s_from_s">ลบ %1$s จาก \"%2$s\" หรือไม่?</string>
   <string name="RecipientBottomSheet_remove">เอาออก</string>
   <string name="RecipientBottomSheet_copied_to_clipboard">คัดลอกไปคลิปบอร์ดแล้ว</string>

--- a/app/src/main/res/values-tl/strings.xml
+++ b/app/src/main/res/values-tl/strings.xml
@@ -267,7 +267,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Maaari kang mag-swipe pakaliwa sa alinmang mensahe upang mabilisang makatugon</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Ang mga papalabas na view-once na media file ay awtomatikong matatanggal matapos ipadala ang mga ito</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Natingnan mo na ang mensaheng ito</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Maaari kang magdagdag ng mga notes para sa iyong sarili sa pag-uusap na ito. Kung ang iyong account ay may naka-link na mga device, ang bagong mga note may masi-sync.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Walang naka-install na browser sa iyong device.</string>
   <!--ConversationListFragment-->
@@ -1764,12 +1763,11 @@
   <string name="recipient_preferences__about">Tungkol dito</string>
   <string name="Recipient_unknown">Hindi alam</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Mensahe</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Tawagan</string> -->
   <string name="RecipientBottomSheet_block">I-block</string>
   <string name="RecipientBottomSheet_unblock">I-unblock</string>
   <string name="RecipientBottomSheet_add_to_contacts">Idagdag sa mga kontak</string>
   <string name="RecipientBottomSheet_view_safety_number">Tingnan ang numerong pangkaligtasan</string>
+  <string name="RecipientBottomSheet_message_description">Mensahe</string>
   <string name="RecipientBottomSheet_remove">Tanggalin</string>
   <string name="RecipientBottomSheet_copied_to_clipboard">Nakopya na sa clipboard</string>
   <string name="GroupRecipientListItem_admin">Admin</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -276,7 +276,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Herhangi bir iletiyi hızlıca yanıtlamak için sola kaydırabilirsiniz</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Gönderilen tek görümlük içerik dosyaları gönderim tamamlandıktan sonra kendiliğinden silinir</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Bu iletiyi zaten görüntülediniz</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Bu konuşmada kendinize notlar ekleyebilirsiniz. Eğer hesabınıza bağlı cihaz varsa, yeni notlar eşzamanlanacaktır.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Cihazınıza yüklü tarayıcı bulunmamaktadır.</string>
   <!--ConversationListFragment-->
@@ -1895,8 +1894,6 @@ Geçersiz protokol sürümünde anahtar değişim iletisi alındı.</string>
   <string name="recipient_preferences__about">Hakkında</string>
   <string name="Recipient_unknown">Bilinmeyen</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">İleti</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Ara</string> -->
   <string name="RecipientBottomSheet_block">Engelle</string>
   <string name="RecipientBottomSheet_unblock">Engeli kaldır</string>
   <string name="RecipientBottomSheet_add_to_contacts">Kişilere ekle</string>
@@ -1904,6 +1901,7 @@ Geçersiz protokol sürümünde anahtar değişim iletisi alındı.</string>
   <string name="RecipientBottomSheet_make_group_admin">Grup yöneticisi yap</string>
   <string name="RecipientBottomSheet_remove_as_admin">Grup yöneticiliğinden çıkart</string>
   <string name="RecipientBottomSheet_remove_from_group">Gruptan çıkart</string>
+  <string name="RecipientBottomSheet_message_description">İleti</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">%1$s grup yöneticiliğinden çıkartılsın mı?</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s bu grubu ve üyelerini düzenleyebilecek.</string>
   <string name="RecipientBottomSheet_remove">Kaldır</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -257,7 +257,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">آپ کسی پیغام کا جلدی سے جواب دینے کیلئے بائیں سوائپ کر سکتے ہیں</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">باہر جانے والے ملاحظہ ایک بار میڈیا فائلیں بھیجے جانے کے بعد خود بخود حذف ہوجاتی ہیں</string>
   <string name="ConversationFragment_you_already_viewed_this_message">آپ یہ پیغام پہلے ہی دیکھ چکے ہیں</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">آپ اس گفتگو میں اپنے لئے نوٹ شامل کرسکتے ہیں۔ اگر آپ کے اکاؤنٹ میں کوئی لنکڈ devices ہیں تو ، نئے نوٹوں کی ہم آہنگی ہوگی۔</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">آپ کی ڈیوائس پر کوئی براؤزر نصب نہیں ہوا۔</string>
   <!--ConversationListFragment-->
@@ -1646,12 +1645,11 @@
   <string name="recipient_preferences__about">متعلق</string>
   <string name="Recipient_unknown">نامعلوم</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">پیغام</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">کال</string> -->
   <string name="RecipientBottomSheet_block">بلاک</string>
   <string name="RecipientBottomSheet_unblock">ان بلاک</string>
   <string name="RecipientBottomSheet_add_to_contacts">رابطوں میں شامل کریں</string>
   <string name="RecipientBottomSheet_view_safety_number">حفاظتی نمبر دیکھیں</string>
+  <string name="RecipientBottomSheet_message_description">پیغام</string>
   <string name="RecipientBottomSheet_remove">ہٹا دیں</string>
   <string name="RecipientBottomSheet_copied_to_clipboard">کلپ بورڈ کو کاپی کریں</string>
   <string name="GroupRecipientListItem_admin">ایڈمن</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -263,7 +263,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">Bạn có thể vuốt tin nhắn sang bên trái để trả lời nhanh</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">Tin nhắn đa phương tiện xem một lần sẽ tự động xóa sau khi được gửi</string>
   <string name="ConversationFragment_you_already_viewed_this_message">Bạn đã xem tin nhắn này rồi</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">Bạn có thể thêm ghi chú trong cuộc trò chuyện này. Nếu tài khoản của bạn có thiết bị liên kết, ghi chú cũng sẽ được đồng bộ.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">Bạn chưa cài trình duyệt nào trên điện thoại.</string>
   <!--ConversationListFragment-->
@@ -1800,12 +1799,11 @@ Nhận thông tin trao đổi mã khóa về phiên bản giao thức không h�
   <string name="recipient_preferences__about">Thông tin</string>
   <string name="Recipient_unknown">Vô danh</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">Tin nhắn</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">Gọi</string> -->
   <string name="RecipientBottomSheet_block">Chặn</string>
   <string name="RecipientBottomSheet_unblock">Bỏ chặn</string>
   <string name="RecipientBottomSheet_add_to_contacts">Thêm vào danh bạ</string>
   <string name="RecipientBottomSheet_view_safety_number">Xem số an toàn</string>
+  <string name="RecipientBottomSheet_message_description">Tin nhắn</string>
   <string name="RecipientBottomSheet_remove">Loại bỏ</string>
   <string name="RecipientBottomSheet_copied_to_clipboard">Đã sao chép vào clipboard</string>
   <string name="GroupRecipientListItem_admin">Quản trị viên</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -257,7 +257,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">左滑任何消息可快速回复</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">一次性媒体文件在发送之后将自动删除</string>
   <string name="ConversationFragment_you_already_viewed_this_message">已查看该消息</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">你可以在这个对话中为自己添加笔记。 如果您的帐户有任何连接设备，新的笔记将同步。</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">设备上没有安装浏览器。</string>
   <!--ConversationListFragment-->
@@ -1723,12 +1722,11 @@
   <string name="recipient_preferences__about">关于</string>
   <string name="Recipient_unknown">未知</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">消息</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">呼叫</string> -->
   <string name="RecipientBottomSheet_block">屏蔽</string>
   <string name="RecipientBottomSheet_unblock">取消屏蔽</string>
   <string name="RecipientBottomSheet_add_to_contacts">添加到联系人</string>
   <string name="RecipientBottomSheet_view_safety_number">查看安全码</string>
+  <string name="RecipientBottomSheet_message_description">消息</string>
   <string name="RecipientBottomSheet_remove">删除</string>
   <string name="RecipientBottomSheet_copied_to_clipboard">已复制到剪切板</string>
   <string name="GroupRecipientListItem_admin">管理员</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -268,7 +268,6 @@
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">你可以在任何訊息上向左滑動以快速回覆</string>
   <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">傳送出去的一次性多媒體檔案被傳送出去之後會自動消除</string>
   <string name="ConversationFragment_you_already_viewed_this_message">你已經看過這個訊息</string>
-  <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">你可以在此對話中為自己增加筆記。 如果你的帳號有任何連結的裝置，則新的筆記將被同步。</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">您的裝置上未安裝瀏覽器。</string>
   <!--ConversationListFragment-->
@@ -1901,8 +1900,6 @@
   <string name="recipient_preferences__about">關於</string>
   <string name="Recipient_unknown">未知</string>
   <!--RecipientBottomSheet-->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_message">訊息</string> -->
-  <!-- Removed by excludeNonTranslatables <string name="RecipientBottomSheet_call">撥打</string> -->
   <string name="RecipientBottomSheet_block">封鎖</string>
   <string name="RecipientBottomSheet_unblock">解除封鎖</string>
   <string name="RecipientBottomSheet_add_to_contacts">新增至聯絡人</string>
@@ -1912,6 +1909,7 @@
   <string name="RecipientBottomSheet_make_group_admin">成為群組管理員</string>
   <string name="RecipientBottomSheet_remove_as_admin">以管理員身份移除</string>
   <string name="RecipientBottomSheet_remove_from_group">從群組中移除</string>
+  <string name="RecipientBottomSheet_message_description">訊息</string>
   <string name="RecipientBottomSheet_remove_s_as_group_admin">以管理員身分移除%1$s嗎？</string>
   <string name="RecipientBottomSheet_s_will_be_able_to_edit_group">%1$s將可以編輯此群組及其成員</string>
   <string name="RecipientBottomSheet_remove_s_from_s">從\"%2$s\"移除%1$s嗎？</string>

--- a/app/witness-verifications.gradle
+++ b/app/witness-verifications.gradle
@@ -432,8 +432,8 @@ dependencyVerification {
         ['org.signal:argon2:13.1',
          '0f686ccff0d4842bfcc74d92e8dc780a5f159b9376e37a1189fabbcdac458bef'],
 
-        ['org.signal:ringrtc-android:2.1.0',
-         'f138f87b3b24a36d670dd27b4c6bcbbd922eb6ff4f0e018619d4f92a7a5ae53d'],
+        ['org.signal:ringrtc-android:2.1.1',
+         '816b7e1e9a0d5009fa5c7a76ef9dda16c5f59dad7e2ec284d0abd2e478445034'],
 
         ['org.signal:signal-metadata-java:0.1.2',
          '6aaeb6a33bf3161a3e6ac9db7678277f7a4cf5a2c96b84342e4007ee49bab1bd'],


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Motorola X Play, Android 7.1.1
 * Virtual Pixel 2, Android 7.1.1
 * Virtual Pixel 2, Android 10.0+
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
On some devices, especially my device, it takes a long time to generate the AudioWaveForm/AudioHash of a voice message.
A voice message of 30 minutes has taken ~112sec on stock Signal, ~160sec with self-built Signal.
The cause was the frequent iterative use of extractor.advance(), which seems to be no problem with other devices.
Instead of extractor.advance() to go through each frame, seekTo(...) is used to go directly to the desired frame whose values are to be used for the audio hash.
Two further values were used for this: BAR_FACTOR and barTimer.
BAR_FACTOR contains the time difference between the desired frames.
barTimer contains the time of the actual frame.

In addition, the newer type 
ByteBuffer inputBuffer = codec.getInputBuffer(inputBufferId);
ByteBuffer outputBuffer = codec.getOutputBuffer(outputBufferId);

is used instead of the deprecated processing with buffer arrays
ByteBuffer[] inputBuffers = codec.getInputBuffers();
ByteBuffer[] outputBuffers = codec.getOutputBuffers();

The time for generation is now ~3sec for a 30 minutes voice message with 99%/100% the same values for the AudioHash.

further note:
seekTo() does not seem to recognize whether the entered time goes beyond the stream.
Therefore, when using it, make sure that the entered time remains below the duration of the audio message.
