### PR TITLE
Draw a dot on a single tap event in the image editor view

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/imageeditor/ImageEditorView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/imageeditor/ImageEditorView.java
@@ -437,8 +437,9 @@ public final class ImageEditorView extends FrameLayout {
         } else {
           tapListener.onEntitySingleTap(null);
         }
+        return true;
       }
-      return true;
+      return false;
     }
 
     @Override


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Pixel 2, Android API 28
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Bubble up ACTION_UP event from single tap event to handle the single tap event.

Returning true from the single tap event handler stops bubbling up the event that effectively cancels the ACTION_UP event in the touch event listener, that may draw something on the view.

Fixes #9745
