### PR TITLE
Implemented hide status bar when call begins

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/WebRtcCallActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/WebRtcCallActivity.java
@@ -82,6 +82,7 @@ public class WebRtcCallActivity extends AppCompatActivity implements SafetyNumbe
     Log.i(TAG, "onCreate()");
     getWindow().addFlags(WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED);
     getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+    getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
     super.onCreate(savedInstanceState);
 
     requestWindowFeature(Window.FEATURE_NO_TITLE);


### PR DESCRIPTION
Solution for https://community.signalusers.org/t/hide-android-status-bar-in-video-call/18185