### PR TITLE
Fixes appearances of option menu items in RTL languages

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -431,13 +431,17 @@ public final class MediaPreviewActivity extends PassphraseRequiredActivity
   }
 
   @Override
-  public boolean onPrepareOptionsMenu(Menu menu) {
-    super.onPrepareOptionsMenu(menu);
-
+  public boolean onCreateOptionsMenu(Menu menu) {
     menu.clear();
     MenuInflater inflater = this.getMenuInflater();
     inflater.inflate(R.menu.media_preview, menu);
 
+    super.onCreateOptionsMenu(menu);
+    return true;
+  }
+
+  @Override
+  public boolean onPrepareOptionsMenu(Menu menu) {
     if (!isMediaInDb()) {
       menu.findItem(R.id.media_preview__overview).setVisible(false);
       menu.findItem(R.id.delete).setVisible(false);
@@ -447,6 +451,7 @@ public final class MediaPreviewActivity extends PassphraseRequiredActivity
       menu.findItem(R.id.media_preview__overview).setVisible(false);
     }
 
+    super.onPrepareOptionsMenu(menu);
     return true;
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/NewConversationActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/NewConversationActivity.java
@@ -138,11 +138,11 @@ public class NewConversationActivity extends ContactSelectionActivity
   }
 
   @Override
-  public boolean onPrepareOptionsMenu(Menu menu) {
+  public boolean onCreateOptionsMenu(Menu menu) {
     menu.clear();
     getMenuInflater().inflate(R.menu.new_conversation_activity, menu);
 
-    super.onPrepareOptionsMenu(menu);
+    super.onCreateOptionsMenu(menu);
     return true;
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/PassphrasePromptActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/PassphrasePromptActivity.java
@@ -132,12 +132,13 @@ public class PassphrasePromptActivity extends PassphraseActivity {
   }
 
   @Override
-  public boolean onPrepareOptionsMenu(Menu menu) {
+  public boolean onCreateOptionsMenu(Menu menu) {
     MenuInflater inflater = this.getMenuInflater();
     menu.clear();
 
     inflater.inflate(R.menu.log_submit, menu);
-    super.onPrepareOptionsMenu(menu);
+
+    super.onCreateOptionsMenu(menu);
     return true;
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationActivity.java
@@ -766,7 +766,7 @@ public class ConversationActivity extends PassphraseRequiredActivity
   }
 
   @Override
-  public boolean onPrepareOptionsMenu(Menu menu) {
+  public boolean onCreateOptionsMenu(Menu menu) {
     MenuInflater inflater = this.getMenuInflater();
     menu.clear();
 
@@ -785,7 +785,7 @@ public class ConversationActivity extends PassphraseRequiredActivity
       if (recipient != null && recipient.get().isMuted()) inflater.inflate(R.menu.conversation_muted, menu);
       else                                                inflater.inflate(R.menu.conversation_unmuted, menu);
 
-      super.onPrepareOptionsMenu(menu);
+      super.onCreateOptionsMenu(menu);
       return true;
     }
 
@@ -921,7 +921,7 @@ public class ConversationActivity extends PassphraseRequiredActivity
       }
     });
 
-    super.onPrepareOptionsMenu(menu);
+    super.onCreateOptionsMenu(menu);
     return true;
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
@@ -54,6 +54,7 @@ import androidx.appcompat.view.ActionMode;
 import androidx.appcompat.widget.Toolbar;
 import androidx.appcompat.widget.TooltipCompat;
 import androidx.core.content.res.ResourcesCompat;
+import androidx.core.view.ViewCompat;
 import androidx.lifecycle.DefaultLifecycleObserver;
 import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.ProcessLifecycleOwner;
@@ -283,12 +284,13 @@ public class ConversationListFragment extends MainFragment implements ActionMode
   }
 
   @Override
-  public void onPrepareOptionsMenu(Menu menu) {
-    MenuInflater inflater = requireActivity().getMenuInflater();
+  public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
     menu.clear();
-
     inflater.inflate(R.menu.text_secure_normal, menu);
+  }
 
+  @Override
+  public void onPrepareOptionsMenu(Menu menu) {
     menu.findItem(R.id.menu_insights).setVisible(TextSecurePreferences.isSmsEnabled(requireContext()));
     menu.findItem(R.id.menu_clear_passphrase).setVisible(!TextSecurePreferences.isPasswordDisabled(requireContext()));
   }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Nexus 5X, Android 5.0 (API 21)
 * AVD Pixel, Android 6.0 (API 23)
 * AVD Pixel 2, Android 9.0 (API 28)
 * AVD Pixel 3a, Android 10.0 (API 29)
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Use onCreateOptionsMenu when to inflate a menu in order for menu items to appear correctly in RTL languages.

The bug was reported in [Beta feedback for the upcoming Android 4.70 release](https://community.signalusers.org/t/beta-feedback-for-the-upcoming-android-4-70-release/16449/20), but it was not necessarily a regression caused by the commit suggested in the forum post. It is more like that the bug was finally exposed by the commit. Before the commit the menu items were not properly aligned nor translated upon configuration changes in RTL languages.

## Steps to verify the fix
1. Set up Signal on an device with Android 6
1. Set the system language to Arabic that Signal also supports.
    * And/or set the system language to English or some other LTR language and set Signal's language setting to Arabic.
1. Open Signal
1. Tap the main activity's option menu (triple dots) to open the menu
1. Confirm it's aligned correctly in RTL
1. Open these other activities and see the menu items:
    * New Conversation activity (select conversations view)
    * Conversation activity
    * Media preview activity (tap an image in a conversation)
    * Set the screen lock, and see PassphrasePromptActivity

## Screenshots

|Before|After|
|----|----|
|![home-before](https://user-images.githubusercontent.com/28482/91640101-1e1b9f80-e9e9-11ea-9c4b-4b5f906ef654.png)|![home-after](https://user-images.githubusercontent.com/28482/91640103-207df980-e9e9-11ea-9f5f-45389705b3f9.png)|
|![newconvo-before](https://user-images.githubusercontent.com/28482/91640241-11e41200-e9ea-11ea-80f2-e4dd19593856.png)|![newconvo-after](https://user-images.githubusercontent.com/28482/91640130-51f6c500-e9e9-11ea-961c-83399ffe5a1f.png)|
|![conversation-before](https://user-images.githubusercontent.com/28482/91640138-59b66980-e9e9-11ea-8d6b-b44b51eb633d.png)|![conversation-after](https://user-images.githubusercontent.com/28482/91640140-5f13b400-e9e9-11ea-97f4-b61bcb2ea967.png)|
|![mediapreview-before](https://user-images.githubusercontent.com/28482/91640145-65099500-e9e9-11ea-822f-9ad3a145d819.png)|![mediapreview-after](https://user-images.githubusercontent.com/28482/91640148-6935b280-e9e9-11ea-81c3-312fa9aa536a.png)|
|![passphrase-before](https://user-images.githubusercontent.com/28482/91640150-6e92fd00-e9e9-11ea-8db9-e9d55c43baf9.png)|![passphrase-after](https://user-images.githubusercontent.com/28482/91640154-72bf1a80-e9e9-11ea-975c-febba196a574.png)|
