### PR TITLE
Added option to delete only the media from a message but keeping the …

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/MmsDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/MmsDatabase.java
@@ -1497,6 +1497,14 @@ public class MmsDatabase extends MessageDatabase {
     return threadDeleted;
   }
 
+  public boolean deleteAttachmentsOnly(long messageId) {
+    long               threadId           = getThreadIdForMessage(messageId);
+    AttachmentDatabase attachmentDatabase = DatabaseFactory.getAttachmentDatabase(context);
+    attachmentDatabase.deleteAttachmentsForMessage(messageId);
+    notifyConversationListeners(threadId);
+    return true;
+  }
+
   @Override
   public void deleteThread(long threadId) {
     Set<Long> singleThreadSet = new HashSet<>();

--- a/app/src/main/java/org/thoughtcrime/securesms/util/AttachmentUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/AttachmentUtil.java
@@ -12,6 +12,7 @@ import android.text.TextUtils;
 import org.thoughtcrime.securesms.attachments.AttachmentId;
 import org.thoughtcrime.securesms.attachments.DatabaseAttachment;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
+import org.thoughtcrime.securesms.database.MmsDatabase;
 import org.thoughtcrime.securesms.database.NoSuchMessageException;
 import org.thoughtcrime.securesms.database.model.MessageRecord;
 import org.thoughtcrime.securesms.logging.Log;
@@ -66,7 +67,12 @@ public class AttachmentUtil {
         .size();
 
     if (attachmentCount <= 1) {
-      DatabaseFactory.getMmsDatabase(context).deleteMessage(mmsId);
+      if (!TextSecurePreferences.isDeleteMediaOnly(context)) {
+        DatabaseFactory.getMmsDatabase(context).deleteMessage(mmsId);
+      }  else {
+        MmsDatabase mmsdb = (MmsDatabase)DatabaseFactory.getMmsDatabase(context);
+        mmsdb.deleteAttachmentsOnly(mmsId);
+      }
     } else {
       DatabaseFactory.getAttachmentDatabase(context).deleteAttachment(attachmentId);
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -209,6 +209,16 @@ public class TextSecurePreferences {
 
   private static final String ARGON2_TESTED = "argon2_tested";
 
+  public static final String DELETE_MEDIA_ONLY = "pref_delete_media_only";
+
+  public static boolean isDeleteMediaOnly(@NonNull Context context) {
+    return getBooleanPreference(context, DELETE_MEDIA_ONLY, false);
+  }
+
+   public static void setDeleteMediaOnly(@NonNull Context context, boolean value) {
+    setBooleanPreference(context, DELETE_MEDIA_ONLY, value);
+  } 
+
   public static boolean isScreenLockEnabled(@NonNull Context context) {
     return getBooleanPreference(context, SCREEN_LOCK, false);
   }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2593,6 +2593,9 @@
     <string name="preferences_chats__create_backup">Create backup</string>
     <string name="preferences_chats__verify_backup_passphrase">Verify backup passphrase</string>
     <string name="preferences_chats__test_your_backup_passphrase_and_verify_that_it_matches">Test your backup passphrase and verify that it matches</string>
+    <string name="preferences_chats__control_message_deletion">Control message deletion</string>
+    <string name="preferences_chats__delete_media_only">Delete media only</string>
+    <string name="preferences_chats__delete_media_only_summary">Delete only media, not the message itself, when media is deleted in the All media screen</string>
     <string name="RegistrationActivity_enter_backup_passphrase">Enter backup passphrase</string>
     <string name="RegistrationActivity_restore">Restore</string>
     <string name="RegistrationActivity_backup_failure_downgrade">Cannot import backups from newer versions of Signal</string>

--- a/app/src/main/res/xml/preferences_chats.xml
+++ b/app/src/main/res/xml/preferences_chats.xml
@@ -69,4 +69,14 @@
                 android:title="@string/preferences_chats__chat_backups" />
     </PreferenceCategory>
 
+    <PreferenceCategory android:layout="@layout/preference_divider"/>
+
+    <PreferenceCategory android:title="@string/preferences_chats__control_message_deletion">
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="pref_delete_media_only"
+            android:title="@string/preferences_chats__delete_media_only"
+            android:summary="@string/preferences_chats__delete_media_only_summary" />
+    </PreferenceCategory>
+
 </PreferenceScreen>


### PR DESCRIPTION
…message itself.

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Z3 Compact, Android 6.0.1
 * Sony M4 Aqua, Android 5.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
One issue I have with Signal is that when you clean up room when deleting large media files or link previews, it also deletes the
associated message which you might want to keep. This option makes Signal only delete the media, not the message text.

When the option is switched on:

![Screenshot_20201018-210316](https://user-images.githubusercontent.com/8427572/96377658-49b83c00-1187-11eb-9b82-547c377639e1.png)

and you have these media messages:

![Screenshot_20201018-210504](https://user-images.githubusercontent.com/8427572/96377687-766c5380-1187-11eb-8a52-bc6c9f170c80.JPG)

after deletion of the media from the All media screen ypu get this:

![Screenshot_20201018-210623](https://user-images.githubusercontent.com/8427572/96377700-90a63180-1187-11eb-8c27-cca1631d0137.JPG)

If one message contains of only an image you are left with an empty message, I decided to keep that. The message can still be manually deleted completely.