### PR TITLE
Fix #10257 hiding the subtitle in conversation banner

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
@@ -131,6 +131,7 @@ import org.thoughtcrime.securesms.util.SetUtil;
 import org.thoughtcrime.securesms.util.SnapToTopDataObserver;
 import org.thoughtcrime.securesms.util.StickyHeaderDecoration;
 import org.thoughtcrime.securesms.util.StorageUtil;
+import org.thoughtcrime.securesms.util.StringUtil;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.util.ThemeUtil;
 import org.thoughtcrime.securesms.util.Util;
@@ -435,7 +436,7 @@ public class ConversationFragment extends LoggingFragment {
       } else if (isSelf) {
         conversationBanner.setSubtitle(context.getString(R.string.ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation));
       } else {
-        String subtitle = recipient.getE164().transform(PhoneNumberFormatter::prettyPrint).orNull();
+        String subtitle = recipient.getE164().transform(PhoneNumberFormatter::prettyPrint).transform(StringUtil::isolateBidi).orNull();
 
         if (subtitle == null || subtitle.equals(title)) {
           conversationBanner.hideSubtitle();


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Device Moto X Play, Android 7.1.1
 * Virtual device Pixel 2, Android 11.0
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fix #10257 

When title and subtitle in the conversationBanner are equal, the subtitle should be hidden.

ConversationFragment.java line 440

```
if (subtitle == null || subtitle.equals(title)) {
 conversationBanner.hideSubtitle();
} else {
 conversationBanner.setSubtitle(subtitle);
}
```
Adding an extra bidi to the subtitle with StringUtil.isolateBidi(name):
The subtitle is only hidden when the title is a phone number (or technical number, see screenshot).
This phone number has double bidi from PhoneNumberFormatter.prettyPrintFormat() and the recipient.getDisplayNameOrUsername.
The subtitle has only one bidi from the PhoneNumberFormatter.prettyPrintFormat().

![signal-2020-12-08-173344 (2)](https://user-images.githubusercontent.com/49990901/101513712-c93edc00-397c-11eb-890f-f45c489a3b36.png) ![signal-2020-12-08-173344 (1)](https://user-images.githubusercontent.com/49990901/101513717-ca700900-397c-11eb-888b-91319fadfbbb.png)
![signal-2020-12-08-173344 (3)](https://user-images.githubusercontent.com/49990901/101513715-c9d77280-397c-11eb-890a-39e2c7c7270a.png) ![signal-2020-12-08-173344](https://user-images.githubusercontent.com/49990901/101513716-c9d77280-397c-11eb-9890-a527a4564486.png)


The only alternative is to delete the code part, because in the most cases (contact name, group name, ...) the subtitle is shown.

```
if (subtitle == null || subtitle.equals(title)) {
 conversationBanner.hideSubtitle();
} else {
 conversationBanner.setSubtitle(subtitle);
}
```

