### PR TITLE
Fix prettyPrint/prettyPrintFormat for e164 == null

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/phonenumbers/PhoneNumberFormatter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/phonenumbers/PhoneNumberFormatter.java
@@ -87,11 +87,14 @@ public class PhoneNumberFormatter {
     this.localCountryCode = localCountryCode;
   }
 
-  public static @NonNull String prettyPrint(@NonNull String e164) {
+  public static String prettyPrint(String e164) {
     return get(ApplicationDependencies.getApplication()).prettyPrintFormat(e164);
   }
 
-  public @NonNull String prettyPrintFormat(@NonNull String e164) {
+  public String prettyPrintFormat(String e164) {
+    if (e164 == null) {
+      return e164;
+    }
     try {
       Phonenumber.PhoneNumber parsedNumber = phoneNumberUtil.parse(e164, localCountryCode);
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:

 * Virtual device Pixel 2, Android 11.0
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Prevent to try to pretty print format of phone numbers when e164 == null.

According to the @NonNull-annotation, both functions (PrettyPrint, PrettyPrintFormat) should receive non-null values, which is not the case for groups.

As an example a comment from the 4.76 beta thread:
https://community.signalusers.org/t/beta-feedback-for-the-upcoming-android-4-76-release/18126/3
