### PR TITLE
Fix app name typo in language translations.

### DIFF
--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -2035,7 +2035,7 @@ Obdržen požadavek na výměnu klíčů pro neplatnou verzi protokolu.
   <string name="preferences_app_protection__reminders_help_you_remember_your_pin">Upomínky vám pomohou zapamatovat si váš PIN, protože ten nelze obnovit. V průběhu času vás budeme žádat méně často.</string>
   <string name="preferences_app_protection__turn_off">Vypnout</string>
   <string name="preferences_app_protection__confirm_pin">Potvrďte PIN</string>
-  <string name="preferences_app_protection__confirm_your_signal_pin">Potvrdit váš Singal PIN</string>
+  <string name="preferences_app_protection__confirm_your_signal_pin">Potvrdit váš Signal PIN</string>
   <string name="preferences_app_protection__make_sure_you_memorize_or_securely_store_your_pin">Ujistěte se, že si PIN pamatujete nebo ho máte bezpečně uložený, protože jej nelze obnovit. Pokud váš PIN zapomenete, můžete při opakované registraci Signal účtu přijít o data.</string>
   <string name="preferences_app_protection__incorrect_pin_try_again">Nesprávný PIN. Zkuste to znovu.</string>
   <string name="preferences_app_protection__failed_to_enable_registration_lock">Aktivace zámku registrace se nezdařila.</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -615,7 +615,7 @@
   <string name="MediaSendActivity_message_to_s">Honentzako mezua: %s</string>
   <string name="MediaSendActivity_message">Mezua</string>
   <string name="MediaSendActivity_select_recipients">Aukeratu hartzaileak</string>
-  <string name="MediaSendActivity_signal_needs_access_to_your_contacts">Singalek zure kontaktuak lortzeko baimena behar du erakutsi ahal izateko.</string>
+  <string name="MediaSendActivity_signal_needs_access_to_your_contacts">Signalek zure kontaktuak lortzeko baimena behar du erakutsi ahal izateko.</string>
   <string name="MediaSendActivity_signal_needs_contacts_permission_in_order_to_show_your_contacts_but_it_has_been_permanently_denied">Signal-ek Kontaktuen baimena behar du zure kontaktuak erakusteko baina ukatu egin diozu. Joan aplikazioaren ezarpenetara, aukeratu \"Baimenak\", eta gaitu \"Kontaktuak\".</string>
   <plurals name="MediaSendActivity_cant_share_more_than_n_items">
     <item quantity="one">Ezin duzu elementu %d baino gehiago partekatu</item>
@@ -1213,7 +1213,7 @@ Gakoaren elkar-trukeraro mezua jaso da protokoloaren bertsio baliogabe baterako.
   <!--blocked_contacts_fragment-->
   <string name="blocked_contacts_fragment__no_blocked_contacts">Blokeatutako kontaturik ez…</string>
   <!--contact_selection_list_fragment-->
-  <string name="contact_selection_list_fragment__signal_needs_access_to_your_contacts_in_order_to_display_them">Singalek zure kontaktuak lortzeko baimena behar du erakutsi ahal izateko.</string>
+  <string name="contact_selection_list_fragment__signal_needs_access_to_your_contacts_in_order_to_display_them">Signalek zure kontaktuak lortzeko baimena behar du erakutsi ahal izateko.</string>
   <string name="contact_selection_list_fragment__show_contacts">Kontaktuak erakutsi</string>
   <!--contact_selection_list_item-->
   <plurals name="contact_selection_list_item__number_of_members">

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -1083,7 +1083,7 @@ a shonrú</string>
   <string name="reminder_header_invite_title">Tabhair cuireadh chuig Signal</string>
   <string name="reminder_header_invite_text">Cuir feabhas le do chomhrá le %1$s.</string>
   <string name="reminder_header_share_title">Tabhair cuirí do do chairde!</string>
-  <string name="reminder_header_share_text">An mó cairde leat a bhaineann feidhm as Singal, is fearrde é.</string>
+  <string name="reminder_header_share_text">An mó cairde leat a bhaineann feidhm as Signal, is fearrde é.</string>
   <!--media_preview-->
   <string name="media_preview__save_title">Cuir i dtaisce é</string>
   <string name="media_preview__forward_title">Cuir ar aghaidh</string>

--- a/app/src/main/res/values-ha/strings.xml
+++ b/app/src/main/res/values-ha/strings.xml
@@ -1239,7 +1239,7 @@
   <string name="preferences__sms_mms">SMS da MMS</string>
   <string name="preferences__pref_all_sms_title">Karba duk SMS</string>
   <string name="preferences__pref_all_mms_title">Karba duk MMS</string>
-  <string name="preferences__use_signal_for_viewing_and_storing_all_incoming_text_messages">Yi amfani da signal wajen karbar sako masu shigowa</string>
+  <string name="preferences__use_signal_for_viewing_and_storing_all_incoming_text_messages">Yi amfani da Signal wajen karbar sako masu shigowa</string>
   <string name="preferences__use_signal_for_viewing_and_storing_all_incoming_multimedia_messages">Yi amfani da Signal domin sakonnin hoto, waka, da bidiyo masu shigowa</string>
   <string name="preferences__pref_enter_sends_title">Tura sako da Enter key</string>
   <string name="preferences__pressing_the_enter_key_will_send_text_messages">Idan ka/kika danna Enter key, sakonnika/ki zasu turu</string>

--- a/app/src/main/res/values-ha/strings.xml
+++ b/app/src/main/res/values-ha/strings.xml
@@ -190,7 +190,7 @@
   <string name="ConversationActivity_unable_to_record_audio">Ankasa daukar odiyo!</string>
   <string name="ConversationActivity_there_is_no_app_available_to_handle_this_link_on_your_device">An rasa app da zai iya daukan wannan hadin a na\'urarka/ki.</string>
   <string name="ConversationActivity_to_send_audio_messages_allow_signal_access_to_your_microphone">Domin aika sakon odiyo, bari Signal ya samu damar aiki da reno.</string>
-  <string name="ConversationActivity_signal_requires_the_microphone_permission_in_order_to_send_audio_messages">Signal na bukatar izinin reno domin aikar da sakwanin odiyo amma an hana wannnan damar dindindin. Cigaba ka/ki shiga mazabar saitin aikace-aikacen signal ka/ki ba da damar \"Microphone\".</string>
+  <string name="ConversationActivity_signal_requires_the_microphone_permission_in_order_to_send_audio_messages">Signal na bukatar izinin reno domin aikar da sakwanin odiyo amma an hana wannnan damar dindindin. Cigaba ka/ki shiga mazabar saitin aikace-aikacen Signal ka/ki ba da damar \"Microphone\".</string>
   <string name="ConversationActivity_signal_needs_the_microphone_and_camera_permissions_in_order_to_call_s">Signal na bukatar izinin Reno da Kyamara domin kiran %s, amma anhana wannan dama dindindin. Cigaba ka/ki shiga saitin affilikashon, zabi \"Permissions\", sannan kunna \"Reno\" da \"Kyamara\".</string>
   <string name="ConversationActivity_to_capture_photos_and_video_allow_signal_access_to_the_camera">Domin kama hotuna ko bidiyo, ka/ki bawa Signal dama.</string>
   <string name="ConversationActivity_signal_needs_the_camera_permission_to_take_photos_or_video">Signal na bukatar izinin Kyamara domin daukan hotuna ko bidiyo amma an hana wannan damar dindindin. Cigaba ka/ki shiga cikin mazabar saitin Signal ka/ki zabi \"Permission\" domin ka/ki bawa \"Camera\" dama.</string>
@@ -726,7 +726,7 @@
   <string name="SmsMessageRecord_secure_session_reset">Ka/kin sake saita mahadin bayanai mai tsari.</string>
   <string name="SmsMessageRecord_secure_session_reset_s">%s sake saitin mahadin bayani mai tsari</string>
   <string name="SmsMessageRecord_duplicate_message">Sako mai kwafi</string>
-  <string name="SmsMessageRecord_this_message_could_not_be_processed_because_it_was_sent_from_a_newer_version">An gaza tantance bayanin wannan sakon domin daga sabon Signal aka turoshi. Gayawa abokin sadarwarka/ki ya/ta sake aikowa bayan kai/kema ka/kin sabunta signal dinka/ki.</string>
+  <string name="SmsMessageRecord_this_message_could_not_be_processed_because_it_was_sent_from_a_newer_version">An gaza tantance bayanin wannan sakon domin daga sabon Signal aka turoshi. Gayawa abokin sadarwarka/ki ya/ta sake aikowa bayan kai/kema ka/kin sabunta Signal dinka/ki.</string>
   <!--StickerManagementActivity-->
   <string name="StickerManagementActivity_stickers">Sitika</string>
   <!--StickerManagementAdapter-->

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -23,7 +23,7 @@
   </plurals>
   <string name="ApplicationPreferencesActivity_delete">ဖျက်ပါ</string>
   <string name="ApplicationPreferencesActivity_disable_passphrase">စကားဝှက်ပိတ်မလား?</string>
-  <string name="ApplicationPreferencesActivity_this_will_permanently_unlock_signal_and_message_notifications">Singal ကိုအမြဲဖွင့်ထားပြီး စာတိုဝင်လာပါကအသိပေးပါမည်။</string>
+  <string name="ApplicationPreferencesActivity_this_will_permanently_unlock_signal_and_message_notifications">Signal ကိုအမြဲဖွင့်ထားပြီး စာတိုဝင်လာပါကအသိပေးပါမည်။</string>
   <string name="ApplicationPreferencesActivity_disable">ပိတ်ထားပါ</string>
   <string name="ApplicationPreferencesActivity_unregistering">စာရင်းမသွင်းထားပါ </string>
   <string name="ApplicationPreferencesActivity_unregistering_from_signal_messages_and_calls">Signal စာတိုနှင့် ဖုန်းခေါ်ဆိုခြင်းများ စာရင်းမသွင်းတော့ပါ</string>
@@ -81,7 +81,7 @@
   <string name="CameraXFragment_open_gallery_description">ဓာတ်ပုံစာအုပ်ဖွင့်ရန်</string>
   <!--CameraContacts-->
   <string name="CameraContacts_recent_contacts">နောက်ဆုံးဖုန်းမှတ်စု</string>
-  <string name="CameraContacts_signal_contacts">signal အဆက်အသွယ်</string>
+  <string name="CameraContacts_signal_contacts">Signal အဆက်အသွယ်</string>
   <string name="CameraContacts_signal_groups">Signal အဖွဲ့</string>
   <string name="CameraContacts_you_can_share_with_a_maximum_of_n_conversations">အများဆုံး%dစကားဝိုင်းကိုမျှဝေနိုင်သည်</string>
   <string name="CameraContacts_you_can_only_use_the_camera_button">Signal သူငယ်ချင်းထံသို့ ကင်မရာခလုတ်နှိပ်၍ဓာတ်ပုံပို့နိုင်သည်</string>
@@ -381,7 +381,7 @@
   <!--MediaRepository-->
   <string name="MediaRepository_all_media">ရုပ်/သံ/ပုံ စာများအားလုံး</string>
   <!--MessageRecord-->
-  <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">ထပ်မံပံ့ပိုးမှုမရှိတော့သော Signal ဗားရှင်းအဟောင်းဖြင့် encrypt လုပ်ထားသော စာကိုလက်ခံရရှိသည်။ စာပို့သူအား signal နောက်ဆုံးဗားရှင်းကိုမြှင့်ပြီး စာအားပြန်ပို့ခုိင်းပါ။</string>
+  <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">ထပ်မံပံ့ပိုးမှုမရှိတော့သော Signal ဗားရှင်းအဟောင်းဖြင့် encrypt လုပ်ထားသော စာကိုလက်ခံရရှိသည်။ စာပို့သူအား Signal နောက်ဆုံးဗားရှင်းကိုမြှင့်ပြီး စာအားပြန်ပို့ခုိင်းပါ။</string>
   <string name="MessageRecord_left_group">အဖွဲ့မှ သင်ထွက်လိုက်သည်။</string>
   <string name="MessageRecord_you_updated_group">အဖွဲ့အား သင်ပြောင်းလဲမှုပြုလိုက်သည်။</string>
   <string name="MessageRecord_you_called">သင်မှခေါ်သည်</string>
@@ -464,7 +464,7 @@
   <string name="RedPhone_recipient_unavailable">ခေါ်ဆိုလိုသည့် တစ်ဖက်လူ မအားပါ</string>
   <string name="RedPhone_network_failed">ကွန်ယက် ကျသွားသည်!</string>
   <string name="RedPhone_number_not_registered">ယခု ဖုန်းနံပါတ်မှာ မှတ်ပုံတင်ထားခြင်း မရှိပါ။</string>
-  <string name="RedPhone_the_number_you_dialed_does_not_support_secure_voice">သင်ခေါ်ဆိုလိုက်သော ဖုန်းနံပါတ်မှာ signal ၏ လုံခြုံစွာဖုန်းခေါ်ဆိုခြင်း စနစ်အား မပံ့ပိုးနိုင်ပါ။</string>
+  <string name="RedPhone_the_number_you_dialed_does_not_support_secure_voice">သင်ခေါ်ဆိုလိုက်သော ဖုန်းနံပါတ်မှာ Signal ၏ လုံခြုံစွာဖုန်းခေါ်ဆိုခြင်း စနစ်အား မပံ့ပိုးနိုင်ပါ။</string>
   <string name="RedPhone_got_it">ရပြီ</string>
   <!--RegistrationActivity-->
   <string name="RegistrationActivity_select_your_country">နိုင်ငံရွေးချယ်ပါ</string>
@@ -564,7 +564,7 @@
   <string name="UsernameEditFragment_submit">တင်မည်</string>
   <string name="UsernameEditFragment_delete">ဖျက်မည်</string>
   <!--VerifyIdentityActivity-->
-  <string name="VerifyIdentityActivity_your_contact_is_running_an_old_version_of_signal">သင့်မိတ်ဆွေသည် signal ဗားရှင်းအဟောင်းအသုံးပြုထားပါသည်။ လုံခြုံရေးနံပါတ်များ အတည်မပြုခင် Signal ဗားရှင်းအား မြှင့်တင်ခိုင်းလိုက်ပါ။</string>
+  <string name="VerifyIdentityActivity_your_contact_is_running_an_old_version_of_signal">သင့်မိတ်ဆွေသည် Signal ဗားရှင်းအဟောင်းအသုံးပြုထားပါသည်။ လုံခြုံရေးနံပါတ်များ အတည်မပြုခင် Signal ဗားရှင်းအား မြှင့်တင်ခိုင်းလိုက်ပါ။</string>
   <string name="VerifyIdentityActivity_your_contact_is_running_a_newer_version_of_Signal">သင့်မိတ်ဆွေသည်  Signal ဗားရှင်းအသစ်နှင့် သင်နှင့်လိုက်လျောညီထွေမရှိသည့် QR code ပုံစံကိုအသုံးပြုထားပါသည်။ နှိုင်းယှဉ်စစ်ဆေးရန် အဆင့်မြှင့်ပါ။</string>
   <string name="VerifyIdentityActivity_the_scanned_qr_code_is_not_a_correctly_formatted_safety_number">စကန်ဖတ်ထားသော QR ကုဒ်သည် မှန်ကန်သော လုံခြုံရေးနံပါတ်ပုံစံမဟုတ်သဖြင့် ထပ်မံ စကန်ဖတ်လိုက်ပါ။</string>
   <string name="VerifyIdentityActivity_share_safety_number_via">… မှတဆင့် လုံခြုံရေးနံပါတ်ကို မျှဝေမယ်</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -920,7 +920,7 @@ Mottok nøkkelutvekslingsmelding for ugyldig protokollversion.</string>
   <string name="MessageNotifier_signal_message">Signal-melding</string>
   <string name="MessageNotifier_unsecured_sms">Usikret SMS</string>
   <string name="MessageNotifier_you_may_have_new_messages">Du kan ha nye meldinger</string>
-  <string name="MessageNotifier_open_signal_to_check_for_recent_notifications">Åpne signal for å se etter nylige varsler.</string>
+  <string name="MessageNotifier_open_signal_to_check_for_recent_notifications">Åpne Signal for å se etter nylige varsler.</string>
   <string name="MessageNotifier_contact_message">%1$s %2$s</string>
   <string name="MessageNotifier_unknown_contact_message">Kontakt</string>
   <string name="MessageNotifier_reacted_s_to_s">Reagerte %1$s til \"%2$s\".</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -478,9 +478,9 @@
   <string name="Megaphones_verify_your_signal_pin">اپنے Signal پن کی تصدیق کریں</string>
   <string name="Megaphones_verify_pin">پن کی تصدیق کریں</string>
   <!--NotificationBarManager-->
-  <string name="NotificationBarManager_signal_call_in_progress">signal کال پروگریس میں ہے</string>
+  <string name="NotificationBarManager_signal_call_in_progress">Signal کال پروگریس میں ہے</string>
   <string name="NotificationBarManager__establishing_signal_call">Signal کال قائم ہو رہی ہے</string>
-  <string name="NotificationBarManager__incoming_signal_call">signal کال آ رہی ہے</string>
+  <string name="NotificationBarManager__incoming_signal_call">Signal کال آ رہی ہے</string>
   <string name="NotificationBarManager__deny_call">کال رد کریں</string>
   <string name="NotificationBarManager__answer_call">کال کا جواب دیں</string>
   <string name="NotificationBarManager__end_call">کال ختم کریں</string>
@@ -921,7 +921,7 @@
   <string name="WebRtcCallActivity_to_answer_the_call_from_s_give_signal_access_to_your_microphone">%sکی طرف سے کال کا جواب دینے کیلئے، Signal کو مائکروفون تک رسائی دیں۔</string>
   <string name="WebRtcCallActivity_signal_requires_microphone_and_camera_permissions_in_order_to_make_or_receive_calls">Signal کو کالیں وصول کرنے یا بنانے کیلئے مائکروفون اور کیمرہ کی اجازت کی ضرورت ہے، لیکن وہ مستقل طور پر انکاری ہیں۔ براہ کرم ایپ کی ترتیبات میں جائیں، \"اجازت نامہ\"منتخب کریں اور \"مائکروفون \"اور \"کیمرہ\" فعال کریں۔</string>
   <!--WebRtcCallScreen-->
-  <string name="WebRtcCallScreen_new_safety_numbers">آپ  کی گفتگو کیلئے حفاظتی نمبر%1$sکے ساتھ تبدیل ہو چکا ہے۔ اس کا دوسرا مطلب یہ ہے کہ کوئی آپ کے ذرائع ابلاغ کو روکنے کی کوشش کر رہا ہے،یا یہ %2$ssignal سادگی سے دوبارہ نصب کیا گیا ہے۔</string>
+  <string name="WebRtcCallScreen_new_safety_numbers">آپ  کی گفتگو کیلئے حفاظتی نمبر%1$sکے ساتھ تبدیل ہو چکا ہے۔ اس کا دوسرا مطلب یہ ہے کہ کوئی آپ کے ذرائع ابلاغ کو روکنے کی کوشش کر رہا ہے،یا یہ %2$sSignal سادگی سے دوبارہ نصب کیا گیا ہے۔</string>
   <string name="WebRtcCallScreen_you_may_wish_to_verify_this_contact">آپ اس رابطے کے ساتھ اپنے حفاظتی نمبر کی تصدیق کرنا چاہتے ہیں۔</string>
   <string name="WebRtcCallScreen_new_safety_number_title">نیا حفاظتی نمبر</string>
   <string name="WebRtcCallScreen_accept">قبول کریں</string>
@@ -1438,7 +1438,7 @@
   <string name="reminder_header_expired_build">آپ کے Signal ورژن کی میعاد ختم ہو چکی ہے!</string>
   <string name="reminder_header_expired_build_details">پیغامات مزید کامیابی کے ساتھ نہیں بھیجے جائیں گے۔ حالیہ ورژن میں تازہ کاری کرنے کیلئے ٹیپ کریں۔</string>
   <string name="reminder_header_sms_default_title">پہلے سے طے شدہ ایس ایم ایس ایپ استعمال کریں</string>
-  <string name="reminder_header_sms_default_text">signal کو اپنا پہلے سے موجود ایس ایم ایس ایپ بنانے کیلئے ٹیپ کریں۔</string>
+  <string name="reminder_header_sms_default_text">Signal کو اپنا پہلے سے موجود ایس ایم ایس ایپ بنانے کیلئے ٹیپ کریں۔</string>
   <string name="reminder_header_sms_import_title">ایس ایم ایس نظام درآمد کریں</string>
   <string name="reminder_header_sms_import_text">Signal  کے خفیہ کردہ ڈیٹا بیس میں اپنے فون کے ایس ایم ایس پیغامات کی کاپی کرنے کیلئے ٹیپ کریں۔ </string>
   <string name="reminder_header_push_title">Signal پیغامات اور کالز فعال کریں</string>
@@ -1448,7 +1448,7 @@
   <string name="reminder_header_share_title">اپنے دوستوں کو مدعو کریں!</string>
   <string name="reminder_header_share_text">زیادہ دوست Signal استعمال کرتے ہیں، یہ بہتر ہو جاتا ہے۔</string>
   <string name="reminder_header_service_outage_text">Signal تکنیکی مشکلات کا تجربہ کر رہا ہے۔جتنا جلدی ممکن ہو ہم سروس بحال کرنے کیلئے سخت محنت کر رہے ہیں۔</string>
-  <string name="reminder_header_the_latest_signal_features_wont_work">تازہ ترین Signal خصوصیت انڈروئڈ کے اس ورژن پر کام نہیں کر رہا۔برائے مہربانی مستقبل میں signal تجدید وصول کرنے کیلئے ڈیوائس کو اپ گریڈ کریں۔</string>
+  <string name="reminder_header_the_latest_signal_features_wont_work">تازہ ترین Signal خصوصیت انڈروئڈ کے اس ورژن پر کام نہیں کر رہا۔برائے مہربانی مستقبل میں Signal تجدید وصول کرنے کیلئے ڈیوائس کو اپ گریڈ کریں۔</string>
   <string name="reminder_header_progress">%1$d%%</string>
   <!--media_preview-->
   <string name="media_preview__save_title">محفوظ کریں</string>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Google Pixel 3 XL, Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fix app name typo in language translations.