### PR TITLE
Fix #10193 backup passphrase dont work in persian language

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/BackupUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/BackupUtil.java
@@ -206,7 +206,7 @@ public class BackupUtil {
     new SecureRandom().nextBytes(random);
 
     for (int i=0;i<30;i+=5) {
-      result[i/5] = String.format("%05d", ByteUtil.byteArray5ToLong(random, i) % 100000);
+      result[i/5] = String.format(Locale.ENGLISH,  "%05d", ByteUtil.byteArray5ToLong(random, i) % 100000);
     }
 
     return result;


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:

 * Virtual device Pixel 2, Android 11.0

- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fix #10193 the not working backup passphrase in persian language.
https://community.signalusers.org/t/backup-passphrase-misrendered-in-rtl/17055/4

While generating the backup passphrase (as string) the formatting of this string is forced to locale.english.
This prevents the formatting of passphrase to a string of persian numbers.

![Screenshot_1605284035](https://user-images.githubusercontent.com/49990901/99109088-91947c80-25e8-11eb-8d3e-947ce13073e6.png)
![Screenshot_1605284123](https://user-images.githubusercontent.com/49990901/99109099-95280380-25e8-11eb-897d-61bede063128.png)

Annotation:
The input order is:
90326 04652 80506 12613 27540 09126

The formatting issue of the backup passphrase in 6 blocks is issue #10195