### PR TITLE
Fix crash in phone registration phase

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/EnterPhoneNumberFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/EnterPhoneNumberFragment.java
@@ -404,7 +404,7 @@ public final class EnterPhoneNumberFragment extends BaseRegistrationFragment {
       s.replace(0, s.length(), formattedNumber);
     }
 
-    if (justDigits.length() == 0) {
+    if (justDigits.length() >= 20 || justDigits.length() == 0) {
       return null;
     }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Emulate Pixel 3, Android 10
 * Emulate Pixel 3 XL, Android 10
 * Emulate Pixel 3a XL, Android 10
 * Pixel 3a XL, Android 11
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
When user enters a number during the setup of Signal with a length greater or equal to 20, the app crash.
Based on the longest possible phone number in the world (15) I made a condition to 20 but you can adapt it.
