### PR TITLE
Complete update of reproducible build instructions

### DIFF
--- a/reproducible-builds/README.md
+++ b/reproducible-builds/README.md
@@ -195,7 +195,7 @@ cd ~/reproducible-signal/signal-source
 To build with the docker image you just built (`signal-android`), run:
 
 ```
-docker run --rm -v $(pwd):/project -w /project signal-android ./gradlew clean assemblePlayRelease
+docker run --rm -v $(pwd):/project -w /project signal-android ./gradlew clean assemblePlayProdRelease
 ```
 
 This will take a few minutes :sleeping:
@@ -221,7 +221,7 @@ And run the diff script to compare (updating the filenames for your specific ver
 
 ```bash
 python3 reproducible-builds/apkdiff/apkdiff.py \
-        build/outputs/apk/play/release/*play-$abi-release-unsigned*.apk \
+        app/build/outputs/apk/playProd/release/*play-prod-$abi-release-unsigned*.apk \
         ../apk-from-google-play-store/Signal-5.0.0.apk
 ```
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Docker Desktop (Windows), Docker Engine v19.03.13; WSL2 (Ubuntu 18.02 LTS)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

An earlier commit https://github.com/signalapp/Signal-Android/commit/a70e8ec7a70e4756c7760b61c20f586ed2e80eec updated the "TL;DR" instructions, but probably forgot to update the rest of the `reproducible-builds/README.md` document. This pull request updates the rest of the `reproducible-builds/README.md` document.

Below is how I tested the updated instructions, with `echo` statements corresponding to the README.md sections:
```bash
echo 'Setting up directories'
install -d ~/reproducible-signal/apk-from-google-play-store

echo 'Getting the Google Play Store version of Signal APK'
echo '... NOTE: Downloading apk using Win32 ADB.EXE within WSL2. Use "adb" instead of "ADB.EXE" if you are on Linux'
cd ~/reproducible-signal/apk-from-google-play-store
APKPATH=$(adb.exe shell pm path org.thoughtcrime.securesms | grep /base.apk | awk -F':' '{print $2}' | tr -cd '\40-\176')
APKVER=$(adb.exe shell dumpsys package org.thoughtcrime.securesms | grep versionName | awk -F'=' '{print $2}' | tr -cd '\40-\176')
(set -x && adb.exe pull $APKPATH Signal-$APKVER.apk)
# + adb.exe pull /data/app/~~0000000000000000000000==/org.thoughtcrime.securesms-0000000000000000000000==/base.apk Signal-4.78.3.apk
# /data/app/~~0000000000000000000000==/org.thoughtcrime.securesms-0000000000000000000000==/base.apk: 1 file pulled, 0 skipped. 31.6 MB/s (44061374 bytes in 1.328s)
echo $APKVER
# 4.78.3

echo 'Identifying the ABI'
export abi=$(unzip -l ~/reproducible-signal/apk-from-google-play-store/Signal-$APKVER.apk | grep lib/ | awk '{print $NF}' | awk 'BEGIN{FS="/"} {print $2; exit 0}')
echo $abi
# arm64-v8a

echo 'Building a Docker image for Signal'
cd ~/reproducible-signal
git clone https://github.com/signalapp/Signal-Android.git signal-source
cd ~/reproducible-signal/signal-source
git checkout --quiet v$APKVER
git clean -d -x -f
cd ~/reproducible-signal/signal-source/reproducible-builds
docker build -t signal-android .
#  => => writing image sha256:4335f74fd1a5cda4b760aa608c274b0c7f8eaa9b65f05823b77fb6ee72f20e70                                                                              0.0s
#  => => naming to docker.io/library/signal-android                                                                                                                         0.0s

echo 'Compiling Signal inside a container'
echo '... NEEDSFIX: The Gradle targets have been changed'
cd ~/reproducible-signal/signal-source
echo DOESNOTWORK: docker run --rm -v $(pwd):/project -w /project signal-android ./gradlew clean assemblePlayRelease
docker run --rm -v $(pwd):/project -w /project signal-android ./gradlew clean assemblePlayProdRelease
# BUILD SUCCESSFUL in 4m 25s
# 46 actionable tasks: 43 executed, 3 up-to-date

echo 'Checking if the APKs match'
echo '... NEEDSFIX: The reproducible builds instructions have typos'
cd ~/reproducible-signal/signal-source
echo DOESNOTWORK: python3 reproducible-builds/apkdiff/apkdiff.py \
        build/outputs/apk/play/release/*play-$abi-release-unsigned*.apk \
        ../apk-from-google-play-store/Signal-5.0.0.apk
python3 reproducible-builds/apkdiff/apkdiff.py \
        app/build/outputs/apk/playProd/release/*play-prod-$abi-release-unsigned*.apk \
        ../apk-from-google-play-store/Signal-$APKVER.apk
# APKs match!
```
