### PR TITLE
Use the light styles in the light theme

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -60,8 +60,8 @@
         <item name="titleTextStyle">@style/TextSecure.TitleTextStyle</item>
         <item name="subtitleTextStyle">@style/TextSecure.SubtitleTextStyle</item>
         <item name="elevation">0dp</item>
-        <item name="actionOverflowButtonStyle">@style/Signal.Toolbar.Overflow</item>
-        <item name="android:actionOverflowButtonStyle">@style/Signal.Toolbar.Overflow</item>
+        <item name="actionOverflowButtonStyle">@style/Signal.Toolbar.Overflow.Light</item>
+        <item name="android:actionOverflowButtonStyle">@style/Signal.Toolbar.Overflow.Light</item>
     </style>
 
     <style name="TextSecure.LightActionBar.DarkText"
@@ -359,6 +359,14 @@
 
     <style name="TextSecure.ActionModeStyle" parent="@style/Widget.AppCompat.ActionMode">
         <item name="titleTextStyle">@style/TextSecure.TitleTextStyle.Conversation</item>
+        <item name="theme">@style/Signal.ActionModeTheme</item>
+    </style>
+
+    <style name="Signal.ActionModeTheme" parent="ThemeOverlay.AppCompat">
+        <!-- Use the brighter version of the three dot button because
+             ActionMode background is darker regardless of the current theme (light or dark) -->
+        <item name="actionOverflowButtonStyle">@style/Signal.Toolbar.Overflow</item>
+        <item name="android:actionOverflowButtonStyle">@style/Signal.Toolbar.Overflow</item>
     </style>
 
     <style name="Widget.Signal.ArcProgressBar" parent="">


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Nexus 5X, Android 5.0 (API 21)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Overflow button style was set to that of the dark mode. Setting it to the other one for the light mode fixes the issue reported in #9932  

In the ActionMode the overflow button should stay lighter gray.

### Screenshots

|Before|After|
|----|----|
|![optionsmenu-before](https://user-images.githubusercontent.com/28482/91640518-245f4b00-e9ec-11ea-9a28-1ea70a1306b5.png)|![optionsmenu-after](https://user-images.githubusercontent.com/28482/91640521-2923ff00-e9ec-11ea-9af0-8cc5c83b4ca6.png)|
||![Screenshot_1598933012](https://user-images.githubusercontent.com/28482/91793621-b59a1180-ebe6-11ea-9251-e603fb603a32.png)|


