### PR TITLE
Fix to a crash bug happens when saving audio, video and other files in devices whose API is 28 or lower

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/StorageUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/StorageUtil.java
@@ -130,7 +130,7 @@ public class StorageUtil {
   }
 
   public static @NonNull Uri getAudioUri() {
-    if (Build.VERSION.SDK_INT < 29) {
+    if (Build.VERSION.SDK_INT < 21) {
       return getLegacyUri(Environment.DIRECTORY_MUSIC);
     } else {
       return MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Pixel 3a API 29
 * AVD Pixel 2 API 28
 * AVD Nexus 6 API 23
 * AVD Nexus 5X API 21
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fixes a crash bug happens when a file with the same name already exists in the specified content uri by checking if the content uri already exists and rename the file until it's valid to insert. Fixes #10159

The commit [3f2b4d60fd00fc53a714e6d1f1017e71ee7627fa] fixes the issue for audio files because it changed the url to be of `file://` so that the logic that checks if the file exists and keep changing the file name until there is no more conflict, kicks in. Unfortunately that fix works only for audio files, and more importantly it kind of downgrades what the updated code was supposed to do, which was to use content uri instead of file uri when saving a file.

This PR effectively reverts the commit [3f2b4d60fd00fc53a714e6d1f1017e71ee7627fa] and adds conflict checking of the file names to content uri too when the OS is older.

## Steps to very the PR

1. Prepare a chat that has a voice note, a picture, a video and a pdf (and maybe another generic file) attachments.
1. Long tap each of those attachments and download it.
1. After downloading all of them, do that again for each.
1. Just to make sure, do that yet agin.

**Actual behavior at [42b0fe78537cc4d6fdd6fb02cec6167c1e4fe9ce]**:

Either app crashes or a toast with an error message.

**Expected behavior after the PR**:

App doesn't crash. The files are saved.