### PR TITLE
Add "Nokia 7.2" to Hardware AEC Blacklist

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
@@ -331,6 +331,7 @@ public class ApplicationContext extends MultiDexApplication implements DefaultLi
         add("Redmi Note 5");
         add("FP2"); // Fairphone FP2
         add("MI 5");
+        add("Nokia 7.2");
       }};
 
       Set<String> OPEN_SL_ES_WHITELIST = new HashSet<String>() {{


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * _Please see explanation below._

- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixes #9817 - echo due to bad hardware AEC when calling persons with Nokia 7.2 (loudspeakers enabled).
"Nokia 7.2" is the correct ro.product.model of this device.

Remark regarding testing:
- Comparing this commit to previous additions to the hardware AEC blacklist (e.g. see https://github.com/signalapp/Signal-Android/pull/8678), such a simple addition to the blacklist has at least previously been possible without testing.
- Currently, I do not have the possibility to compile/test this commit - would be great if you could consider this anyway. Switching to software AEC should not do any harm in this case.
