### PR TITLE
Fixes signalapp/Signal-Android#10149

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
@@ -7,6 +7,7 @@ import android.content.DialogInterface.OnClickListener;
 import android.media.MediaScannerConnection;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Environment;
 import android.provider.MediaStore;
 import android.text.TextUtils;
 import android.webkit.MimeTypeMap;
@@ -31,6 +32,8 @@ import java.io.OutputStream;
 import java.lang.ref.WeakReference;
 import java.text.SimpleDateFormat;
 import java.util.Objects;
+
+import static org.thoughtcrime.securesms.R.string.SaveAttachmentTask_saved_to;
 
 public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTask.Attachment, Void, Pair<Integer, String>> {
   private static final String TAG = SaveAttachmentTask.class.getSimpleName();
@@ -214,7 +217,10 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
                        Toast.LENGTH_LONG).show();
         break;
       case SUCCESS:
-        String message = !TextUtils.isEmpty(result.second())  ? context.getResources().getString(R.string.SaveAttachmentTask_saved_to, result.second())
+        String path = Environment.getExternalStorageDirectory().getPath();
+        String downloadPath = path + "/Download/";
+        final Pair<Integer, String> new_result =  new Pair<>(result.first(), downloadPath);
+        String message = !TextUtils.isEmpty(new_result.second())  ? context.getResources().getString(R.string.SaveAttachmentTask_saved_to, new_result.second())
                                                               : context.getResources().getString(R.string.SaveAttachmentTask_saved);
         Toast.makeText(context, message, Toast.LENGTH_LONG).show();
         break;


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual Device Pixel 3 API 30, Android 11.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
This pull request resolves the change that issue [#10149](https://github.com/signalapp/Signal-Android/issues/10149) reported. The issue was prevalent in any chat conversations when one user would receive an attachment from another user, save it, and not know the location of the saved file. 

Before any changes, as stated in the reported issue ([#10149](https://github.com/signalapp/Signal-Android/issues/10149)), the pop-up text that is created when a file is saved only states "File saved in media", but not the actual path, causing the file to **not be able to be found afterwards**. With the changes I have made, instead of vaguely stating "media", I made it so that the pop-up text will provide the **specific path the downloaded file is located** (as requested in [#10149](https://github.com/signalapp/Signal-Android/issues/10149)). Below is a screenshot:

<img width="557" alt="Screen Shot 2020-12-15 at 4 49 00 AM" src="https://user-images.githubusercontent.com/48782466/102217513-88b9f380-3e91-11eb-817f-b4e36df063a1.png">

The fix was to change the result pair's string value to the actual path of the local device's external storage directory, accessible by importing the Environment library. 

This was tested for spending photos and videos, and performs expectedly for both scenarios.