### PR TITLE
Fix "Advanced PIN settings" pushing wrong fragment

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -67,7 +67,7 @@ public class AdvancedPreferenceFragment extends CorrectedPreferenceFragment {
 
     Preference pinSettings = this.findPreference(ADVANCED_PIN_PREF);
     pinSettings.setOnPreferenceClickListener(preference -> {
-      getApplicationPreferencesActivity().pushFragment(new AdvancedPreferenceFragment());
+      getApplicationPreferencesActivity().pushFragment(new AdvancedPinPreferenceFragment());
       return false;
     });
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
- Virtual device: Pixel 4 Android 11
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Fixes "Advanced PIN settings" pushing wrong fragment (as [noticed in Signal Community](https://community.signalusers.org/t/18811/51)), which was caused by a typo in https://github.com/signalapp/Signal-Android/commit/edb2a17bcbf1ae9c4387217ff98effa861de0829#diff-dcccc6dc59d0a097153a0d3cf9b4798dfb29b8a14227e2df74c12e136499dee8L66-R70.