### PR TITLE
Fixes the shape of message bubbles when the app is set to use RTL languages

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/LinkPreviewView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/LinkPreviewView.java
@@ -28,6 +28,7 @@ import java.text.SimpleDateFormat;
 import java.util.Locale;
 
 import okhttp3.HttpUrl;
+import org.thoughtcrime.securesms.util.ViewUtil;
 
 /**
  * The view shown in the compose box or conversation that represents the state of the link preview.
@@ -181,10 +182,16 @@ public class LinkPreviewView extends FrameLayout {
     }
   }
 
-  public void setCorners(int topLeft, int topRight) {
-    cornerMask.setRadii(topLeft, topRight, 0, 0);
-    outliner.setRadii(topLeft, topRight, 0, 0);
-    thumbnail.setCorners(topLeft, defaultRadius, defaultRadius, defaultRadius);
+  public void setCorners(int topStart, int topEnd) {
+    if (ViewUtil.isRtl(this)) {
+      cornerMask.setRadii(topEnd, topStart, 0, 0);
+      outliner.setRadii(topEnd, topStart, 0, 0);
+      thumbnail.setCorners(defaultRadius, topEnd, defaultRadius, defaultRadius);
+    } else {
+      cornerMask.setRadii(topStart, topEnd, 0, 0);
+      outliner.setRadii(topStart, topEnd, 0, 0);
+      thumbnail.setCorners(topStart, defaultRadius, defaultRadius, defaultRadius);
+    }
     postInvalidate();
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
@@ -889,59 +889,63 @@ public final class ConversationItem extends RelativeLayout implements BindableCo
     int defaultRadius  = readDimen(R.dimen.message_corner_radius);
     int collapseRadius = readDimen(R.dimen.message_corner_collapse_radius);
 
-    int topLeft     = defaultRadius;
-    int topRight    = defaultRadius;
-    int bottomLeft  = defaultRadius;
-    int bottomRight = defaultRadius;
+    int topStart    = defaultRadius;
+    int topEnd      = defaultRadius;
+    int bottomStart = defaultRadius;
+    int bottomEnd   = defaultRadius;
 
     if (isSingularMessage(current, previous, next, isGroupThread)) {
-      topLeft     = defaultRadius;
-      topRight    = defaultRadius;
-      bottomLeft  = defaultRadius;
-      bottomRight = defaultRadius;
+      topStart    = defaultRadius;
+      topEnd      = defaultRadius;
+      bottomStart = defaultRadius;
+      bottomEnd   = defaultRadius;
     } else if (isStartOfMessageCluster(current, previous, isGroupThread)) {
       if (current.isOutgoing()) {
-        bottomRight = collapseRadius;
+        bottomEnd = collapseRadius;
       } else {
-        bottomLeft = collapseRadius;
+        bottomStart = collapseRadius;
       }
     } else if (isEndOfMessageCluster(current, next, isGroupThread)) {
       if (current.isOutgoing()) {
-        topRight = collapseRadius;
+        topEnd = collapseRadius;
       } else {
-        topLeft = collapseRadius;
+        topStart = collapseRadius;
       }
     } else {
       if (current.isOutgoing()) {
-        topRight    = collapseRadius;
-        bottomRight = collapseRadius;
+        topEnd    = collapseRadius;
+        bottomEnd = collapseRadius;
       } else {
-        topLeft    = collapseRadius;
-        bottomLeft = collapseRadius;
+        topStart    = collapseRadius;
+        bottomStart = collapseRadius;
       }
     }
 
     if (!TextUtils.isEmpty(current.getDisplayBody(getContext()))) {
-      bottomLeft  = 0;
-      bottomRight = 0;
+      bottomStart = 0;
+      bottomEnd   = 0;
     }
 
     if (isStartOfMessageCluster(current, previous, isGroupThread) && !current.isOutgoing() && isGroupThread) {
-      topLeft  = 0;
-      topRight = 0;
+      topStart = 0;
+      topEnd   = 0;
     }
 
     if (hasQuote(messageRecord)) {
-      topLeft  = 0;
-      topRight = 0;
+      topStart = 0;
+      topEnd   = 0;
     }
 
     if (hasLinkPreview(messageRecord) || hasExtraText(messageRecord)) {
-      bottomLeft  = 0;
-      bottomRight = 0;
+      bottomStart = 0;
+      bottomEnd   = 0;
     }
 
-    mediaThumbnailStub.get().setCorners(topLeft, topRight, bottomRight, bottomLeft);
+    if (ViewUtil.isRtl(this)) {
+      mediaThumbnailStub.get().setCorners(topEnd, topStart, bottomStart, bottomEnd);
+    } else {
+      mediaThumbnailStub.get().setCorners(topStart, topEnd, bottomEnd, bottomStart);
+    }
   }
 
   private void setSharedContactCorners(@NonNull MessageRecord current, @NonNull Optional<MessageRecord> previous, @NonNull Optional<MessageRecord> next, boolean isGroupThread) {
@@ -1229,6 +1233,14 @@ public final class ConversationItem extends RelativeLayout implements BindableCo
     }
   }
 
+  private void setOutlinerRadii(Outliner outliner, int topStart, int topEnd, int bottomEnd, int bottomStart) {
+    if (ViewUtil.isRtl(this)) {
+      outliner.setRadii(topEnd, topStart, bottomStart, bottomEnd);
+    } else {
+      outliner.setRadii(topStart, topEnd, bottomEnd, bottomStart);
+    }
+  }
+
   private void setMessageShape(@NonNull MessageRecord current, @NonNull Optional<MessageRecord> previous, @NonNull Optional<MessageRecord> next, boolean isGroupThread) {
     int bigRadius   = readDimen(R.dimen.message_corner_radius);
     int smallRadius = readDimen(R.dimen.message_corner_collapse_radius);
@@ -1248,32 +1260,32 @@ public final class ConversationItem extends RelativeLayout implements BindableCo
     } else if (isStartOfMessageCluster(current, previous, isGroupThread)) {
       if (current.isOutgoing()) {
         background = R.drawable.message_bubble_background_sent_start;
-        outliner.setRadii(bigRadius, bigRadius, smallRadius, bigRadius);
-        pulseOutliner.setRadii(bigRadius, bigRadius, smallRadius, bigRadius);
+        setOutlinerRadii(outliner, bigRadius, bigRadius, smallRadius, bigRadius);
+        setOutlinerRadii(pulseOutliner, bigRadius, bigRadius, smallRadius, bigRadius);
       } else {
         background = R.drawable.message_bubble_background_received_start;
-        outliner.setRadii(bigRadius, bigRadius, bigRadius, smallRadius);
-        pulseOutliner.setRadii(bigRadius, bigRadius, bigRadius, smallRadius);
+        setOutlinerRadii(outliner, bigRadius, bigRadius, bigRadius, smallRadius);
+        setOutlinerRadii(pulseOutliner, bigRadius, bigRadius, bigRadius, smallRadius);
       }
     } else if (isEndOfMessageCluster(current, next, isGroupThread)) {
       if (current.isOutgoing()) {
         background = R.drawable.message_bubble_background_sent_end;
-        outliner.setRadii(bigRadius, smallRadius, bigRadius, bigRadius);
-        pulseOutliner.setRadii(bigRadius, smallRadius, bigRadius, bigRadius);
+        setOutlinerRadii(outliner, bigRadius, smallRadius, bigRadius, bigRadius);
+        setOutlinerRadii(pulseOutliner, bigRadius, smallRadius, bigRadius, bigRadius);
       } else {
         background = R.drawable.message_bubble_background_received_end;
-        outliner.setRadii(smallRadius, bigRadius, bigRadius, bigRadius);
-        pulseOutliner.setRadii(smallRadius, bigRadius, bigRadius, bigRadius);
+        setOutlinerRadii(outliner, smallRadius, bigRadius, bigRadius, bigRadius);
+        setOutlinerRadii(pulseOutliner, smallRadius, bigRadius, bigRadius, bigRadius);
       }
     } else {
       if (current.isOutgoing()) {
         background = R.drawable.message_bubble_background_sent_middle;
-        outliner.setRadii(bigRadius, smallRadius, smallRadius, bigRadius);
-        pulseOutliner.setRadii(bigRadius, smallRadius, smallRadius, bigRadius);
+        setOutlinerRadii(outliner, bigRadius, smallRadius, smallRadius, bigRadius);
+        setOutlinerRadii(pulseOutliner, bigRadius, smallRadius, smallRadius, bigRadius);
       } else {
         background = R.drawable.message_bubble_background_received_middle;
-        outliner.setRadii(smallRadius, bigRadius, bigRadius, smallRadius);
-        pulseOutliner.setRadii(smallRadius, bigRadius, bigRadius, smallRadius);
+        setOutlinerRadii(outliner, smallRadius, bigRadius, bigRadius, smallRadius);
+        setOutlinerRadii(pulseOutliner, smallRadius, bigRadius, bigRadius, smallRadius);
       }
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/util/CachedInflater.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/CachedInflater.java
@@ -92,6 +92,7 @@ public class CachedInflater {
     private long  lastClearTime;
     private int   nightModeConfiguration;
     private float fontScale;
+    private int   layoutDirection;
 
     static ViewCache getInstance() {
       return INSTANCE;
@@ -102,11 +103,16 @@ public class CachedInflater {
       Configuration configuration                 = context.getResources().getConfiguration();
       int           currentNightModeConfiguration = ConfigurationUtil.getNightModeConfiguration(configuration);
       float         currentFontScale              = ConfigurationUtil.getFontScale(configuration);
+      int           currentLayoutDirection        = configuration.getLayoutDirection();
 
-      if (nightModeConfiguration != currentNightModeConfiguration || fontScale != currentFontScale) {
+      if (nightModeConfiguration != currentNightModeConfiguration ||
+          fontScale              != currentFontScale              ||
+          layoutDirection        != currentLayoutDirection)
+      {
         clear();
         nightModeConfiguration = currentNightModeConfiguration;
         fontScale              = currentFontScale;
+        layoutDirection        = currentLayoutDirection;
       }
 
       AsyncLayoutInflater inflater = new AsyncLayoutInflater(context);
@@ -146,7 +152,10 @@ public class CachedInflater {
 
     @MainThread
     @Nullable View pull(@LayoutRes int layoutRes, @NonNull Configuration configuration) {
-      if (this.nightModeConfiguration != ConfigurationUtil.getNightModeConfiguration(configuration) || this.fontScale != ConfigurationUtil.getFontScale(configuration)) {
+      if (this.nightModeConfiguration != ConfigurationUtil.getNightModeConfiguration(configuration) ||
+          this.fontScale              != ConfigurationUtil.getFontScale(configuration)              ||
+          this.layoutDirection        != configuration.getLayoutDirection())
+      {
         clear();
         return null;
       }

--- a/app/src/main/res/drawable-ldrtl/message_bubble_background_received_end.xml
+++ b/app/src/main/res/drawable-ldrtl/message_bubble_background_received_end.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:bottom="2px"
+        android:top="2px">
+        <shape android:shape="rectangle">
+            <corners
+                android:bottomLeftRadius="@dimen/message_corner_radius"
+                android:bottomRightRadius="@dimen/message_corner_radius"
+                android:topLeftRadius="@dimen/message_corner_radius"
+                android:topRightRadius="@dimen/message_corner_collapse_radius" />
+            <solid android:color="@color/white" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable-ldrtl/message_bubble_background_received_middle.xml
+++ b/app/src/main/res/drawable-ldrtl/message_bubble_background_received_middle.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:bottom="2px"
+        android:top="2px">
+
+        <shape android:shape="rectangle">
+            <corners
+                android:bottomLeftRadius="@dimen/message_corner_radius"
+                android:bottomRightRadius="@dimen/message_corner_collapse_radius"
+                android:topLeftRadius="@dimen/message_corner_radius"
+                android:topRightRadius="@dimen/message_corner_collapse_radius" />
+            <solid android:color="@color/white" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable-ldrtl/message_bubble_background_received_start.xml
+++ b/app/src/main/res/drawable-ldrtl/message_bubble_background_received_start.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:bottom="2px"
+        android:top="2px">
+        <shape android:shape="rectangle">
+            <corners
+              android:bottomLeftRadius="@dimen/message_corner_radius"
+                android:bottomRightRadius="@dimen/message_corner_collapse_radius"
+                android:topLeftRadius="@dimen/message_corner_radius"
+                android:topRightRadius="@dimen/message_corner_radius" />
+            <solid android:color="@color/white" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable-ldrtl/message_bubble_background_sent_end.xml
+++ b/app/src/main/res/drawable-ldrtl/message_bubble_background_sent_end.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:top="2px"
+        android:bottom="2px">
+
+        <shape android:shape="rectangle">
+            <corners
+                android:topLeftRadius="@dimen/message_corner_collapse_radius"
+                android:topRightRadius="@dimen/message_corner_radius"
+                android:bottomRightRadius="@dimen/message_corner_radius"
+                android:bottomLeftRadius="@dimen/message_corner_radius" />
+            <solid android:color="@color/white" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable-ldrtl/message_bubble_background_sent_middle.xml
+++ b/app/src/main/res/drawable-ldrtl/message_bubble_background_sent_middle.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:top="2px"
+        android:bottom="2px">
+
+        <shape android:shape="rectangle">
+            <corners
+                android:topLeftRadius="@dimen/message_corner_collapse_radius"
+                android:topRightRadius="@dimen/message_corner_radius"
+                android:bottomLeftRadius="@dimen/message_corner_collapse_radius"
+                android:bottomRightRadius="@dimen/message_corner_radius" />
+            <solid android:color="@color/white" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable-ldrtl/message_bubble_background_sent_start.xml
+++ b/app/src/main/res/drawable-ldrtl/message_bubble_background_sent_start.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:top="2px"
+        android:bottom="2px">
+
+        <shape android:shape="rectangle">
+            <corners
+                android:topLeftRadius="@dimen/message_corner_radius"
+                android:topRightRadius="@dimen/message_corner_radius"
+                android:bottomLeftRadius="@dimen/message_corner_collapse_radius"
+                android:bottomRightRadius="@dimen/message_corner_radius" />
+            <solid android:color="@color/white" />
+        </shape>
+    </item>
+</layer-list>


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Nexus 5x API 21
 * AVD Pixel API 23
 * AVD Pixel 2 API 28
 * AVD Pixel 3a API 29
 * AVD Pixel 3a API 30
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Message bubbles change their border radius depending on how they are placed in a cluster. The border radiuses are set for each corner i.e. topLeft, topRight, bottomRight and bottomLeft. In RTL languages, topLeft is the "end" of the item while topRight is the "start" of the item as opposed to in LTR languages, yet the code didn't take it into account. This PR adds a few lines to take RTL/LTR into account to determine which value to set to which corner.

**Note to dev**
Please note that this fix was also in [the other RTL related PR](https://github.com/signalapp/Signal-Android/pull/11012) because it was also required there. I cherry picked the commit in order for this PR to be self contained. It should not conflict in merging but let me know if it does. I will resolve the conflict right away.

### Screenshots
| LTR | RTL before the fix | RTL after the fix |
| --- | --- | --- |
| ![bubbleRoundedBorderLTR](https://user-images.githubusercontent.com/28482/94999992-2e481100-058b-11eb-95aa-8492bde40c8e.png) | ![bubbleRoundedBorderRTL](https://user-images.githubusercontent.com/28482/94999996-32742e80-058b-11eb-99eb-31de549bca13.png) | ![fixedRTL](https://user-images.githubusercontent.com/28482/95000002-36a04c00-058b-11eb-89c6-ac409fff8388.png) |


