### PR TITLE
Show correct fragment layout preview.

### DIFF
--- a/app/src/main/res/navigation/pin_restore.xml
+++ b/app/src/main/res/navigation/pin_restore.xml
@@ -25,6 +25,6 @@
         android:id="@+id/pinLockedFragment"
         android:name="org.thoughtcrime.securesms.pin.PinRestoreLockedFragment"
         android:label="fragment_pin_locked"
-        tools:layout="@layout/account_locked_fragment"/>
+        tools:layout="@layout/pin_restore_locked_fragment"/>
 
 </navigation>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Google Pixel 3 XL, Android 11
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

This fixes PinRestoreLockedFragment show incorrect layout preview in navigation.