### PR TITLE
Make menu and back button on a toolbar clickable in media preview activities

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/AvatarPreviewActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/AvatarPreviewActivity.java
@@ -129,7 +129,7 @@ public final class AvatarPreviewActivity extends PassphraseRequiredActivity {
 
     findViewById(android.R.id.content).setOnClickListener(v -> fullscreenHelper.toggleUiVisibility());
 
-    fullscreenHelper.configureToolbarSpacer(findViewById(R.id.toolbar_cutout_spacer));
+    fullscreenHelper.configureToolbarLayout(findViewById(R.id.toolbar_cutout_spacer), toolbar);
 
     fullscreenHelper.showAndHideWithSystemUI(getWindow(), findViewById(R.id.toolbar_layout));
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -283,7 +283,7 @@ public final class MediaPreviewActivity extends PassphraseRequiredActivity
 
     anchorMarginsToBottomInsets(detailsContainer);
 
-    fullscreenHelper.configureToolbarSpacer(findViewById(R.id.toolbar_cutout_spacer));
+    fullscreenHelper.configureToolbarLayout(findViewById(R.id.toolbar_cutout_spacer), findViewById(R.id.toolbar));
 
     fullscreenHelper.showAndHideWithSystemUI(getWindow(), detailsContainer, toolbarLayout);
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/util/FullscreenHelper.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/FullscreenHelper.java
@@ -1,18 +1,26 @@
 package org.thoughtcrime.securesms.util;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.pm.ActivityInfo;
+import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.os.Build;
+import android.view.Surface;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowManager;
 
 import androidx.annotation.NonNull;
+import androidx.core.graphics.Insets;
+import androidx.core.view.DisplayCutoutCompat;
 import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 
 /**
  * Encapsulates logic to properly show/hide system UI/chrome in a full screen setting. Also
- * handles adjusting to notched devices as long as you call {@link #configureToolbarSpacer(View)}.
+ * handles adjusting to notched devices as long as you call {@link #configureToolbarLayout(View, View)}.
  */
 public final class FullscreenHelper {
 
@@ -28,14 +36,22 @@ public final class FullscreenHelper {
     showSystemUI();
   }
 
-  public void configureToolbarSpacer(@NonNull View spacer) {
+  public void configureToolbarLayout(@NonNull View spacer, @NonNull View toolbar) {
     if (Build.VERSION.SDK_INT == 19) {
       setSpacerHeight(spacer, ViewUtil.getStatusBarHeight(spacer));
+      int[] padding = makePaddingValuesForAPI19();
+      toolbar.setPadding(padding[0], 0, padding[1], 0);
       return;
     }
 
     ViewCompat.setOnApplyWindowInsetsListener(spacer, (view, insets) -> {
       setSpacerHeight(view, insets.getSystemWindowInsetTop());
+      return insets;
+    });
+
+    ViewCompat.setOnApplyWindowInsetsListener(toolbar, (view, insets) -> {
+      int[] padding = makePaddingValues(insets);
+      toolbar.setPadding(padding[0], 0, padding[1], 0);
       return insets;
     });
   }
@@ -47,6 +63,41 @@ public final class FullscreenHelper {
 
     spacer.setLayoutParams(params);
     spacer.setVisibility(View.VISIBLE);
+  }
+
+  @SuppressLint("SwitchIntDef")
+  private int[] makePaddingValuesForAPI19() {
+    int rotation = activity.getWindowManager().getDefaultDisplay().getRotation();
+    if (rotation == Surface.ROTATION_0 || rotation == Surface.ROTATION_180) {
+      return new int[]{0, 0};
+    }
+
+    Resources resources   = activity.getResources();
+    int statusBarHeightId = resources.getIdentifier("status_bar_height", "dimen", "android");
+    int navBarHeightId    = resources.getIdentifier("navigation_bar_height", "dimen", "android");
+    int statusBarHeight   = resources.getDimensionPixelSize(statusBarHeightId);
+    int navBarHeight      = resources.getDimensionPixelSize(navBarHeightId);
+
+    switch (rotation) {
+      case Surface.ROTATION_90:
+        return new int[]{statusBarHeight, navBarHeight};
+      case Surface.ROTATION_270:
+        return new int[]{navBarHeight, statusBarHeight};
+      default:
+        return new int[]{0, 0};
+    }
+  }
+
+  private int[] makePaddingValues(WindowInsetsCompat insets) {
+    Insets              tappable = insets.getTappableElementInsets();
+    DisplayCutoutCompat cutout   = insets.getDisplayCutout();
+
+    int leftPad  = cutout == null ? tappable.left
+                                  : Math.max(tappable.left, cutout.getSafeInsetLeft());
+    int rightPad = cutout == null ? tappable.right
+                                  : Math.max(tappable.right, cutout.getSafeInsetRight());
+
+    return new int[]{leftPad, rightPad};
   }
 
   public void showAndHideWithSystemUI(@NonNull Window window, @NonNull View... views) {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Pixel 3a API 29
 * AVD Pixel API 23
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Adds padding to the toolbar in media preview activities to avoid the menu and the back button appear below system windows. Fixes #10298

The media preview activity opens in the immersive full screen mode regardless of the toolbar's visibility so the toolbar starts rendering at point 0,0 and its width take all the way to the available screen. But when the system windows (navigation bar and status bar) appears when you tap on the screen, the system windows are rendered on top of the activity, thus above the toolbars. Those constructs such as the menu and the back arrow that are to be rendered at the edges of the toolbar are pushed behind the system windows, which made them unclickable.

This PR adds code to check the clickable area of the screen and adds necessary padding to the toolbar so the buttons are rendered inside the clickable area.

### Screenshots

|  |Before|After|
|---|---|---|
|LTR/90|![Screenshot_1608408078](https://user-images.githubusercontent.com/28482/102698653-0d4b9f80-420d-11eb-987d-5154eba7038e.png)|![Screenshot_1608407679](https://user-images.githubusercontent.com/28482/102698664-1dfc1580-420d-11eb-893d-dca41dd2c5db.png)|
|LTR/270|![Screenshot_1608408086](https://user-images.githubusercontent.com/28482/102698673-294f4100-420d-11eb-9f7c-849266389af4.png)|![Screenshot_1608407688](https://user-images.githubusercontent.com/28482/102698678-34a26c80-420d-11eb-8dc2-289746e9c160.png)|
|RTL/90|![Screenshot_1608408031](https://user-images.githubusercontent.com/28482/102698699-5c91d000-420d-11eb-9707-55926a4c0114.png)|![Screenshot_1608407732](https://user-images.githubusercontent.com/28482/102698702-63b8de00-420d-11eb-8434-ce3d3bfad89d.png)|
|RTL/270|![Screenshot_1608408041](https://user-images.githubusercontent.com/28482/102698711-6ca9af80-420d-11eb-83ef-a1906c6aa58e.png)|![Screenshot_1608407741](https://user-images.githubusercontent.com/28482/102698715-759a8100-420d-11eb-92e9-e5e2f0c2c3df.png)|







