### PR TITLE
Fixes the broken layout in notification preferences view

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/widgets/SignalPreference.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/widgets/SignalPreference.java
@@ -1,19 +1,13 @@
 package org.thoughtcrime.securesms.preferences.widgets;
 
-
 import android.content.Context;
 import android.util.AttributeSet;
-import android.widget.TextView;
 
 import androidx.preference.Preference;
-import androidx.preference.PreferenceViewHolder;
 
 import org.thoughtcrime.securesms.R;
 
 public class SignalPreference extends Preference {
-
-  private TextView rightSummary;
-  private CharSequence summary;
 
   public SignalPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
     super(context, attrs, defStyleAttr, defStyleRes);
@@ -36,26 +30,6 @@ public class SignalPreference extends Preference {
   }
 
   private void initialize() {
-    setWidgetLayoutResource(R.layout.preference_right_summary_widget);
+    setLayoutResource(R.layout.preference_right_summary);
   }
-
-  @Override
-  public void onBindViewHolder(PreferenceViewHolder view) {
-    super.onBindViewHolder(view);
-
-    this.rightSummary = (TextView)view.findViewById(R.id.right_summary);
-    setSummary(this.summary);
-  }
-
-  @Override
-  public void setSummary(CharSequence summary) {
-    super.setSummary(null);
-
-    this.summary = summary;
-
-    if (this.rightSummary != null) {
-      this.rightSummary.setText(summary);
-    }
-  }
-
 }

--- a/app/src/main/res/layout/preference_right_summary.xml
+++ b/app/src/main/res/layout/preference_right_summary.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:minHeight="?android:attr/listPreferredItemHeight"
+              android:gravity="center_vertical"
+              android:paddingEnd="?android:attr/scrollbarSize"
+              android:paddingRight="?android:attr/scrollbarSize"
+              android:background="?android:attr/selectableItemBackground">
+
+    <TextView android:id="@android:id/title"
+              android:layout_width="0dp"
+              android:layout_height="wrap_content"
+              android:layout_marginStart="15dip"
+              android:layout_marginLeft="15dip"
+              android:layout_marginTop="6dip"
+              android:layout_marginBottom="6dip"
+              android:layout_weight="1"
+              android:singleLine="true"
+              android:textSize="16sp"
+              android:textColor="?android:attr/textColorPrimary"
+              android:ellipsize="marquee"
+              android:fadingEdge="horizontal" />
+
+    <TextView android:id="@android:id/summary"
+              android:layout_width="0dp"
+              android:layout_height="wrap_content"
+              android:layout_marginEnd="6dip"
+              android:layout_marginRight="6dip"
+              android:layout_marginTop="6dip"
+              android:layout_marginBottom="6dip"
+              android:layout_weight="1"
+              android:layout_gravity="end|center_vertical"
+              android:gravity="end|center_vertical"
+              android:textSize="16sp"
+              android:textColor="?colorAccent"
+              android:singleLine="true"
+              android:ellipsize="marquee"/>
+
+</LinearLayout>


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Pixel 3a API 29
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Replace the whole layout of the preference to separate the space 1:1 between the title and the summary text. Fixes #9514

### Screenshot
|Before|After|
|---|---|
|![Screenshot_1608567744](https://user-images.githubusercontent.com/28482/102798930-c6ca8200-437f-11eb-8d1c-1ad693d3174f.png)|![Screenshot_1608567929](https://user-images.githubusercontent.com/28482/102798937-ca5e0900-437f-11eb-9537-5fda9f7d4d71.png)|

