### PR TITLE
Fixes signalapp/Signal-Android#10182

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -18,11 +18,15 @@
 package org.thoughtcrime.securesms;
 
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.PorterDuff;
 import android.os.Build;
 import android.os.Bundle;
+import android.view.View;
+import android.view.Window;
+import android.view.WindowManager;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -50,6 +54,7 @@ import org.thoughtcrime.securesms.service.KeyCachingService;
 import org.thoughtcrime.securesms.util.CachedInflater;
 import org.thoughtcrime.securesms.util.CommunicationActions;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
+import org.thoughtcrime.securesms.util.DynamicNoActionBarTheme;
 import org.thoughtcrime.securesms.util.DynamicTheme;
 import org.thoughtcrime.securesms.util.FeatureFlags;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
@@ -99,6 +104,11 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActivity
   protected void onCreate(Bundle icicle, boolean ready) {
     //noinspection ConstantConditions
     this.getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    // consistency in navigation bar colors, requires sdk version 21+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      getWindow().addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+      getWindow().setNavigationBarColor(ContextCompat.getColor(this, R.color.transparent));
+    }
 
     if (getIntent() != null && getIntent().getCategories() != null && getIntent().getCategories().contains("android.intent.category.NOTIFICATION_PREFERENCES")) {
       initFragment(android.R.id.content, new NotificationsPreferenceFragment());

--- a/app/src/main/java/org/thoughtcrime/securesms/messagedetails/MessageDetailsActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/messagedetails/MessageDetailsActivity.java
@@ -3,10 +3,13 @@ package org.thoughtcrime.securesms.messagedetails;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.drawable.ColorDrawable;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.MenuItem;
+import android.view.WindowManager;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import androidx.lifecycle.ViewModelProviders;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -59,8 +62,6 @@ public final class MessageDetailsActivity extends PassphraseRequiredActivity {
   protected void onCreate(Bundle savedInstanceState, boolean ready) {
     super.onCreate(savedInstanceState, ready);
     setContentView(R.layout.message_details_activity);
-
-    glideRequests = GlideApp.with(this);
 
     initializeList();
     initializeViewModel();

--- a/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/notifications/CustomNotificationsDialogFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/notifications/CustomNotificationsDialogFragment.java
@@ -6,11 +6,13 @@ import android.content.Intent;
 import android.media.Ringtone;
 import android.media.RingtoneManager;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.widget.CompoundButton;
 import android.widget.TextView;
 
@@ -19,6 +21,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.lifecycle.ViewModelProviders;
 

--- a/app/src/main/res/values-v21/themes.xml
+++ b/app/src/main/res/values-v21/themes.xml
@@ -10,6 +10,11 @@
         <item name="android:navigationBarColor">@color/core_grey_95</item>
     </style>
 
+    <style name="TextSecure.DarkClearNavbarTheme" parent="@style/TextSecure.BaseDarkTheme">
+        <item name="android:statusBarColor">@color/core_grey_95</item>
+        <item name="android:navigationBarColor">@color/transparent</item>
+    </style>
+
     <style name="TextSecure.DarkNoActionBar" parent="@style/TextSecure.BaseDarkNoActionBar">
         <item name="android:statusBarColor">@color/core_grey_95</item>
         <item name="android:navigationBarColor">@color/core_grey_95</item>
@@ -19,7 +24,6 @@
     <style name="TextSecure.LightNoActionBar" parent="TextSecure.BaseLightNoActionBar">
         <item name="android:statusBarColor">@color/core_grey_60</item>
     </style>
-
 
     <style name="TextSecure.LightRegistrationTheme" parent="TextSecure.LightNoActionBar">
         <item name="android:statusBarColor">@color/core_grey_60</item>
@@ -42,6 +46,12 @@
 
     <style name="Theme.Signal.BottomSheetDialog.Fixed">
         <item name="android:windowIsFloating">false</item>
+        <item name="android:statusBarColor">@color/core_grey_95</item>
+        <item name="android:navigationBarColor">@color/transparent</item>
+    </style>
+
+    <style name="Signal.DayNight.Dialog.Animated" parent="Signal.DayNight">
+        <item name="android:windowAnimationStyle">@style/FadeScale</item>
         <item name="android:statusBarColor">@color/core_grey_95</item>
         <item name="android:navigationBarColor">@color/transparent</item>
     </style>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -78,6 +78,7 @@
 
         <item name="android:textColorHint">@color/white</item>
         <item name="android:windowBackground">@color/core_grey_95</item>
+
     </style>
 
     <style name="TextSecure.LightTheme.Popup" parent="TextSecure.LightTheme">

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -2,7 +2,6 @@
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
-
     <org.thoughtcrime.securesms.preferences.widgets.ProfilePreference
             android:key="preference_category_profile"/>
 


### PR DESCRIPTION
### First time contributor checklist
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual device Pixel 4 API 28, Android 9.0
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

This pull request fixes inconsistencies in dark mode navbar colors (bug report #10182 ). The affected pages were **Settings**, certain pages in **Group Settings**, and **Insights.** Screenshots of before and after are attached below.

**Settings Before** 
<img width="472" alt="Settings-before" src="https://user-images.githubusercontent.com/45076267/102201723-7ab9a200-3e94-11eb-920f-a74914631a8f.png">
**After**
<img width="446" alt="Settings after" src="https://user-images.githubusercontent.com/45076267/102201737-7d1bfc00-3e94-11eb-81cb-6642f7b3c1f0.png">

**Group settings/Custom notification Before** <img width="491" alt="Group Settings:Custom Notifications-before" src="https://user-images.githubusercontent.com/45076267/102201798-902ecc00-3e94-11eb-9abb-82aa80a589dd.png">
**After**
<img width="510" alt="Group settings:custom notifications-after" src="https://user-images.githubusercontent.com/45076267/102201809-93c25300-3e94-11eb-889a-a9af0a6c913a.png">

**Group settings/Shareable Group Link Before** 
<img width="520" alt="Group Settings:Shareable group link-before" src="https://user-images.githubusercontent.com/45076267/102201868-a63c8c80-3e94-11eb-93dc-2dcf15ee8a55.png">
**After**
<img width="512" alt="Group Settings:Shareable group link-after" src="https://user-images.githubusercontent.com/45076267/102201882-a9d01380-3e94-11eb-8996-e5d2ebe0de0d.png">

**Insights Before** 
<img width="468" alt="insights-before" src="https://user-images.githubusercontent.com/45076267/102201927-ba808980-3e94-11eb-8f8a-6bd7ddae1341.png">
**After**
<img width="444" alt="Insights-after" src="https://user-images.githubusercontent.com/45076267/102201941-bd7b7a00-3e94-11eb-91c4-a8e239fce7f0.png">

Fix was adding style updates to themes.xml v21 and setting window.navbar to transparent.

