### PR TITLE
remove easy issue label on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ https://www.transifex.com/projects/p/signal-android/
 
 ## Contributing Code
 
-If you're new to the Signal codebase, we recommend going through our issues and picking out a simple bug to fix (check the "easy" label in our issues) in order to get yourself familiar. Also please have a look at the [CONTRIBUTING.md](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md), that might answer some of your questions.
+If you're new to the Signal codebase, we recommend going through our issues and picking out a simple bug to fix in order to get yourself familiar. Also please have a look at the [CONTRIBUTING.md](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md), that might answer some of your questions.
 
 For larger changes and feature ideas, we ask that you propose it on the [unofficial Community Forum](https://community.signalusers.org) for a high-level discussion with the wider community before implementation.
 


### PR DESCRIPTION
### First time contributor checklist
- [ x ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [ x ] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [ x ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ x ] I have tested my contribution on these devices:
 * Since I just modified README.md, it is not necessary to test on android devices since it is not related to the code itself
- [ x ] My contribution is fully baked and ready to be merged as is
- [ x ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Since there is no "easy" label on issues, I deleted a phrase about it from **Contributing Code** section on README.md

