### PR TITLE
Force LTR layout for each audio conversation item

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/WaveFormSeekBarView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/WaveFormSeekBarView.java
@@ -120,10 +120,6 @@ public final class WaveFormSeekBarView extends AppCompatSeekBar {
     canvas.save();
     canvas.translate(getPaddingLeft(), getPaddingTop());
 
-    if (getLayoutDirection() == LAYOUT_DIRECTION_RTL) {
-      canvas.scale(-1, 1, usableWidth / 2f, usableHeight / 2f);
-    }
-
     for (int bar = 0; bar < data.length; bar++) {
       float x        = bar * (barWidth + barGap) + barWidth / 2f;
       float y        = data[bar] * maxHeight;

--- a/app/src/main/res/layout/conversation_activity_attachment_editor_stub.xml
+++ b/app/src/main/res/layout/conversation_activity_attachment_editor_stub.xml
@@ -36,6 +36,7 @@
                 android:id="@+id/attachment_audio"
                 android:layout_width="210dp"
                 android:layout_height="wrap_content"
+                android:layoutDirection="ltr"
                 android:visibility="gone"
                 android:paddingTop="15dp"
                 android:paddingBottom="15dp"

--- a/app/src/main/res/layout/conversation_item_received_audio.xml
+++ b/app/src/main/res/layout/conversation_item_received_audio.xml
@@ -6,6 +6,7 @@
         android:id="@+id/audio_view"
         android:layout_width="@dimen/message_audio_width"
         android:layout_height="wrap_content"
+        android:layoutDirection="ltr"
         android:visibility="gone"
         app:foregroundTintColor="@color/white"
         app:backgroundTintColor="@color/blue_500"

--- a/app/src/main/res/layout/conversation_item_sent_audio.xml
+++ b/app/src/main/res/layout/conversation_item_sent_audio.xml
@@ -5,6 +5,7 @@
         android:id="@+id/audio_view"
         android:layout_width="@dimen/message_audio_width"
         android:layout_height="wrap_content"
+        android:layoutDirection="ltr"
         app:foregroundTintColor="@color/grey_500"
         app:backgroundTintColor="@color/white"
         app:waveformPlayedBarsColor="@color/core_ultramarine_light"


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD API 30
 * Essential PH-1 Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixes #9893 by forcing these views' layout direction to LTR because even if the language is a RTL, these audio controls that displays values related to time should not move from right to left according to UI guidelines [1][2]. See also the discussion in #9893.

This effectively reverts [599e89b1f9d1444ac33436467dc0f38edc40c7c8] that fixed #9823.

 * [1] https://material.io/design/usability/bidirectionality.html
 * [2] https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/RTL_Guidelines

### Screenshots
| Before | After |
| ------------- | ------------- |
| ![beforeRTLaudio](https://user-images.githubusercontent.com/28482/94999733-5fbfdd00-0589-11eb-9c5f-3e9a1236ac82.png) | ![fixedRTLaudio](https://user-images.githubusercontent.com/28482/94999742-6bab9f00-0589-11eb-8f79-f7d321fc20a4.png) |