### PR TITLE
Fix #10204 "recent chats" in "share with" has no phone number pretty …

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/contacts/ContactsCursorLoader.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/contacts/ContactsCursorLoader.java
@@ -37,6 +37,7 @@ import org.thoughtcrime.securesms.database.model.ThreadRecord;
 import org.thoughtcrime.securesms.logging.Log;
 import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.phonenumbers.NumberUtil;
+import org.thoughtcrime.securesms.phonenumbers.PhoneNumberFormatter;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.RecipientId;
 import org.thoughtcrime.securesms.util.FeatureFlags;
@@ -273,7 +274,7 @@ public class ContactsCursorLoader extends CursorLoader {
       ThreadRecord threadRecord;
       while ((threadRecord = reader.getNext()) != null) {
         Recipient recipient = threadRecord.getRecipient();
-        String    stringId  = recipient.isGroup() ? recipient.requireGroupId().toString() : recipient.getE164().or(recipient.getEmail()).or("");
+        String    stringId  = recipient.isGroup() ? recipient.requireGroupId().toString() : recipient.getE164().transform(PhoneNumberFormatter::prettyPrint).or(recipient.getEmail()).or("");
 
         recentConversations.addRow(new Object[] { recipient.getId().serialize(),
                                                   recipient.getDisplayName(getContext()),


### PR DESCRIPTION
…printing

<!-- You can remove this first section if you have contributed before -->

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual device Pixel 2, Android 11.0
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------


### Description

Fix #10204
Adds phone number pretty printing to the recent chat contacts

![Screenshot_1606931587](https://user-images.githubusercontent.com/49990901/100912122-60fd7f80-34d0-11eb-9a84-1ad81f8ed202.png)

