### PR TITLE
Adds 8 hour mute option

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/MuteDialog.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/MuteDialog.java
@@ -39,9 +39,10 @@ public class MuteDialog extends AlertDialog {
         switch (which) {
           case 0:  muteUntil = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1);  break;
           case 1:  muteUntil = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(2);  break;
-          case 2:  muteUntil = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1);   break;
-          case 3:  muteUntil = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(7);   break;
-          case 4:  muteUntil = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(365); break;
+          case 2:  muteUntil = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(8);  break;
+          case 3:  muteUntil = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1);   break;
+          case 4:  muteUntil = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(7);   break;
+          case 5:  muteUntil = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(365); break;
           default: muteUntil = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1);  break;
         }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [ ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This has not been tested, and I don't know how the language translation part works, but the code is very straight forward. I just inserted an "8 hour" option into the mute selection list, and renumbered the cases. If it is easier to append the 8 hour option to "case 5", for translation/string purposes, I can do that as well.
