### PR TITLE
Reset the title of the action bar when it was a long click in the "review storage" view

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/mediaoverview/MediaOverviewPageFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediaoverview/MediaOverviewPageFragment.java
@@ -261,6 +261,8 @@ public final class MediaOverviewPageFragment extends Fragment
 
     if (actionMode == null) {
       enterMultiSelect();
+    } else {
+      refreshActionModeTitle();
     }
   }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Essential PH-1, Android 10
 * Virtual device Pixel 2 API 28
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Adds a call to trigger refreshing the actionMode title to onMediaLongClicked that fixes #9698.

### Steps to verify
1. Go to Signal Settings
1. Storage
1. Review Storage
1. Long tap an item to enter the action mode
1. Long tap another item

**Actual result at master@[d3c59585fd1d6ad90cd80a9ff8a0f33fa4004f4a]**
Toolbar title doesn't update to reflect that we have two items selected.

Long tap to deselect an item does not update the toolbar title and action mode either.

**Expected result after this PR**
Toolbar title updates to indicate that 2 items are selected.

### Screenshots of the actual results at master@[d3c59585fd1d6ad90cd80a9ff8a0f33fa4004f4a]

![Screenshot_1600118573](https://user-images.githubusercontent.com/28482/93145942-9e195900-f6bb-11ea-94a3-9b31be238c9d.png)
![Screenshot_1600118592](https://user-images.githubusercontent.com/28482/93145943-9eb1ef80-f6bb-11ea-9b7e-fca5e6ae121c.png)


