### PR TITLE
Optimization of runtime in generateWaveForm

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/audio/AudioWaveForm.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/audio/AudioWaveForm.java
@@ -167,6 +167,8 @@ public final class AudioWaveForm {
       boolean               sawInputEOS     = false;
       boolean               sawOutputEOS    = false;
       int                   noOutputCounter = 0;
+      final long            BAR_FACTOR      = (totalDurationUs / (BAR_COUNT * SAMPLES_PER_BAR) + 1);
+      long                  barTimer        = BAR_FACTOR;
 
       while (!sawOutputEOS && noOutputCounter < 50) {
         noOutputCounter++;
@@ -177,11 +179,13 @@ public final class AudioWaveForm {
             int        sampleSize         = extractor.readSampleData(dstBuf, 0);
             long       presentationTimeUs = 0;
 
-            if (sampleSize < 0) {
+            if (sampleSize < 0 || barTimer > totalDurationUs) {
               sawInputEOS = true;
               sampleSize  = 0;
             } else {
               presentationTimeUs = extractor.getSampleTime();
+              extractor.seekTo(barTimer, MediaExtractor.SEEK_TO_NEXT_SYNC);
+              barTimer  += BAR_FACTOR;
             }
 
             codec.queueInputBuffer(
@@ -190,18 +194,6 @@ public final class AudioWaveForm {
               sampleSize,
               presentationTimeUs,
               sawInputEOS ? MediaCodec.BUFFER_FLAG_END_OF_STREAM : 0);
-
-            if (!sawInputEOS) {
-              int barSampleIndex = (int) (SAMPLES_PER_BAR * (wave.length * extractor.getSampleTime()) / totalDurationUs);
-              sawInputEOS = !extractor.advance();
-              int nextBarSampleIndex = (int) (SAMPLES_PER_BAR * (wave.length * extractor.getSampleTime()) / totalDurationUs);
-              while (!sawInputEOS && nextBarSampleIndex == barSampleIndex) {
-                sawInputEOS = !extractor.advance();
-                if (!sawInputEOS) {
-                  nextBarSampleIndex = (int) (SAMPLES_PER_BAR * (wave.length * extractor.getSampleTime()) / totalDurationUs);
-                }
-              }
-            }
           }
         }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/audio/AudioWaveForm.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/audio/AudioWaveForm.java
@@ -157,83 +157,75 @@ public final class AudioWaveForm {
       codec.configure(format, null, null, 0);
       codec.start();
 
-      ByteBuffer[] codecInputBuffers  = codec.getInputBuffers();
-      ByteBuffer[] codecOutputBuffers = codec.getOutputBuffers();
-
       extractor.selectTrack(0);
 
-      long                  kTimeOutUs      = 5000;
+      final long            TIMEOUT_US      = 5000;
       MediaCodec.BufferInfo info            = new MediaCodec.BufferInfo();
       boolean               sawInputEOS     = false;
       boolean               sawOutputEOS    = false;
       int                   noOutputCounter = 0;
 
+      final long            BAR_FACTOR      = totalDurationUs / (BAR_COUNT * SAMPLES_PER_BAR);
+      long                  barTimer        = 0;
+
+      int                   barIndex;
+      int                   sampleSize;
+      long                  presentationTimeUs;
+      long                  total;
+      short                 aShort;
+      int                   inputBufferId;
+      int                   outputBufferId;
+      ByteBuffer            codecInputBuffer;
+      ByteBuffer            codecOutputBuffer;
+
       while (!sawOutputEOS && noOutputCounter < 50) {
         noOutputCounter++;
         if (!sawInputEOS) {
-          int inputBufIndex = codec.dequeueInputBuffer(kTimeOutUs);
-          if (inputBufIndex >= 0) {
-            ByteBuffer dstBuf             = codecInputBuffers[inputBufIndex];
-            int        sampleSize         = extractor.readSampleData(dstBuf, 0);
-            long       presentationTimeUs = 0;
-
-            if (sampleSize < 0) {
-              sawInputEOS = true;
-              sampleSize  = 0;
+          inputBufferId = codec.dequeueInputBuffer(TIMEOUT_US);
+          if (inputBufferId >= 0) {
+            codecInputBuffer = codec.getInputBuffer(inputBufferId);
+            extractor.seekTo(barTimer, MediaExtractor.SEEK_TO_NEXT_SYNC);
+            barTimer  += BAR_FACTOR;
+            sampleSize = extractor.readSampleData(codecInputBuffer, 0);
+            if (sampleSize < 0 || barTimer > totalDurationUs) {
+              sawInputEOS        = true;
+              sampleSize         = 0;
+              presentationTimeUs = 0;
             } else {
               presentationTimeUs = extractor.getSampleTime();
             }
 
             codec.queueInputBuffer(
-              inputBufIndex,
+              inputBufferId,
               0,
               sampleSize,
               presentationTimeUs,
               sawInputEOS ? MediaCodec.BUFFER_FLAG_END_OF_STREAM : 0);
-
-            if (!sawInputEOS) {
-              int barSampleIndex = (int) (SAMPLES_PER_BAR * (wave.length * extractor.getSampleTime()) / totalDurationUs);
-              sawInputEOS = !extractor.advance();
-              int nextBarSampleIndex = (int) (SAMPLES_PER_BAR * (wave.length * extractor.getSampleTime()) / totalDurationUs);
-              while (!sawInputEOS && nextBarSampleIndex == barSampleIndex) {
-                sawInputEOS = !extractor.advance();
-                if (!sawInputEOS) {
-                  nextBarSampleIndex = (int) (SAMPLES_PER_BAR * (wave.length * extractor.getSampleTime()) / totalDurationUs);
-                }
-              }
-            }
           }
         }
-
-        int outputBufferIndex;
-        do {
-          outputBufferIndex = codec.dequeueOutputBuffer(info, kTimeOutUs);
-          if (outputBufferIndex >= 0) {
-            if (info.size > 0) {
-              noOutputCounter = 0;
-            }
-
-            ByteBuffer buf = codecOutputBuffers[outputBufferIndex];
-            int barIndex = (int) ((wave.length * info.presentationTimeUs) / totalDurationUs);
-            long total = 0;
-            for (int i = 0; i < info.size; i += 2 * 4) {
-              short aShort = buf.getShort(i);
-              total += Math.abs(aShort);
-            }
-            if (barIndex >= 0 && barIndex < wave.length) {
-              wave[barIndex] += total;
-              waveSamples[barIndex] += info.size / 2;
-            }
-            codec.releaseOutputBuffer(outputBufferIndex, false);
-            if ((info.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
-              sawOutputEOS = true;
-            }
-          } else if (outputBufferIndex == MediaCodec.INFO_OUTPUT_BUFFERS_CHANGED) {
-            codecOutputBuffers = codec.getOutputBuffers();
-          } else if (outputBufferIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
-            Log.d(TAG, "output format has changed to " + codec.getOutputFormat());
+        outputBufferId = codec.dequeueOutputBuffer(info, TIMEOUT_US);
+        if (outputBufferId >= 0) {
+          if (info.size > 0) {
+            noOutputCounter = 0;
           }
-        } while (outputBufferIndex >= 0);
+          codecOutputBuffer = codec.getOutputBuffer(outputBufferId);
+          barIndex = (int) ((wave.length * info.presentationTimeUs) / totalDurationUs);
+          total = 0;
+          for (int i = 0; i < info.size; i += 2 * 4) {
+            aShort = codecOutputBuffer.getShort(i);
+            total += Math.abs(aShort);
+          }
+          if (barIndex >= 0 && barIndex < wave.length) {
+            wave[barIndex] += total;
+            waveSamples[barIndex] += info.size;
+          }
+          if (info.flags == MediaCodec.BUFFER_FLAG_END_OF_STREAM) {
+            sawOutputEOS = true;
+          }
+          codec.releaseOutputBuffer(outputBufferId, false);
+        } else if (outputBufferId == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
+          Log.d(TAG, "output format has changed to " + codec.getOutputFormat());
+        }
       }
 
       codec.stop();


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Motorola X Play, Android 7.1.1
 * Virtual Pixel 2, Android 7.1.1
 * Virtual Pixel 2, Android 10.0+
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
On some devices, especially my device, it takes a long time to generate the AudioWaveForm/AudioHash of a voice message.
A voice message of 30 minutes has taken ~112sec on stock Signal, ~160sec with self-built Signal.
The cause was the frequent iterative use of extractor.advance(), which seems to be no problem with other devices.
Instead of extractor.advance() to go through each frame, seekTo(...) is used to go directly to the desired frame whose values are to be used for the audio hash.
Two further values were used for this: BAR_FACTOR and barTimer.
BAR_FACTOR contains the time difference between the desired frames.
barTimer contains the time of the actual frame.

In addition, the newer type 
ByteBuffer inputBuffer = codec.getInputBuffer(inputBufferId);
ByteBuffer outputBuffer = codec.getOutputBuffer(outputBufferId);

is used instead of the deprecated processing with buffer arrays
ByteBuffer[] inputBuffers = codec.getInputBuffers();
ByteBuffer[] outputBuffers = codec.getOutputBuffers();

The time for generation is now ~3sec for a 30 minutes voice message with 99%/100% the same values for the AudioHash.

further note:
seekTo() does not seem to recognize whether the entered time goes beyond the stream.
Therefore, when using it, make sure that the entered time remains below the duration of the audio message.
