### PR TITLE
Update Dockerfile image tag to ubuntu:20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,20 @@
-FROM ubuntu:17.10
+FROM ubuntu:20.04
 
 RUN dpkg --add-architecture i386 && \
     apt-get update -y && \
     apt-get install -y software-properties-common && \
     apt-get update -y && \
-    apt-get install -y libc6:i386=2.26-0ubuntu2.1 libncurses5:i386=6.0+20160625-1ubuntu1 libstdc++6:i386=7.2.0-8ubuntu3.2 lib32z1=1:1.2.11.dfsg-0ubuntu2 wget openjdk-8-jdk=8u171-b11-0ubuntu0.17.10.1 git unzip opensc pcscd && \
+    apt-get install -y \
+        libc6:i386=2.31-0ubuntu9 \
+        libncurses5:i386=6.2-0ubuntu2 \
+        libstdc++6:i386=10-20200411-0ubuntu1 \
+        lib32z1=1:1.2.11.dfsg-2ubuntu1 \
+        openjdk-8-jdk=8u252-b09-1ubuntu1 \
+        wget \
+        git \
+        unzip \
+        opensc \
+        pcscd && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \
     apt-get clean


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 6P, Android 8.1.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Updated Dockerfile for reproducible builds to use Ubuntu 20.04, along with package version updates for what's available from `apt`, allowing reproducible builds from master branch again. I used this container to build Signal 4.64.5 and compared to 4.64.5 APK from Google Play Store on my Nexus 6P / Android 8.1.0 with the following output:
```
root@48450a10d881:/signal-build/Signal-Android# export abi=arm64-v8a
root@48450a10d881:/signal-build/Signal-Android# python3 apkdiff/apkdiff.py \
  app/build/outputs/apk/play/release/*play-$abi-release-unsigned*.apk \
  ../apk-from-google-play-store/Signal-4.64.5.apk
APKs match!

```