### PR TITLE
Do not attempt to create link previews for .i2p links

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/linkpreview/LinkPreviewUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/linkpreview/LinkPreviewUtil.java
@@ -39,7 +39,7 @@ public final class LinkPreviewUtil {
   private static final Pattern FAVICON_PATTERN            = Pattern.compile("<\\s*link[^>]*rel\\s*=\\s*\".*icon.*\"[^>]*>");
   private static final Pattern FAVICON_HREF_PATTERN       = Pattern.compile("href\\s*=\\s*\"([^\"]*)\"");
 
-  private static final Set<String> INVALID_TOP_LEVEL_DOMAINS = Sets.newHashSet("onion");
+  private static final Set<String> INVALID_TOP_LEVEL_DOMAINS = Sets.newHashSet("onion", "i2p");
 
   /**
    * @return All whitelisted URLs in the source text.
@@ -176,3 +176,4 @@ public final class LinkPreviewUtil {
     @NonNull String fromEncoded(@NonNull String html);
   }
 }
+

--- a/app/src/test/java/org/thoughtcrime/securesms/linkpreview/LinkPreviewUtilTest_isLegal.java
+++ b/app/src/test/java/org/thoughtcrime/securesms/linkpreview/LinkPreviewUtilTest_isLegal.java
@@ -29,6 +29,7 @@ public class LinkPreviewUtilTest_isLegal {
         { "http://asĸ.com",                        false },
         { "http://foo.кц.рф",                      false },
         { "https://abcdefg.onion",                 false },
+        { "https://abcdefg.i2p",                   false },
         { "",                                      false }
     });
   }


### PR DESCRIPTION

### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution.
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

My change is meant to prevent Signal from attempting to create link previews for `.i2p` links, in conjuction with `.onion` links, as seen on 3f7dd21.

`.i2p` links can be accessed with [I2P](https://en.wikipedia.org/wiki/I2P), which falls under the category of anonymity software-- similarly to Tor itself.

#### Testing

I'm presuming that it wasn't necessar for me to test that change, because my change is 2 lines wide and just an addition of another string in a `Sets.newHashSet()` function. I'd be more than happy to do so, if it so happens to be an obligatory procedure that I will need to follow before my change gets merged.