### PR TITLE
Fixes #10188 - Accessibility Text Size Not Respected with Message Replies

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/QuoteView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/QuoteView.java
@@ -274,6 +274,11 @@ public class QuoteView extends FrameLayout implements RecipientForeverObserver {
     footerView.setBackgroundColor(author.get().getColor().toQuoteFooterColor(getContext(), messageType != MESSAGE_TYPE_INCOMING));
   }
 
+
+  public void setTextSize(int unit, float size) {
+    bodyView.setTextSize(unit, size);
+  }
+
   public long getQuoteId() {
     return id;
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
@@ -1003,6 +1003,7 @@ public final class ConversationItem extends RelativeLayout implements BindableCo
       //noinspection ConstantConditions
       quoteView.setQuote(glideRequests, quote.getId(), Recipient.live(quote.getAuthor()).get(), quote.getDisplayText(), quote.isOriginalMissing(), quote.getAttachment());
       quoteView.setVisibility(View.VISIBLE);
+      quoteView.setTextSize(TypedValue.COMPLEX_UNIT_SP, TextSecurePreferences.getMessageBodyTextSize(context));
       quoteView.getLayoutParams().width = ViewGroup.LayoutParams.WRAP_CONTENT;
 
       quoteView.setOnClickListener(view -> {


### PR DESCRIPTION
Fix inconsistent text scaling between quotes and conversation item text by
applying the configured text size to the quote text

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x ] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ x] I have tested my contribution on these devices:
 * Fairphone 3, Android 10
- [ x] My contribution is fully baked and ready to be merged as is
- [ x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Setting the in-app preference for text size with preference key "MESSAGE_BODY_TEXT_SIZE_PREF" will modify the text message size, but not the quote text for a reply.

This is because in ConversationItem#setBodyText the text size will be set respecting the setting.
In ConversationItem#setQuote the text size setting is ignored.


To have UI components behave in a consistent way, the QuoteItem has a new "setTextSize" method.
This is the same as the EmojiTextView#setTextSize(int, float) that is used in 
* ConversationItem bodyText
* QuoteItem to display the text

Now that both UI components have a consistent way to set the used text size in respect to the user setting, ConversationItem#setQuote can now also set the users preferred text size.

This will display quote and message text in a consistent text size and fix the issue.

# Before the fix
![image](https://user-images.githubusercontent.com/645185/99157775-4784c700-26cc-11eb-91aa-d8e6dafb11bb.png)

# After the fix
![image](https://user-images.githubusercontent.com/645185/99157732-ed840180-26cb-11eb-9ed6-a4f1615b2260.png)
![image](https://user-images.githubusercontent.com/645185/99157739-02609500-26cc-11eb-9f3e-139a6c011795.png)
