### PR TITLE
Fixes these views in media send activity had older theme

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/ThemeUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/ThemeUtil.java
@@ -2,16 +2,16 @@ package org.thoughtcrime.securesms.util;
 
 import android.content.Context;
 import android.content.res.Resources;
+import android.content.res.TypedArray;
 import android.graphics.Color;
+import android.os.Build;
 import androidx.annotation.AttrRes;
 import androidx.annotation.ColorInt;
-import androidx.annotation.DimenRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StyleRes;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.appcompat.view.ContextThemeWrapper;
-import androidx.core.content.ContextCompat;
 
 import android.graphics.drawable.Drawable;
 import android.util.TypedValue;
@@ -82,6 +82,17 @@ public class ThemeUtil {
     }
 
     return 0;
+  }
+
+  public static @ColorInt int getLightThemeNavigationBarColor(@NonNull Context context) {
+    if (Build.VERSION.SDK_INT < 21) return context.getResources().getColor(R.color.core_white);
+
+    int[]      attrs  = {android.R.attr.navigationBarColor};
+    TypedArray values = context.obtainStyledAttributes(R.style.TextSecure_LightNoActionBar, attrs);
+    int        color  = values.getInt(0, R.color.core_white);
+
+    values.recycle();
+    return color;
   }
 
   private static String getAttribute(Context context, int attribute, String defaultValue) {

--- a/app/src/main/res/layout/camera_contact_selection_fragment.xml
+++ b/app/src/main/res/layout/camera_contact_selection_fragment.xml
@@ -14,14 +14,8 @@
         android:background="?attr/conversation_list_toolbar_background"
         android:theme="?actionBarStyle"
         app:title="@string/CameraContacts_select_signal_recipients"
+        app:titleTextAppearance="@style/TextSecure.TitleTextStyle"
         app:layout_constraintTop_toTopOf="parent" />
-
-    <View
-        android:id="@+id/camera_contacts_top_shadow"
-        android:layout_width="match_parent"
-        android:layout_height="2dp"
-        android:background="@drawable/search_toolbar_shadow"
-        app:layout_constraintTop_toBottomOf="@id/camera_contacts_toolbar" />
 
     <LinearLayout
         android:id="@+id/camera_contacts_empty"

--- a/app/src/main/res/layout/mediapicker_folder_fragment.xml
+++ b/app/src/main/res/layout/mediapicker_folder_fragment.xml
@@ -13,6 +13,7 @@
         android:minHeight="?attr/actionBarSize"
         android:background="?attr/conversation_list_toolbar_background"
         android:theme="?attr/actionBarStyle"
+        app:titleTextAppearance="@style/TextSecure.TitleTextStyle"
         app:navigationIcon="@drawable/ic_arrow_left_24"/>
 
     <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/layout/mediapicker_item_fragment.xml
+++ b/app/src/main/res/layout/mediapicker_item_fragment.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
@@ -12,7 +13,8 @@
         android:layout_height="?attr/actionBarSize"
         android:minHeight="?attr/actionBarSize"
         android:background="?attr/conversation_list_toolbar_background"
-        android:theme="?attr/actionBarStyle" />
+        android:theme="?attr/actionBarStyle"
+        app:titleTextAppearance="@style/TextSecure.TitleTextStyle" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/mediapicker_item_list"


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual Device Pixel 2, API 28
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
1. Fixes the font size on the action bar of both media picker fragment and contact picker fragment to follow the modern theme applied elsewhere.
1. Sets the navigation bar color and style, the status bar and style, and also removes full screen flag when contact picker fragment appears. This fragment follows the user's selected theme (light or dark) unlike other fragments in MediaSendActivity which forces dark theme. The navigation bar and the status bar appear dark even if the user chooses light theme.

### Screenshots
#### Current at master @ [5cd4b82ed0fd6cea80f138b7ec3bd099cf44163d]

![ContactPicker-before](https://user-images.githubusercontent.com/28482/89748212-12932380-da90-11ea-8493-187a7be28bcf.png)|![MediaPicker-before](https://user-images.githubusercontent.com/28482/89748220-2e96c500-da90-11ea-88c1-3675a20b9cc6.png)


#### After this PR

![ContactPicker-after](https://user-images.githubusercontent.com/28482/89748243-5423ce80-da90-11ea-9883-dba1fbb487b5.png)|![MediaPicker-after](https://user-images.githubusercontent.com/28482/89748251-5a19af80-da90-11ea-84e2-005aad84bf8f.png)

