### PR TITLE
Screenlock improvements

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/PassphrasePromptActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/PassphrasePromptActivity.java
@@ -348,15 +348,15 @@ public class PassphrasePromptActivity extends PassphraseActivity {
       onAuthenticationFailed();
     }
 
-    @Override
-    public void onAuthenticationSucceeded(FingerprintManagerCompat.AuthenticationResult result) {
-      Log.i(TAG, "onAuthenticationSucceeded");
-      fingerprintPrompt.setImageResource(R.drawable.ic_check_white_48dp);
-      fingerprintPrompt.getBackground().setColorFilter(getResources().getColor(R.color.green_500), PorterDuff.Mode.SRC_IN);
-      fingerprintPrompt.animate().setInterpolator(new BounceInterpolator()).scaleX(1.1f).scaleY(1.1f).setDuration(500).setListener(new AnimationCompleteListener() {
         @Override
-        public void onAnimationEnd(Animator animation) {
-          handleAuthenticated();
+        public void onAuthenticationSucceeded(FingerprintManagerCompat.AuthenticationResult result) {
+            Log.i(TAG, "onAuthenticationSucceeded");
+            fingerprintPrompt.setImageResource(R.drawable.ic_check_white_48dp);
+            fingerprintPrompt.getBackground().setColorFilter(getResources().getColor(R.color.green_500), PorterDuff.Mode.SRC_IN);
+            fingerprintPrompt.animate().setInterpolator(new BounceInterpolator()).scaleX(1.1f).scaleY(1.1f).setDuration(TextSecurePreferences.getScreenLockAnimationDuration(getBaseContext())).setListener(new AnimationCompleteListener() {
+                @Override
+                public void onAnimationEnd(Animator animation) {
+                    handleAuthenticated();
 
           fingerprintPrompt.setImageResource(R.drawable.ic_fingerprint_white_48dp);
           fingerprintPrompt.getBackground().setColorFilter(getResources().getColor(R.color.core_ultramarine), PorterDuff.Mode.SRC_IN);

--- a/app/src/main/java/org/thoughtcrime/securesms/PassphrasePromptActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/PassphrasePromptActivity.java
@@ -348,20 +348,20 @@ public class PassphrasePromptActivity extends PassphraseActivity {
       onAuthenticationFailed();
     }
 
-        @Override
-        public void onAuthenticationSucceeded(FingerprintManagerCompat.AuthenticationResult result) {
-            Log.i(TAG, "onAuthenticationSucceeded");
-            fingerprintPrompt.setImageResource(R.drawable.ic_check_white_48dp);
-            fingerprintPrompt.getBackground().setColorFilter(getResources().getColor(R.color.green_500), PorterDuff.Mode.SRC_IN);
-            fingerprintPrompt.animate().setInterpolator(new BounceInterpolator()).scaleX(1.1f).scaleY(1.1f).setDuration(TextSecurePreferences.getScreenLockAnimationDuration(getBaseContext())).setListener(new AnimationCompleteListener() {
-                @Override
-                public void onAnimationEnd(Animator animation) {
-                    handleAuthenticated();
+    @Override
+    public void onAuthenticationSucceeded(FingerprintManagerCompat.AuthenticationResult result) {
+        Log.i(TAG, "onAuthenticationSucceeded");
+        fingerprintPrompt.setImageResource(R.drawable.ic_check_white_48dp);
+        fingerprintPrompt.getBackground().setColorFilter(getResources().getColor(R.color.green_500), PorterDuff.Mode.SRC_IN);
+        fingerprintPrompt.animate().setInterpolator(new BounceInterpolator()).scaleX(1.1f).scaleY(1.1f).setDuration(TextSecurePreferences.getScreenLockAnimationDuration(getBaseContext())).setListener(new AnimationCompleteListener() {
+            @Override
+            public void onAnimationEnd(Animator animation) {
+                handleAuthenticated();
 
-          fingerprintPrompt.setImageResource(R.drawable.ic_fingerprint_white_48dp);
-          fingerprintPrompt.getBackground().setColorFilter(getResources().getColor(R.color.core_ultramarine), PorterDuff.Mode.SRC_IN);
-        }
-      }).start();
+                fingerprintPrompt.setImageResource(R.drawable.ic_fingerprint_white_48dp);
+                fingerprintPrompt.getBackground().setColorFilter(getResources().getColor(R.color.core_ultramarine), PorterDuff.Mode.SRC_IN);
+            }
+        }).start();
     }
 
     @Override

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.java
@@ -533,7 +533,7 @@ public class DefaultMessageNotifier implements MessageNotifier {
       }
 
       if (isUnreadMessage) {
-        if (KeyCachingService.isLocked(context)) {
+        if (KeyCachingService.isLocked(context) && !TextSecurePreferences.isScreenLockShowNotificationContentEnabled(context)) {
           body = SpanUtil.italic(context.getString(R.string.MessageNotifier_locked_message));
         } else if (record.isMms() && !((MmsMessageRecord) record).getSharedContacts().isEmpty()) {
           Contact contact = ((MmsMessageRecord) record).getSharedContacts().get(0);
@@ -566,7 +566,7 @@ public class DefaultMessageNotifier implements MessageNotifier {
             continue;
           }
 
-          if (KeyCachingService.isLocked(context)) {
+          if (KeyCachingService.isLocked(context) && !TextSecurePreferences.isScreenLockShowNotificationContentEnabled(context)) {
             body = SpanUtil.italic(context.getString(R.string.MessageNotifier_locked_message));
           } else {
             String   text  = SpanUtil.italic(getReactionMessageBody(context, record)).toString();

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
@@ -94,9 +94,9 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
     ((SwitchPreferenceCompat) this.findPreference(PinValues.PIN_REMINDERS_ENABLED)).setChecked(SignalStore.pinValues().arePinRemindersEnabled());
     this.findPreference(PinValues.PIN_REMINDERS_ENABLED).setOnPreferenceChangeListener(new PinRemindersChangedListener());
 
-        this.findPreference(TextSecurePreferences.SCREEN_LOCK).setOnPreferenceChangeListener(new ScreenLockListener());
-        this.findPreference(TextSecurePreferences.SCREEN_LOCK_TIMEOUT).setOnPreferenceClickListener(new ScreenLockTimeoutListener());
-        this.findPreference(TextSecurePreferences.SCREEN_LOCK_ANIMATION_DURATION).setOnPreferenceChangeListener(new ScreenLockDurationListener());
+      this.findPreference(TextSecurePreferences.SCREEN_LOCK).setOnPreferenceChangeListener(new ScreenLockListener());
+      this.findPreference(TextSecurePreferences.SCREEN_LOCK_TIMEOUT).setOnPreferenceClickListener(new ScreenLockTimeoutListener());
+      this.findPreference(TextSecurePreferences.SCREEN_LOCK_ANIMATION_DURATION).setOnPreferenceChangeListener(new ScreenLockDurationListener());
 
     this.findPreference(TextSecurePreferences.CHANGE_PASSPHRASE_PREF).setOnPreferenceClickListener(new ChangePassphraseClickListener());
     this.findPreference(TextSecurePreferences.PASSPHRASE_TIMEOUT_INTERVAL_PREF).setOnPreferenceClickListener(new PassphraseIntervalClickListener());
@@ -240,18 +240,18 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
         }
     }
 
-    private class ScreenLockDurationListener implements SeekBarPreference.OnPreferenceChangeListener {
+  private class ScreenLockDurationListener implements SeekBarPreference.OnPreferenceChangeListener {
 
-        @Override
-        public boolean onPreferenceChange(Preference preference, Object newValue) {
-            if (newValue instanceof Integer) {
-                TextSecurePreferences.setScreenLockAnimationDuration(getContext(), (Integer) newValue);
-                return true;
-            }
-
-            return false;
+     @Override
+     public boolean onPreferenceChange(Preference preference, Object newValue) {
+        if (newValue instanceof Integer) {
+           TextSecurePreferences.setScreenLockAnimationDuration(getContext(), (Integer) newValue);
+            return true;
         }
-    }
+
+        return false;
+     }
+   }
 
   private class ScreenLockTimeoutListener implements Preference.OnPreferenceClickListener {
 

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
@@ -25,6 +25,7 @@ import androidx.core.app.DialogCompat;
 import androidx.core.view.ViewCompat;
 import androidx.preference.CheckBoxPreference;
 import androidx.preference.Preference;
+import androidx.preference.SeekBarPreference;
 
 import com.google.android.material.snackbar.Snackbar;
 
@@ -93,8 +94,9 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
     ((SwitchPreferenceCompat) this.findPreference(PinValues.PIN_REMINDERS_ENABLED)).setChecked(SignalStore.pinValues().arePinRemindersEnabled());
     this.findPreference(PinValues.PIN_REMINDERS_ENABLED).setOnPreferenceChangeListener(new PinRemindersChangedListener());
 
-    this.findPreference(TextSecurePreferences.SCREEN_LOCK).setOnPreferenceChangeListener(new ScreenLockListener());
-    this.findPreference(TextSecurePreferences.SCREEN_LOCK_TIMEOUT).setOnPreferenceClickListener(new ScreenLockTimeoutListener());
+        this.findPreference(TextSecurePreferences.SCREEN_LOCK).setOnPreferenceChangeListener(new ScreenLockListener());
+        this.findPreference(TextSecurePreferences.SCREEN_LOCK_TIMEOUT).setOnPreferenceClickListener(new ScreenLockTimeoutListener());
+        this.findPreference(TextSecurePreferences.SCREEN_LOCK_ANIMATION_DURATION).setOnPreferenceChangeListener(new ScreenLockDurationListener());
 
     this.findPreference(TextSecurePreferences.CHANGE_PASSPHRASE_PREF).setOnPreferenceClickListener(new ChangePassphraseClickListener());
     this.findPreference(TextSecurePreferences.PASSPHRASE_TIMEOUT_INTERVAL_PREF).setOnPreferenceClickListener(new PassphraseIntervalClickListener());
@@ -231,12 +233,25 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
       boolean enabled = (Boolean)newValue;
       TextSecurePreferences.setScreenLockEnabled(getContext(), enabled);
 
-      Intent intent = new Intent(getContext(), KeyCachingService.class);
-      intent.setAction(KeyCachingService.LOCK_TOGGLED_EVENT);
-      getContext().startService(intent);
-      return true;
+            Intent intent = new Intent(getContext(), KeyCachingService.class);
+            intent.setAction(KeyCachingService.LOCK_TOGGLED_EVENT);
+            getContext().startService(intent);
+            return true;
+        }
     }
-  }
+
+    private class ScreenLockDurationListener implements SeekBarPreference.OnPreferenceChangeListener {
+
+        @Override
+        public boolean onPreferenceChange(Preference preference, Object newValue) {
+            if (newValue instanceof Integer) {
+                TextSecurePreferences.setScreenLockAnimationDuration(getContext(), (Integer) newValue);
+                return true;
+            }
+
+            return false;
+        }
+    }
 
   private class ScreenLockTimeoutListener implements Preference.OnPreferenceClickListener {
 

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
@@ -94,9 +94,9 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
     ((SwitchPreferenceCompat) this.findPreference(PinValues.PIN_REMINDERS_ENABLED)).setChecked(SignalStore.pinValues().arePinRemindersEnabled());
     this.findPreference(PinValues.PIN_REMINDERS_ENABLED).setOnPreferenceChangeListener(new PinRemindersChangedListener());
 
-      this.findPreference(TextSecurePreferences.SCREEN_LOCK).setOnPreferenceChangeListener(new ScreenLockListener());
-      this.findPreference(TextSecurePreferences.SCREEN_LOCK_TIMEOUT).setOnPreferenceClickListener(new ScreenLockTimeoutListener());
-      this.findPreference(TextSecurePreferences.SCREEN_LOCK_ANIMATION_DURATION).setOnPreferenceChangeListener(new ScreenLockDurationListener());
+    this.findPreference(TextSecurePreferences.SCREEN_LOCK).setOnPreferenceChangeListener(new ScreenLockListener());
+    this.findPreference(TextSecurePreferences.SCREEN_LOCK_TIMEOUT).setOnPreferenceClickListener(new ScreenLockTimeoutListener());
+    this.findPreference(TextSecurePreferences.SCREEN_LOCK_ANIMATION_DURATION).setOnPreferenceChangeListener(new ScreenLockDurationListener());
 
     this.findPreference(TextSecurePreferences.CHANGE_PASSPHRASE_PREF).setOnPreferenceClickListener(new ChangePassphraseClickListener());
     this.findPreference(TextSecurePreferences.PASSPHRASE_TIMEOUT_INTERVAL_PREF).setOnPreferenceClickListener(new PassphraseIntervalClickListener());

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
@@ -230,28 +230,29 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
   private class ScreenLockListener implements Preference.OnPreferenceChangeListener {
     @Override
     public boolean onPreferenceChange(Preference preference, Object newValue) {
-      boolean enabled = (Boolean)newValue;
+      boolean enabled = (Boolean) newValue;
       TextSecurePreferences.setScreenLockEnabled(getContext(), enabled);
 
-            Intent intent = new Intent(getContext(), KeyCachingService.class);
-            intent.setAction(KeyCachingService.LOCK_TOGGLED_EVENT);
-            getContext().startService(intent);
-            return true;
-        }
+      Intent intent = new Intent(getContext(), KeyCachingService.class);
+      intent.setAction(KeyCachingService.LOCK_TOGGLED_EVENT);
+      getContext().startService(intent);
+      return true;
     }
+  }
 
   private class ScreenLockDurationListener implements SeekBarPreference.OnPreferenceChangeListener {
 
-     @Override
-     public boolean onPreferenceChange(Preference preference, Object newValue) {
-        if (newValue instanceof Integer) {
-           TextSecurePreferences.setScreenLockAnimationDuration(getContext(), (Integer) newValue);
-            return true;
-        }
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+      if (newValue instanceof Integer) {
+        TextSecurePreferences.setScreenLockAnimationDuration(getContext(), (Integer) newValue);
+        return true;
+      }
 
-        return false;
-     }
-   }
+      return false;
+    }
+  }
+   
 
   private class ScreenLockTimeoutListener implements Preference.OnPreferenceClickListener {
 

--- a/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -152,6 +152,7 @@ public class TextSecurePreferences {
   public static final String SCREEN_LOCK = "pref_android_screen_lock";
   public static final String SCREEN_LOCK_TIMEOUT = "pref_android_screen_lock_timeout";
   public static final String SCREEN_LOCK_ANIMATION_DURATION = "pref_android_screen_lock_animation_duration";
+  public static final String SCREEN_LOCK_SHOW_NOTIFICATION_CONTENT = "pref_android_screen_lock_show_notification_content";
 
   @Deprecated
   public static final  String REGISTRATION_LOCK_PREF_V1                = "pref_registration_lock";
@@ -234,6 +235,14 @@ public class TextSecurePreferences {
 
   public static void setScreenLockAnimationDuration(@NonNull Context context, int value) {
     setIntegerPrefrence(context, SCREEN_LOCK_ANIMATION_DURATION, value);
+  }
+
+  public static boolean isScreenLockShowNotificationContentEnabled(@NonNull Context context){
+    return getBooleanPreference(context, SCREEN_LOCK_SHOW_NOTIFICATION_CONTENT, false);
+  }
+
+  public static void setScreenLockShowNotificationContentEnabled(@NonNull Context context, boolean value) {
+    setBooleanPreference(context, SCREEN_LOCK_SHOW_NOTIFICATION_CONTENT, value);
   }
 
   public static boolean isV1RegistrationLockEnabled(@NonNull Context context) {

--- a/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -149,8 +149,9 @@ public class TextSecurePreferences {
   public  static final String BACKUP_NOW                  = "pref_backup_create";
   public  static final String BACKUP_PASSPHRASE_VERIFY    = "pref_backup_passphrase_verify";
 
-  public static final String SCREEN_LOCK         = "pref_android_screen_lock";
-  public static final String SCREEN_LOCK_TIMEOUT = "pref_android_screen_lock_timeout";
+    public static final String SCREEN_LOCK = "pref_android_screen_lock";
+    public static final String SCREEN_LOCK_TIMEOUT = "pref_android_screen_lock_timeout";
+    public static final String SCREEN_LOCK_ANIMATION_DURATION = "pref_android_screen_lock_animation_duration";
 
   @Deprecated
   public static final  String REGISTRATION_LOCK_PREF_V1                = "pref_registration_lock";
@@ -227,10 +228,18 @@ public class TextSecurePreferences {
     setLongPreference(context, SCREEN_LOCK_TIMEOUT, value);
   }
 
-  public static boolean isV1RegistrationLockEnabled(@NonNull Context context) {
-    //noinspection deprecation
-    return getBooleanPreference(context, REGISTRATION_LOCK_PREF_V1, false);
-  }
+    public static long getScreenLockAnimationDuration(@NonNull Context context) {
+        return getIntegerPreference(context, SCREEN_LOCK_ANIMATION_DURATION, 500);
+    }
+
+    public static void setScreenLockAnimationDuration(@NonNull Context context, int value) {
+        setIntegerPrefrence(context, SCREEN_LOCK_ANIMATION_DURATION, value);
+    }
+
+    public static boolean isV1RegistrationLockEnabled(@NonNull Context context) {
+        //noinspection deprecation
+        return getBooleanPreference(context, REGISTRATION_LOCK_PREF_V1, false);
+    }
 
   /**
    * @deprecated Use only during re-reg where user had pinV1.

--- a/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -149,9 +149,9 @@ public class TextSecurePreferences {
   public  static final String BACKUP_NOW                  = "pref_backup_create";
   public  static final String BACKUP_PASSPHRASE_VERIFY    = "pref_backup_passphrase_verify";
 
-    public static final String SCREEN_LOCK = "pref_android_screen_lock";
-    public static final String SCREEN_LOCK_TIMEOUT = "pref_android_screen_lock_timeout";
-    public static final String SCREEN_LOCK_ANIMATION_DURATION = "pref_android_screen_lock_animation_duration";
+  public static final String SCREEN_LOCK = "pref_android_screen_lock";
+  public static final String SCREEN_LOCK_TIMEOUT = "pref_android_screen_lock_timeout";
+  public static final String SCREEN_LOCK_ANIMATION_DURATION = "pref_android_screen_lock_animation_duration";
 
   @Deprecated
   public static final  String REGISTRATION_LOCK_PREF_V1                = "pref_registration_lock";
@@ -228,18 +228,18 @@ public class TextSecurePreferences {
     setLongPreference(context, SCREEN_LOCK_TIMEOUT, value);
   }
 
-    public static long getScreenLockAnimationDuration(@NonNull Context context) {
-        return getIntegerPreference(context, SCREEN_LOCK_ANIMATION_DURATION, 500);
-    }
+  public static long getScreenLockAnimationDuration(@NonNull Context context) {
+    return getIntegerPreference(context, SCREEN_LOCK_ANIMATION_DURATION, 500);
+  }
 
-    public static void setScreenLockAnimationDuration(@NonNull Context context, int value) {
-        setIntegerPrefrence(context, SCREEN_LOCK_ANIMATION_DURATION, value);
-    }
+  public static void setScreenLockAnimationDuration(@NonNull Context context, int value) {
+    setIntegerPrefrence(context, SCREEN_LOCK_ANIMATION_DURATION, value);
+  }
 
-    public static boolean isV1RegistrationLockEnabled(@NonNull Context context) {
-        //noinspection deprecation
-        return getBooleanPreference(context, REGISTRATION_LOCK_PREF_V1, false);
-    }
+  public static boolean isV1RegistrationLockEnabled(@NonNull Context context) {
+    //noinspection deprecation
+    return getBooleanPreference(context, REGISTRATION_LOCK_PREF_V1, false);
+  }
 
   /**
    * @deprecated Use only during re-reg where user had pinV1.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2647,6 +2647,8 @@
     <string name="GroupLinkBottomSheet_the_link_is_not_currently_active">The link is not currently active</string>
     <string name="preferences_app_protection__fingerprint_success_animation_duration">If fingerprint is set up, this changes the duration of the animation after the fingerprint has successfully been authenticated</string>
     <string name="preferences_app_protection__screen_lock_fingerprint_animation_duration">Screen lock animation duration (ms)</string>
+    <string name="preferences_app_protection__screen_lock_show_notification_content">Screen lock show notification content</string>
+    <string name="preferences_app_protection__show_notification_content">Show notification content, even if Signal is currently locked by screen lock</string>
 
     <!-- EOF -->
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2645,6 +2645,8 @@
     <string name="GroupLinkBottomSheet_share">Share</string>
     <string name="GroupLinkBottomSheet_copied_to_clipboard">Copied to clipboard</string>
     <string name="GroupLinkBottomSheet_the_link_is_not_currently_active">The link is not currently active</string>
+    <string name="preferences_app_protection__fingerprint_success_animation_duration">If fingerprint is set up, this changes the duration of the animation after the fingerprint has successfully been authenticated</string>
+    <string name="preferences_app_protection__screen_lock_fingerprint_animation_duration">Screen lock animation duration (ms)</string>
 
     <!-- EOF -->
 

--- a/app/src/main/res/xml/preferences_app_protection.xml
+++ b/app/src/main/res/xml/preferences_app_protection.xml
@@ -29,19 +29,26 @@
         android:key="pref_android_screen_lock_timeout"
         android:title="@string/preferences_app_protection__screen_lock_inactivity_timeout" />
 
-        <SeekBarPreference
-                android:defaultValue="500"
-                android:dependency="pref_android_screen_lock"
-                android:key="pref_android_screen_lock_animation_duration"
-                android:max="500"
-                android:summary="@string/preferences_app_protection__fingerprint_success_animation_duration"
-                android:title="@string/preferences_app_protection__screen_lock_fingerprint_animation_duration" />
+    <SeekBarPreference
+       android:defaultValue="500"
+       android:dependency="pref_android_screen_lock"
+       android:key="pref_android_screen_lock_animation_duration"
+       android:max="500"
+       android:summary="@string/preferences_app_protection__fingerprint_success_animation_duration"
+       android:title="@string/preferences_app_protection__screen_lock_fingerprint_animation_duration" />
 
-        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
-                android:defaultValue="true"
-                android:key="pref_enable_passphrase_temporary"
-                android:summary="@string/preferences__lock_signal_and_message_notifications_with_a_passphrase"
-                android:title="@string/preferences__enable_passphrase" />
+    <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+        android:defaultValue="true"
+        android:key="pref_enable_passphrase_temporary"
+        android:summary="@string/preferences__lock_signal_and_message_notifications_with_a_passphrase"
+        android:title="@string/preferences__enable_passphrase" />
+
+    <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+        android:dependency="pref_android_screen_lock"
+        android:key="pref_android_screen_lock_show_notification_content"
+        android:defaultValue="false"
+        android:summary="@string/preferences_app_protection__show_notification_content"
+        android:title="@string/preferences_app_protection__screen_lock_show_notification_content" />
 
     <Preference
         android:dependency="pref_enable_passphrase_temporary"

--- a/app/src/main/res/xml/preferences_app_protection.xml
+++ b/app/src/main/res/xml/preferences_app_protection.xml
@@ -29,11 +29,19 @@
         android:key="pref_android_screen_lock_timeout"
         android:title="@string/preferences_app_protection__screen_lock_inactivity_timeout" />
 
-    <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
-        android:defaultValue="true"
-        android:key="pref_enable_passphrase_temporary"
-        android:summary="@string/preferences__lock_signal_and_message_notifications_with_a_passphrase"
-        android:title="@string/preferences__enable_passphrase" />
+        <SeekBarPreference
+                android:defaultValue="500"
+                android:dependency="pref_android_screen_lock"
+                android:key="pref_android_screen_lock_animation_duration"
+                android:max="500"
+                android:summary="@string/preferences_app_protection__fingerprint_success_animation_duration"
+                android:title="@string/preferences_app_protection__screen_lock_fingerprint_animation_duration" />
+
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+                android:defaultValue="true"
+                android:key="pref_enable_passphrase_temporary"
+                android:summary="@string/preferences__lock_signal_and_message_notifications_with_a_passphrase"
+                android:title="@string/preferences__enable_passphrase" />
 
     <Preference
         android:dependency="pref_enable_passphrase_temporary"


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Huawei P9 Lite (VNS-L21), Android 7.1 (OmniRom)
 * Honor 9 (STF-L09), Android 10 (AOSPExtended)

- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
I have recently set up the screen lock feature with my fingerprint. When unlocking, the animation with the green success checkmark is, in my opinion, too long, so I added a preference in the settings which makes it modifyable. 
I also added a settingstoggle which allows the user to enable notification content even if signal is currently screenlocked.

I have tested it on both of my devices by just setting it to different values (e.g. 0 and 500) and just checking if it is "instant"/takes 500ms. I also tested the notification content preference by texting myself from another phone while signal was locked. 

Screenshot of the settings:
![Screenshot_20200913-140719_Signal](https://user-images.githubusercontent.com/58902674/93017631-bf921c00-f5b9-11ea-8667-2d43df92f7b4.png)

