### PR TITLE
Use existing content descriptions for call screen. Fixes issue #9774:

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/webrtc/WebRtcCallView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/webrtc/WebRtcCallView.java
@@ -151,7 +151,19 @@ public class WebRtcCallView extends FrameLayout {
       runIfNonNull(controlsListener, listener -> listener.onMicChanged(isOn));
     });
 
-    cameraDirectionToggle.setOnClickListener(v -> runIfNonNull(controlsListener, ControlsListener::onCameraDirectionChanged));
+    final int descYourCam = R.string.WebRtcCallControls_your_camera_button_description;
+    final int descRearCam = R.string.WebRtcCallControls_switch_to_rear_camera_button_description;
+    cameraDirectionToggle.setOnClickListener(new OnClickListener() {
+
+      int currentDesc = descRearCam;
+
+      @Override
+      public void onClick(View v) {
+        currentDesc = currentDesc == descYourCam ? descRearCam : descYourCam;
+        cameraDirectionToggle.setContentDescription(getResources().getText(currentDesc));
+        runIfNonNull(controlsListener, ControlsListener::onCameraDirectionChanged);
+      }
+    });
 
     hangup.setOnClickListener(v -> runIfNonNull(controlsListener, ControlsListener::onEndCallPressed));
     decline.setOnClickListener(v -> runIfNonNull(controlsListener, ControlsListener::onDenyCallPressed));

--- a/app/src/main/java/org/thoughtcrime/securesms/components/webrtc/WebRtcCallView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/webrtc/WebRtcCallView.java
@@ -151,19 +151,7 @@ public class WebRtcCallView extends FrameLayout {
       runIfNonNull(controlsListener, listener -> listener.onMicChanged(isOn));
     });
 
-    final int descYourCam = R.string.WebRtcCallControls_your_camera_button_description;
-    final int descRearCam = R.string.WebRtcCallControls_switch_to_rear_camera_button_description;
-    cameraDirectionToggle.setOnClickListener(new OnClickListener() {
-
-      int currentDesc = descRearCam;
-
-      @Override
-      public void onClick(View v) {
-        currentDesc = currentDesc == descYourCam ? descRearCam : descYourCam;
-        cameraDirectionToggle.setContentDescription(getResources().getText(currentDesc));
-        runIfNonNull(controlsListener, ControlsListener::onCameraDirectionChanged);
-      }
-    });
+    cameraDirectionToggle.setOnClickListener(v -> runIfNonNull(controlsListener, ControlsListener::onCameraDirectionChanged));
 
     hangup.setOnClickListener(v -> runIfNonNull(controlsListener, ControlsListener::onEndCallPressed));
     decline.setOnClickListener(v -> runIfNonNull(controlsListener, ControlsListener::onDenyCallPressed));

--- a/app/src/main/res/layout/webrtc_call_view.xml
+++ b/app/src/main/res/layout/webrtc_call_view.xml
@@ -14,7 +14,8 @@
         android:id="@+id/call_screen_recipient_avatar"
         android:layout_width="200dp"
         android:layout_height="200dp"
-        android:layout_gravity="center" />
+        android:layout_gravity="center"
+        android:contentDescription="@string/WebRtcCallControls_contact_photo_description" />
 
     <ImageView
         android:id="@+id/call_screen_recipient_avatar_call_card"
@@ -161,6 +162,7 @@
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toStartOf="parent"
             app:srcCompat="@drawable/webrtc_call_screen_speaker_toggle"
+            android:contentDescription="@string/WebRtcCallControls_speaker_button_description"
             tools:visibility="visible" />
 
         <ImageView
@@ -177,6 +179,7 @@
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toEndOf="@id/call_screen_speaker_toggle"
             app:srcCompat="@drawable/webrtc_call_screen_camera_toggle"
+            android:contentDescription="@string/WebRtcCallControls_switch_to_rear_camera_button_description"
             tools:visibility="visible" />
 
         <org.thoughtcrime.securesms.components.AccessibleToggleButton
@@ -192,6 +195,7 @@
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toEndOf="@id/call_screen_camera_direction_toggle"
             tools:checked="true"
+            android:contentDescription="@string/WebRtcCallControls_video_button_description"
             tools:visibility="visible" />
 
         <org.thoughtcrime.securesms.components.AccessibleToggleButton
@@ -206,6 +210,7 @@
             app:layout_constraintEnd_toStartOf="@id/call_screen_end_call"
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toEndOf="@id/call_screen_video_toggle"
+            android:contentDescription="@string/WebRtcCallControls_mute_button_description"
             tools:visibility="visible" />
 
         <ImageView
@@ -221,6 +226,7 @@
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toEndOf="@id/call_screen_audio_mic_toggle"
             app:srcCompat="@drawable/webrtc_call_screen_hangup"
+            android:contentDescription="@string/WebRtcCallScreen_end_call"
             tools:visibility="visible" />
 
         <ImageView
@@ -235,6 +241,7 @@
             app:layout_constraintHorizontal_chainStyle="spread_inside"
             app:layout_constraintStart_toStartOf="parent"
             app:srcCompat="@drawable/webrtc_call_screen_hangup"
+            android:contentDescription="@string/WebRtcCallControls_reject_call_description"
             tools:visibility="visible" />
 
         <TextView
@@ -262,6 +269,7 @@
             app:layout_constraintHorizontal_chainStyle="spread_inside"
             app:layout_constraintStart_toEndOf="@id/call_screen_decline_call"
             app:srcCompat="@drawable/webrtc_call_screen_answer"
+            android:contentDescription="@string/WebRtcCallControls_answer_call_description"
             tools:visibility="visible" />
 
         <TextView
@@ -287,6 +295,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:srcCompat="@drawable/webrtc_call_screen_answer_without_video"
+            android:contentDescription="@string/WebRtcCallScreen__answer_without_video"
             tools:visibility="visible" />
 
         <TextView

--- a/app/src/main/res/layout/webrtc_call_view.xml
+++ b/app/src/main/res/layout/webrtc_call_view.xml
@@ -155,6 +155,7 @@
             android:layout_height="56dp"
             android:layout_marginEnd="16dp"
             android:layout_marginBottom="34dp"
+            android:contentDescription="@string/WebRtcCallControls_speaker_button_description"
             android:scaleType="fitXY"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
@@ -162,7 +163,6 @@
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toStartOf="parent"
             app:srcCompat="@drawable/webrtc_call_screen_speaker_toggle"
-            android:contentDescription="@string/WebRtcCallControls_speaker_button_description"
             tools:visibility="visible" />
 
         <ImageView
@@ -172,6 +172,7 @@
             android:layout_marginEnd="16dp"
             android:layout_marginBottom="34dp"
             android:clickable="false"
+            android:contentDescription="@string/WebRtcCallControls_toggle_camera_description"
             android:scaleType="fitXY"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
@@ -179,7 +180,6 @@
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toEndOf="@id/call_screen_speaker_toggle"
             app:srcCompat="@drawable/webrtc_call_screen_camera_toggle"
-            android:contentDescription="@string/WebRtcCallControls_switch_to_rear_camera_button_description"
             tools:visibility="visible" />
 
         <org.thoughtcrime.securesms.components.AccessibleToggleButton
@@ -188,6 +188,7 @@
             android:layout_marginEnd="16dp"
             android:layout_marginBottom="34dp"
             android:background="@drawable/webrtc_call_screen_video_toggle"
+            android:contentDescription="@string/WebRtcCallControls_video_button_description"
             android:stateListAnimator="@null"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
@@ -195,7 +196,6 @@
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toEndOf="@id/call_screen_camera_direction_toggle"
             tools:checked="true"
-            android:contentDescription="@string/WebRtcCallControls_video_button_description"
             tools:visibility="visible" />
 
         <org.thoughtcrime.securesms.components.AccessibleToggleButton
@@ -204,13 +204,13 @@
             android:layout_marginEnd="16dp"
             android:layout_marginBottom="34dp"
             android:background="@drawable/webrtc_call_screen_mic_toggle"
+            android:contentDescription="@string/WebRtcCallControls_mute_button_description"
             android:stateListAnimator="@null"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/call_screen_end_call"
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toEndOf="@id/call_screen_video_toggle"
-            android:contentDescription="@string/WebRtcCallControls_mute_button_description"
             tools:visibility="visible" />
 
         <ImageView
@@ -219,6 +219,7 @@
             android:layout_height="56dp"
             android:layout_marginBottom="34dp"
             android:clickable="false"
+            android:contentDescription="@string/WebRtcCallScreen_end_call"
             android:scaleType="fitXY"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
@@ -226,7 +227,6 @@
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toEndOf="@id/call_screen_audio_mic_toggle"
             app:srcCompat="@drawable/webrtc_call_screen_hangup"
-            android:contentDescription="@string/WebRtcCallScreen_end_call"
             tools:visibility="visible" />
 
         <ImageView
@@ -235,13 +235,13 @@
             android:layout_height="56dp"
             android:layout_marginStart="66dp"
             android:layout_marginBottom="65dp"
+            android:contentDescription="@string/WebRtcCallControls_reject_call_description"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/call_screen_answer_call"
             app:layout_constraintHorizontal_chainStyle="spread_inside"
             app:layout_constraintStart_toStartOf="parent"
             app:srcCompat="@drawable/webrtc_call_screen_hangup"
-            android:contentDescription="@string/WebRtcCallControls_reject_call_description"
             tools:visibility="visible" />
 
         <TextView
@@ -263,13 +263,13 @@
             android:layout_height="56dp"
             android:layout_marginEnd="66dp"
             android:layout_marginBottom="65dp"
+            android:contentDescription="@string/WebRtcCallControls_answer_call_description"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_chainStyle="spread_inside"
             app:layout_constraintStart_toEndOf="@id/call_screen_decline_call"
             app:srcCompat="@drawable/webrtc_call_screen_answer"
-            android:contentDescription="@string/WebRtcCallControls_answer_call_description"
             tools:visibility="visible" />
 
         <TextView
@@ -290,12 +290,12 @@
             android:layout_width="56dp"
             android:layout_height="56dp"
             android:layout_marginBottom="5dp"
+            android:contentDescription="@string/WebRtcCallScreen__answer_without_video"
             android:visibility="gone"
             app:layout_constraintBottom_toTopOf="@id/call_screen_answer_with_audio_label"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:srcCompat="@drawable/webrtc_call_screen_answer_without_video"
-            android:contentDescription="@string/WebRtcCallScreen__answer_without_video"
             tools:visibility="visible" />
 
         <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1362,6 +1362,7 @@
     <string name="WebRtcCallControls_contact_photo_description">Contact photo</string>
     <string name="WebRtcCallControls_speaker_button_description">Speaker</string>
     <string name="WebRtcCallControls_bluetooth_button_description">Bluetooth</string>
+    <string name="WebRtcCallControls_video_button_description">Video</string>
     <string name="WebRtcCallControls_mute_button_description">Mute</string>
     <string name="WebRtcCallControls_your_camera_button_description">Your camera</string>
     <string name="WebRtcCallControls_switch_to_rear_camera_button_description">Switch to rear camera</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1366,6 +1366,7 @@
     <string name="WebRtcCallControls_mute_button_description">Mute</string>
     <string name="WebRtcCallControls_your_camera_button_description">Your camera</string>
     <string name="WebRtcCallControls_switch_to_rear_camera_button_description">Switch to rear camera</string>
+    <string name="WebRtcCallControls_toggle_camera_description">Toggle camera</string>
 
     <string name="WebRtcCallControls_answer_call_description">Answer call</string>
     <string name="WebRtcCallControls_reject_call_description">Reject call</string>


### PR DESCRIPTION
https://github.com/signalapp/Signal-Android/issues/9774

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Google Pixel 3a, Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This PR fixes #9774 by utilizing existing content description strings on the call screen.  The only complex part is flipping between descriptions for the camera toggle.

There were a few minor bugs I noticed while testing, but thought to limit to fixing just the issue of missing accessibility strings, to keep the PR concise.
