### PR TITLE
Skip reading intent data when the app is loaded from the list of recent apps

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationActivity.java
@@ -1420,6 +1420,14 @@ public class ConversationActivity extends PassphraseRequiredActivity
   ///// Initializers
 
   private ListenableFuture<Boolean> initializeDraft() {
+    // Do not read the intent and just fall back to database when the activity was launched
+    // from the list of recent apps. The intent does not clear itself even after
+    // we have sent a message, so that the data from the intent appears over and over again
+    // when the activity was opened from the list of recent apps.
+    if ((getIntent().getFlags() & Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0) {
+      return initializeDraftFromDatabase();
+    }
+
     final SettableFuture<Boolean> result = new SettableFuture<>();
 
     final CharSequence   draftText        = getIntent().getCharSequenceExtra(TEXT_EXTRA);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Essential PH-1, Android 10
 * AVD Android 11 (API 30)
 * AVD Android 10 (API 29)
 * AVD Android 9 (API 28)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Ignore the data from the intent when the activity was launched from the list of recent apps to avoid making a draft message of the same shared content over and over even after a message was sent. Fixes #8947
