### PR TITLE
Fixes #8344 - Dark theme archive icon displays on wrong layer (4.30.2)

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
@@ -118,6 +118,7 @@ import org.thoughtcrime.securesms.util.ServiceUtil;
 import org.thoughtcrime.securesms.util.SnapToTopDataObserver;
 import org.thoughtcrime.securesms.util.StickyHeaderDecoration;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
+import org.thoughtcrime.securesms.util.ThemeUtil;
 import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.ViewUtil;
 import org.thoughtcrime.securesms.util.concurrent.SignalExecutors;
@@ -1012,6 +1013,10 @@ public class ConversationListFragment extends MainFragment implements ActionMode
                        (float) itemView.getLeft() + getResources().getDimension(R.dimen.conversation_list_fragment_archive_padding),
                        (float) itemView.getTop() + ((float) itemView.getBottom() - (float) itemView.getTop() - icon.getHeight())/2,
                        p);
+
+          p.setColor(ThemeUtil.getThemedColor(getContext(),R.attr.conversation_background));
+          c.drawRect(dX, (float) itemView.getTop(), (float) itemView.getRight(),
+                  (float) itemView.getBottom(), p);
         }
 
         viewHolder.itemView.setAlpha(alpha);

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -98,7 +98,7 @@
 
     <dimen name="tooltip_popup_margin">8dp</dimen>
 
-    <dimen name="conversation_list_fragment_archive_padding">16dp</dimen>
+    <dimen name="conversation_list_fragment_archive_padding">24dp</dimen>
     <dimen name="contact_selection_actions_tap_area">10dp</dimen>
 
     <dimen name="unread_count_bubble_radius">13sp</dimen>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Motorola X Play, Android 7.1.1
 * Virtual Pixel 2, Android 10.0+


- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
fixes #8344  issue on the dark theme when swiping on a conversation to archive, the archive icon is displayed on the "wrong" layer.

Added a themed background colored rectangle from dX to right end of conversation.
Additional changed the padding for the archive icon, that this is in one vertical line with the avatar images.

![Screenshot_20200622-220534](https://user-images.githubusercontent.com/49990901/85413366-06e4af80-b56b-11ea-95f9-3a2c4efb4ee1.png)
