### PR TITLE
Elimination of country code 0 in Delete account

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/delete/DeleteAccountViewModel.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/delete/DeleteAccountViewModel.java
@@ -41,7 +41,7 @@ public class DeleteAccountViewModel extends ViewModel {
   public DeleteAccountViewModel(@NonNull DeleteAccountRepository repository) {
     this.repository         = repository;
     this.allCountries       = repository.getAllCountries();
-    this.regionCode         = new DefaultValueLiveData<>(PhoneNumberUtil.REGION_CODE_FOR_NON_GEO_ENTITY);
+    this.regionCode         = new DefaultValueLiveData<>("ZZ"); // PhoneNumberUtil private static final String UNKNOWN_REGION = "ZZ";
     this.nationalNumber     = new MutableLiveData<>();
     this.query              = new DefaultValueLiveData<>("");
     this.countryDisplayName = Transformations.map(regionCode, repository::getRegionDisplayName);


### PR DESCRIPTION
### Contributor checklist
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:

 * Virtual Pixel 2, Android 11.0
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Fix #10296 

- Eliminates the 0 in the country code input.
- Eliminates the two debug log entries for "Invalid or missing region code (001) provided"
```
12-15 17:34:11.170  6532  6532 W PhoneNumberUtil: Invalid or missing region code (001) provided.
12-15 17:34:11.171  6532  6532 W PhoneNumberUtil: Invalid or missing region code (001) provided.
```

The country code is initialized with "001" = `REGION_CODE_FOR_NON_GEO_ENTITY `


- `this.regionCode         = new DefaultValueLiveData<>(PhoneNumberUtil.REGION_CODE_FOR_NON_GEO_ENTITY);` 
    in DeleteAccountViewModel

The 0 in the country code comes from `countryCode.setText(String.valueOf(util.getCountryCodeForRegion(regionCode)));`
- `countryCode.setText(String.valueOf(util.getCountryCodeForRegion("001")));`
   from `handleRegionUpdated` in DeleteAccountFragment

The first log warning comes from `util.getAsYouTypeFormatter(regionCode)`
-  `util.getAsYouTypeFormatter("001")`
     from `handleRegionUpdated` in DeleteAccountFragment

The second log warning comes from `util.getCountryCodeForRegion(regionCode)`
- `util.getCountryCodeForRegion("001")`

A few more notes:
The region code should never be empty. It either contains a valid country code or "ZZ" for an unknown region.
So this part could be deleted: `!TextUtils.isEmpty(regionCode)`

