### PR TITLE
Remove unused GMS inclusion in SQLiteDatabase.java

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/SQLiteDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/SQLiteDatabase.java
@@ -5,8 +5,6 @@ import android.content.ContentValues;
 
 import androidx.annotation.Nullable;
 
-import com.google.android.gms.vision.Tracker;
-
 import net.sqlcipher.Cursor;
 import net.sqlcipher.SQLException;
 import net.sqlcipher.database.SQLiteQueryStats;


### PR DESCRIPTION
### Description

`import com.google.android.gms.vision.Tracker;` isn't needed and seems to have snuck in there. Can be deleted.