### PR TITLE
Fix crash when enter long phone number on registration.

### DIFF
--- a/app/src/main/res/layout/phone_text.xml
+++ b/app/src/main/res/layout/phone_text.xml
@@ -12,6 +12,7 @@
     android:background="@color/transparent"
     android:singleLine="true"
     android:inputType="phone"
+    android:maxLength="18"
     android:saveEnabled="false"
     android:hint="@string/RegistrationActivity_phone_number_description"
     tools:text="867-5309" />


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Google Pixel 3 XL, Android 11
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fix crash when enter a long phone number on registration, which the value is greater than Long.MAX_VALUE (9223372036854775807, length=19) that causes the parsing to fail. 