### PR TITLE
Fix #9607 more info button on safety number doesn't direct to the rig…

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/VerifyIdentityActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/VerifyIdentityActivity.java
@@ -59,6 +59,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.text.HtmlCompat;
 import androidx.core.view.OneShotPreDrawListener;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
@@ -512,7 +513,9 @@ public class VerifyIdentityActivity extends PassphraseRequiredActivity implement
     }
 
     private void setRecipientText(Recipient recipient) {
-      description.setText(Html.fromHtml(String.format(getActivity().getString(R.string.verify_display_fragment__to_verify_the_security_of_your_end_to_end_encryption_with_s), recipient.getDisplayName(getContext()))));
+      String link     = String.format("<a href=\"%s\">%s</a>", getString(R.string.safety_number_support_url), getString(R.string.verify_display_fragment__learn_more));
+      String infoText = getString(R.string.verify_display_fragment__to_verify_the_security_of_your_end_to_end_encryption_with_s, recipient.getDisplayName(getContext()), link);
+      description.setText(HtmlCompat.fromHtml(infoText, 0));
       description.setMovementMethod(LinkMovementMethod.getInstance());
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="donate_url" translatable="false">https://signal.org/donate</string>
     <string name="backup_support_url" translatable="false">https://support.signal.org/hc/articles/360007059752</string>
     <string name="transfer_support_url" translatable="false">https://support.signal.org/hc/articles/360007059752</string>
+    <string name="safety_number_support_url" translatable="false">https://support.signal.org/hc/articles/360007060632</string>
     <string name="support_center_url" translatable="false">https://support.signal.org/</string>
     <string name="terms_and_privacy_policy_url" translatable="false">https://signal.org/legal</string>
 
@@ -2160,13 +2161,14 @@
     <string name="recipients_panel__to"><small>Enter a name or number</small></string>
 
     <!-- verify_display_fragment -->
-    <string name="verify_display_fragment__to_verify_the_security_of_your_end_to_end_encryption_with_s"><![CDATA[To verify the security of your end-to-end encryption with %s, compare the numbers above with their device. You can also scan the code on their phone. <a href="https://signal.org/redirect/safety-numbers">Learn more.</a>]]></string>
+    <string name="verify_display_fragment__to_verify_the_security_of_your_end_to_end_encryption_with_s">To verify the security of your end-to-end encryption with %1$s, compare the numbers above with their device. You can also scan the code on their phone. %2$s</string>
     <string name="verify_display_fragment__tap_to_scan">Tap to scan</string>
     <string name="verify_display_fragment__successful_match">Successful match</string>
     <string name="verify_display_fragment__failed_to_verify_safety_number">Failed to verify safety number</string>
     <string name="verify_display_fragment__loading">Loading…</string>
     <string name="verify_display_fragment__mark_as_verified">Mark as verified</string>
     <string name="verify_display_fragment__clear_verification">Clear verification</string>
+    <string name="verify_display_fragment__learn_more">Learn more</string>
 
     <!-- verify_identity -->
     <string name="verify_identity__share_safety_number">Share safety number</string>


### PR DESCRIPTION
…ht locale

### Contributor checklist
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:

 * Virtual Pixel 2, Android 11.0
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fixes #9607 

Changed the used strings for the description of the safety number with a recipient.
Replaced the `https://signal.org/redirect/safety-numbers` with `https://support.signal.org/hc/articles/360007060632`
Oriented towards the implementation of `setInfo()` in BackupPreferenceFragment.

Note:
I got an error message that `Cannot resolve symbol '@drawable/splash_logo' ` in the verify_display_fragment.xml
I haven't deleted this line.

![grafik](https://user-images.githubusercontent.com/49990901/102364400-adf45200-3fb6-11eb-987c-fa157a9c7db8.png)
