### PR TITLE
Display the NotificationChannel importance as a summary for the priority preference

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/NotificationChannels.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/NotificationChannels.java
@@ -309,6 +309,17 @@ public class NotificationChannels {
   }
 
   /**
+   * @return The user specified importance e.g. NotificationManager#IMPORTANCE_LOW for the default
+   * message channel. Returns -1 if channels are not supported.
+   */
+  public static synchronized int getChannelImportance(@NonNull Context context) {
+    if (!supported()) {
+      return -1;
+    }
+    return ServiceUtil.getNotificationManager(context).getNotificationChannel(getMessagesChannel(context)).getImportance();
+  }
+
+  /**
    * @return The vibrate settings for the default message channel.
    */
   public static synchronized boolean getMessageVibrate(@NonNull Context context) {

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
@@ -99,18 +99,7 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
     initializeListSummary((ListPreference) findPreference(TextSecurePreferences.REPEAT_ALERTS_PREF));
     initializeListSummary((ListPreference) findPreference(TextSecurePreferences.NOTIFICATION_PRIVACY_PREF));
 
-    if (NotificationChannels.supported()) {
-      this.findPreference(TextSecurePreferences.NOTIFICATION_PRIORITY_PREF)
-          .setOnPreferenceClickListener(preference -> {
-            Intent intent = new Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS);
-            intent.putExtra(Settings.EXTRA_CHANNEL_ID, NotificationChannels.getMessagesChannel(getContext()));
-            intent.putExtra(Settings.EXTRA_APP_PACKAGE, getContext().getPackageName());
-            startActivity(intent);
-            return true;
-          });
-    } else {
-      initializeListSummary((ListPreference) findPreference(TextSecurePreferences.NOTIFICATION_PRIORITY_PREF));
-    }
+    initializePrioritySummary((ListPreference) findPreference(TextSecurePreferences.NOTIFICATION_PRIORITY_PREF));
 
     initializeRingtoneSummary(findPreference(TextSecurePreferences.RINGTONE_PREF));
     initializeCallRingtoneSummary(findPreference(TextSecurePreferences.CALL_RINGTONE_PREF));
@@ -127,6 +116,8 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
   public void onResume() {
     super.onResume();
     ((ApplicationPreferencesActivity) getActivity()).getSupportActionBar().setTitle(R.string.preferences__notifications);
+    /* Always check to see if the NotificationChannel priority has been updated */
+    initializePrioritySummary((ListPreference) findPreference(TextSecurePreferences.NOTIFICATION_PRIORITY_PREF));
   }
 
   @Override
@@ -196,6 +187,22 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
 
   private void initializeCallVibrateSummary(SwitchPreferenceCompat pref) {
     pref.setChecked(TextSecurePreferences.isCallNotificationVibrateEnabled(getContext()));
+  }
+
+  private void initializePrioritySummary(ListPreference pref) {
+    if (NotificationChannels.supported()) {
+      pref.setOnPreferenceClickListener(preference -> {
+                Intent intent = new Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS);
+                intent.putExtra(Settings.EXTRA_CHANNEL_ID, NotificationChannels.getMessagesChannel(getContext()));
+                intent.putExtra(Settings.EXTRA_APP_PACKAGE, getContext().getPackageName());
+                startActivity(intent);
+                return true;
+              });
+      pref.setValue(String.valueOf(NotificationChannels.getChannelImportance(getContext())));
+      pref.setSummary(pref.getEntry());
+    } else {
+      initializeListSummary(pref);
+    }
   }
 
   public static CharSequence getSummary(Context context) {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -329,15 +329,18 @@
     </string-array>
 
     <string-array name="pref_notification_priority_entries">
+        <!-- Use 'Silent' for NotificationManager#IMPORTANCE_LOW -->
+        <item>@string/preferences__silent</item>
         <item>@string/arrays__default</item>
         <item>@string/arrays__high</item>
         <item>@string/arrays__max</item>
     </string-array>
 
     <string-array name="pref_notification_priority_values">
-        <item>0</item>
-        <item>1</item>
         <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
     </string-array>
 
     <string-array name="MediaOverviewActivity_Sort_by">

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -329,7 +329,8 @@
     </string-array>
 
     <string-array name="pref_notification_priority_entries">
-        <!-- Use 'Silent' for NotificationManager#IMPORTANCE_LOW -->
+        <!-- Use 'Silent' for NotificationManager#IMPORTANCE_LOW and IMPORTANCE_MIN-->
+        <item>@string/preferences__silent</item>
         <item>@string/preferences__silent</item>
         <item>@string/arrays__default</item>
         <item>@string/arrays__high</item>
@@ -337,6 +338,7 @@
     </string-array>
 
     <string-array name="pref_notification_priority_values">
+        <item>1</item>
         <item>2</item>
         <item>3</item>
         <item>4</item>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * OnePlus 7T, Android 10.0.12
 * Virtual device Pixel 3a API 29, Android 10
 * Virtual device Pixel 4 API 30, Android 11
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
This updates the summary for the priority preference to display the current value of the main NotificationChannel's importance. This makes the current importance visible in the Notifications panel. 
| Before | After (Default) |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/15882635/103711995-4d857e80-4f7e-11eb-85c6-f1bbee55c5b3.png" width="300"> | <img src="https://user-images.githubusercontent.com/15882635/103711980-43638000-4f7e-11eb-9b5a-506fda55f916.png" width="300"> |

| After (High) | After (Silent) |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/15882635/103712356-3abf7980-4f7f-11eb-89b9-19b8bc2d0347.png" width="300">| <img src="https://user-images.githubusercontent.com/15882635/103712436-6fcbcc00-4f7f-11eb-8aa6-aaa074bc84d2.png" width="300">

Tested on Android 10 (OnePlus 7T, Emulated Pixel 3a) and Android 11 (Emulated Pixel 4). 






