### PR TITLE
Hide keyboard when navigate up from select contact at blocked users.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/blocked/BlockedUsersActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/blocked/BlockedUsersActivity.java
@@ -62,12 +62,13 @@ public class BlockedUsersActivity extends PassphraseRequiredActivity implements 
     });
     contactFilterToolbar.setHint(R.string.BlockedUsersActivity__add_blocked_user);
 
-    //noinspection CodeBlock2Expr
     getSupportFragmentManager().addOnBackStackChangedListener(() -> {
       viewSwitcher.setDisplayedChild(getSupportFragmentManager().getBackStackEntryCount());
 
       if (getSupportFragmentManager().getBackStackEntryCount() == 1) {
         contactFilterToolbar.focusAndShowKeyboard();
+      } else {
+        contactFilterToolbar.hideKeyboard();
       }
     });
 
@@ -105,6 +106,7 @@ public class BlockedUsersActivity extends PassphraseRequiredActivity implements 
                                                     .setCancelable(true)
                                                     .create();
 
+    //noinspection CodeBlock2Expr
     confirmationDialog.setOnShowListener(dialog -> {
       confirmationDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(Color.RED);
     });

--- a/app/src/main/java/org/thoughtcrime/securesms/components/ContactFilterToolbar.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/ContactFilterToolbar.java
@@ -130,6 +130,10 @@ public final class ContactFilterToolbar extends DarkOverflowToolbar {
     ViewUtil.focusAndShowKeyboard(searchText);
   }
 
+  public void hideKeyboard() {
+    ViewUtil.hideKeyboard(getContext(), searchText);
+  }
+
   public void clear() {
     searchText.setText("");
     notifyListener();


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Google Pixel 3 XL, Android 11
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

This fixes where the keyboard not closed when navigate up from select contact at blocked users.