### PR TITLE
Fix #10195 formatting issue of the backup passphrase in RTL languages

### DIFF
--- a/app/src/main/res/layout/backup_enable_dialog.xml
+++ b/app/src/main/res/layout/backup_enable_dialog.xml
@@ -22,6 +22,7 @@
                  android:focusable="true">
 
         <TableRow android:gravity="center_horizontal"
+                  android:layoutDirection="ltr"
                   android:clickable="false"
                   android:focusable="false">
 
@@ -46,7 +47,9 @@
                       tools:text="42738" />
         </TableRow>
 
-        <TableRow android:gravity="center_horizontal">
+        <TableRow android:gravity="center_horizontal"
+                  android:layoutDirection="ltr">
+
             <TextView android:id="@+id/code_fourth"
                       android:layout_width="wrap_content"
                       android:layout_height="wrap_content"

--- a/app/src/main/res/layout/backup_enable_dialog_v29.xml
+++ b/app/src/main/res/layout/backup_enable_dialog_v29.xml
@@ -49,6 +49,7 @@
         <TableRow
             android:clickable="false"
             android:focusable="false"
+            android:layoutDirection="ltr"
             android:gravity="center_horizontal">
 
             <TextView
@@ -75,7 +76,8 @@
                 tools:text="42738" />
         </TableRow>
 
-        <TableRow android:gravity="center_horizontal">
+        <TableRow android:gravity="center_horizontal"
+                  android:layoutDirection="ltr">
 
             <TextView
                 android:id="@+id/code_fourth"

--- a/app/src/main/res/layout/enter_backup_passphrase_dialog.xml
+++ b/app/src/main/res/layout/enter_backup_passphrase_dialog.xml
@@ -12,6 +12,7 @@
             android:id="@+id/restore_passphrase_input"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layoutDirection="ltr"
             android:fontFamily="monospace"
             android:hint="@string/enter_backup_passphrase_dialog__backup_passphrase"
             android:imeOptions="actionDone"


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:

 * Virtual device Pixel 2, Android 11.0

- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Fix #10195
Forces the representation of the backup passphrase and the input for restore/verify to LTR.

![Screenshot_1606924363](https://user-images.githubusercontent.com/49990901/100898298-e6793380-34c0-11eb-9f16-04228a2e0140.png) ![Screenshot_1606924411](https://user-images.githubusercontent.com/49990901/100898302-e8db8d80-34c0-11eb-8c1c-bbac46be4970.png)

