### PR TITLE
PIN skip visibility and back navigation fix.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/lock/v2/ConfirmKbsPinFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/lock/v2/ConfirmKbsPinFragment.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 
 public class ConfirmKbsPinFragment extends BaseKbsPinFragment<ConfirmKbsPinViewModel> {
 
-  private ConfirmKbsPinViewModel    viewModel;
+  private ConfirmKbsPinViewModel viewModel;
 
   @Override
   protected void initializeViewStates() {
@@ -164,9 +164,11 @@ public class ConfirmKbsPinFragment extends BaseKbsPinFragment<ConfirmKbsPinViewM
     if (saveAnimation == ConfirmKbsPinViewModel.SaveAnimation.NONE) {
       getInput().setVisibility(View.VISIBLE);
       getLottieProgress().setVisibility(View.GONE);
+      setMenuVisibility(true);
     } else {
       getInput().setVisibility(View.GONE);
       getLottieProgress().setVisibility(View.VISIBLE);
+      setMenuVisibility(false);
     }
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/pin/PinRestoreActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/pin/PinRestoreActivity.java
@@ -34,5 +34,6 @@ public final class PinRestoreActivity extends AppCompatActivity {
     final Intent chained   = PassphraseRequiredActivity.chainIntent(createPin, main);
 
     startActivity(chained);
+    finish();
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/pin/PinRestoreActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/pin/PinRestoreActivity.java
@@ -36,4 +36,9 @@ public final class PinRestoreActivity extends AppCompatActivity {
     startActivity(chained);
     finish();
   }
+
+  @Override
+  public void onBackPressed() {
+    finish();
+  }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/pin/PinRestoreEntryFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/pin/PinRestoreEntryFragment.java
@@ -151,17 +151,20 @@ public class PinRestoreEntryFragment extends LoggingFragment {
         cancelSpinning(pinButton);
         pinEntry.getText().clear();
         enableAndFocusPinEntry();
+        skipButton.setVisibility(View.VISIBLE);
         break;
       case PIN_TOO_SHORT:
         Toast.makeText(requireContext(), getString(R.string.RegistrationActivity_your_pin_has_at_least_d_digits_or_characters, MINIMUM_PIN_LENGTH), Toast.LENGTH_LONG).show();
         cancelSpinning(pinButton);
         pinEntry.getText().clear();
         enableAndFocusPinEntry();
+        skipButton.setVisibility(View.VISIBLE);
         break;
       case PIN_INCORRECT:
         cancelSpinning(pinButton);
         pinEntry.getText().clear();
         enableAndFocusPinEntry();
+        skipButton.setVisibility(View.VISIBLE);
         break;
       case PIN_LOCKED:
         onAccountLocked();
@@ -169,8 +172,8 @@ public class PinRestoreEntryFragment extends LoggingFragment {
       case NETWORK_ERROR:
         Toast.makeText(requireContext(), R.string.RegistrationActivity_error_connecting_to_service, Toast.LENGTH_LONG).show();
         cancelSpinning(pinButton);
-        pinEntry.setEnabled(true);
         enableAndFocusPinEntry();
+        skipButton.setVisibility(View.VISIBLE);
         break;
     }
   }
@@ -185,6 +188,9 @@ public class PinRestoreEntryFragment extends LoggingFragment {
     pinEntry.setEnabled(false);
     viewModel.onPinSubmitted(pinEntry.getText().toString(), getPinEntryKeyboardType());
     setSpinning(pinButton);
+    errorLabel.setText("");
+    helpButton.setVisibility(View.GONE);
+    skipButton.setVisibility(View.GONE);
   }
 
   private void onNeedHelpClicked() {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Google Pixel 3 XL, Android 11
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Hide skip menu and button when submitting/confirming PIN.
Prevent navigate back to PIN restore fragment after skipped or locked.