### PR TITLE
Fixes #9908

### DIFF
--- a/app/src/main/res/layout/conversation_reaction_long_press_toolbar.xml
+++ b/app/src/main/res/layout/conversation_reaction_long_press_toolbar.xml
@@ -4,7 +4,6 @@
     android:layout_width="match_parent"
     android:layout_height="?attr/actionBarSize"
     android:background="?attr/reactions_overlay_toolbar_background_color"
-    android:theme="?reactions_overlay_toolbar_overflow_style"
     app:contentInsetStart="0dp"
     app:contentInsetStartWithNavigation="48sp"
     app:menu="@menu/conversation_reactions_long_press_menu"


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
* Galaxy S9, Android 10
* Pixel 3, Android 10
* LG Aristo 2 PLUS, 8.1.0

- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
I was able to reproduce this following the steps in the bug report (#9908). It occurs when a conversation item selection has enough options to require an overflow menu. The overflow menu is simply broken.

I found that removing the theme from `conversation_reaction_long_press_toolbar.xml` fixed this problem and other styling issues.

If you look at the theme applied `reactions_overlay_toolbar_overflow_style` which is assigned to `@style/Signal.Toolbar.Overflow.Light` or `@style/Signal.Toolbar.Overflow`, there doesn't seem to be anything that would cause this bug to happen. The parent style is `Widget.AppCompat.ActionButton.Overflow` and I suspect the problem lies there. This theme is applied to other toolbars in the app and works properly. But in this case it doesn't work. I found that the other usages of this theme are in cases where the target `Toolbar` is sent to `setSupportActionBar`. `conversation_reaction_long_press_toolbar.xml` is not. I suspect there is some Android SDK "magic" happening in the background causing this composition issue.

I'm not sure what the intent of adding this theme to the toolbar was. I thought removing this theme might break dark or light mode support but in the screenshots below you can see it does not:
![Screenshot_2020-08-10-21-36-34](https://user-images.githubusercontent.com/1737565/89848661-b514da80-db54-11ea-84e2-af158b108ee3.png)
![Screenshot_2020-08-10-21-35-37](https://user-images.githubusercontent.com/1737565/89848671-ba722500-db54-11ea-93e2-2cc5e78f4eea.png)

As far as I can tell this theme does not serve a purpose in the case of this specific toolbar. Once the theme is removed, the actions in the overflow menu have padding consistent with other overflow menus and actions can be clicked and work as expected.