### PR TITLE
Generate key material in StrongBox if available

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/crypto/KeyStoreHelper.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/crypto/KeyStoreHelper.java
@@ -1,10 +1,10 @@
 package org.thoughtcrime.securesms.crypto;
 
 
-import android.content.pm.PackageManager;
 import android.os.Build;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
+import android.security.keystore.StrongBoxUnavailableException;
 import android.util.Base64;
 
 import androidx.annotation.NonNull;
@@ -92,7 +92,13 @@ public final class KeyStoreHelper {
           .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE);
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-        keyGenParameterSpec.setIsStrongBoxBacked(getContext().getPackageManager().hasSystemFeature(PackageManager.FEATURE_STRONGBOX_KEYSTORE));
+        keyGenParameterSpec.setIsStrongBoxBacked(true);
+        try {
+          keyGenerator.init(keyGenParameterSpec.build());
+          return keyGenerator.generateKey();
+        } catch (StrongBoxUnavailableException e2) {
+          keyGenParameterSpec.setIsStrongBoxBacked(false);
+        }
       }
       keyGenerator.init(keyGenParameterSpec.build());
 

--- a/app/src/main/java/org/thoughtcrime/securesms/crypto/KeyStoreHelper.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/crypto/KeyStoreHelper.java
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms.crypto;
 
 
+import android.content.pm.PackageManager;
 import android.os.Build;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
@@ -86,12 +87,14 @@ public final class KeyStoreHelper {
   private static SecretKey createKeyStoreEntry() {
     try {
       KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
-      KeyGenParameterSpec keyGenParameterSpec = new KeyGenParameterSpec.Builder(KEY_ALIAS, KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+      KeyGenParameterSpec.Builder keyGenParameterSpec = new KeyGenParameterSpec.Builder(KEY_ALIAS, KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
           .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
-          .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-          .build();
+          .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE);
 
-      keyGenerator.init(keyGenParameterSpec);
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        keyGenParameterSpec.setIsStrongBoxBacked(getContext().getPackageManager().hasSystemFeature(PackageManager.FEATURE_STRONGBOX_KEYSTORE));
+      }
+      keyGenerator.init(keyGenParameterSpec.build());
 
       return keyGenerator.generateKey();
     } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {


### PR DESCRIPTION
Based on https://github.com/signalapp/Signal-Android/pull/8143

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Unfortunately I don't have a test device without a StrongBox implementation. Please, could someone test this?
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
For whatever reason, a previously contributed StrongBox patch was never merged: https://github.com/signalapp/Signal-Android/pull/8143
This is just an update for the current Signal version and adds a test to check if StrongBox feature is actually available before trying to force it.