### PR TITLE
Expand the search view to the edge of the screen when in landscape mode

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/SearchToolbar.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/SearchToolbar.java
@@ -58,6 +58,7 @@ public class SearchToolbar extends LinearLayout {
     EditText   searchText = searchView.findViewById(R.id.search_src_text);
 
     searchView.setSubmitButtonEnabled(false);
+    searchView.setMaxWidth(Integer.MAX_VALUE);
 
     if (searchText != null) searchText.setHint(R.string.SearchToolbar_search);
     else                    searchView.setQueryHint(getResources().getString(R.string.SearchToolbar_search));


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Pixel API 23
 * AVD Pixel 3a API 29
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Implements an easy workaround of a bug that prevents the search view from expanding to the edge of the screen. Fixes #10299
