### PR TITLE
Update safety number verification status on scan

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/VerifyIdentityActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/VerifyIdentityActivity.java
@@ -352,9 +352,11 @@ public class VerifyIdentityActivity extends PassphraseRequiredActivity implement
 
       if (animateSuccessOnDraw) {
         animateSuccessOnDraw = false;
+        verified.setChecked(true);
         animateVerifiedSuccess();
       } else if (animateFailureOnDraw) {
         animateFailureOnDraw = false;
+        verified.setChecked(false);
         animateVerifiedFailure();
       }
     }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual Pixel 2, Android 10
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Upon successfully scanning another user's safety numbers, the user sees a checkmark animation which seems to imply the safety numbers have been successfully verified, but they have not. I don't think the current behaviour matches user expectations. This PR sets the verification status of the safety numbers based on the result of the scan. 