### PR TITLE
Fixes a UI glitch found in a dialog when the language is RTL

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -498,4 +498,12 @@
         <item name="android:insetTop">0dp</item>
         <item name="android:insetBottom">0dp</item>
     </style>
+
+    <!-- Override a style defined in a library (mobi.upod:time-duration-picker) to force LTR layout -->
+    <style name="Widget.TimeDurationPicker.Dialog">
+        <item name="durationDisplayBackground">?colorControlActivated</item>
+        <item name="textAppearanceDisplay">@style/TextAppearance.TimeDurationPicker.Display.Large.Dark</item>
+        <item name="textAppearanceUnit">@style/TextAppearance.TimeDurationPicker.Unit.Large.Dark</item>
+        <item name="android:layoutDirection">ltr</item>
+    </style>
 </resources>


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Pixel API 23
 * AVD Pixel 3a API 30
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Overrides a style defined in a library to force the dialog implemented by the library, to fix how it appears in RTL languages. Fixes #9892 .

### Screenshot
See the screenshot of the current (broken) UI in the issue #9892.

After this PR:
![Screenshot_1601672658](https://user-images.githubusercontent.com/28482/94999593-5124f600-0588-11eb-8532-7ad591037f82.png)
