### PR TITLE
Fix to small AudioView appearance in the storage activity

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/AudioView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/AudioView.java
@@ -371,10 +371,11 @@ public final class AudioView extends FrameLayout {
   }
 
   private void showPlayButton() {
-    if (!smallView || seekBar.getProgress() == 0) {
+    if (!smallView) {
+      circleProgress.setVisibility(GONE);
+    } else if (seekBar.getProgress() == 0) {
       circleProgress.setInstantProgress(1);
     }
-    circleProgress.setVisibility(GONE);
     playPauseButton.setVisibility(VISIBLE);
     controlToggle.displayQuick(progressAndPlay);
   }

--- a/app/src/main/res/layout/media_overview_detail_item_audio.xml
+++ b/app/src/main/res/layout/media_overview_detail_item_audio.xml
@@ -18,6 +18,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:autoRewind="true"
+            app:progressAndPlayTint="@android:color/transparent"
             app:foregroundTintColor="@color/core_ultramarine"
             app:small="true" />
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Pixel 3a, Android 30
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

The issue was first reported in [the community forum for beta 4.75](https://community.signalusers.org/t/beta-feedback-for-the-upcoming-android-4-75-release/17727/69). I think it was not a design decision to remove the progress circle and the black background, but rather an oversight.

This PR updates only the appearances of the audio views in the storage activity. It does not change how it appears in the conversation activities.

### Screenshots
|uiMode|Before|After|
|---|---|---|
|Light|![Screenshot_1605200167](https://user-images.githubusercontent.com/28482/98990645-ba3d4900-24f8-11eb-857e-04594d3bcac2.png)|![Screenshot_1605199520](https://user-images.githubusercontent.com/28482/98990664-c0cbc080-24f8-11eb-8591-de5e6ec99cae.png)|
|Dark|![Screenshot_1605200431](https://user-images.githubusercontent.com/28482/98990760-e48f0680-24f8-11eb-8440-a1a9c9069759.png)|![Screenshot_1605199583](https://user-images.githubusercontent.com/28482/98990778-e953ba80-24f8-11eb-9c89-beec3be04235.png)|



