### PR TITLE
Increase attachment upload timeout

### DIFF
--- a/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java
+++ b/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java
@@ -205,7 +205,7 @@ public class PushServiceSocket {
 
   private static final long CDN2_RESUMABLE_LINK_LIFETIME_MILLIS = TimeUnit.DAYS.toMillis(7);
 
-  private       long      soTimeoutMillis = TimeUnit.SECONDS.toMillis(30);
+  private       long      soTimeoutMillis = TimeUnit.SECONDS.toMillis(90);
   private final Set<Call> connections     = new HashSet<>();
 
   private final ServiceConnectionHolder[]        serviceClients;


### PR DESCRIPTION
Fixes https://github.com/signalapp/Signal-Android/issues/9814

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Motorola G8 Power, Android 10
 * Nexus 5X, Android 9 (custom ROM)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
When uploading attachments via a throttled LTE connection, this timeout is often reached, causing the upload to fail and restart an infinite amount of times. There's some discussion about this in the issue, and another issue also mentions this problem.