### PR TITLE
Do not collapse list to hide only one entry

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/groups/ui/managegroup/ManageGroupViewModel.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/ui/managegroup/ManageGroupViewModel.java
@@ -48,7 +48,8 @@ import java.util.List;
 
 public class ManageGroupViewModel extends ViewModel {
 
-  private static final int MAX_COLLAPSED_MEMBERS = 5;
+  private static final int MAX_UNCOLLAPSED_MEMBERS = 6;
+  private static final int SHOW_COLLAPSED_MEMBERS  = 5;
 
   private final Context                                     context;
   private final ManageGroupRepository                       manageGroupRepository;
@@ -89,7 +90,7 @@ public class ManageGroupViewModel extends ViewModel {
                                                                                            : title);
     this.isAdmin                   = liveGroup.isSelfAdmin();
     this.canCollapseMemberList     = LiveDataUtil.combineLatest(memberListCollapseState,
-                                                                Transformations.map(liveGroup.getFullMembers(), m -> m.size() > MAX_COLLAPSED_MEMBERS),
+                                                                Transformations.map(liveGroup.getFullMembers(), m -> m.size() > MAX_UNCOLLAPSED_MEMBERS),
                                                                 (state, hasEnoughMembers) -> state != CollapseState.OPEN && hasEnoughMembers);
     this.members                   = LiveDataUtil.combineLatest(liveGroup.getFullMembers(),
                                                                 memberListCollapseState,
@@ -262,8 +263,8 @@ public class ManageGroupViewModel extends ViewModel {
   private static @NonNull List<GroupMemberEntry.FullMember> filterMemberList(@NonNull List<GroupMemberEntry.FullMember> members,
                                                                              @NonNull CollapseState collapseState)
   {
-    if (collapseState == CollapseState.COLLAPSED && members.size() > MAX_COLLAPSED_MEMBERS) {
-      return members.subList(0, MAX_COLLAPSED_MEMBERS);
+    if (collapseState == CollapseState.COLLAPSED && members.size() > MAX_UNCOLLAPSED_MEMBERS) {
+      return members.subList(0, SHOW_COLLAPSED_MEMBERS);
     } else {
       return members;
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/managerecipient/ManageRecipientViewModel.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/managerecipient/ManageRecipientViewModel.java
@@ -41,7 +41,8 @@ import java.util.List;
 
 public final class ManageRecipientViewModel extends ViewModel {
 
-  private static final int MAX_COLLAPSED_GROUPS = 5;
+  private static final int MAX_UNCOLLAPSED_GROUPS = 6;
+  private static final int SHOW_COLLAPSED_GROUPS  = 5;
 
   private final Context                                          context;
   private final ManageRecipientRepository                        manageRecipientRepository;
@@ -80,7 +81,7 @@ public final class ManageRecipientViewModel extends ViewModel {
     });
 
     this.canCollapseMemberList = LiveDataUtil.combineLatest(this.groupListCollapseState,
-                                                            Transformations.map(allSharedGroups, m -> m.size() > MAX_COLLAPSED_GROUPS),
+                                                            Transformations.map(allSharedGroups, m -> m.size() > MAX_UNCOLLAPSED_GROUPS),
                                                             (state, hasEnoughMembers) -> state != CollapseState.OPEN && hasEnoughMembers);
     this.visibleSharedGroups   = Transformations.map(LiveDataUtil.combineLatest(allSharedGroups,
                                                      this.groupListCollapseState,
@@ -198,8 +199,8 @@ public final class ManageRecipientViewModel extends ViewModel {
   private static @NonNull List<Recipient> filterSharedGroupList(@NonNull List<Recipient> groups,
                                                                 @NonNull CollapseState collapseState)
   {
-    if (collapseState == CollapseState.COLLAPSED && groups.size() > MAX_COLLAPSED_GROUPS) {
-      return groups.subList(0, MAX_COLLAPSED_GROUPS);
+    if (collapseState == CollapseState.COLLAPSED && groups.size() > MAX_UNCOLLAPSED_GROUPS) {
+      return groups.subList(0, SHOW_COLLAPSED_GROUPS);
     } else {
       return groups;
     }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device, Android 8.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Currently if you have a group of exactly 6 members the group member list will show 5 group members and one additional entry to expand the list. So the collapsed list has 6 entries, but the full list has 6 entries as well. It makes more sense to collapse the list only if two or more entries are hidden.

With this PR:
- up to 6 group members: all members are shown immediately
- 7 or more members:  show 5 members and allow to expand

I chose the parameters so that the list has a maximum number of 6 entries, as it is now. Alternatively you could of course use parameters 5/4 to limit the number of initially shown members to a maximum of 5 (as it is now as well).

And obviously instead of introducing a new variable you could just subtract 1, but I thought that this was nicer.