### PR TITLE
fix message compose hint (fullscreen) as already done in #5348

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/ComposeText.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/ComposeText.java
@@ -137,12 +137,12 @@ public class ComposeText extends EmojiEditText {
       inputType = (inputType & ~InputType.TYPE_MASK_VARIATION) | InputType.TYPE_TEXT_VARIATION_SHORT_MESSAGE;
     }
 
-    setInputType(inputType);
     setImeOptions(imeOptions);
     setHint(transport.getComposeHint(),
             transport.getSimName().isPresent()
                 ? getContext().getString(R.string.conversation_activity__from_sim_name, transport.getSimName().get())
                 : null);
+    setInputType(inputType);
   }
 
   @Override


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
I still had the issue that the hint in message compose input is wrong when keyboard opens in fullscreen / landscape mode (Android 7.0, Signal 4.66.8).
I found out that this was already fixed (by @unrulygnu, dab76dc032d246c366de16205f32327e563596fa) but the PR (#5438) is not merged yet because of a merge conflict. See there for more details about the bug and the fix.

Actually I wanted to resolve the merge conflict in #5348 but that was not possible because files were renamed/moved. So I just re-did that change based on the current master.

That means this PR will close #5348.
