### PR TITLE
Translation of display strings in Tamil is not complete Fixes #10472

### DIFF
--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -10,7 +10,7 @@
   <string name="AbstractNotificationBuilder_new_message">புதிய செய்தி</string>
   <!--AlbumThumbnailView-->
   <!--ApplicationMigrationActivity-->
-  <string name="ApplicationMigrationActivity__signal_is_updating">Signal புதுப்பிக்கிறது …</string>
+  <string name="ApplicationMigrationActivity__signal_is_updating">சிக்னல் புதுப்பிக்கிறது …</string>
   <!--ApplicationPreferencesActivity-->
   <string name="ApplicationPreferencesActivity_currently_s">தற்போது: %s</string>
   <string name="ApplicationPreferenceActivity_you_havent_set_a_passphrase_yet"> நீங்கள் இன்னும் ஒரு கடவுச்சொல்லை அமைக்கவில்லை!</string>
@@ -25,12 +25,12 @@
   </plurals>
   <string name="ApplicationPreferencesActivity_delete">நீக்கு</string>
   <string name="ApplicationPreferencesActivity_disable_passphrase">கடவுச்சொல்லை முடக்கு?</string>
-  <string name="ApplicationPreferencesActivity_this_will_permanently_unlock_signal_and_message_notifications">இது நிரந்தரமாக Signal செய்தி அறிவிப்புகளைத் திறக்கும்.</string>
+  <string name="ApplicationPreferencesActivity_this_will_permanently_unlock_signal_and_message_notifications">இது நிரந்தரமாக சிக்னல் செய்தி அறிவிப்புகளைத் திறக்கும்.</string>
   <string name="ApplicationPreferencesActivity_disable">முடக்கு</string>
   <string name="ApplicationPreferencesActivity_unregistering">பதிவுநீக்குதல்</string>
   <string name="ApplicationPreferencesActivity_unregistering_from_signal_messages_and_calls">Signal குறுஞ்செய்தி மற்றும் அழைப்பு பதிவுநீக்கப்படுகிறது …</string>
-  <string name="ApplicationPreferencesActivity_disable_signal_messages_and_calls">Signal குறுஞ்செய்தி மற்றும் அழைப்பை முடக்கு ?</string>
-  <string name="ApplicationPreferencesActivity_disable_signal_messages_and_calls_by_unregistering">சேவையகத்திலிருந்து பதிவுசெய்வதன் மூலம் Signal செய்திகள் மற்றும் அழைப்புகளை முடக்கு. எதிர்காலத்தில் மீண்டும் அவற்றைப் பயன்படுத்த நீங்கள் உங்கள் தொலைபேசி எண்ணை மீண்டும் பதிவு செய்ய வேண்டும்.</string>
+  <string name="ApplicationPreferencesActivity_disable_signal_messages_and_calls">சிக்னல் குறுஞ்செய்தி மற்றும் அழைப்பை முடக்கு ?</string>
+  <string name="ApplicationPreferencesActivity_disable_signal_messages_and_calls_by_unregistering">சேவையகத்திலிருந்து பதிவுசெய்வதன் மூலம் சிக்னல் செய்திகள் மற்றும் அழைப்புகளை முடக்கு. எதிர்காலத்தில் மீண்டும் அவற்றைப் பயன்படுத்த நீங்கள் உங்கள் தொலைபேசி எண்ணை மீண்டும் பதிவு செய்ய வேண்டும்.</string>
   <string name="ApplicationPreferencesActivity_error_connecting_to_server">சர்வருடன் இணைவதில் பிழை!</string>
   <string name="ApplicationPreferencesActivity_sms_enabled">SMS செயல்படுத்தப்பட்டது</string>
   <string name="ApplicationPreferencesActivity_touch_to_change_your_default_sms_app">இதை உங்கள் இயல்புநிலை SMS மென்பொருளாக்க தொடவும் </string>
@@ -44,9 +44,9 @@
   <string name="ApplicationPreferencesActivity_privacy_summary">திரை பூட்டு %1$s, பதிவு பூட்டு %2$s</string>
   <string name="ApplicationPreferencesActivity_privacy_summary_screen_lock">திரை பூட்டு %1$s</string>
   <string name="ApplicationPreferencesActivity_appearance_summary">பின்புலத்தோற்றம் %1$s, மொழி %2$s</string>
-  <string name="ApplicationPreferencesActivity_pins_are_required_for_registration_lock">பதிவு பூட்டுக்கு PIN தேவை. PIN-ஐ முடக்க, முதலில் பதிவு பூட்டை முடக்கவும்.</string>
-  <string name="ApplicationPreferencesActivity_pin_created">PIN உருவாக்கப்பட்டது.</string>
-  <string name="ApplicationPreferencesActivity_pin_disabled">PIN முடக்கப்பட்டது.</string>
+  <string name="ApplicationPreferencesActivity_pins_are_required_for_registration_lock">பதிவு பூட்டுக்கு கடவு எண் தேவை. கடவு எண்-ஐ முடக்க, முதலில் பதிவு பூட்டை முடக்கவும்.</string>
+  <string name="ApplicationPreferencesActivity_pin_created">கடவு எண் உருவாக்கப்பட்டது.</string>
+  <string name="ApplicationPreferencesActivity_pin_disabled">கடவு எண் முடக்கப்பட்டது.</string>
   <string name="ApplicationPreferencesActivity_hide">மறை</string>
   <string name="ApplicationPreferencesActivity_hide_reminder">நினைவூட்டலை மறைக்கவா?</string>
   <!--AppProtectionPreferenceFragment-->
@@ -305,7 +305,7 @@
   <string name="ConversationFragment_failed_to_open_message">செய்தியைத் திறப்பதில் தோல்வி</string>
   <string name="ConversationFragment_you_can_swipe_to_the_right_reply">விரைவாக பதிலளிக்க எந்த செய்தியிலும் வலதுபுறமாக ஸ்வைப் செய்யலாம்</string>
   <string name="ConversationFragment_you_can_swipe_to_the_left_reply">விரைவாக பதிலளிக்க, எந்த செய்தியிலும் இடதுபுறமாக ஸ்வைப் செய்யலாம்</string>
-  <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">வெளிச்செல்லும் காண்க-ஒருமுறை கோப்புகள் அனுப்பப்பட்ட பின் தானாகவே அகற்றப்படும்</string>
+  <string name="ConversationFragment_outgoing_view_once_media_files_are_automatically_removed">வெளிச்செல்லும் காண்க-ஒருமுறை கோப்புகள் அனுப்பப்பட்ட கடவு எண் தானாகவே அகற்றப்படும்</string>
   <string name="ConversationFragment_you_already_viewed_this_message">நீங்கள் ஏற்கனவே இந்த செய்தியைப் பார்த்தீர்கள்</string>
   <string name="ConversationFragment__you_can_add_notes_for_yourself_in_this_conversation">இந்த உரையாடலில் உங்களுக்காக குறிப்புகளைச் சேர்க்கலாம். உங்கள் கணக்கில் இணைக்கப்பட்ட பிற சாதனங்கள் இருந்தால், புதிய குறிப்புகள் ஒத்திசைக்கப்படும்.</string>
   <string name="ConversationFragment__d_group_members_have_the_same_name">%1$dகுழு உறுப்பினர்களுக்கு ஒரே பெயர் உண்டு.</string>
@@ -864,9 +864,9 @@
   <string name="Megaphones_introducing_reactions">எதிர்வினைகளை அறிமுகப்படுத்துகிறது</string>
   <string name="Megaphones_tap_and_hold_any_message_to_quicky_share_how_you_feel">நீங்கள் எப்படி உணர்கிறீர்கள் என்பதை விரைவாகப் பகிர எந்த செய்தியையும் தட்டிப் பிடிக்கவும்.</string>
   <string name="Megaphones_remind_me_later">பிறகு என்னிடம் ஞாபகபடுத்து</string>
-  <string name="Megaphones_verify_your_signal_pin">உங்கள் Signal PIN-ஐ சரிபார்க்கவும்</string>
-  <string name="Megaphones_well_occasionally_ask_you_to_verify_your_pin">உங்கள் PIN-ஐ நினைவில் வைத்துக் கொள்ளும்படி நாங்கள் எப்போதாவது உங்களிடம் கேட்போம்.</string>
-  <string name="Megaphones_verify_pin">பின் சரிபார்க்கவும்</string>
+  <string name="Megaphones_verify_your_signal_pin">உங்கள் Signal கடவு எண்-ஐ சரிபார்க்கவும்</string>
+  <string name="Megaphones_well_occasionally_ask_you_to_verify_your_pin">உங்கள் கடவு எண்-ஐ நினைவில் வைத்துக் கொள்ளும்படி நாங்கள் எப்போதாவது உங்களிடம் கேட்போம்.</string>
+  <string name="Megaphones_verify_pin">கடவு எண் சரிபார்க்கவும்</string>
   <string name="Megaphones_get_started">தொடங்குகள்</string>
   <string name="Megaphones_new_group">புதிய குழு</string>
   <string name="Megaphones_invite_friends">நண்பர்களை அழை</string>
@@ -1163,27 +1163,27 @@
   <string name="PinRestoreEntryFragment_incorrect_pin">தவறான பின்</string>
   <string name="PinRestoreEntryFragment_skip_pin_entry">சிக்னல் பின்னைத் தவிர்க்கவா?</string>
   <string name="PinRestoreEntryFragment_need_help">உங்களுக்கு உதவி வேண்டுமா?</string>
-  <string name="PinRestoreEntryFragment_your_pin_is_a_d_digit_code">உங்கள் பின் என்பது நீங்கள் உருவாக்கிய %1$d இலக்கக் குறியீடாகும், இது எண் அல்லது எண்ணெழுத்து ஆகும். உங்கள் பின்னை நினைவில் கொள்ள முடியாவிட்டால், புதிய ஒன்றை உருவாக்கலாம். உங்கள் கணக்கைப் பதிவுசெய்து பயன்படுத்தலாம், ஆனால் உங்கள் சுயவிவரத் தகவல் போன்ற சில சேமிக்கப்பட்ட அமைப்புகளை இழப்பீர்கள்.</string>
+  <string name="PinRestoreEntryFragment_your_pin_is_a_d_digit_code">உங்கள் கடவு எண் என்பது நீங்கள் உருவாக்கிய %1$d இலக்கக் குறியீடாகும், இது எண் அல்லது எண்ணெழுத்து ஆகும். உங்கள் பின்னை நினைவில் கொள்ள முடியாவிட்டால், புதிய ஒன்றை உருவாக்கலாம். உங்கள் கணக்கைப் பதிவுசெய்து பயன்படுத்தலாம், ஆனால் உங்கள் சுயவிவரத் தகவல் போன்ற சில சேமிக்கப்பட்ட அமைப்புகளை இழப்பீர்கள்.</string>
   <string name="PinRestoreEntryFragment_if_you_cant_remember_your_pin">என்றால் நீங்கள் நினைவில் இல்லை உங்கள் பின், நீங்கள் முடியும் உருவாக்கு புதியது. நீங்கள் பதிவு செய்யலாம் மற்றும் பயன்பாடு உங்கள் கணக்கு ஆனால் நீங்கள்சேமித்த சிலவற்றை இழப்பேன் அமைப்புகள் போன்ற உங்கள் சுயவிவரம் தகவல்.</string>
   <string name="PinRestoreEntryFragment_create_new_pin">உருவாக்கு புதியது பின்</string>
   <string name="PinRestoreEntryFragment_contact_support">தொடர்பு ஆதரவு</string>
   <string name="PinRestoreEntryFragment_cancel">ரத்து</string>
   <string name="PinRestoreEntryFragment_skip">தவிர்</string>
   <plurals name="PinRestoreEntryFragment_you_have_d_attempt_remaining">
-    <item quantity="one">உங்களிடம் %1$d முயற்சிகள் உள்ளன. உங்கள் வரையறுக்கப்பட்ட முயற்சிகள் முடிந்தால், நீங்கள் ஒரு புதிய பின்னை உருவாக்கலாம். புதிய PIN மூலம் உங்கள் கணக்கைப் பதிவுசெய்து பயன்படுத்தலாம், ஆனால் உங்கள் சுயவிவரத் தகவல் போன்ற சில சேமிக்கப்பட்ட அமைப்புகளை இழப்பீர்கள்.</item>
-    <item quantity="other">உங்களிடம் %1$d முயற்சிகள் உள்ளன. நீங்கள் வரையறுக்கப்பட்ட முயற்சிகள் முடிந்தால், நீங்கள் ஒரு புதிய பின்னை உருவாக்கலாம். புதிய PIN மூலம் உங்கள் கணக்கைப் பதிவுசெய்து பயன்படுத்தலாம், ஆனால் உங்கள் சுயவிவரத் தகவல் போன்ற சில சேமிக்கப்பட்ட அமைப்புகளை இழப்பீர்கள்.</item>
+    <item quantity="one">உங்களிடம் %1$d முயற்சிகள் உள்ளன. உங்கள் வரையறுக்கப்பட்ட முயற்சிகள் முடிந்தால், நீங்கள் ஒரு புதிய பின்னை உருவாக்கலாம். புதிய கடவு எண் மூலம் உங்கள் கணக்கைப் பதிவுசெய்து பயன்படுத்தலாம், ஆனால் உங்கள் சுயவிவரத் தகவல் போன்ற சில சேமிக்கப்பட்ட அமைப்புகளை இழப்பீர்கள்.</item>
+    <item quantity="other">உங்களிடம் %1$d முயற்சிகள் உள்ளன. நீங்கள் வரையறுக்கப்பட்ட முயற்சிகள் முடிந்தால், நீங்கள் ஒரு புதிய பின்னை உருவாக்கலாம். புதிய கடவு எண் மூலம் உங்கள் கணக்கைப் பதிவுசெய்து பயன்படுத்தலாம், ஆனால் உங்கள் சுயவிவரத் தகவல் போன்ற சில சேமிக்கப்பட்ட அமைப்புகளை இழப்பீர்கள்.</item>
   </plurals>
-  <string name="PinRestoreEntryFragment_signal_registration_need_help_with_pin">Signal பதிவு - Android க்கான PIN உடன் உதவி தேவை</string>
+  <string name="PinRestoreEntryFragment_signal_registration_need_help_with_pin">Signal பதிவு - Android க்கான கடவு எண் உடன் உதவி தேவை</string>
   <string name="PinRestoreEntryFragment_enter_alphanumeric_pin">எண்ணெழுத்து பின்னை உள்ளிடவும்</string>
   <string name="PinRestoreEntryFragment_enter_numeric_pin">எண் பின்னை உள்ளிடவும்</string>
   <!--PinRestoreLockedFragment-->
   <string name="PinRestoreLockedFragment_create_your_pin">உங்கள் பின்னை உருவாக்கவும்</string>
-  <string name="PinRestoreLockedFragment_youve_run_out_of_pin_guesses">நீங்கள் PIN முயற்சிகளை முடித்துவிட்டீர்கள், ஆனால் புதிய PIN ஐ உருவாக்குவதன் மூலம் உங்கள் சிக்னல் கணக்கை அணுகலாம். உங்கள் தனியுரிமை மற்றும் பாதுகாப்பிற்காக சேமிக்கப்பட்ட சுயவிவரத் தகவல் அல்லது அமைப்புகள் இல்லாமல் உங்கள் கணக்கு மீட்டமைக்கப்படும்.</string>
+  <string name="PinRestoreLockedFragment_youve_run_out_of_pin_guesses">நீங்கள் கடவு எண் முயற்சிகளை முடித்துவிட்டீர்கள், ஆனால் புதிய கடவு எண் ஐ உருவாக்குவதன் மூலம் உங்கள் சிக்னல் கணக்கை அணுகலாம். உங்கள் தனியுரிமை மற்றும் பாதுகாப்பிற்காக சேமிக்கப்பட்ட சுயவிவரத் தகவல் அல்லது அமைப்புகள் இல்லாமல் உங்கள் கணக்கு மீட்டமைக்கப்படும்.</string>
   <string name="PinRestoreLockedFragment_create_new_pin">புதிய பின்னை உருவாக்கவும்</string>
   <!--PinOptOutDialog-->
   <string name="PinOptOutDialog_warning">எச்சரிக்கை</string>
-  <string name="PinOptOutDialog_if_you_disable_the_pin_you_will_lose_all_data">நீங்கள் PIN-ஐ முடக்கினால், நீங்கள் கைமுறையாக காப்புப்பிரதி எடுத்து மீட்டெடுக்காவிட்டால் Signal-ஐ மீண்டும் பதிவுசெய்யும்போது எல்லா தரவையும் இழப்பீர்கள். PIN முடக்கப்பட்டிருக்கும் போது நீங்கள் பதிவு பூட்டை இயக்க முடியாது.</string>
-  <string name="PinOptOutDialog_disable_pin">PIN-ஐ முடக்கு</string>
+  <string name="PinOptOutDialog_if_you_disable_the_pin_you_will_lose_all_data">நீங்கள் கடவு எண்-ஐ முடக்கினால், நீங்கள் கைமுறையாக காப்புப்பிரதி எடுத்து மீட்டெடுக்காவிட்டால் Signal-ஐ மீண்டும் பதிவுசெய்யும்போது எல்லா தரவையும் இழப்பீர்கள். கடவு எண் முடக்கப்பட்டிருக்கும் போது நீங்கள் பதிவு பூட்டை இயக்க முடியாது.</string>
+  <string name="PinOptOutDialog_disable_pin">கடவு எண்-ஐ முடக்கு</string>
   <!--RatingManager-->
   <string name="RatingManager_rate_this_app">இச் செயலியை மதிப்புரை செய்க</string>
   <string name="RatingManager_if_you_enjoy_using_this_app_please_take_a_moment">இச் செயலியின்  பயன்பாட்டை விரும்பினால் தயை கூர்ந்து  எங்கள் செயலியை   மதிப்புரை செய்க    </string>
@@ -1302,7 +1302,7 @@
   <!--RegistrationLockV2Dialog-->
   <string name="RegistrationLockV2Dialog_turn_on_registration_lock">பதிவு பூட்டை இயக்கவா?</string>
   <string name="RegistrationLockV2Dialog_turn_off_registration_lock">பதிவு பூட்டை அணைக்கவா?</string>
-  <string name="RegistrationLockV2Dialog_if_you_forget_your_signal_pin_when_registering_again">Signal உடன் மீண்டும் பதிவுசெய்யும்போது உங்கள் Signal PIN-ஐ மறந்துவிட்டால், உங்கள் கணக்கிலிருந்து 7 நாட்களுக்கு பூட்டப்படுவீர்கள்.</string>
+  <string name="RegistrationLockV2Dialog_if_you_forget_your_signal_pin_when_registering_again">Signal உடன் மீண்டும் பதிவுசெய்யும்போது உங்கள் Signal கடவு எண்-ஐ மறந்துவிட்டால், உங்கள் கணக்கிலிருந்து 7 நாட்களுக்கு பூட்டப்படுவீர்கள்.</string>
   <string name="RegistrationLockV2Dialog_turn_on">இயக்கவும்</string>
   <string name="RegistrationLockV2Dialog_turn_off">அணைக்க</string>
   <!--RevealableMessageView-->
@@ -2017,10 +2017,10 @@
   <string name="preferences__dark_theme">இருட்டு</string>
   <string name="preferences__appearance">தோற்றம்</string>
   <string name="preferences__theme">நிறவடிவமைப்பு</string>
-  <string name="preferences__disable_pin">PIN-ஐ முடக்கு</string>
+  <string name="preferences__disable_pin">கடவு எண்-ஐ முடக்கு</string>
   <string name="preferences__enable_pin">பின்னை மீண்டும் திறக்கவும்</string>
-  <string name="preferences__if_you_disable_the_pin_you_will_lose_all_data">நீங்கள் Signal PIN-ஐ முடக்கினால், நீங்கள் கைமுறையாக காப்புப்பிரதி எடுத்து மீட்டெடுக்காவிட்டால் Signal-ஐ மீண்டும் பதிவுசெய்யும்போது எல்லா தரவையும் இழப்பீர்கள். PIN முடக்கப்பட்டிருக்கும் போது நீங்கள் பதிவு பூட்டை இயக்க முடியாது.</string>
-  <string name="preferences__pins_keep_information_stored_with_signal_encrypted_so_only_you_can_access_it">Signal இடம் சேமிக்கப்படும் தகவல்களை மறையாக்கி நீங்கள் மட்டும் அணுகும் வகையில் PIN-கள் வைக்கும். நீங்கள் மீண்டும் நிறுவும்போது உங்கள் சுயவிவரம், அமைப்புகள் மற்றும் தொடர்புகள் மீட்டமைக்கப்படும். பயன்பாட்டைத் திறக்க உங்கள் PIN தேவைப்படாது.</string>
+  <string name="preferences__if_you_disable_the_pin_you_will_lose_all_data">நீங்கள் Signal கடவு எண்-ஐ முடக்கினால், நீங்கள் கைமுறையாக காப்புப்பிரதி எடுத்து மீட்டெடுக்காவிட்டால் Signal-ஐ மீண்டும் பதிவுசெய்யும்போது எல்லா தரவையும் இழப்பீர்கள். கடவு எண் முடக்கப்பட்டிருக்கும் போது நீங்கள் பதிவு பூட்டை இயக்க முடியாது.</string>
+  <string name="preferences__pins_keep_information_stored_with_signal_encrypted_so_only_you_can_access_it">Signal இடம் சேமிக்கப்படும் தகவல்களை மறையாக்கி நீங்கள் மட்டும் அணுகும் வகையில் கடவு எண்-கள் வைக்கும். நீங்கள் மீண்டும் நிறுவும்போது உங்கள் சுயவிவரம், அமைப்புகள் மற்றும் தொடர்புகள் மீட்டமைக்கப்படும். பயன்பாட்டைத் திறக்க உங்கள் கடவு எண் தேவைப்படாது.</string>
   <string name="preferences__system_default">கருவி இயல்புநிலை</string>
   <string name="preferences__default">இயல்புநிலை</string>
   <string name="preferences__language">மொழி</string>
@@ -2243,67 +2243,67 @@
     <item quantity="other">பின் குறைந்தது %1$d எழுத்துக்களாக இருக்க வேண்டும்</item>
   </plurals>
   <plurals name="CreateKbsPinFragment__pin_must_be_at_least_digits">
-    <item quantity="one">பின் அல்லது கடவுஎண் குறைந்தது %1$d இலக்கங்களாக இருக்க வேண்டும்</item>
-    <item quantity="other">பின் குறைந்தது %1$d இலக்கங்களாக இருக்க வேண்டும்</item>
+    <item quantity="one">பின் அல்லது கடவு எண் குறைந்தது %1$d இலக்கங்களாக இருக்க வேண்டும்</item>
+    <item quantity="other">கடவு எண் குறைந்தது %1$d இலக்கங்களாக இருக்க வேண்டும்</item>
   </plurals>
-  <string name="CreateKbsPinFragment__create_a_new_pin">புதிய பின்னை உருவாக்கவும்</string>
-  <string name="CreateKbsPinFragment__you_can_choose_a_new_pin_as_long_as_this_device_is_registered">நீங்கள் முடியும் மாற்றம் உங்கள் பின் இந்த வரை சாதனம் பதிவு செய்யப்பட்டுள்ளது.</string>
+  <string name="CreateKbsPinFragment__create_a_new_pin">புதிய கடவு எண்ணை உருவாக்கவும்</string>
+  <string name="CreateKbsPinFragment__you_can_choose_a_new_pin_as_long_as_this_device_is_registered">நீங்கள் முடியும் மாற்றம் உங்கள் கடவு எண் இந்த வரை சாதனம் பதிவு செய்யப்பட்டுள்ளது.</string>
   <string name="CreateKbsPinFragment__create_your_pin">உங்கள் பின்னை உருவாக்கவும்</string>
-  <string name="CreateKbsPinFragment__pins_keep_information_stored_with_signal_encrypted">Signal இடம் சேமிக்கப்படும் தகவல்களை மறையாக்கி நீங்கள் மட்டும் அணுகும் வகையில் PIN-கள் வைக்கும். நீங்கள் மீண்டும் நிறுவும்போது உங்கள் சுயவிவரம், அமைப்புகள் மற்றும் தொடர்புகள் மீட்டமைக்கப்படும். பயன்பாட்டைத் திறக்க உங்கள் PIN தேவைப்படாது.</string>
+  <string name="CreateKbsPinFragment__pins_keep_information_stored_with_signal_encrypted">Signal இடம் சேமிக்கப்படும் தகவல்களை மறையாக்கி நீங்கள் மட்டும் அணுகும் வகையில் கடவு எண்-கள் வைக்கும். நீங்கள் மீண்டும் நிறுவும்போது உங்கள் சுயவிவரம், அமைப்புகள் மற்றும் தொடர்புகள் மீட்டமைக்கப்படும். பயன்பாட்டைத் திறக்க உங்கள் கடவு எண் தேவைப்படாது.</string>
   <string name="CreateKbsPinFragment__choose_a_stronger_pin">வலுவானதைத் தேர்வுசெய்க பின்</string>
   <!--ConfirmKbsPinFragment-->
-  <string name="ConfirmKbsPinFragment__pins_dont_match">பின்-கள் பொருந்தவில்லை. மீண்டும் முயற்சி செய்க.</string>
+  <string name="ConfirmKbsPinFragment__pins_dont_match">கடவு எண்-கள் பொருந்தவில்லை. மீண்டும் முயற்சி செய்க.</string>
   <string name="ConfirmKbsPinFragment__confirm_your_pin">உங்கள் பின்னை உறுதிப்படுத்தவும்.</string>
-  <string name="ConfirmKbsPinFragment__pin_creation_failed">பின் உருவாக்கம் தோல்வியடைந்தது</string>
-  <string name="ConfirmKbsPinFragment__your_pin_was_not_saved">உங்கள் பின் சேமிக்கப்படவில்லை. பின்னை உருவாக்க நாங்கள் உங்களைத் தூண்டுவோம்.</string>
-  <string name="ConfirmKbsPinFragment__pin_created">பின் உருவாக்கப்பட்டது.</string>
-  <string name="ConfirmKbsPinFragment__re_enter_your_pin">உங்கள் பின்னை மீண்டும் உள்ளிடவும்</string>
-  <string name="ConfirmKbsPinFragment__creating_pin">பின் உருவாக்குகிறது…</string>
+  <string name="ConfirmKbsPinFragment__pin_creation_failed">கடவு எண் உருவாக்கம் தோல்வியடைந்தது</string>
+  <string name="ConfirmKbsPinFragment__your_pin_was_not_saved">உங்கள் கடவு எண் சேமிக்கப்படவில்லை. பின்னை உருவாக்க நாங்கள் உங்களைத் தூண்டுவோம்.</string>
+  <string name="ConfirmKbsPinFragment__pin_created">கடவு எண் உருவாக்கப்பட்டது.</string>
+  <string name="ConfirmKbsPinFragment__re_enter_your_pin">உங்கள் கடவு எண்ணை மீண்டும் உள்ளிடவும்</string>
+  <string name="ConfirmKbsPinFragment__creating_pin">கடவு எண் உருவாக்குகிறது…</string>
   <!--KbsSplashFragment-->
   <string name="KbsSplashFragment__introducing_pins">பின்களை  அறிமுகப்படுத்துகிறது</string>
-  <string name="KbsSplashFragment__pins_keep_information_stored_with_signal_encrypted">Signal இடம் சேமிக்கப்படும் தகவல்களை மறையாக்கி நீங்கள் மட்டும் அணுகும் வகையில் PIN-கள் வைக்கும். நீங்கள் மீண்டும் நிறுவும்போது உங்கள் சுயவிவரம், அமைப்புகள் மற்றும் தொடர்புகள் மீட்டமைக்கப்படும். பயன்பாட்டைத் திறக்க உங்கள் PIN தேவைப்படாது.</string>
+  <string name="KbsSplashFragment__pins_keep_information_stored_with_signal_encrypted">Signal இடம் சேமிக்கப்படும் தகவல்களை மறையாக்கி நீங்கள் மட்டும் அணுகும் வகையில் கடவு எண்-கள் வைக்கும். நீங்கள் மீண்டும் நிறுவும்போது உங்கள் சுயவிவரம், அமைப்புகள் மற்றும் தொடர்புகள் மீட்டமைக்கப்படும். பயன்பாட்டைத் திறக்க உங்கள் கடவு எண் தேவைப்படாது.</string>
   <string name="KbsSplashFragment__learn_more">மேலும் அறிக</string>
-  <string name="KbsSplashFragment__registration_lock_equals_pin">பதிவு பூட்டு = PIN</string>
-  <string name="KbsSplashFragment__your_registration_lock_is_now_called_a_pin">உங்கள் பதிவு பூட்டு இப்போது PIN என அழைக்கப்படுகிறது, மேலும் இது மேலும் செய்கிறது. இப்போது புதுப்பிக்கவும்.</string>
+  <string name="KbsSplashFragment__registration_lock_equals_pin">பதிவு பூட்டு = கடவு எண்</string>
+  <string name="KbsSplashFragment__your_registration_lock_is_now_called_a_pin">உங்கள் பதிவு பூட்டு இப்போது கடவு எண் என அழைக்கப்படுகிறது, மேலும் இது மேலும் செய்கிறது. இப்போது புதுப்பிக்கவும்.</string>
   <string name="KbsSplashFragment__read_more_about_pins">பின்ஸைப் பற்றி மேலும் வாசிக்க.</string>
   <string name="KbsSplashFragment__update_pin">பின்னைப் புதுப்பிக்கவும்</string>
   <string name="KbsSplashFragment__create_your_pin">உங்கள் பின்னை உருவாக்கவும்</string>
   <string name="KbsSplashFragment__learn_more_about_pins">பின்கள் பற்றி மேலும் அறிக</string>
-  <string name="KbsSplashFragment__disable_pin">PIN-ஐ முடக்கு</string>
+  <string name="KbsSplashFragment__disable_pin">கடவு எண்-ஐ முடக்கு</string>
   <!--KBS Reminder Dialog-->
   <string name="KbsReminderDialog__enter_your_signal_pin">உங்கள் Signal பின்னை உள்ளிடவும்</string>
   <string name="KbsReminderDialog__to_help_you_memorize_your_pin">உங்கள் பின்னை மனப்பாடம் செய்ய உங்களுக்கு உதவ, அதை அவ்வப்போது உள்ளிடுமாறு கேட்டுக்கொள்கிறோம். காலப்போக்கில் நாங்கள் உங்களிடம் குறைவாகக் கேட்கிறோம்.</string>
   <string name="KbsReminderDialog__skip">தவிர்</string>
   <string name="KbsReminderDialog__submit">சமர்ப்பி</string>
-  <string name="KbsReminderDialog__forgot_pin">பின் மறந்துவிட்டீர்களா?</string>
+  <string name="KbsReminderDialog__forgot_pin">கடவு எண் மறந்துவிட்டீர்களா?</string>
   <string name="KbsReminderDialog__incorrect_pin_try_again">தவறான பின். மீண்டும் முயற்சி செய்க.</string>
   <!--AccountLockedFragment-->
   <string name="AccountLockedFragment__account_locked">கணக்கில் பூட்டப்பட்டுள்ளது</string>
-  <string name="AccountLockedFragment__your_account_has_been_locked_to_protect_your_privacy">உங்கள் தனியுரிமை மற்றும் பாதுகாப்பைப் பாதுகாக்க உங்கள் கணக்கு பூட்டப்பட்டுள்ளது. உங்கள் கணக்கில் %1$dநாட்கள் செயலற்ற நிலையில் இருந்தபின், உங்கள் பின் தேவைப்படாமல் இந்த தொலைபேசி எண்ணை மீண்டும் பதிவு செய்ய முடியும். எல்லா உள்ளடக்கமும் நீக்கப்படும்.</string>
+  <string name="AccountLockedFragment__your_account_has_been_locked_to_protect_your_privacy">உங்கள் தனியுரிமை மற்றும் பாதுகாப்பைப் பாதுகாக்க உங்கள் கணக்கு பூட்டப்பட்டுள்ளது. உங்கள் கணக்கில் %1$dநாட்கள் செயலற்ற நிலையில் இருந்தபின், உங்கள் கடவு எண் தேவைப்படாமல் இந்த தொலைபேசி எண்ணை மீண்டும் பதிவு செய்ய முடியும். எல்லா உள்ளடக்கமும் நீக்கப்படும்.</string>
   <string name="AccountLockedFragment__next">அடுத்தது</string>
   <string name="AccountLockedFragment__learn_more">மேலும் அறிக</string>
   <!--KbsLockFragment-->
-  <string name="RegistrationLockFragment__enter_your_pin">உங்கள் பின்னை உள்ளிடவும்</string>
+  <string name="RegistrationLockFragment__enter_your_pin">உங்கள் கடவு எண்ணை உள்ளிடவும்</string>
   <string name="RegistrationLockFragment__enter_the_pin_you_created">உங்கள் கணக்கிற்கு நீங்கள் உருவாக்கிய பின்னை உள்ளிடவும். இது உங்கள் SMS சரிபார்ப்புக் குறியீட்டிலிருந்து வேறுபட்டது.</string>
-  <string name="RegistrationLockFragment__enter_alphanumeric_pin">எண்ணெழுத்து பின்னை உள்ளிடவும்</string>
-  <string name="RegistrationLockFragment__enter_numeric_pin">எண் பின்னை உள்ளிடவும்</string>
+  <string name="RegistrationLockFragment__enter_alphanumeric_pin">எண்ணெழுத்துக்கள் உள்ளடக்கிய கடவு எண் உள்ளிடவும்</string>
+  <string name="RegistrationLockFragment__enter_numeric_pin">எண்கள் உள்ளடக்கிய கடவு எண் உள்ளிடவும்</string>
   <string name="RegistrationLockFragment__next">அடுத்தது</string>
-  <string name="RegistrationLockFragment__incorrect_pin_try_again">தவறான பின். மீண்டும் முயற்சி செய்க.</string>
-  <string name="RegistrationLockFragment__forgot_pin">பின் மறந்துவிட்டீர்களா?</string>
-  <string name="RegistrationLockFragment__incorrect_pin">தவறான பின்</string>
-  <string name="RegistrationLockFragment__forgot_your_pin">உங்கள் பின்னை மறந்துவிட்டீர்களா?</string>
-  <string name="RegistrationLockFragment__not_many_tries_left">பல முயற்சிகள் மீதமில்லை!</string>
+  <string name="RegistrationLockFragment__incorrect_pin_try_again">தவறான கடவு எண், மீண்டும் முயற்சி செய்க.</string>
+  <string name="RegistrationLockFragment__forgot_pin">கடவு எண் மறந்துவிட்டீர்களா?</string>
+  <string name="RegistrationLockFragment__incorrect_pin">தவறான கடவு எண்</string>
+  <string name="RegistrationLockFragment__forgot_your_pin">உங்கள் கடவு எண்ணை மறந்துவிட்டீர்களா?</string>
+  <string name="RegistrationLockFragment__not_many_tries_left">சில முயற்சிகள் மீதமுண்டு!</string>
   <plurals name="RegistrationLockFragment__for_your_privacy_and_security_there_is_no_way_to_recover">
-    <item quantity="one">உங்கள் தனியுரிமை மற்றும் பாதுகாப்பிற்காக, உங்கள் பின்னை மீட்டெடுக்க வழி இல்லை. உங்கள் பின்னை நினைவில் கொள்ள முடியாவிட்டால், %1$d நாட்கள் செயலற்ற நிலைக்குப் பிறகு நீங்கள் எஸ்எம்எஸ் மூலம் மீண்டும் சரிபார்க்கலாம். இந்த வழக்கில், உங்கள் கணக்கு அழிக்கப்பட்டு அனைத்து உள்ளடக்கமும் நீக்கப்படும்.</item>
-    <item quantity="other">உங்கள் தனியுரிமை மற்றும் பாதுகாப்பிற்காக, உங்கள் பின்னை மீட்டெடுக்க வழி இல்லை. உங்கள் பின்னை நினைவில் கொள்ள முடியாவிட்டால், %1$d நாட்கள் செயலற்ற நிலைக்குப் பிறகு நீங்கள் SMS மூலம் மீண்டும் சரிபார்க்கலாம். இந்த நிலையில், உங்கள் கணக்கு அழிக்கப்பட்டு அனைத்து உள்ளடக்களும் நீக்கப்படும்.</item>
+    <item quantity="one">உங்கள் தனியுரிமை மற்றும் பாதுகாப்பிற்காக, உங்கள் கடவு எண்ணை மீட்டெடுக்க வழி இல்லை. உங்கள் கடவு எண்ணை நினைவில் கொள்ள முடியாவிட்டால், %1$d நாட்கள் செயலற்ற நிலைக்குப் பிறகு நீங்கள் எஸ்எம்எஸ் மூலம் மீண்டும் சரிபார்க்கலாம். இந்த வழக்கில், உங்கள் கணக்கு அழிக்கப்பட்டு அனைத்து உள்ளடக்கமும் நீக்கப்படும்.</item>
+    <item quantity="other">உங்கள் தனியுரிமை மற்றும் பாதுகாப்பிற்காக, உங்கள் கடவு எண்ணை மீட்டெடுக்க வழி இல்லை. உங்கள் கடவு எண்ணை நினைவில் கொள்ள முடியாவிட்டால், %1$d நாட்கள் செயலற்ற நிலைக்குப் பிறகு நீங்கள் எஸ்.எம்.எஸ். மூலம் மீண்டும் சரிபார்க்கலாம். இந்த நிலையில், உங்கள் கணக்கு அழிக்கப்பட்டு அனைத்து உள்ளடக்களும் நீக்கப்படும்.</item>
   </plurals>
   <plurals name="RegistrationLockFragment__incorrect_pin_d_attempts_remaining">
     <item quantity="one">தவறான பின். %1$d முயற்சிகள் மீதமுள்ளன.</item>
     <item quantity="other">தவறான பின். %1$dமுயற்சிகள் மீதமுள்ளன.</item>
   </plurals>
   <plurals name="RegistrationLockFragment__if_you_run_out_of_attempts_your_account_will_be_locked_for_d_days">
-    <item quantity="one">நீங்கள் முயற்சிகள் முடிந்தால், உங்கள் கணக்கு %1$d நாட்களுக்கு பூட்டப்படும். %1$d நாட்கள் செயலற்ற நிலைக்குப் பிறகு, உங்கள் பின் இல்லாமல் மீண்டும் பதிவு செய்யலாம். உங்கள் நடப்புக் கணக்கு அழிக்கப்பட்டு அனைத்து உள்ளடக்கமும் நீக்கப்படும்.</item>
-    <item quantity="other">நீங்கள் முயற்சிகள் முடிந்தால், உங்கள் கணக்கு %1$dநாட்களுக்கு பூட்டப்படும். %1$d நாட்கள் செயலற்ற நிலைக்குப் பிறகு, உங்கள் பின் இல்லாமல் மீண்டும் பதிவு செய்யலாம். உங்கள் நடப்புக் கணக்கு அழிக்கப்பட்டு அனைத்து உள்ளடக்கமும் நீக்கப்படும்.</item>
+    <item quantity="one">நீங்கள் முயற்சிகள் முடிந்தால், உங்கள் கணக்கு %1$d நாட்களுக்கு பூட்டப்படும். %1$d நாட்கள் செயலற்ற நிலைக்குப் பிறகு, உங்கள் கடவு எண் இல்லாமல் மீண்டும் பதிவு செய்யலாம். உங்கள் நடப்புக் கணக்கு அழிக்கப்பட்டு அனைத்து உள்ளடக்கமும் நீக்கப்படும்.</item>
+    <item quantity="other">நீங்கள் முயற்சிகள் முடிந்தால், உங்கள் கணக்கு %1$dநாட்களுக்கு பூட்டப்படும். %1$d நாட்கள் செயலற்ற நிலைக்குப் பிறகு, உங்கள் கடவு எண் இல்லாமல் மீண்டும் பதிவு செய்யலாம். உங்கள் நடப்புக் கணக்கு அழிக்கப்பட்டு அனைத்து உள்ளடக்கமும் நீக்கப்படும்.</item>
   </plurals>
   <plurals name="RegistrationLockFragment__you_have_d_attempts_remaining">
     <item quantity="one">உங்களிடம் %1$d முயற்சிகள் மீதமுள்ளது</item>
@@ -2317,13 +2317,13 @@
   <string name="CalleeMustAcceptMessageRequestDialogFragment__okay">சரி</string>
   <string name="CalleeMustAcceptMessageRequestDialogFragment__s_will_get_a_message_request_from_you">%1$s உங்களிடமிருந்து செய்தி கோரிக்கையைப் பெறும். உங்கள் செய்தி கோரிக்கை ஏற்றுக்கொள்ளப்பட்டவுடன் நீங்கள் அழைக்கலாம்.</string>
   <!--KBS Megaphone-->
-  <string name="KbsMegaphone__create_a_pin">பின்னை உருவாக்கவும்</string>
-  <string name="KbsMegaphone__pins_keep_information_thats_stored_with_signal_encrytped">Signal இடம் சேமிக்கப்படும் தகவல்களை மறையாக்கி நீங்கள் மட்டும் அணுகும் வகையில் PIN-கள் வைக்கும்.</string>
-  <string name="KbsMegaphone__create_pin">பின் உருவாக்கவும்</string>
-  <string name="KbsMegaphone__introducing_pins">பின்களை  அறிமுகப்படுத்துகிறது</string>
-  <string name="KbsMegaphone__update_pin">பின்னைப் புதுப்பிக்கவும்</string>
-  <string name="KbsMegaphone__well_remind_you_later_creating_a_pin">நாங்கள் உங்களுக்கு பின்னர் நினைவூட்டுவோம். PIN ஐ உருவாக்குவது %1$dநாட்களில் கட்டாயமாகிவிடும்.</string>
-  <string name="KbsMegaphone__well_remind_you_later_confirming_your_pin">நாங்கள் உங்களுக்கு பின்னர் நினைவூட்டுவோம்.%1$dநாட்களில் உங்கள் பின்னை உறுதிப்படுத்துவது கட்டாயமாகிவிடும்.</string>
+  <string name="KbsMegaphone__create_a_pin">கடவு எண்ணை உருவாக்கவும்</string>
+  <string name="KbsMegaphone__pins_keep_information_thats_stored_with_signal_encrytped">Signal இடம் சேமிக்கப்படும் தகவல்களை மறையாக்கி நீங்கள் மட்டும் அணுகும் வகையில் கடவு எண்-கள் வைக்கும்.</string>
+  <string name="KbsMegaphone__create_pin">கடவு எண் உருவாக்கவும்</string>
+  <string name="KbsMegaphone__introducing_pins">கடவு எண்களை  அறிமுகப்படுத்துகிறது</string>
+  <string name="KbsMegaphone__update_pin">கடவு எண்ணைப் புதுப்பிக்கவும்</string>
+  <string name="KbsMegaphone__well_remind_you_later_creating_a_pin">நாங்கள் உங்களுக்கு பின்னர் நினைவூட்டுவோம். கடவு எண்ணை ஐ உருவாக்குவது %1$dநாட்களில் கட்டாயமாகிவிடும்.</string>
+  <string name="KbsMegaphone__well_remind_you_later_confirming_your_pin">நாங்கள் உங்களுக்கு பின்னர் நினைவூட்டுவோம்.%1$dநாட்களில் உங்கள் கடவு எண்ணை உறுதிப்படுத்துவது கட்டாயமாகிவிடும்.</string>
   <!--Research Megaphone-->
   <string name="ResearchMegaphone_tell_signal_what_you_think">நீங்கள் என்ன நினைக்கிறீர்கள் என்று Signal லிடம் சொல்லுங்கள்</string>
   <string name="ResearchMegaphone_to_make_signal_the_best_messaging_app_on_the_planet">சிக்னலை உலகின் சிறந்த செய்தியிடல் பயன்பாடாக மாற்ற, உங்கள் கருத்தைக் கேட்க நாங்கள் விரும்புகிறோம்.</string>
@@ -2411,55 +2411,55 @@
   <string name="preferences_app_protection__screen_lock">திரை பூட்டு</string>
   <string name="preferences_app_protection__lock_signal_access_with_android_screen_lock_or_fingerprint">அண்ட்ராய்டு திரை பூட்டு அல்லது கைரேகையுடன் Signal அணுகலைப் பூட்டு</string>
   <string name="preferences_app_protection__screen_lock_inactivity_timeout">திரை பூட்டு செயலற்ற நேரம் முடிந்தது</string>
-  <string name="preferences_app_protection__signal_pin">Signal பின்</string>
+  <string name="preferences_app_protection__signal_pin">Signal கடவு எண்</string>
   <string name="preferences_app_protection__create_a_pin">பின்னை உருவாக்கவும்</string>
-  <string name="preferences_app_protection__change_your_pin">உங்கள் பின்னை மாற்றவும்</string>
-  <string name="preferences_app_protection__pin_reminders">கடவுஎண் பின் நினைவூட்டல்கள்</string>
-  <string name="preferences_app_protection__pins_keep_information_stored_with_signal_encrypted">Signal இடம் சேமிக்கப்படும் தகவல்களை மறையாக்கி நீங்கள் மட்டும் அணுகும் வகையில் PIN-கள் வைக்கும். நீங்கள் மீண்டும் நிறுவும்போது உங்கள் சுயவிவரம், அமைப்புகள் மற்றும் தொடர்புகள் மீட்டமைக்கப்படும்.</string>
-  <string name="preferences_app_protection__add_extra_security_by_requiring_your_signal_pin_to_register">உங்கள் தொலைபேசி எண்ணை மீண்டும் சிக்னலுடன் பதிவு செய்ய உங்கள் சிக்னல் பின் தேவைப்படுவதன் மூலம் கூடுதல் பாதுகாப்பைச் சேர்க்கவும்.</string>
+  <string name="preferences_app_protection__change_your_pin">உங்கள் கடவு எண்ணை மாற்றவும்</string>
+  <string name="preferences_app_protection__pin_reminders">கடவு எண் நினைவூட்டல்கள்</string>
+  <string name="preferences_app_protection__pins_keep_information_stored_with_signal_encrypted">Signal இடம் சேமிக்கப்படும் தகவல்களை மறையாக்கி நீங்கள் மட்டும் அணுகும் வகையில் கடவு எண்-கள் வைக்கும். நீங்கள் மீண்டும் நிறுவும்போது உங்கள் சுயவிவரம், அமைப்புகள் மற்றும் தொடர்புகள் மீட்டமைக்கப்படும்.</string>
+  <string name="preferences_app_protection__add_extra_security_by_requiring_your_signal_pin_to_register">உங்கள் தொலைபேசி எண்ணை மீண்டும் சிக்னலுடன் பதிவு செய்ய உங்கள் சிக்னல் கடவு எண் தேவைப்படுவதன் மூலம் கூடுதல் பாதுகாப்பைச் சேர்க்கவும்.</string>
   <string name="preferences_app_protection__reminders_help_you_remember_your_pin">உங்கள் பின்னை மீட்டெடுக்க முடியாததால் நினைவூட்டல்கள் உங்களுக்கு உதவுகின்றன. காலப்போக்கில் உங்களிடம் குறைவாகவே கேட்கப்படும்.</string>
   <string name="preferences_app_protection__turn_off">அணைக்க</string>
-  <string name="preferences_app_protection__confirm_pin">பின்னை உறுதிப்படுத்தவும்</string>
-  <string name="preferences_app_protection__confirm_your_signal_pin">உறுதிப்படுத்தவும் உங்கள் Signal பின்</string>
-  <string name="preferences_app_protection__make_sure_you_memorize_or_securely_store_your_pin">உங்கள் PIN ஐ மீட்டெடுக்க முடியாததால் அதை நினைவில் வைத்துக் கொள்ளுங்கள் அல்லது பாதுகாப்பாக சேமித்து வைக்கவும். உங்கள் பின்னை மறந்துவிட்டால், உங்கள் சிக்னல் கணக்கை மீண்டும் பதிவு செய்யும் போது தரவை இழக்க நேரிடும்.</string>
-  <string name="preferences_app_protection__incorrect_pin_try_again">தவறான பின். மீண்டும் முயற்சி செய்க.</string>
+  <string name="preferences_app_protection__confirm_pin">கடவு எண்ணை உறுதிப்படுத்தவும்</string>
+  <string name="preferences_app_protection__confirm_your_signal_pin">உறுதிப்படுத்தவும் உங்கள் Signal கடவு எண்</string>
+  <string name="preferences_app_protection__make_sure_you_memorize_or_securely_store_your_pin">உங்கள் கடவு எண்-ஐ மீட்டெடுக்க முடியாததால் அதை நினைவில் வைத்துக் கொள்ளுங்கள் அல்லது பாதுகாப்பாக சேமித்து வைக்கவும். உங்கள் பின்னை மறந்துவிட்டால், உங்கள் சிக்னல் கணக்கை மீண்டும் பதிவு செய்யும் போது தரவை இழக்க நேரிடும்.</string>
+  <string name="preferences_app_protection__incorrect_pin_try_again">தவறான கடவு எண். மீண்டும் முயற்சி செய்க.</string>
   <string name="preferences_app_protection__failed_to_enable_registration_lock">பதிவு பூட்டை இயக்குவதில் தோல்வி.</string>
   <string name="preferences_app_protection__failed_to_disable_registration_lock">பதிவு பூட்டை முடக்குவதில் தோல்வி.</string>
   <string name="AppProtectionPreferenceFragment_none">எதுவும் இல்லை</string>
-  <string name="registration_activity__the_registration_lock_pin_is_not_the_same_as_the_sms_verification_code_you_just_received_please_enter_the_pin_you_previously_configured_in_the_application">பதிவு பூட்டு பின் நீங்கள் பெற்ற SMS சரிபார்ப்புக் குறியீடு அல்ல. பயன்பாட்டில் நீங்கள் முன்பு கட்டமைத்த பின்னை உள்ளிடவும்.</string>
+  <string name="registration_activity__the_registration_lock_pin_is_not_the_same_as_the_sms_verification_code_you_just_received_please_enter_the_pin_you_previously_configured_in_the_application">பதிவு பூட்டு கடவு எண் நீங்கள் பெற்ற SMS சரிபார்ப்புக் குறியீடு அல்ல. பயன்பாட்டில் நீங்கள் முன்பு கட்டமைத்த பின்னை உள்ளிடவும்.</string>
   <string name="registration_activity__registration_lock_pin">பதிவு பூட்டு பின்</string>
-  <string name="registration_activity__forgot_pin">பின் மறந்துவிட்டீர்களா?</string>
-  <string name="registration_lock_dialog_view__the_pin_can_consist_of_four_or_more_digits_if_you_forget_your_pin_you_could_be_locked_out_of_your_account_for_up_to_seven_days">பின் நான்கு அல்லது அதற்கு மேற்பட்ட இலக்கங்களைக் கொண்டிருக்கலாம். உங்கள் பின்னை மறந்துவிட்டால், ஏழு நாட்கள் வரை உங்கள் கணக்கு லிருந்து பூட்டப்படலாம்.</string>
-  <string name="registration_lock_dialog_view__enter_pin">பின்னை உள்ளிடவும்</string>
-  <string name="registration_lock_dialog_view__confirm_pin">பின்னை உறுதிப்படுத்தவும்</string>
-  <string name="registration_lock_reminder_view__enter_your_registration_lock_pin">உங்கள் பதிவு பூட்டு பின்னை உள்ளிடவும்</string>
-  <string name="registration_lock_reminder_view__enter_pin">பின்னை உள்ளிடவும்</string>
-  <string name="preferences_app_protection__enable_a_registration_lock_pin_that_will_be_required">இந்த தொலைபேசி எண்ணை மீண்டும் Signal லுடன் பதிவு செய்ய வேண்டிய பதிவு பூட்டு பின்னை இயக்கவும்.</string>
-  <string name="preferences_app_protection__registration_lock_pin">பதிவு பூட்டு பின்</string>
+  <string name="registration_activity__forgot_pin">கடவு எண் மறந்துவிட்டீர்களா?</string>
+  <string name="registration_lock_dialog_view__the_pin_can_consist_of_four_or_more_digits_if_you_forget_your_pin_you_could_be_locked_out_of_your_account_for_up_to_seven_days">கடவு எண் நான்கு அல்லது அதற்கு மேற்பட்ட இலக்கங்களைக் கொண்டிருக்கலாம். உங்கள் பின்னை மறந்துவிட்டால், ஏழு நாட்கள் வரை உங்கள் கணக்கு லிருந்து பூட்டப்படலாம்.</string>
+  <string name="registration_lock_dialog_view__enter_pin">கடவு எண் உள்ளிடவும்</string>
+  <string name="registration_lock_dialog_view__confirm_pin">கடவு எண் உறுதிப்படுத்தவும்</string>
+  <string name="registration_lock_reminder_view__enter_your_registration_lock_pin">உங்கள் பதிவு பூட்டு கடவு எண்ணை உள்ளிடவும்</string>
+  <string name="registration_lock_reminder_view__enter_pin">கடவு எண்ணை உள்ளிடவும்</string>
+  <string name="preferences_app_protection__enable_a_registration_lock_pin_that_will_be_required">இந்த தொலைபேசி எண்ணை மீண்டும் Signal லுடன் பதிவு செய்ய வேண்டிய பதிவு பூட்டு கடவு எண்ணை இயக்கவும்.</string>
+  <string name="preferences_app_protection__registration_lock_pin">பதிவு பூட்டு கடவு எண்</string>
   <string name="preferences_app_protection__registration_lock">பதிவு பூட்டு</string>
-  <string name="RegistrationActivity_you_must_enter_your_registration_lock_PIN">உங்கள் பதிவு பூட்டு பின்னை உள்ளிட வேண்டும்</string>
-  <string name="RegistrationActivity_your_pin_has_at_least_d_digits_or_characters">உங்கள் PIN இல் குறைந்தது %d இலக்கங்கள் அல்லது எழுத்துக்கள் இருக்க வேண்டும்</string>
-  <string name="RegistrationActivity_incorrect_registration_lock_pin">தவறான பதிவு பூட்டு பின்</string>
+  <string name="RegistrationActivity_you_must_enter_your_registration_lock_PIN">உங்கள் பதிவு பூட்டு கடவு எண்ணை உள்ளிட வேண்டும்</string>
+  <string name="RegistrationActivity_your_pin_has_at_least_d_digits_or_characters">உங்கள் கடவு எண் இல் குறைந்தது %d இலக்கங்கள் அல்லது எழுத்துக்கள் இருக்க வேண்டும்</string>
+  <string name="RegistrationActivity_incorrect_registration_lock_pin">தவறான பதிவு பூட்டு கடவு எண்</string>
   <string name="RegistrationActivity_too_many_attempts">மிக அதிக முயற்சிகள்</string>
-  <string name="RegistrationActivity_you_have_made_too_many_incorrect_registration_lock_pin_attempts_please_try_again_in_a_day">நீங்கள் பல தவறான பதிவு பூட்டு பின் முயற்சிகளை செய்துள்ளீர்கள். ஒரு நாளில் மீண்டும் முயற்சிக்கவும்.</string>
+  <string name="RegistrationActivity_you_have_made_too_many_incorrect_registration_lock_pin_attempts_please_try_again_in_a_day">நீங்கள் பல தவறான பதிவு பூட்டு கடவு எண் முயற்சிகளை செய்துள்ளீர்கள். ஒரு நாளில் மீண்டும் முயற்சிக்கவும்.</string>
   <string name="RegistrationActivity_you_have_made_too_many_attempts_please_try_again_later">நீங்கள் பல முயற்சிகள் செய்துள்ளீர்கள். சிறிது நேரம் கழித்து மீண்டும் முயற்சிக்கவும்.</string>
   <string name="RegistrationActivity_error_connecting_to_service">சேவைக்கு இணைப்பதில் பிழை</string>
   <string name="RegistrationActivity_oh_no">அச்சச்சோ!</string>
-  <string name="RegistrationActivity_registration_of_this_phone_number_will_be_possible_without_your_registration_lock_pin_after_seven_days_have_passed">பதிவு பூட்டு PIN இல்லாமல் இந்த தொலைபேசி எண்ணை பதிவு செய்ய, Signal-இல் இந்த தொலைபேசி எண் கடைசியாக செயலில் இருந்து 7 நாட்கள் கடந்துவிட்ட பின் சாத்தியமாகும். உங்களுக்கு %d நாட்கள் மீதம் உள்ளன.</string>
+  <string name="RegistrationActivity_registration_of_this_phone_number_will_be_possible_without_your_registration_lock_pin_after_seven_days_have_passed">பதிவு பூட்டு கடவு எண் இல்லாமல் இந்த தொலைபேசி எண்ணை பதிவு செய்ய, Signal-இல் இந்த தொலைபேசி எண் கடைசியாக செயலில் இருந்து 7 நாட்கள் கடந்துவிட்ட பின் சாத்தியமாகும். உங்களுக்கு %d நாட்கள் மீதம் உள்ளன.</string>
   <string name="RegistrationActivity_registration_lock_pin">பதிவு பூட்டு பின்</string>
   <string name="RegistrationActivity_this_phone_number_has_registration_lock_enabled_please_enter_the_registration_lock_pin">இந்த தொலைபேசி எண்ணில் பதிவு பூட்டு இயக்கப்பட்டுள்ளது. பதிவு பூட்டு பின்னை உள்ளிடவும்.</string>
-  <string name="RegistrationLockDialog_registration_lock_is_enabled_for_your_phone_number">உங்கள் தொலைபேசி எண்ணுக்கு பதிவு பூட்டு இயக்கப்பட்டது. உங்கள் பதிவு பூட்டு PIN-ஐ மனப்பாடம் செய்ய உங்களுக்கு உதவ, Signal அவ்வப்போது அதை உறுதிப்படுத்தும்படி கேட்கும்.</string>
+  <string name="RegistrationLockDialog_registration_lock_is_enabled_for_your_phone_number">உங்கள் தொலைபேசி எண்ணுக்கு பதிவு பூட்டு இயக்கப்பட்டது. உங்கள் பதிவு பூட்டு கடவு எண்-ஐ மனப்பாடம் செய்ய உங்களுக்கு உதவ, Signal அவ்வப்போது அதை உறுதிப்படுத்தும்படி கேட்கும்.</string>
   <string name="RegistrationLockDialog_i_forgot_my_pin">எனது பின்னை மறந்துவிட்டேன்.</string>
   <string name="RegistrationLockDialog_forgotten_pin">பின்னை மறந்துவிட்டர்களா?</string>
   <string name="RegistrationLockDialog_registration_lock_helps_protect_your_phone_number_from_unauthorized_registration_attempts">பதிவு பூட்டு உங்கள் தொலைபேசி எண்ணை அங்கீகரிக்கப்படாத பதிவு முயற்சிகளிலிருந்து பாதுகாக்க உதவுகிறது. உங்கள் Signal தனியுரிமை அமைப்புகளில் எந்த நேரத்திலும் இந்த அம்சத்தை முடக்கலாம்</string>
   <string name="RegistrationLockDialog_registration_lock">பதிவு பூட்டு</string>
   <string name="RegistrationLockDialog_enable">செயல்படுத்து</string>
-  <string name="RegistrationLockDialog_the_registration_lock_pin_must_be_at_least_d_digits">பதிவு பூட்டு பின் குறைந்தபட்சம்  %d இலக்கங்கள் இருக்க வேண்டும்.</string>
+  <string name="RegistrationLockDialog_the_registration_lock_pin_must_be_at_least_d_digits">பதிவு பூட்டு கடவு எண் குறைந்தபட்சம்  %d இலக்கங்கள் இருக்க வேண்டும்.</string>
   <string name="RegistrationLockDialog_the_two_pins_you_entered_do_not_match">நீங்கள் உள்ளிட்ட இரண்டு பின்களும்  பொருந்தவில்லை.</string>
   <string name="RegistrationLockDialog_error_connecting_to_the_service">சேவைக்கு இணைப்பதில் பிழை</string>
-  <string name="RegistrationLockDialog_disable_registration_lock_pin">பதிவு பூட்டு PIN-ஐ முடக்கவா?</string>
+  <string name="RegistrationLockDialog_disable_registration_lock_pin">பதிவு பூட்டு கடவு எண்-ஐ முடக்கவா?</string>
   <string name="RegistrationLockDialog_disable">முடக்கு</string>
-  <string name="RegistrationActivity_pin_incorrect">பின் தவறானது</string>
+  <string name="RegistrationActivity_pin_incorrect">கடவு எண் தவறானது</string>
   <string name="RegistrationActivity_you_have_d_tries_remaining">உங்களிடம் %d முயற்சிகள் மீதமுள்ளது </string>
   <string name="preferences_chats__backups">காப்புப் பிரதிகள்</string>
   <string name="prompt_passphrase_activity__signal_is_locked">Signal பூட்டப்பட்டுள்ளது</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -28,7 +28,7 @@
   <string name="ApplicationPreferencesActivity_this_will_permanently_unlock_signal_and_message_notifications">இது நிரந்தரமாக சிக்னல் செய்தி அறிவிப்புகளைத் திறக்கும்.</string>
   <string name="ApplicationPreferencesActivity_disable">முடக்கு</string>
   <string name="ApplicationPreferencesActivity_unregistering">பதிவுநீக்குதல்</string>
-  <string name="ApplicationPreferencesActivity_unregistering_from_signal_messages_and_calls">Signal குறுஞ்செய்தி மற்றும் அழைப்பு பதிவுநீக்கப்படுகிறது …</string>
+  <string name="ApplicationPreferencesActivity_unregistering_from_signal_messages_and_calls">சிக்னல் குறுஞ்செய்தி மற்றும் அழைப்பு பதிவுநீக்கப்படுகிறது …</string>
   <string name="ApplicationPreferencesActivity_disable_signal_messages_and_calls">சிக்னல் குறுஞ்செய்தி மற்றும் அழைப்பை முடக்கு ?</string>
   <string name="ApplicationPreferencesActivity_disable_signal_messages_and_calls_by_unregistering">சேவையகத்திலிருந்து பதிவுசெய்வதன் மூலம் சிக்னல் செய்திகள் மற்றும் அழைப்புகளை முடக்கு. எதிர்காலத்தில் மீண்டும் அவற்றைப் பயன்படுத்த நீங்கள் உங்கள் தொலைபேசி எண்ணை மீண்டும் பதிவு செய்ய வேண்டும்.</string>
   <string name="ApplicationPreferencesActivity_error_connecting_to_server">சர்வருடன் இணைவதில் பிழை!</string>
@@ -70,10 +70,10 @@
   <string name="AttachmentKeyboard_give_access">அணுகல் கொடுங்கள்</string>
   <!--AttachmentManager-->
   <string name="AttachmentManager_cant_open_media_selection">மீடியாவை தேர்வுசெய்யும் ஒரு பயன்பாட்டை கண்டுபிடிக்க முடியவில்லை.</string>
-  <string name="AttachmentManager_signal_requires_the_external_storage_permission_in_order_to_attach_photos_videos_or_audio">புகைப்படங்கள், காணொளிகள் அல்லது ஆடியோவை இணைக்கவும் Signal க்கு சேமிப்பக அனுமதி தேவைப்படுகிறது, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகள் மெனுவில் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து \"சேமிப்பகத்தை\" இயக்கவும்.</string>
-  <string name="AttachmentManager_signal_requires_contacts_permission_in_order_to_attach_contact_information">தொடர்பு தகவலை இணைக்கவும் Signal க்கு தொடர்புகளின் அனுமதி தேவைப்படுகிறது, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகள் மெனுவில் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து, \"தொடர்புகளை\" இயக்கவும்.</string>
-  <string name="AttachmentManager_signal_requires_location_information_in_order_to_attach_a_location">இருப்பிடத்தை இணைக்கவும், Signal க்கு இருப்பிட அனுமதி தேவைப்படுகிறது, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகள் மெனுவில் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து, \"இருப்பிடம்\" ஐ இயக்கவும்.</string>
-  <string name="AttachmentManager_signal_requires_the_camera_permission_in_order_to_take_photos_but_it_has_been_permanently_denied">புகைப்படங்களை எடுக்க Signal க்கு கேமரா அனுமதி தேவைப்படுகிறது, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகள் மெனுவில் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து \"கேமரா\" ஐ இயக்கவும்.</string>
+  <string name="AttachmentManager_signal_requires_the_external_storage_permission_in_order_to_attach_photos_videos_or_audio">புகைப்படங்கள், காணொளிகள் அல்லது ஆடியோவை இணைக்கவும் சிக்னல்-க்கு சேமிப்பக அனுமதி தேவைப்படுகிறது, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகள் மெனுவில் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து \"சேமிப்பகத்தை\" இயக்கவும்.</string>
+  <string name="AttachmentManager_signal_requires_contacts_permission_in_order_to_attach_contact_information">தொடர்பு தகவலை இணைக்கவும் சிக்னல்-க்கு தொடர்புகளின் அனுமதி தேவைப்படுகிறது, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகள் மெனுவில் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து, \"தொடர்புகளை\" இயக்கவும்.</string>
+  <string name="AttachmentManager_signal_requires_location_information_in_order_to_attach_a_location">இருப்பிடத்தை இணைக்கவும், சிக்னல்-க்கு இருப்பிட அனுமதி தேவைப்படுகிறது, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகள் மெனுவில் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து, \"இருப்பிடம்\" ஐ இயக்கவும்.</string>
+  <string name="AttachmentManager_signal_requires_the_camera_permission_in_order_to_take_photos_but_it_has_been_permanently_denied">புகைப்படங்களை எடுக்க சிக்னல்-க்கு கேமரா அனுமதி தேவைப்படுகிறது, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகள் மெனுவில் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து \"கேமரா\" ஐ இயக்கவும்.</string>
   <!--AttachmentUploadJob-->
   <string name="AttachmentUploadJob_uploading_media">மீடியா பதிவேற்றுகிறது …</string>
   <string name="AttachmentUploadJob_compressing_video_start">காணொளி சுறுக்கப்படுகிறது…</string>
@@ -122,26 +122,26 @@
   <string name="CameraXFragment_open_gallery_description">கேலரியை திற </string>
   <!--CameraContacts-->
   <string name="CameraContacts_recent_contacts">சமீபத்திய தொடர்புகள்</string>
-  <string name="CameraContacts_signal_contacts">Signal தொடர்புகள்</string>
-  <string name="CameraContacts_signal_groups">Signal குழுக்கள்</string>
+  <string name="CameraContacts_signal_contacts">சிக்னல் தொடர்புகள்</string>
+  <string name="CameraContacts_signal_groups">சிக்னல் குழுக்கள்</string>
   <string name="CameraContacts_you_can_share_with_a_maximum_of_n_conversations">நீங்கள் அதிகபட்சம்  1%d உரையாடல்களுடன் பகிரலாம்.</string>
-  <string name="CameraContacts_select_signal_recipients">Signal பெறுநர்களைத் தேர்ந்தெடுக்கவும்</string>
-  <string name="CameraContacts_no_signal_contacts">Signal தொடர்புகள் இல்லை</string>
-  <string name="CameraContacts_you_can_only_use_the_camera_button">Signal தொடர்புகளுக்கு புகைப்படங்களை அனுப்ப கேமரா பொத்தானை மட்டுமே நீங்கள் பயன்படுத்த முடியும்.</string>
+  <string name="CameraContacts_select_signal_recipients">சிக்னல் பெறுநர்களைத் தேர்ந்தெடுக்கவும்</string>
+  <string name="CameraContacts_no_signal_contacts">சிக்னல் தொடர்புகள் இல்லை</string>
+  <string name="CameraContacts_you_can_only_use_the_camera_button">சிக்னல் தொடர்புகளுக்கு புகைப்படங்களை அனுப்ப கேமரா பொத்தானை மட்டுமே நீங்கள் பயன்படுத்த முடியும்.</string>
   <string name="CameraContacts_cant_find_who_youre_looking_for">நீங்கள் யாரைத் தேடுகிறீர்கள் என்று கண்டுபிடிக்க முடியவில்லையா?</string>
-  <string name="CameraContacts_invite_a_contact_to_join_signal">Signal லில் சேர ஒரு தொடர்பை அழைக்கவும்</string>
+  <string name="CameraContacts_invite_a_contact_to_join_signal">சிக்னலில் சேர ஒரு தொடர்பை அழைக்கவும்</string>
   <string name="CameraContacts__menu_search">தேடல்</string>
   <!--ClearProfileActivity-->
   <string name="ClearProfileActivity_remove">நீக்கு</string>
   <string name="ClearProfileActivity_remove_profile_photo">சுயவிவர படத்தை நீக்கவா?</string>
   <string name="ClearProfileActivity_remove_group_photo">குழு புகைப்படத்தை அகற்றவா?</string>
   <!--ClientDeprecatedActivity-->
-  <string name="ClientDeprecatedActivity_update_signal">Signal லைப் புதுப்பிக்கவும்</string>
+  <string name="ClientDeprecatedActivity_update_signal">சிக்னலைப் புதுப்பிக்கவும்</string>
   <string name="ClientDeprecatedActivity_this_version_of_the_app_is_no_longer_supported">பயன்பாட்டின் இந்த பதிப்பு இனி ஆதரிக்கப்படாது. செய்திகளை அனுப்புவதையும் பெறுவதையும் தொடர, சமீபத்திய பதிப்பிற்கு புதுப்பிக்கவும்.</string>
   <string name="ClientDeprecatedActivity_update">புதுப்பிக்கப்பட்டது</string>
   <string name="ClientDeprecatedActivity_dont_update">புதுப்பிக்க வேண்டாம்</string>
   <string name="ClientDeprecatedActivity_warning">எச்சரிக்கை</string>
-  <string name="ClientDeprecatedActivity_your_version_of_signal_has_expired_you_can_view_your_message_history">Signal லின் உங்கள் பதிப்பு காலாவதியானது. உங்கள் செய்தி வரலாற்றை நீங்கள் காணலாம், ஆனால் நீங்கள் புதுப்பிக்கும் வரை செய்திகளை அனுப்பவோ பெறவோ முடியாது.</string>
+  <string name="ClientDeprecatedActivity_your_version_of_signal_has_expired_you_can_view_your_message_history">சிக்னலின் உங்கள் பதிப்பு காலாவதியானது. உங்கள் செய்தி வரலாற்றை நீங்கள் காணலாம், ஆனால் நீங்கள் புதுப்பிக்கும் வரை செய்திகளை அனுப்பவோ பெறவோ முடியாது.</string>
   <!--CommunicationActions-->
   <string name="CommunicationActions_no_browser_found">இணைய உலாவி இல்லை.</string>
   <string name="CommunicationActions_no_email_app_found">மின்னஞ்சல் பயன்பாடு எதுவும் கிடைக்கவில்லை.</string>
@@ -165,7 +165,7 @@
   <string name="ContactsCursorLoader_username_search">பயனர்பெயர் தேடல்</string>
   <!--ContactsDatabase-->
   <string name="ContactsDatabase_message_s">செய்தி %s</string>
-  <string name="ContactsDatabase_signal_call_s"> Signal அழைப்பு %s</string>
+  <string name="ContactsDatabase_signal_call_s"> சிக்னல் அழைப்பு %s</string>
   <!--ContactNameEditActivity-->
   <string name="ContactNameEditActivity_given_name">கொடுக்கப்பட்ட பெயர்</string>
   <string name="ContactNameEditActivity_family_name">குடும்ப பெயர்</string>
@@ -187,7 +187,7 @@
   <string name="ConversationItem_click_to_approve_unencrypted">அனுப்புதல் தோல்வியுற்றது, பாதுகாப்பற்ற மாற்று செய்ய  தட்டவும்</string>
   <string name="ConversationItem_click_to_approve_unencrypted_sms_dialog_title">மாற்றாக மறையாக்கப்படாத SMS-ஆக அனுப்பலாமா?</string>
   <string name="ConversationItem_click_to_approve_unencrypted_mms_dialog_title">மாற்றாக மறையாக்கப்படாத MMS-ஆக அனுப்பலாமா?</string>
-  <string name="ConversationItem_click_to_approve_unencrypted_dialog_message">பெறுநர் இனி Signal பயனராக இல்லாததால் இந்த செய்தி மறையாக்கம் <b>செய்யப்படாது</b>. \n\nபாதுகாப்பற்ற செய்தியாக அனுப்பவா?</string>
+  <string name="ConversationItem_click_to_approve_unencrypted_dialog_message">பெறுநர் இனி சிக்னல் பயனராக இல்லாததால் இந்த செய்தி மறையாக்கம் <b>செய்யப்படாது</b>. \n\nபாதுகாப்பற்ற செய்தியாக அனுப்பவா?</string>
   <string name="ConversationItem_unable_to_open_media">இந்த ஊடகத்தை திறக்க பயன்படும் ஒரு பயன்பாட்டை கண்டுபிடிக்க இயலவில்லை</string>
   <string name="ConversationItem_copied_text">நகலெடுக்கப்பட்டன %s</string>
   <string name="ConversationItem_from_s">அனுப்பினர் %s</string>
@@ -230,17 +230,17 @@
   <string name="ConversationActivity_there_is_no_app_available_to_handle_this_link_on_your_device">உஙகள் சாதனத்தில் இந்த இணைப்பை பெறக்கூடிய  செயலி கிடைப்பில்  இல்லை  .</string>
   <string name="ConversationActivity_your_request_to_join_has_been_sent_to_the_group_admin">குழுவில் சேர உங்கள் கோரிக்கை குழு நிர்வாகிக்கு அனுப்பப்பட்டுள்ளது. அவர்கள் நடவடிக்கை எடுக்கும்போது உங்களுக்கு அறிவிக்கப்படும்.</string>
   <string name="ConversationActivity_cancel_request">கோரிக்கையை ரத்துசெய்</string>
-  <string name="ConversationActivity_to_send_audio_messages_allow_signal_access_to_your_microphone">ஆடியோ செய்திகளை அனுப்ப, உங்கள் மைக்ரோஃபோனுக்கு Signal அணுகலை அனுமதிக்கவும்.</string>
-  <string name="ConversationActivity_signal_requires_the_microphone_permission_in_order_to_send_audio_messages">ஆடியோ செய்திகளை அனுப்ப Signal க்கு மைக்ரோஃபோன் அனுமதி தேவைப்படுகிறது, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகளைத் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து, \"மைக்ரோஃபோனை\" இயக்கவும்.</string>
-  <string name="ConversationActivity_signal_needs_the_microphone_and_camera_permissions_in_order_to_call_s">Signal லை அழைக்க மைக்ரோஃபோன் மற்றும் கேமரா அனுமதிகள் தேவை%s, ஆனால் அவை நிரந்தரமாக மறுக்கப்பட்டுள்ளன. பயன்பாடு அமைப்புகளைத் தொடரவும், \"அனுமதி\" என்பதைத் தேர்ந்தெடுத்து, \"மைக்ரோஃபோன்\" மற்றும் \"கேமரா\" ஐ இயக்கவும்.</string>
+  <string name="ConversationActivity_to_send_audio_messages_allow_signal_access_to_your_microphone">ஆடியோ செய்திகளை அனுப்ப, உங்கள் மைக்ரோஃபோனுக்கு சிக்னல் அணுகலை அனுமதிக்கவும்.</string>
+  <string name="ConversationActivity_signal_requires_the_microphone_permission_in_order_to_send_audio_messages">ஆடியோ செய்திகளை அனுப்ப சிக்னலுக்கு மைக்ரோஃபோன் அனுமதி தேவைப்படுகிறது, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகளைத் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து, \"மைக்ரோஃபோனை\" இயக்கவும்.</string>
+  <string name="ConversationActivity_signal_needs_the_microphone_and_camera_permissions_in_order_to_call_s">சிக்னலை அழைக்க மைக்ரோஃபோன் மற்றும் கேமரா அனுமதிகள் தேவை%s, ஆனால் அவை நிரந்தரமாக மறுக்கப்பட்டுள்ளன. பயன்பாடு அமைப்புகளைத் தொடரவும், \"அனுமதி\" என்பதைத் தேர்ந்தெடுத்து, \"மைக்ரோஃபோன்\" மற்றும் \"கேமரா\" ஐ இயக்கவும்.</string>
   <string name="ConversationActivity_to_capture_photos_and_video_allow_signal_access_to_the_camera">புகைப்படங்கள் மற்றும் காணொளி பிடிக்க, Signal-ஐ கேமராவை அணுக அனுமதிக்கவும்.</string>
   <string name="ConversationActivity_signal_needs_the_camera_permission_to_take_photos_or_video">புகைப்படங்கள் அல்லது வீடியோ எடுக்க Signal-க்கு கேமரா அனுமதி தேவை, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. செயலியின் அமைப்புகளுக்கு சென்று, \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து \"கேமரா\"-ஐ இயலச் செய்யவும்.</string>
   <string name="ConversationActivity_signal_needs_camera_permissions_to_take_photos_or_video">புகைப்படங்கள் அல்லது காணொளி எடுக்க Signal-க்கு கேமரா அனுமதி தேவை</string>
   <string name="ConversationActivity_enable_the_microphone_permission_to_capture_videos_with_sound">ஒலியுடன் காணொளிகளைப் பிடிக்க மைக்ரோஃபோன் அனுமதியை இயலச் செய்யவும்.</string>
-  <string name="ConversationActivity_signal_needs_the_recording_permissions_to_capture_video">காணொளிகளைப் பதிவு செய்ய Signal மைக்ரோஃபோன் அனுமதி தேவை, ஆனால் அது மறுக்கப்பட்டது. செயலியின் அமைப்புகளுக்கு சென்று, \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து  \"மைக்ரோஃபோன்\" மற்றும் \"கேமரா\" என்பவற்றை இயலச் செய்யவும்.</string>
+  <string name="ConversationActivity_signal_needs_the_recording_permissions_to_capture_video">காணொளிகளைப் பதிவு செய்ய சிக்னல் மைக்ரோஃபோன் அனுமதி தேவை, ஆனால் அது மறுக்கப்பட்டது. செயலியின் அமைப்புகளுக்கு சென்று, \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து  \"மைக்ரோஃபோன்\" மற்றும் \"கேமரா\" என்பவற்றை இயலச் செய்யவும்.</string>
   <string name="ConversationActivity_signal_needs_recording_permissions_to_capture_video">காணொளிகளைப் பதிவு செய்ய Signal-க்கு மைக்ரோஃபோன் அனுமதி தேவை.</string>
   <string name="ConversationActivity_quoted_contact_message">%1$s %2$s</string>
-  <string name="ConversationActivity_signal_cannot_sent_sms_mms_messages_because_it_is_not_your_default_sms_app">Signal SMS/MMS செய்திகளை அனுப்ப முடியாது, ஏனெனில் இது உங்கள் இயல்புநிலை SMS பயன்பாடு அல்ல. உங்கள் ஆண்ட்ராய்டு அமைப்புகளில் இதை மாற்ற விரும்புகிறீர்களா?</string>
+  <string name="ConversationActivity_signal_cannot_sent_sms_mms_messages_because_it_is_not_your_default_sms_app">சிக்னல் SMS/MMS செய்திகளை அனுப்ப முடியாது, ஏனெனில் இது உங்கள் இயல்புநிலை SMS பயன்பாடு அல்ல. உங்கள் ஆண்ட்ராய்டு அமைப்புகளில் இதை மாற்ற விரும்புகிறீர்களா?</string>
   <string name="ConversationActivity_yes">ஆம்</string>
   <string name="ConversationActivity_no">இல்லை</string>
   <string name="ConversationActivity_search_position">%2$d இன் %1$d</string>
@@ -311,7 +311,7 @@
   <string name="ConversationFragment__d_group_members_have_the_same_name">%1$dகுழு உறுப்பினர்களுக்கு ஒரே பெயர் உண்டு.</string>
   <string name="ConversationFragment__tap_to_review">மதிப்பாய்வு செய்ய தட்டவும்</string>
   <string name="ConversationFragment__review_requests_carefully">கோரிக்கைகளை கவனமாக மதிப்பாய்வு செய்யவும்</string>
-  <string name="ConversationFragment__signal_found_another_contact_with_the_same_name">அதே பெயருடன் மற்றொரு தொடர்பை Signal கண்டறிந்தது.</string>
+  <string name="ConversationFragment__signal_found_another_contact_with_the_same_name">அதே பெயருடன் மற்றொரு தொடர்பை சிக்னல் கண்டறிந்தது.</string>
   <!--ConversationListActivity-->
   <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">உங்கள் சாதனத்தில் எந்த உலாவியும் நிறுவப்படவில்லை.</string>
   <!--ConversationListFragment-->
@@ -377,7 +377,7 @@
   <string name="BackupsPreferenceFragment__learn_more">மேலும் அறிக</string>
   <string name="BackupsPreferenceFragment__in_progress">செயல்நிலையில் உள்ளது…</string>
   <string name="BackupsPreferenceFragment__d_so_far">%1$dஇதுவரை…</string>
-  <string name="BackupsPreferenceFragment_signal_requires_external_storage_permission_in_order_to_create_backups">காப்புப்பிரதிகளை உருவாக்க Signal கு வெளிப்புற சேமிப்பக அனுமதி தேவைப்படுகிறது, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகளைத் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து \"சேமிப்பகத்தை\" இயக்கவும்.</string>
+  <string name="BackupsPreferenceFragment_signal_requires_external_storage_permission_in_order_to_create_backups">காப்புப்பிரதிகளை உருவாக்க சிக்னலுக்கு வெளிப்புற சேமிப்பக அனுமதி தேவைப்படுகிறது, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகளைத் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து \"சேமிப்பகத்தை\" இயக்கவும்.</string>
   <!--CustomDefaultPreference-->
   <string name="CustomDefaultPreference_using_custom">பயன்படுத்தப்படும் வழக்கம் : %s</string>
   <string name="CustomDefaultPreference_using_default">பயன்படுத்தப்படும் இயல்புநிலை: %s</string>
@@ -416,7 +416,7 @@
   <string name="DocumentView_unnamed_file">பெயரிடப்படாத கோப்பு</string>
   <!--DonateMegaphone-->
   <string name="DonateMegaphone_donate_to_signal">Signal-க்கு நன்கொடை அளி</string>
-  <string name="DonateMegaphone_Signal_is_powered_by_people_like_you_show_your_support_today">Signal லை உங்களைப் போன்றவர்கள் ஆதரிக்கிறார்கள். இன்று உங்கள் ஆதரவைக் காட்டுங்கள்!</string>
+  <string name="DonateMegaphone_Signal_is_powered_by_people_like_you_show_your_support_today">சிக்னலை உங்களைப் போன்றவர்கள் ஆதரிக்கிறார்கள். இன்று உங்கள் ஆதரவைக் காட்டுங்கள்!</string>
   <string name="DonateMegaphone_donate">நன்கொடை</string>
   <string name="DonateMegaphone_no_thanks">வேண்டாம், நன்றி</string>
   <!--GroupCallingMegaphone-->
@@ -424,9 +424,9 @@
   <string name="GroupCallingMegaphone__open_a_new_group_to_start">திற a புதிய குழு இலவசமாக தொடங்க மறையாக்கப்பட்ட குழு அழைப்பு</string>
   <!--DozeReminder-->
   <string name="DozeReminder_optimize_for_missing_play_services">காணாமல் போன விளையாட்டு சேவைகளை மேம்படுத்தவும்</string>
-  <string name="DozeReminder_this_device_does_not_support_play_services_tap_to_disable_system_battery">இந்த சாதனம் Play சேவைகளை ஆதரிக்காது. செயலற்ற நிலையில் செய்திகளை மீட்டெடுப்பதில் இருந்து Signal லைத் தடுக்கும் கணினி பேட்டரி மேம்படுத்தல்களை முடக்க தட்டவும்.</string>
+  <string name="DozeReminder_this_device_does_not_support_play_services_tap_to_disable_system_battery">இந்த சாதனம் Play சேவைகளை ஆதரிக்காது. செயலற்ற நிலையில் செய்திகளை மீட்டெடுப்பதில் இருந்து சிக்னலைத் தடுக்கும் கணினி பேட்டரி மேம்படுத்தல்களை முடக்க தட்டவும்.</string>
   <!--ExpiredBuildReminder-->
-  <string name="ExpiredBuildReminder_this_version_of_signal_has_expired">Signal லின் இந்த பதிப்பு காலாவதியானது. செய்திகளை அனுப்ப மற்றும் பெற பயன்பாட்டைப் புதுப்பிக்கவும்.</string>
+  <string name="ExpiredBuildReminder_this_version_of_signal_has_expired">சிக்னலின் இந்த பதிப்பு காலாவதியானது. செய்திகளை அனுப்ப மற்றும் பெற பயன்பாட்டைப் புதுப்பிக்கவும்.</string>
   <string name="ExpiredBuildReminder_update_now">இப்பொழுது மேம்படுத்து</string>
   <!--PendingGroupJoinRequestsReminder-->
   <plurals name="PendingGroupJoinRequestsReminder_d_pending_member_requests">
@@ -440,7 +440,7 @@
   <!--GcmBroadcastReceiver-->
   <string name="GcmBroadcastReceiver_retrieving_a_message">ஒரு செய்தியை மீட்டெடுக்கிறது …</string>
   <!--GcmRefreshJob-->
-  <string name="GcmRefreshJob_Permanent_Signal_communication_failure">நிரந்தர Signal தொடர்பு தோல்வி!</string>
+  <string name="GcmRefreshJob_Permanent_Signal_communication_failure">நிரந்தர சிக்னல் தொடர்பு தோல்வி!</string>
   <string name="GcmRefreshJob_Signal_was_unable_to_register_with_Google_Play_Services">Google Play சேவை உடன் TextSecure-ஐ பதிவு செய்ய இயலவில்லை. இணையதளம் வழியாக தொடர்புடையாடல் முடக்கப்பட்டுள்ளது, TextSecure அமைப்புகள் மெனுவில் மறுபதிவுச்செய்ய முயற்சிக்கவும்</string>
   <!--GiphyActivity-->
   <string name="GiphyActivity_error_while_retrieving_full_resolution_gif">முழு தெளிவுத்திறன் GIF ஐ மீட்டெடுக்கும்போது பிழை</string>
@@ -605,7 +605,7 @@
   <string name="AddGroupDetailsFragment__groups_require_at_least_two_members">குழுக்களுக்கு குறைந்தது இரண்டு உறுப்பினர்கள் தேவை.</string>
   <string name="AddGroupDetailsFragment__group_creation_failed">குழு உருவாக்கம் தோல்வியடைந்தது.</string>
   <string name="AddGroupDetailsFragment__try_again_later">பின்னர் மீண்டும் முயற்சிக்கவும்.</string>
-  <string name="AddGroupDetailsFragment__youve_selected_a_contact_that_doesnt">Signal அல்லாத பயனர் தொடர்பை நீங்கள் தேர்ந்தெடுத்துள்ளீர்கள், எனவே இந்த குழு எம்.எம்.எஸ்.</string>
+  <string name="AddGroupDetailsFragment__youve_selected_a_contact_that_doesnt">சிக்னல் அல்லாத பயனர் தொடர்பை நீங்கள் தேர்ந்தெடுத்துள்ளீர்கள், எனவே இந்த குழு எஸே.எம்.எஸ்.</string>
   <string name="AddGroupDetailsFragment_custom_mms_group_names_and_photos_will_only_be_visible_to_you">தனிப்பயன் எம்.எம்.எஸ் குழு பெயர்கள் மற்றும் புகைப்படங்கள் உங்களுக்கு மட்டுமே தெரியும்.</string>
   <string name="AddGroupDetailsFragment__remove">நீக்கு</string>
   <string name="AddGroupDetailsFragment__sms_contact">SMS தொடர்பு</string>
@@ -619,10 +619,10 @@
     <item quantity="other">%dஉறுப்பினர்கள் புதிய குழுக்களை ஆதரிக்க மாட்டார்கள், எனவே இந்த குழுவை உருவாக்க முடியாது.</item>
   </plurals>
   <!--NonGv2MemberDialog-->
-  <string name="NonGv2MemberDialog_single_users_are_non_gv2_capable">“%1$s” பழைய Signal பதிப்பைப் பயன்படுத்துவதால் ஒரு பழைய மரபு குழு உருவாக்கப்படும். அவர்கள் Signal புதுப்பித்த பிறகு அவர்களுடன் ஒரு புதிய பாணி குழுவை உருவாக்கலாம் அல்லது குழுவை உருவாக்கும் முன் இந்த உறுப்பினரை அகற்றலாம்.</string>
+  <string name="NonGv2MemberDialog_single_users_are_non_gv2_capable">“%1$s” பழைய சிக்னல் பதிப்பைப் பயன்படுத்துவதால் ஒரு பழைய மரபு குழு உருவாக்கப்படும். அவர்கள் சிக்னல் புதுப்பித்த பிறகு அவர்களுடன் ஒரு புதிய பாணி குழுவை உருவாக்கலாம் அல்லது குழுவை உருவாக்கும் முன் இந்த உறுப்பினரை அகற்றலாம்.</string>
   <plurals name="NonGv2MemberDialog_d_users_are_non_gv2_capable">
-    <item quantity="one">%1$d உறுப்பினர் பழைய Signal பதிப்பைப் பயன்படுத்துவதால் பழைய மரபு குழு உருவாக்கப்படும். அவர்கள் Signal புதுப்பித்த பிறகு அவர்களுடன் புதிய பாணி குழுவை உருவாக்கலாம் அல்லது குழுவை உருவாக்கும் முன் அவரை அகற்றலாம்.</item>
-    <item quantity="other">%1$d உறுப்பினர்கள் பழைய Signal பதிப்பைப் பயன்படுத்துவதால் பழைய மரபு குழு உருவாக்கப்படும். அவர்கள் Signal புதுப்பித்த பிறகு அவர்களுடன் புதிய பாணி குழுவை உருவாக்கலாம் அல்லது குழுவை உருவாக்கும் முன் அவர்களை அகற்றலாம்.</item>
+    <item quantity="one">%1$d உறுப்பினர் பழைய சிக்னல் பதிப்பைப் பயன்படுத்துவதால் பழைய மரபு குழு உருவாக்கப்படும். அவர்கள் சிக்னல் புதுப்பித்த பிறகு அவர்களுடன் புதிய பாணி குழுவை உருவாக்கலாம் அல்லது குழுவை உருவாக்கும் முன் அவரை அகற்றலாம்.</item>
+    <item quantity="other">%1$d உறுப்பினர்கள் பழைய சிக்னல் பதிப்பைப் பயன்படுத்துவதால் பழைய மரபு குழு உருவாக்கப்படும். அவர்கள் சிக்னல் புதுப்பித்த பிறகு அவர்களுடன் புதிய பாணி குழுவை உருவாக்கலாம் அல்லது குழுவை உருவாக்கும் முன் அவர்களை அகற்றலாம்.</item>
   </plurals>
   <string name="NonGv2MemberDialog_single_users_are_non_gv2_capable_forced_migration">இந்த குழுவை உருவாக்க முடியாது, ஏனென்றால் \"%1$s\" சிக்னலின் பழைய பதிப்பைப் பயன்படுத்துகிறார். குழுவை உருவாக்கும் முன் அத்தகைய உறுப்பினர்களை நீக்க வேண்டும்.</string>
   <plurals name="NonGv2MemberDialog_d_users_are_non_gv2_capable_forced_migration">
@@ -661,7 +661,7 @@
   <string name="ManageGroupActivity_only_admins_can_enable_or_disable_the_option_to_approve_new_members">புதிய உறுப்பினர்களை அங்கீகரிப்பதற்கான அமைப்பை நிர்வாகிகளால் மட்டுமே இயக்க முடியும் அல்லது முடக்க முடியும்.</string>
   <string name="ManageGroupActivity_only_admins_can_reset_the_sharable_group_link">நிர்வாகிகள் மட்டுமே பகிரக்கூடிய குழு இணைப்பை மீட்டமைக்க முடியும்.</string>
   <string name="ManageGroupActivity_you_dont_have_the_rights_to_do_this">இதைச் செய்ய உங்களுக்கு உரிமை இல்லை</string>
-  <string name="ManageGroupActivity_not_capable">நீங்கள் சேர்த்த ஒருவரின் தொலைபேசி புதிய குழுக்களை ஆதரிக்காது, அவர்கள் சிக்னல் பயன்பாட்டைப் Signal update புதுப்பிக்க வேண்டும்</string>
+  <string name="ManageGroupActivity_not_capable">நீங்கள் சேர்த்த ஒருவரின் தொலைபேசி புதிய குழுக்களை ஆதரிக்காது, அவர்கள் சிக்னல் பயன்பாட்டைப் சிக்னல் update புதுப்பிக்க வேண்டும்</string>
   <string name="ManageGroupActivity_failed_to_update_the_group">குழுவைப் புதுப்பிப்பதில் தோல்வி</string>
   <string name="ManageGroupActivity_youre_not_a_member_of_the_group">நீங்கள் இந்த குழுவில் உறுப்பினராக இல்லை</string>
   <string name="ManageGroupActivity_failed_to_update_the_group_please_retry_later">குழுவைப் புதுப்பிப்பதில் தோல்வி, பின்னர் மீண்டும் முயற்சிக்கவும்</string>
@@ -672,7 +672,7 @@
   <string name="ManageGroupActivity_legacy_group_upgrade">இது ஒரு மரபு குழு. @குறிப்புகள் மற்றும் நிர்வாகிகள் போன்ற புதிய அம்சங்களை அணுக,</string>
   <string name="ManageGroupActivity_legacy_group_too_large">இந்த மரபு குழுவை புதிய குழுவாக மேம்படுத்த முடியாது, ஏனெனில் அது அளவு மிகப் பெரியது. அதிகபட்ச குழு அளவு%1$d.</string>
   <string name="ManageGroupActivity_upgrade_this_group">இந்த குழுவை மேம்படுத்தவும்.</string>
-  <string name="ManageGroupActivity_this_is_an_insecure_mms_group">இது பாதுகாப்பற்ற எம்.எம்.எஸ் குழு. தனிப்பட்ட முறையில் அரட்டையடிக்க, உங்கள் தொடர்புகளை Signal க்கு அழைக்கவும்.</string>
+  <string name="ManageGroupActivity_this_is_an_insecure_mms_group">இது பாதுகாப்பற்ற எம்.எம்.எஸ் குழு. தனிப்பட்ட முறையில் அரட்டையடிக்க, உங்கள் தொடர்புகளை சிக்னலுக்கு அழைக்கவும்.</string>
   <string name="ManageGroupActivity_invite_now">இப்போது அழைக்கவும்</string>
   <!--GroupMentionSettingDialog-->
   <string name="GroupMentionSettingDialog_notify_me_for_mentions">என் பெயர் குறிப்புகளை எனக்கு அறிவி</string>
@@ -763,8 +763,8 @@
   <!--GroupJoinUpdateRequiredBottomSheetDialogFragment-->
   <string name="GroupJoinUpdateRequiredBottomSheetDialogFragment_group_links_coming_soon">குழு இணைப்புகள் விரைவில் வருகின்றன</string>
   <string name="GroupJoinUpdateRequiredBottomSheetDialogFragment_update_signal_to_use_group_links">குழு இணைப்புகளைப் பயன்படுத்த சிக்னலைப் புதுப்பிக்கவும்</string>
-  <string name="GroupJoinUpdateRequiredBottomSheetDialogFragment_update_message">நீங்கள் பயன்படுத்தும் Signal லின் பதிப்பு இந்த குழு இணைப்பை ஆதரிக்காது. இணைப்பு வழியாக இந்த குழுவில் சேர சமீபத்திய பதிப்பிற்கு புதுப்பிக்கவும்.</string>
-  <string name="GroupJoinUpdateRequiredBottomSheetDialogFragment_update_signal">Signal லைப் புதுப்பிக்கவும்</string>
+  <string name="GroupJoinUpdateRequiredBottomSheetDialogFragment_update_message">நீங்கள் பயன்படுத்தும் சிக்னலின் பதிப்பு இந்த குழு இணைப்பை ஆதரிக்காது. இணைப்பு வழியாக இந்த குழுவில் சேர சமீபத்திய பதிப்பிற்கு புதுப்பிக்கவும்.</string>
+  <string name="GroupJoinUpdateRequiredBottomSheetDialogFragment_update_signal">சிக்னலைப் புதுப்பிக்கவும்</string>
   <string name="GroupJoinUpdateRequiredBottomSheetDialogFragment_update_linked_device_message">இணைக்கப்பட்ட சாதனங்களில் ஒன்று அல்லது அதற்கு மேற்பட்டவை, குழு இணைப்புகளை ஆதரிக்காத சிக்னலின் பதிப்பை இயக்குகின்றன. இந்த குழுவில் சேர உங்கள் இணைக்கப்பட்ட சாதனம் (களில்) சிக்னலைப் புதுப்பிக்கவும்.</string>
   <string name="GroupJoinUpdateRequiredBottomSheetDialogFragment_group_link_is_not_valid">குழு இணைப்புகள் செல்லுபடியாகாது.</string>
   <!--GroupInviteLinkEnableAndShareBottomSheetDialogFragment-->
@@ -864,16 +864,16 @@
   <string name="Megaphones_introducing_reactions">எதிர்வினைகளை அறிமுகப்படுத்துகிறது</string>
   <string name="Megaphones_tap_and_hold_any_message_to_quicky_share_how_you_feel">நீங்கள் எப்படி உணர்கிறீர்கள் என்பதை விரைவாகப் பகிர எந்த செய்தியையும் தட்டிப் பிடிக்கவும்.</string>
   <string name="Megaphones_remind_me_later">பிறகு என்னிடம் ஞாபகபடுத்து</string>
-  <string name="Megaphones_verify_your_signal_pin">உங்கள் Signal கடவு எண்-ஐ சரிபார்க்கவும்</string>
+  <string name="Megaphones_verify_your_signal_pin">உங்கள் சிக்னல் கடவு எண்-ஐ சரிபார்க்கவும்</string>
   <string name="Megaphones_well_occasionally_ask_you_to_verify_your_pin">உங்கள் கடவு எண்-ஐ நினைவில் வைத்துக் கொள்ளும்படி நாங்கள் எப்போதாவது உங்களிடம் கேட்போம்.</string>
   <string name="Megaphones_verify_pin">கடவு எண் சரிபார்க்கவும்</string>
   <string name="Megaphones_get_started">தொடங்குகள்</string>
   <string name="Megaphones_new_group">புதிய குழு</string>
   <string name="Megaphones_invite_friends">நண்பர்களை அழை</string>
   <!--NotificationBarManager-->
-  <string name="NotificationBarManager_signal_call_in_progress">Signal அழைப்புப் போய்க்கொண்டிருக்கிறது</string>
-  <string name="NotificationBarManager__establishing_signal_call">Signal அழைப்பு நிறுவுப்படுகிறது</string>
-  <string name="NotificationBarManager__incoming_signal_call">உள்வரும் Signal அழைப்பு</string>
+  <string name="NotificationBarManager_signal_call_in_progress">சிக்னல் அழைப்புப் போய்க்கொண்டிருக்கிறது</string>
+  <string name="NotificationBarManager__establishing_signal_call">சிக்னல் அழைப்பு நிறுவுப்படுகிறது</string>
+  <string name="NotificationBarManager__incoming_signal_call">உள்வரும் சிக்னல் அழைப்பு</string>
   <string name="NotificationBarManager__deny_call">அழைப்பை மறுதளி</string>
   <string name="NotificationBarManager__answer_call">அழைப்பை எடு</string>
   <string name="NotificationBarManager__end_call">அழைப்பைத் துண்டி</string>
@@ -894,8 +894,8 @@
   <string name="MediaSendActivity_message_to_s">%s க்கு செய்தி</string>
   <string name="MediaSendActivity_message">செய்தி</string>
   <string name="MediaSendActivity_select_recipients">பெறுநர்களைத் தேர்ந்தெடுக்கவும்</string>
-  <string name="MediaSendActivity_signal_needs_access_to_your_contacts">உங்கள் தொடர்புகளைக் காண்பிக்க Signal அணுகல் தேவை.</string>
-  <string name="MediaSendActivity_signal_needs_contacts_permission_in_order_to_show_your_contacts_but_it_has_been_permanently_denied">உங்கள் தொடர்புகளைக் காண்பிக்க Signal தொடர்புகளின் அனுமதி தேவை, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகளைத் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து, \"தொடர்புகளை\" இயக்கவும்.</string>
+  <string name="MediaSendActivity_signal_needs_access_to_your_contacts">உங்கள் தொடர்புகளைக் காண்பிக்க சிக்னல் அணுகல் தேவை.</string>
+  <string name="MediaSendActivity_signal_needs_contacts_permission_in_order_to_show_your_contacts_but_it_has_been_permanently_denied">உங்கள் தொடர்புகளைக் காண்பிக்க சிக்னல் தொடர்புகளின் அனுமதி தேவை, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகளைத் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து, \"தொடர்புகளை\" இயக்கவும்.</string>
   <plurals name="MediaSendActivity_cant_share_more_than_n_items">
     <item quantity="one">நீங்கள் %d ஐ விட அதிகமாக பகிர முடியாது.</item>
     <item quantity="other">நீங்கள் %d ஐ விட அதிகமாக பகிர முடியாது.</item>
@@ -917,7 +917,7 @@
   <string name="MessageRecord_s_updated_group">%s குழு புதுப்பிக்கப்பட்டது .</string>
   <string name="MessageRecord_s_called_you_date">%1$sஉங்களை அழைத்தார்%2$s</string>
   <string name="MessageRecord_called_s">%sயை அழைத்தீர்கள்</string>
-  <string name="MessageRecord_s_joined_signal">%s Signal லில் உள்ளது!</string>
+  <string name="MessageRecord_s_joined_signal">%s சிக்னலில் உள்ளது!</string>
   <string name="MessageRecord_you_disabled_disappearing_messages">காணாமல் போகும் செய்திகளை முடக்கியுள்ளீர்கள்.</string>
   <string name="MessageRecord_s_disabled_disappearing_messages">%1$s ஆல் காணாமல் போகும் செய்திகள் முடக்கப்பட்டது .</string>
   <string name="MessageRecord_you_set_disappearing_message_time_to_s">காணாமல் போகும் செய்திகளின் நேரத்தை %1$s ஆக அமைத்துள்ளீர்கள்.</string>
@@ -1131,9 +1131,9 @@
   <string name="DeviceProvisioningActivity_content_progress_key_error">QR குறியீடு செல்லாது.</string>
   <string name="DeviceProvisioningActivity_sorry_you_have_too_many_devices_linked_already">மன்னிக்கவும், ஏற்கனவே பல சாதனங்கள் இணைக்கப்பட்டுள்ளது, சிலவற்றை வெளியேற்றவும்  …</string>
   <string name="DeviceActivity_sorry_this_is_not_a_valid_device_link_qr_code">மன்னிக்கவும், இது சரியான சாதன இணைப்பு QR குறியீடு அல்ல.</string>
-  <string name="DeviceProvisioningActivity_link_a_signal_device">Signal சாதனத்தை இணைக்கவா?</string>
-  <string name="DeviceProvisioningActivity_it_looks_like_youre_trying_to_link_a_signal_device_using_a_3rd_party_scanner">3 வது தரப்பு ஸ்கேனரைப் பயன்படுத்தி Signal சாதனத்தை இணைக்க முயற்சிக்கிறீர்கள் என்று தெரிகிறது. உங்கள் பாதுகாப்பிற்காக, Signal இருந்து குறியீட்டை மீண்டும் ஸ்கேன் செய்யுங்கள்.</string>
-  <string name="DeviceActivity_signal_needs_the_camera_permission_in_order_to_scan_a_qr_code">QR குறியீட்டை ஸ்கேன் செய்ய Signal கேமரா அனுமதி தேவை, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகளைத் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து \"கேமரா\" ஐ இயக்கவும்.</string>
+  <string name="DeviceProvisioningActivity_link_a_signal_device">சிக்னல் சாதனத்தை இணைக்கவா?</string>
+  <string name="DeviceProvisioningActivity_it_looks_like_youre_trying_to_link_a_signal_device_using_a_3rd_party_scanner">3 வது தரப்பு ஸ்கேனரைப் பயன்படுத்தி சிக்னல் சாதனத்தை இணைக்க முயற்சிக்கிறீர்கள் என்று தெரிகிறது. உங்கள் பாதுகாப்பிற்காக, சிக்னல் இருந்து குறியீட்டை மீண்டும் ஸ்கேன் செய்யுங்கள்.</string>
+  <string name="DeviceActivity_signal_needs_the_camera_permission_in_order_to_scan_a_qr_code">QR குறியீட்டை ஸ்கேன் செய்ய சிக்னல் கேமரா அனுமதி தேவை, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகளைத் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து \"கேமரா\" ஐ இயக்கவும்.</string>
   <string name="DeviceActivity_unable_to_scan_a_qr_code_without_the_camera_permission">கேமரா அனுமதியின்றி QR குறியீட்டை ஸ்கேன் செய்ய முடியவில்லை</string>
   <!--ExpirationDialog-->
   <string name="ExpirationDialog_disappearing_messages">காணாமல் போகும் செய்திகள்</string>
@@ -1148,10 +1148,10 @@
   </plurals>
   <!--PassphrasePromptActivity-->
   <string name="PassphrasePromptActivity_enter_passphrase">கடவுச்சொல்லை உள்ளிடவும். </string>
-  <string name="PassphrasePromptActivity_watermark_content_description">Signal ஐகான்</string>
+  <string name="PassphrasePromptActivity_watermark_content_description">சிக்னல் ஐகான்</string>
   <string name="PassphrasePromptActivity_ok_button_content_description">கடவுச்சொல்லை சமர்ப்பிக்க</string>
   <string name="PassphrasePromptActivity_invalid_passphrase_exclamation">தவறான கடவுச்சொல்!</string>
-  <string name="PassphrasePromptActivity_unlock_signal">Signal லைத் திற</string>
+  <string name="PassphrasePromptActivity_unlock_signal">சிக்னலைத் திற</string>
   <!--PlacePickerActivity-->
   <string name="PlacePickerActivity_title">வரைபடம்</string>
   <string name="PlacePickerActivity_not_a_valid_address">சரியான முகவரி அல்ல</string>
@@ -1173,7 +1173,7 @@
     <item quantity="one">உங்களிடம் %1$d முயற்சிகள் உள்ளன. உங்கள் வரையறுக்கப்பட்ட முயற்சிகள் முடிந்தால், நீங்கள் ஒரு புதிய பின்னை உருவாக்கலாம். புதிய கடவு எண் மூலம் உங்கள் கணக்கைப் பதிவுசெய்து பயன்படுத்தலாம், ஆனால் உங்கள் சுயவிவரத் தகவல் போன்ற சில சேமிக்கப்பட்ட அமைப்புகளை இழப்பீர்கள்.</item>
     <item quantity="other">உங்களிடம் %1$d முயற்சிகள் உள்ளன. நீங்கள் வரையறுக்கப்பட்ட முயற்சிகள் முடிந்தால், நீங்கள் ஒரு புதிய பின்னை உருவாக்கலாம். புதிய கடவு எண் மூலம் உங்கள் கணக்கைப் பதிவுசெய்து பயன்படுத்தலாம், ஆனால் உங்கள் சுயவிவரத் தகவல் போன்ற சில சேமிக்கப்பட்ட அமைப்புகளை இழப்பீர்கள்.</item>
   </plurals>
-  <string name="PinRestoreEntryFragment_signal_registration_need_help_with_pin">Signal பதிவு - Android க்கான கடவு எண் உடன் உதவி தேவை</string>
+  <string name="PinRestoreEntryFragment_signal_registration_need_help_with_pin">சிக்னல் பதிவு - ஆன்ட்ராய்டுக்கான கடவு எண் உடன் உதவி தேவை</string>
   <string name="PinRestoreEntryFragment_enter_alphanumeric_pin">எண்ணெழுத்து பின்னை உள்ளிடவும்</string>
   <string name="PinRestoreEntryFragment_enter_numeric_pin">எண் பின்னை உள்ளிடவும்</string>
   <!--PinRestoreLockedFragment-->
@@ -1220,13 +1220,13 @@
   <string name="RedPhone_got_it">அறிந்துகொண்டேன் .</string>
   <!--WebRtcCallActivity-->
   <string name="WebRtcCallActivity__tap_here_to_turn_on_your_video">உங்கள் வீடியோவை இயக்க இங்கே தட்டவும்</string>
-  <string name="WebRtcCallActivity__to_call_s_signal_needs_access_to_your_camera">%1$s ஐ அழைக்க, சிக்னலுக்கு உங்கள் கேமரா அனுமதி தேவை Signal Camera permission</string>
-  <string name="WebRtcCallActivity__signal_s">சிக்னல் Signal %1$s</string>
+  <string name="WebRtcCallActivity__to_call_s_signal_needs_access_to_your_camera">%1$s ஐ அழைக்க, சிக்னலுக்கு உங்கள் கேமரா அனுமதி தேவை சிக்னல் Camera permission</string>
+  <string name="WebRtcCallActivity__signal_s">சிக்னல் %1$s</string>
   <string name="WebRtcCallActivity__calling">அழைக்கிறது…</string>
   <string name="WebRtcCallActivity__group_call">குழு அழைப்பு</string>
   <!--WebRtcCallView-->
-  <string name="WebRtcCallView__signal_voice_call">Signal குரல் அழைப்பு…</string>
-  <string name="WebRtcCallView__signal_video_call">Signal காணொளி அழைப்பு…</string>
+  <string name="WebRtcCallView__signal_voice_call">சிக்னல் குரல் அழைப்பு…</string>
+  <string name="WebRtcCallView__signal_video_call">சிக்னல் காணொளி அழைப்பு…</string>
   <string name="WebRtcCallView__start_call">அழைப்பைத் தொடங்கு</string>
   <string name="WebRtcCallView__join_call">அழைப்பில் சேர்</string>
   <string name="WebRtcCallView__call_is_full">அழைப்பு நிரம்பியுள்ளது</string>
@@ -1269,7 +1269,7 @@
   <string name="RegistrationActivity_the_number_you_specified_s_is_invalid">நீங்கள் குறிப்பிட்ட 
 எண் (%s) செல்லாது.</string>
   <string name="RegistrationActivity_missing_google_play_services">Google Play சேவைகளைக் காணவில்லை</string>
-  <string name="RegistrationActivity_this_device_is_missing_google_play_services">இந்த சாதனத்தில்  Google Play சேவைகள் இல்லை . இருந்தும் நீங்கள் Signal ஐ பயன்படுத்தலாம் , ஆனால் இந்த உள்ளமைவு நம்பகத்தன்மை அல்லது செயல்திறனைக் குறைக்கலாம். \n\n நீங்கள் ஒரு மேம்பட்ட பயனராக இல்லாவிட்டால், சந்தைக்குப்பிறகான அண்ட்ராய்டு ROM ஐ இயக்கவில்லை அல்லது இதை பிழையாகப் பார்க்கிறீர்கள் என்று நம்பினால், தயவுசெய்து ஆதரவைத் தொடர்பு கொள்ளவும் @ சிக்கல்  support@signal.org.</string>
+  <string name="RegistrationActivity_this_device_is_missing_google_play_services">இந்த சாதனத்தில்  Google Play சேவைகள் இல்லை . இருந்தும் நீங்கள் சிக்னல் ஐ பயன்படுத்தலாம் , ஆனால் இந்த உள்ளமைவு நம்பகத்தன்மை அல்லது செயல்திறனைக் குறைக்கலாம். \n\n நீங்கள் ஒரு மேம்பட்ட பயனராக இல்லாவிட்டால், சந்தைக்குப்பிறகான அண்ட்ராய்டு ROM ஐ இயக்கவில்லை அல்லது இதை பிழையாகப் பார்க்கிறீர்கள் என்று நம்பினால், தயவுசெய்து ஆதரவைத் தொடர்பு கொள்ளவும் @ சிக்கல்  support@signal.org.</string>
   <string name="RegistrationActivity_i_understand">எனக்கு புரிகிறது</string>
   <string name="RegistrationActivity_play_services_error">சேவைகளில் பிழை</string>
   <string name="RegistrationActivity_google_play_services_is_updating_or_unavailable">Google Play சேவைகள் புதுப்பித்தல் அல்லது தற்காலிகமாக கிடைக்கவில்லை. தயவு செய்து மீண்டும் முயற்சிக்கவும்.</string>
@@ -1277,11 +1277,11 @@
   <string name="RegistrationActivity_no_browser">இந்த இணைப்பைத் திறக்க முடியவில்லை. வலை உலாவி எதுவும் கிடைக்கவில்லை.</string>
   <string name="RegistrationActivity_more_information">மேலும் தகவல்</string>
   <string name="RegistrationActivity_less_information">குறைந்த தகவல்</string>
-  <string name="RegistrationActivity_signal_needs_access_to_your_contacts_and_media_in_order_to_connect_with_friends">நண்பர்களுடன் இணைவதற்கும், செய்திகளைப் பரிமாறிக் கொள்வதற்கும், பாதுகாப்பான அழைப்புகளைச் செய்வதற்கும் Signal உங்கள் தொடர்புகள் மற்றும் ஊடகங்களுக்கான அணுகல் தேவை</string>
+  <string name="RegistrationActivity_signal_needs_access_to_your_contacts_and_media_in_order_to_connect_with_friends">நண்பர்களுடன் இணைவதற்கும், செய்திகளைப் பரிமாறிக் கொள்வதற்கும், பாதுகாப்பான அழைப்புகளைச் செய்வதற்கும் சிக்னல் உங்கள் தொடர்புகள் மற்றும் ஊடகங்களுக்கான அணுகல் தேவை</string>
   <string name="RegistrationActivity_signal_needs_access_to_your_contacts_in_order_to_connect_with_friends">உங்கள் நண்பர்களுடன் தொடர்புகொள்வதற்கும், செய்திகளைப் பரிமாறிக்கொள்வதற்கும், பாதுகாப்பான அழைப்புகளைச் செய்வதற்கும், சிக்னலுக்கு உங்கள் தொடர்புகள் பிரிவுக்கு அணுகல் அனுமதி தேவை.</string>
   <string name="RegistrationActivity_rate_limited_to_service">இந்த எண்ணை பதிவு செய்ய நீங்கள் பல முயற்சிகளை செய்துள்ளீர்கள். சிறிது நேரம் கழித்து மீண்டும் முயற்சிக்கவும்.</string>
   <string name="RegistrationActivity_unable_to_connect_to_service">சேவையுடன் இணைக்க முடியவில்லை. பிணைய இணைப்பைச் சரிபார்த்து மீண்டும் முயற்சிக்கவும்.</string>
-  <string name="RegistrationActivity_to_easily_verify_your_phone_number_signal_can_automatically_detect_your_verification_code">உங்கள் தொலைபேசி எண்ணை எளிதில் சரிபார்க்க, SMS செய்திகளைக் காண Signal அனுமதித்தால் Signal தானாகவே உங்கள் சரிபார்ப்புக் குறியீட்டைக் கண்டறிய முடியும்.</string>
+  <string name="RegistrationActivity_to_easily_verify_your_phone_number_signal_can_automatically_detect_your_verification_code">உங்கள் தொலைபேசி எண்ணை எளிதில் சரிபார்க்க, SMS செய்திகளைக் காண சிக்னல் அனுமதித்தால் சிக்னல் தானாகவே உங்கள் சரிபார்ப்புக் குறியீட்டைக் கண்டறிய முடியும்.</string>
   <plurals name="RegistrationActivity_debug_log_hint">
     <item quantity="one">பிழைத்திருத்த பதிவைச் சமர்ப்பிப்பதில் இருந்து இப்போது நீங்கள் %d விலகிவிட்டீர்கள்.</item>
     <item quantity="other">பிழைத்திருத்த பதிவைச் சமர்ப்பிப்பதில் இருந்து இப்போது நீங்கள் %d படிகள் தொலைவில் உள்ளீர்கள்.</item>
@@ -1302,7 +1302,7 @@
   <!--RegistrationLockV2Dialog-->
   <string name="RegistrationLockV2Dialog_turn_on_registration_lock">பதிவு பூட்டை இயக்கவா?</string>
   <string name="RegistrationLockV2Dialog_turn_off_registration_lock">பதிவு பூட்டை அணைக்கவா?</string>
-  <string name="RegistrationLockV2Dialog_if_you_forget_your_signal_pin_when_registering_again">Signal உடன் மீண்டும் பதிவுசெய்யும்போது உங்கள் Signal கடவு எண்-ஐ மறந்துவிட்டால், உங்கள் கணக்கிலிருந்து 7 நாட்களுக்கு பூட்டப்படுவீர்கள்.</string>
+  <string name="RegistrationLockV2Dialog_if_you_forget_your_signal_pin_when_registering_again">சிக்னல் உடன் மீண்டும் பதிவுசெய்யும்போது உங்கள் சிக்னல் கடவு எண்-ஐ மறந்துவிட்டால், உங்கள் கணக்கிலிருந்து 7 நாட்களுக்கு பூட்டப்படுவீர்கள்.</string>
   <string name="RegistrationLockV2Dialog_turn_on">இயக்கவும்</string>
   <string name="RegistrationLockV2Dialog_turn_off">அணைக்க</string>
   <!--RevealableMessageView-->
@@ -1320,13 +1320,13 @@
   <!--ShakeToReport-->
   <!--SharedContactDetailsActivity-->
   <string name="SharedContactDetailsActivity_add_to_contacts">தொடர்பு பட்டியலில் சேர்க்க</string>
-  <string name="SharedContactDetailsActivity_invite_to_signal">Signalக்கு அழை</string>
-  <string name="SharedContactDetailsActivity_signal_message">Signal செய்தி</string>
-  <string name="SharedContactDetailsActivity_signal_call">Signal அழைப்பு</string>
+  <string name="SharedContactDetailsActivity_invite_to_signal">சிக்னலுக்கு அழை</string>
+  <string name="SharedContactDetailsActivity_signal_message">சிக்னல் செய்தி</string>
+  <string name="SharedContactDetailsActivity_signal_call">சிக்னல் அழைப்பு</string>
   <!--SharedContactView-->
   <string name="SharedContactView_add_to_contacts">தொடர்பு பட்டியலில் சேர்க்க</string>
   <string name="SharedContactView_invite_to_signal">Signalக்கு அழை</string>
-  <string name="SharedContactView_message">Signal செய்தி</string>
+  <string name="SharedContactView_message">சிக்னல் செய்தி</string>
   <!--SignalPinReminders-->
   <string name="SignalPinReminders_well_remind_you_again_later">பின்னர் உங்களுக்கு நினைவூட்டுவோம்.</string>
   <string name="SignalPinReminders_well_remind_you_again_tomorrow">நாளை மீண்டும் உங்களுக்கு நினைவூட்டுவோம்.</string>
@@ -1348,14 +1348,14 @@
   <string name="SmsMessageRecord_secure_session_reset">பாதுகாப்பான அமர்வை மீட்டமைக்கிறீர்கள்.</string>
   <string name="SmsMessageRecord_secure_session_reset_s">%s பாதுகாப்பான அமர்வை மீட்டமைக்கவும்.</string>
   <string name="SmsMessageRecord_duplicate_message">நகல் செய்தி.</string>
-  <string name="SmsMessageRecord_this_message_could_not_be_processed_because_it_was_sent_from_a_newer_version">இந்தச் செய்தியை செயலாக்க முடியவில்லை, ஏனெனில் இது Signal புதிய பதிப்பிலிருந்து அனுப்பப்பட்டது. நீங்கள் புதுப்பித்த பிறகு இந்த செய்தியை மீண்டும் அனுப்ப உங்கள் தொடர்பைக் கேட்கலாம்.</string>
+  <string name="SmsMessageRecord_this_message_could_not_be_processed_because_it_was_sent_from_a_newer_version">இந்தச் செய்தியை செயலாக்க முடியவில்லை, ஏனெனில் இது சிக்னல் புதிய பதிப்பிலிருந்து அனுப்பப்பட்டது. நீங்கள் புதுப்பித்த பிறகு இந்த செய்தியை மீண்டும் அனுப்ப உங்கள் தொடர்பைக் கேட்கலாம்.</string>
   <string name="SmsMessageRecord_error_handling_incoming_message">உள்வரும் செய்தியைக் கையாளுவதில் பிழை.</string>
   <!--StickerManagementActivity-->
   <string name="StickerManagementActivity_stickers">ஒட்டிகள்</string>
   <!--StickerManagementAdapter-->
   <string name="StickerManagementAdapter_installed_stickers">நிறுவப்பட்ட ஒட்டிகள்</string>
   <string name="StickerManagementAdapter_stickers_you_received">நீங்கள் பெற்ற ஒட்டிகள்</string>
-  <string name="StickerManagementAdapter_signal_artist_series">Signal கலைஞர் தொடர்</string>
+  <string name="StickerManagementAdapter_signal_artist_series">சிக்னல் கலைஞர் தொடர்</string>
   <string name="StickerManagementAdapter_no_stickers_installed">ஸ்டிக்கர்கள் எதுவும் நிறுவப்படவில்லை</string>
   <string name="StickerManagementAdapter_stickers_from_incoming_messages_will_appear_here">உள்வரும் செய்திகளின் ஒட்டிகள் இங்கே தோன்றும்</string>
   <string name="StickerManagementAdapter_untitled">பெயரிடாத</string>
@@ -1378,12 +1378,12 @@
   <string name="SubmitDebugLogActivity_copied_to_clipboard">கிளிப்போர்டுக்கு நகலெடுக்கப்பட்டது</string>
   <string name="SubmitDebugLogActivity_share">பகிர்</string>
   <!--SupportEmailUtil-->
-  <string name="SupportEmailUtil_subject">Subject: பொருள்:</string>
-  <string name="SupportEmailUtil_signal_android_support_request">Signal Android ஆதரவு கோரிக்கை</string>
-  <string name="SupportEmailUtil_device_info">Device info: சாதனத் தகவல்:</string>
-  <string name="SupportEmailUtil_android_version">Android version: Android பதிப்பு:</string>
-  <string name="SupportEmailUtil_signal_version">Signal version: Signal பதிப்பு:</string>
-  <string name="SupportEmailUtil_signal_package">Signal package: சிக்னல் தொகுப்பு:</string>
+  <string name="SupportEmailUtil_subject">பொருள்:</string>
+  <string name="SupportEmailUtil_signal_android_support_request">சிக்னல் ஆன்ட்ராய்டுஆதரவு கோரிக்கை</string>
+  <string name="SupportEmailUtil_device_info">சாதனத் தகவல்:</string>
+  <string name="SupportEmailUtil_android_version">ஆன்ட்ராய்டு பதிப்பு:</string>
+  <string name="SupportEmailUtil_signal_version">சிக்னல் பதிப்பு:</string>
+  <string name="SupportEmailUtil_signal_package">சிக்னல் தொகுப்பு:</string>
   <string name="SupportEmailUtil_registration_lock">பதிவு பூட்டு:</string>
   <string name="SupportEmailUtil_locale">Locale: இடம்:</string>
   <!--ThreadRecord-->
@@ -1402,7 +1402,7 @@
   <string name="ThreadRecord_view_once_media">காண்க-ஒருமுறை ஊடகம் </string>
   <string name="ThreadRecord_this_message_was_deleted">இந்த செய்தி இருந்தது நீக்கப்பட்டது</string>
   <string name="ThreadRecord_you_deleted_this_message">இந்த செய்தியை நீக்கிவிட்டீர்கள்.</string>
-  <string name="ThreadRecord_s_is_on_signal">%s Signal உள்ளது!</string>
+  <string name="ThreadRecord_s_is_on_signal">%s சிக்னல் உள்ளது!</string>
   <string name="ThreadRecord_disappearing_messages_disabled">காணாமல் போகும் செய்திகள் முடக்கப்பட்டது</string>
   <string name="ThreadRecord_disappearing_message_time_updated_to_s">காணாமல் போகும் செய்திகளின் நேரம் %s ஆக அமைக்கப்பட்டுள்ளது</string>
   <string name="ThreadRecord_safety_number_changed">பாதுகாப்பு எண் மாறிவிட்டது</string>
@@ -1420,8 +1420,8 @@
   <string name="ThreadRecord_file">கோப்பு</string>
   <string name="ThreadRecord_video">காணொளி</string>
   <!--UpdateApkReadyListener-->
-  <string name="UpdateApkReadyListener_Signal_update">Signal புதுப்பிப்பு</string>
-  <string name="UpdateApkReadyListener_a_new_version_of_signal_is_available_tap_to_update">Signal புதிய பதிப்பு கிடைக்கும், புதுப்பிக்க தட்டவும்</string>
+  <string name="UpdateApkReadyListener_Signal_update">சிக்னல் புதுப்பிப்பு</string>
+  <string name="UpdateApkReadyListener_a_new_version_of_signal_is_available_tap_to_update">சிக்னல் புதிய பதிப்பு கிடைக்கும், புதுப்பிக்க தட்டவும்</string>
   <!--UntrustedSendDialog-->
   <string name="UntrustedSendDialog_send_message">செய்தி அனுப்ப?</string>
   <string name="UntrustedSendDialog_send">அனுப்புக</string>
@@ -1431,22 +1431,22 @@
   <!--UsernameEditFragment-->
   <string name="UsernameEditFragment_username">பயனர்பெயர்</string>
   <string name="UsernameEditFragment_delete">அழி</string>
-  <string name="UsernameEditFragment_successfully_set_username">பயனர்பெயர் வெற்றிகரமாக அமைக்கப்பட்டது.</string>
-  <string name="UsernameEditFragment_successfully_removed_username">பயனர்பெயரை வெற்றிகரமாக நீக்கியது.</string>
+  <string name="UsernameEditFragment_successfully_set_username">பயனர் பெயர் வெற்றிகரமாக அமைக்கப்பட்டது.</string>
+  <string name="UsernameEditFragment_successfully_removed_username">பயனர் பெயரை வெற்றிகரமாக நீக்கியது.</string>
   <string name="UsernameEditFragment_encountered_a_network_error">பிணைய பிழையை எதிர்கொண்டது.</string>
-  <string name="UsernameEditFragment_this_username_is_taken">இந்த பயனர்பெயர் எடுக்கப்பட்டது.</string>
-  <string name="UsernameEditFragment_this_username_is_available">இந்த பயனர்பெயர் கிடைப்பில் உள்ளது .</string>
+  <string name="UsernameEditFragment_this_username_is_taken">இந்த பயனர் பெயர் எடுக்கப்பட்டது.</string>
+  <string name="UsernameEditFragment_this_username_is_available">இந்த பயனர் பெயர் கிடைப்பில் உள்ளது .</string>
   <string name="UsernameEditFragment_usernames_can_only_include">பயனர்பெயர்களில் அ - ஃ, a-Z, 0–9 மற்றும் அடிக்கோடிட்டுக் காட்டலாம்.</string>
-  <string name="UsernameEditFragment_usernames_cannot_begin_with_a_number">பயனர்பெயர்கள் எண்ணுடன் தொடங்க முடியாது.</string>
-  <string name="UsernameEditFragment_username_is_invalid">பயனர்பெயர் தவறானது.</string>
-  <string name="UsernameEditFragment_usernames_must_be_between_a_and_b_characters">பயனர்பெயர்கள் %1$d மற்றும் %2$d  எழுத்துக்களுக்கு இடையில் இருக்க வேண்டும்.</string>
-  <string name="UsernameEditFragment_usernames_on_signal_are_optional">Signal-லில் உள்ள பயனர்பெயர்கள் விருப்பத்தேர்வானவை. பயனர்பெயரை உருவாக்க நீங்கள் தேர்வு செய்தால், பிற Signal பயனர்கள் இந்த பயனர்பெயர் மூலம் உங்களை கண்டுபிடித்து, உங்கள் தொலைபேசி எண்ணை அறியாத வகையில் உங்களை தொடர்பு கொள்ள முடியும்.</string>
+  <string name="UsernameEditFragment_usernames_cannot_begin_with_a_number">பயனர் பெயர்கள் எண்ணுடன் தொடங்க முடியாது.</string>
+  <string name="UsernameEditFragment_username_is_invalid">பயனர் பெயர் தவறானது.</string>
+  <string name="UsernameEditFragment_usernames_must_be_between_a_and_b_characters">பயனர் பெயர்கள் %1$d மற்றும் %2$d  எழுத்துக்களுக்கு இடையில் இருக்க வேண்டும்.</string>
+  <string name="UsernameEditFragment_usernames_on_signal_are_optional">சிக்னலில் உள்ள பயனர் பெயர்கள் விருப்பத் தேர்வானவை. பயனர் பெயரை உருவாக்க நீங்கள் தேர்வு செய்தால், பிற சிக்னல் பயனர்கள் இந்த பயனர் பெயர் மூலம் உங்களை கண்டுபிடித்து, உங்கள் தொலைபேசி எண்ணை அறியாத வகையில் உங்களை தொடர்பு கொள்ள முடியும்.</string>
   <!--VerifyIdentityActivity-->
-  <string name="VerifyIdentityActivity_your_contact_is_running_an_old_version_of_signal">உங்கள் தொடர்பு Signal பழைய பதிப்பை இயக்குகிறார். உங்கள் பாதுகாப்பு எண்ணைச் சரிபார்க்கும் முன் புதுப்பிக்குமாறு அவர்களிடம் கேளுங்கள்.</string>
-  <string name="VerifyIdentityActivity_your_contact_is_running_a_newer_version_of_Signal">உங்கள் தொடர்பு, பொருந்தாத QR குறியீடு வடிவத்துடன் Signal புதிய பதிப்பை இயக்குகிறது. ஒப்பீடு செய்ய  புதுப்பிக்கவும்.</string>
+  <string name="VerifyIdentityActivity_your_contact_is_running_an_old_version_of_signal">உங்கள் தொடர்பு சிக்னல் பழைய பதிப்பை இயக்குகிறார். உங்கள் பாதுகாப்பு எண்ணைச் சரிபார்க்கும் முன் புதுப்பிக்குமாறு அவர்களிடம் கேளுங்கள்.</string>
+  <string name="VerifyIdentityActivity_your_contact_is_running_a_newer_version_of_Signal">உங்கள் தொடர்பு, பொருந்தாத QR குறியீடு வடிவத்துடன் சிக்னல் புதிய பதிப்பை இயக்குகிறது. ஒப்பீடு செய்ய  புதுப்பிக்கவும்.</string>
   <string name="VerifyIdentityActivity_the_scanned_qr_code_is_not_a_correctly_formatted_safety_number">ஸ்கேன் செய்யப்பட்ட QR குறியீடு சரியாக வடிவமைக்கப்பட்ட பாதுகாப்பு எண் சரிபார்ப்புக் குறியீடு அல்ல. மீண்டும் ஸ்கேன் செய்ய முயற்சிக்கவும்.</string>
   <string name="VerifyIdentityActivity_share_safety_number_via">வழியாக பாதுகாப்பு எண்ணைப் பகிரவும் …</string>
-  <string name="VerifyIdentityActivity_our_signal_safety_number">எங்கள் Signal பாதுகாப்பு எண்:</string>
+  <string name="VerifyIdentityActivity_our_signal_safety_number">எங்கள் சிக்னல் பாதுகாப்பு எண்:</string>
   <string name="VerifyIdentityActivity_no_app_to_share_to">உங்களிடம் பகிர எந்த பயன்பாடுகளும் இல்லை என்று தெரிகிறது.</string>
   <string name="VerifyIdentityActivity_no_safety_number_to_compare_was_found_in_the_clipboard">ஒப்பிடுவதற்கான பாதுகாப்பு எண் எதுவும் கிளிப்போர்டில் காணப்படவில்லை</string>
   <string name="VerifyIdentityActivity_signal_needs_the_camera_permission_in_order_to_scan_a_qr_code_but_it_has_been_permanently_denied">QR குறியீட்டை ஸ்கேன் செய்ய சிக்னலுக்கு கேமரா அனுமதி தேவை, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாட்டு அமைப்புகளைத் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து \"கேமரா\" ஐ இயக்கவும்.</string>
@@ -1470,13 +1470,13 @@
   <!--KeyCachingService-->
   <string name="KeyCachingService_signal_passphrase_cached">திறக்க தொடு.</string>
   <string name="KeyCachingService_signal_passphrase_cached_with_lock">திறக்கத் தொடவும் அல்லது மூட பூட்டைத் தொடவும்.</string>
-  <string name="KeyCachingService_passphrase_cached">Signal  திறக்கப்பட்டது</string>
-  <string name="KeyCachingService_lock">Signal ஐ பூட்டு</string>
+  <string name="KeyCachingService_passphrase_cached">சிக்னல் திறக்கப்பட்டது</string>
+  <string name="KeyCachingService_lock">சிக்னல்-ஐ பூட்டு</string>
   <!--MediaPreviewActivity-->
   <string name="MediaPreviewActivity_you">நீங்கள்</string>
   <string name="MediaPreviewActivity_unssuported_media_type">ஆதரிக்கப்படாத மீடியா வகை</string>
   <string name="MediaPreviewActivity_draft">வரைவு</string>
-  <string name="MediaPreviewActivity_signal_needs_the_storage_permission_in_order_to_write_to_external_storage_but_it_has_been_permanently_denied">வெளிப்புற சேமிப்பகத்தில் சேமிக்க Signal சேமிப்பக அனுமதி தேவை, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகளைத் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து, \"சேமிப்பகத்தை\" இயக்கவும்.</string>
+  <string name="MediaPreviewActivity_signal_needs_the_storage_permission_in_order_to_write_to_external_storage_but_it_has_been_permanently_denied">வெளிப்புற சேமிப்பகத்தில் சேமிக்க சிக்னல் சேமிப்பக அனுமதி தேவை, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகளைத் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து, \"சேமிப்பகத்தை\" இயக்கவும்.</string>
   <string name="MediaPreviewActivity_unable_to_write_to_external_storage_without_permission">அனுமதியின்றி வெளிப்புற சேமிப்பகத்தில் சேமிக்க முடியவில்லை</string>
   <string name="MediaPreviewActivity_media_delete_confirmation_title">செய்தியை நீக்கவா?</string>
   <string name="MediaPreviewActivity_media_delete_confirmation_message">இது இந்த செய்தியை நிரந்தரமாக நீக்கும்.</string>
@@ -1499,10 +1499,10 @@
   <string name="MessageNotifier_view_once_photo">காண்க-ஒருமுறை புகைப்படம்</string>
   <string name="MessageNotifier_view_once_video">காண்க-ஒருமுறை காணொளி</string>
   <string name="MessageNotifier_reply">மறுமொழி கூறு</string>
-  <string name="MessageNotifier_signal_message">Signal செய்தி</string>
+  <string name="MessageNotifier_signal_message">சிக்னல் செய்தி</string>
   <string name="MessageNotifier_unsecured_sms">பாதுகாப்பற்ற SMS</string>
   <string name="MessageNotifier_you_may_have_new_messages">உங்களிடம் புதிய செய்திகள் இருக்கலாம்</string>
-  <string name="MessageNotifier_open_signal_to_check_for_recent_notifications">சமீபத்திய அறிவிப்புகளைச் சரிபார்க்க Signal திறக்கவும்.</string>
+  <string name="MessageNotifier_open_signal_to_check_for_recent_notifications">சமீபத்திய அறிவிப்புகளைச் சரிபார்க்க சிக்னல் திறக்கவும்.</string>
   <string name="MessageNotifier_contact_message">%1$s %2$s</string>
   <string name="MessageNotifier_unknown_contact_message">தொடர்பு</string>
   <string name="MessageNotifier_reacted_s_to_s">%1$s என வினைபுரிந்தார்: \"%2$s\" க்கு.</string>
@@ -1513,7 +1513,7 @@
   <string name="MessageNotifier_reacted_s_to_your_view_once_media">  %1$sஉங்கள் பார்வைக்கு ஒரு முறை ஊடகங்களுக்கு அவர் பதில்செயல் காட்டியுள்ளீர்கள்</string>
   <string name="MessageNotifier_reacted_s_to_your_sticker">உங்கள் ஒட்டிக்கு %1$s என வினைபுரிந்தார்.</string>
   <string name="MessageNotifier_this_message_was_deleted">இந்த செய்தி இருந்தது நீக்கப்பட்டது</string>
-  <string name="TurnOffContactJoinedNotificationsActivity__turn_off_contact_joined_signal">இணைந்த சிக்னல் Signal அறிவிப்புகளை முடக்குவதா? அமைப்புகள் மற்றும் அறிவிப்புகளுக்குச் சென்று அவற்றை Signal settings சிக்னலில் மீண்டும் இயக்கலாம்.</string>
+  <string name="TurnOffContactJoinedNotificationsActivity__turn_off_contact_joined_signal">சிக்னலில் இணைந்த சிக்னல் அறிவிப்புகளை முடக்குவதா? அமைப்புகள் மற்றும் அறிவிப்புகளுக்குச் சென்று அவற்றை Signal settings சிக்னலில் மீண்டும் இயக்கலாம்.</string>
   <!--Notification Channels-->
   <string name="NotificationChannel_messages">இயல்புநிலை</string>
   <string name="NotificationChannel_calls">அழைப்புகள்</string>
@@ -1529,7 +1529,7 @@
   <string name="ProfileEditNameFragment_successfully_set_profile_name">சுயவிவரப் பெயர் வெற்றிகரமாக அமைக்கப்பட்டது .</string>
   <string name="ProfileEditNameFragment_encountered_a_network_error">பிணைய பிழையை எதிர்கொண்டது.</string>
   <!--QuickResponseService-->
-  <string name="QuickResponseService_quick_response_unavailable_when_Signal_is_locked">Signal பூட்டப்பட்டிருக்கும் போது விரைவான பதில் கிடைக்காது!</string>
+  <string name="QuickResponseService_quick_response_unavailable_when_Signal_is_locked">சிக்னல் பூட்டப்பட்டிருக்கும் போது விரைவான பதில் கிடைக்காது!</string>
   <string name="QuickResponseService_problem_sending_message">செய்தி அனுப்புவதில் பிரச்சணை!</string>
   <!--SaveAttachmentTask-->
   <string name="SaveAttachmentTask_saved_to">%s இல் சேமிக்கப்பட்டது</string>
@@ -1552,12 +1552,12 @@
   </plurals>
   <!--UnauthorizedReminder-->
   <string name="UnauthorizedReminder_device_no_longer_registered">சாதனம் இனி பதிவு செய்யப்படவில்லை</string>
-  <string name="UnauthorizedReminder_this_is_likely_because_you_registered_your_phone_number_with_Signal_on_a_different_device">உங்கள் தொலைபேசி எண்ணை Signal வேறு சாதனத்தில் பதிவு செய்ததால் இது நிகழலாம். மீண்டும் பதிவு செய்ய தட்டவும்.</string>
+  <string name="UnauthorizedReminder_this_is_likely_because_you_registered_your_phone_number_with_Signal_on_a_different_device">உங்கள் தொலைபேசி எண்ணை சிக்னல் வேறு சாதனத்தில் பதிவு செய்ததால் இது நிகழலாம். மீண்டும் பதிவு செய்ய தட்டவும்.</string>
   <!--VideoPlayer-->
   <string name="VideoPlayer_error_playing_video">காணொளியை ஓட்டுவதில் பிழை ஏற்பட்டது</string>
   <!--WebRtcCallActivity-->
-  <string name="WebRtcCallActivity_to_answer_the_call_from_s_give_signal_access_to_your_microphone">%s இலிருந்து அழைப்பிற்கு பதிலளிக்க, உங்கள் மைக்ரோஃபோனுக்கு Signal அணுகலை வழங்கவும்.</string>
-  <string name="WebRtcCallActivity_signal_requires_microphone_and_camera_permissions_in_order_to_make_or_receive_calls">அழைப்புகளைச் செய்ய அல்லது பெற Signal கு மைக்ரோஃபோன் மற்றும் கேமரா அனுமதிகள் தேவை, ஆனால் அவை நிரந்தரமாக மறுக்கப்பட்டுள்ளன. பயன்பாடு அமைப்புகளைத் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து, \"மைக்ரோஃபோன்\" மற்றும் \"கேமரா\" ஐ இயக்கவும்.</string>
+  <string name="WebRtcCallActivity_to_answer_the_call_from_s_give_signal_access_to_your_microphone">%s இலிருந்து அழைப்பிற்கு பதிலளிக்க, உங்கள் மைக்ரோஃபோனுக்கு சிக்னல் அணுகலை வழங்கவும்.</string>
+  <string name="WebRtcCallActivity_signal_requires_microphone_and_camera_permissions_in_order_to_make_or_receive_calls">அழைப்புகளைச் செய்ய அல்லது பெற சிக்னலுக்கு மைக்ரோஃபோன் மற்றும் கேமரா அனுமதிகள் தேவை, ஆனால் அவை நிரந்தரமாக மறுக்கப்பட்டுள்ளன. பயன்பாடு அமைப்புகளைத் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து, \"மைக்ரோஃபோன்\" மற்றும் \"கேமரா\" ஐ இயக்கவும்.</string>
   <string name="WebRtcCallActivity__answered_on_a_linked_device">இணைக்கப்பட்ட சாதனத்தில் பதிலளிக்கப்பட்டது.</string>
   <string name="WebRtcCallActivity__declined_on_a_linked_device">இணைக்கப்பட்ட சாதனத்தில் மறுக்கப்பட்டது.</string>
   <string name="WebRtcCallActivity__busy_on_a_linked_device">இணைக்கப்பட்ட சாதனத்தில் பயனர் அழைப்பில் இருக்கிறார்.</string>
@@ -1623,10 +1623,10 @@
   <!--single_contact_selection_activity-->
   <string name="SingleContactSelectionActivity_contact_photo">தொடர்பின் புகைப்படம்</string>
   <!--ContactSelectionListFragment-->
-  <string name="ContactSelectionListFragment_signal_requires_the_contacts_permission_in_order_to_display_your_contacts">உங்கள் தொடர்புகளைக் காண்பிக்க Signal கு தொடர்புகளின் அனுமதி தேவைப்படுகிறது, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகள் மெனுவில் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து, \"தொடர்புகளை\" இயக்கவும்.</string>
+  <string name="ContactSelectionListFragment_signal_requires_the_contacts_permission_in_order_to_display_your_contacts">உங்கள் தொடர்புகளைக் காண்பிக்க சிக்னலுக்கு தொடர்புகளின் அனுமதி தேவைப்படுகிறது, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகள் மெனுவில் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து, \"தொடர்புகளை\" இயக்கவும்.</string>
   <string name="ContactSelectionListFragment_error_retrieving_contacts_check_your_network_connection">தொடர்புகளை மீட்டெடுப்பதில் பிழை, உங்கள் பிணைய இணைப்பைச் சரிபார்க்கவும்</string>
   <string name="ContactSelectionListFragment_username_not_found">பயனர்பெயர் கிடைக்கவில்லை</string>
-  <string name="ContactSelectionListFragment_s_is_not_a_signal_user">\"%1$s\" Signal பயனர் அல்ல. தயவுசெய்து பயனர்பெயரை சரிபார்த்து மீண்டும் முயற்சிக்கவும்.</string>
+  <string name="ContactSelectionListFragment_s_is_not_a_signal_user">\"%1$s\" சிக்னல் பயனர் அல்ல. தயவுசெய்து பயனர்பெயரை சரிபார்த்து மீண்டும் முயற்சிக்கவும்.</string>
   <string name="ContactSelectionListFragment_you_do_not_need_to_add_yourself_to_the_group">உங்களை நீங்களே குழுவில் சேர்க்க தேவையில்லை</string>
   <string name="ContactSelectionListFragment_maximum_group_size_reached">அதிகபட்ச குழு அளவு எட்டப்பட்டுள்ளது</string>
   <string name="ContactSelectionListFragment_signal_groups_can_have_a_maximum_of_d_members">சிக்னல் குழுக்கள் அதிகபட்சம் %1$d உறுப்பினர்களைக் கொண்டிருக்கலாம்.</string>
@@ -1647,7 +1647,7 @@
     <item quantity="other">%1$d உறுப்பினர்கள்</item>
   </plurals>
   <!--conversation_activity-->
-  <string name="conversation_activity__type_message_push">Signal செய்தி</string>
+  <string name="conversation_activity__type_message_push">சிக்னல் செய்தி</string>
   <string name="conversation_activity__type_message_sms_insecure">பாதுகாப்பற்ற SMS</string>
   <string name="conversation_activity__type_message_mms_insecure">பாதுகாப்பற்ற எம்.எம்.எஸ்</string>
   <string name="conversation_activity__from_sim_name">%1$s இலிருந்து</string>
@@ -1755,7 +1755,7 @@
   <string name="IdentityUtil_unverified_banner_many">%1$s, %2$s மற்றும் %3$s உடன் உங்கள் பாதுகாப்பு எண்கள் இனி சரிபார்க்கப்படாது</string>
   <string name="IdentityUtil_unverified_dialog_one">%1$s உடனான உங்கள் பாதுகாப்பு எண் மாறிவிட்டது, இனி சரிபார்க்கப்பட்டதாகாது. இது, உங்கள் தகவல்தொடர்புகளை யாரேனும் இடைமறிக்க முயற்சிக்கிறார்கள் அல்லது %1$s Signal-ஐ மீண்டும் நிறுவியிருக்கிறார்கள், என்பதை குறிக்கும்.</string>
   <string name="IdentityUtil_unverified_dialog_two">%1$s மற்றும் %2$s உடனான உங்கள் பாதுகாப்பு எண்கள் இனி சரிபார்க்கப்பட்டதாகாது. இது, உங்கள் தகவல்தொடர்புகளை யாரேனும் இடைமறிக்க முயற்சிக்கிறார்கள் அல்லது அவர்கள் Signal-ஐ மீண்டும் நிறுவியிருக்கிறார்கள், என்பதை குறிக்கும்.</string>
-  <string name="IdentityUtil_unverified_dialog_many">%1$s , %2$s மற்றும் %3$s உடனான உங்கள் பாதுகாப்பு எண்கள் இனி சரிபார்க்கப்பட்டதாகாது. இது, உங்கள் தகவல்தொடர்புகளை யாராவது இடைமறிக்க முயற்சிக்கிறார்கள் அல்லது அவர்கள் Signal மீண்டும் நிறுவியிக்கிறார்கள் என்பதை குறிக்கும்.</string>
+  <string name="IdentityUtil_unverified_dialog_many">%1$s , %2$s மற்றும் %3$s உடனான உங்கள் பாதுகாப்பு எண்கள் இனி சரிபார்க்கப்பட்டதாகாது. இது, உங்கள் தகவல்தொடர்புகளை யாராவது இடைமறிக்க முயற்சிக்கிறார்கள் அல்லது அவர்கள் சிக்னல் மீண்டும் நிறுவியிருக்கிறார்கள் என்பதை குறிக்கும்.</string>
   <string name="IdentityUtil_untrusted_dialog_one">%s உடனான உங்கள் பாதுகாப்பு எண் இப்போது மாறிவிட்டது.</string>
   <string name="IdentityUtil_untrusted_dialog_two">%1$s மற்றும் %2$s உடனான உங்கள் பாதுகாப்பு எண்கள் இப்போது மாறிவிட்டது.</string>
   <string name="IdentityUtil_untrusted_dialog_many">%1$s , %2$s மற்றும் %3$s உடனான உங்கள் பாதுகாப்பு எண்கள் இப்போது மாறிவிட்டது.</string>
@@ -1812,7 +1812,7 @@
   <!--prompt_passphrase_activity-->
   <string name="prompt_passphrase_activity__unlock">திற</string>
   <!--prompt_mms_activity-->
-  <string name="prompt_mms_activity__signal_requires_mms_settings_to_deliver_media_and_group_messages">உங்கள் வயர்லெஸ் கேரியர் மூலம் மீடியா மற்றும் குழு செய்திகளை வழங்க Signal கு எம்எம்எஸ் அமைப்புகள் தேவை. உங்கள் சாதனத்தில் இந்த தகவல் கிடைக்கும்  இருப்பில் இருக்காது, இது பூட்டப்பட்ட சாதனங்கள், மற்றும் பிற கட்டுப்பாட்டு உள்ளமைவுகளுக்கு, அவ்வப்போது பொருந்தும்  உண்மை.</string>
+  <string name="prompt_mms_activity__signal_requires_mms_settings_to_deliver_media_and_group_messages">உங்கள் வயர்லெஸ் கேரியர் மூலம் மீடியா மற்றும் குழு செய்திகளை வழங்க சிக்னலுக்கு எம்எம்எஸ் அமைப்புகள் தேவை. உங்கள் சாதனத்தில் இந்த தகவல் கிடைக்கும்  இருப்பில் இருக்காது, இது பூட்டப்பட்ட சாதனங்கள், மற்றும் பிற கட்டுப்பாட்டு உள்ளமைவுகளுக்கு, அவ்வப்போது பொருந்தும்  உண்மை.</string>
   <string name="prompt_mms_activity__to_send_media_and_group_messages_tap_ok">மீடியா மற்றும் குழு செய்திகளை அனுப்ப, \'சரி\' என்பதைத் தட்டவும், கோரப்பட்ட அமைப்புகளை முடிக்கவும். \'உங்கள் கேரியர் APN\' ஐத் தேடுவதன் மூலம் உங்கள் கேரியருக்கான MMS அமைப்புகள் பொதுவாக அமைந்திருக்கும். நீங்கள் இதை ஒரு முறை மட்டுமே செய்ய வேண்டும்.</string>
   <!--profile_create_activity-->
   <string name="CreateProfileActivity_first_name_required">முதல் பெயர் (தேவை)</string>
@@ -1827,10 +1827,10 @@
   <!--recipient_preferences_activity-->
   <string name="recipient_preference_activity__shared_media">பகிரப்பட்ட மீடியா</string>
   <!--- redphone_call_controls-->
-  <string name="redphone_call_card__signal_call">Signal  அழைப்பு</string>
+  <string name="redphone_call_card__signal_call">சிக்னல் அழைப்பு</string>
   <!--registration_activity-->
   <string name="registration_activity__phone_number">தொலைபேசி எண்</string>
-  <string name="registration_activity__registration_will_transmit_some_contact_information_to_the_server_temporariliy">உங்கள் இருக்கும் தொலைபேசி எண் மற்றும் முகவரி புத்தகத்தைப் பயன்படுத்தி Signal தொடர்புகொள்வதை எளிதாக்குகிறது. தொலைபேசியில் உங்களை எவ்வாறு தொடர்பு கொள்வது என்பது ஏற்கனவே அறிந்த நண்பர்கள் மற்றும் தொடர்புகள் Signal மூலம் எளிதில் தொடர்பு கொள்ள முடியும். \ N \ n பதிவுசெய்தல் சில தொடர்பு தகவல்களை சேவையகத்திற்கு அனுப்புகிறது. இது சேமிக்கப்படவில்லை.</string>
+  <string name="registration_activity__registration_will_transmit_some_contact_information_to_the_server_temporariliy">உங்கள் இருக்கும் தொலைபேசி எண் மற்றும் முகவரி புத்தகத்தைப் பயன்படுத்தி சிக்னல் தொடர்புகொள்வதை எளிதாக்குகிறது. தொலைபேசியில் உங்களை எவ்வாறு தொடர்பு கொள்வது என்பது ஏற்கனவே அறிந்த நண்பர்கள் மற்றும் தொடர்புகள் சிக்னல் மூலம் எளிதில் தொடர்பு கொள்ள முடியும். \ N \ n பதிவுசெய்தல் சில தொடர்பு தகவல்களை சேவையகத்திற்கு அனுப்புகிறது. இது சேமிக்கப்படவில்லை.</string>
   <string name="registration_activity__verify_your_number">உங்கள் எண்ணைச் சரிபார்க்கவும்</string>
   <string name="registration_activity__please_enter_your_mobile_number_to_receive_a_verification_code_carrier_rates_may_apply">சரிபார்ப்புக் குறியீட்டைப் பெற உங்கள் மொபைல் எண்ணை உள்ளிடவும். கேரியர் கட்டணங்கள் பொருந்தக்கூடும்.</string>
   <!--recipients_panel-->
@@ -1896,11 +1896,11 @@
   <string name="HelpFragment__whats_this">இது என்ன?</string>
   <string name="HelpFragment__how_do_you_feel">செய்தியிடல் அனுபவத்தைப் பற்றி நீங்கள் எப்படி உணருகிறீர்கள்? (விரும்பினால்)</string>
   <string name="HelpFragment__support_info">ஆதரவு தகவல்</string>
-  <string name="HelpFragment__signal_android_support_request">Signal Android ஆதரவு கோரிக்கை</string>
+  <string name="HelpFragment__signal_android_support_request">சிக்னல் ஆன்ட்ராய்டுஆதரவு கோரிக்கை</string>
   <string name="HelpFragment__debug_log">பிழைத்திருத்த பதிவு:</string>
   <string name="HelpFragment__na">N/A பொருந்தாது</string>
   <string name="HelpFragment__could_not_upload_logs">பதிவுகளை பதிவேற்ற முடியவில்லை</string>
-  <string name="HelpFragment__signal_support">Signal ஆதரவு</string>
+  <string name="HelpFragment__signal_support">சிக்னல் ஆதரவு</string>
   <string name="HelpFragment__please_be_as_descriptive_as_possible">சிக்கலைப் புரிந்துகொள்ள எங்களுக்கு உதவ முடிந்தவரை விளக்கமாகச் சொல்லுங்கள்.</string>
   <string name="HelpFragment__no_email_app_found">மின்னஞ்சல் பயன்பாடு எதுவும் கிடைக்கவில்லை.</string>
   <!--ReactWithAnyEmojiBottomSheetDialogFragment-->
@@ -1950,8 +1950,8 @@
   <string name="preferences__sms_mms">SMS மற்றும் MMS</string>
   <string name="preferences__pref_all_sms_title">அனைத்து SMSகளையும் பெறுக</string>
   <string name="preferences__pref_all_mms_title">அனைத்து MMSகளையும் பெறுக</string>
-  <string name="preferences__use_signal_for_viewing_and_storing_all_incoming_text_messages">உள்வரும் அனைத்து உரை செய்திகளுக்கும் Signal பயன்படுத்தவும்</string>
-  <string name="preferences__use_signal_for_viewing_and_storing_all_incoming_multimedia_messages">உள்வரும் அனைத்து மல்டிமீடியா செய்திகளுக்கும் Signal பயன்படுத்தவும்</string>
+  <string name="preferences__use_signal_for_viewing_and_storing_all_incoming_text_messages">உள்வரும் அனைத்து உரை செய்திகளுக்கும் சிக்னல் பயன்படுத்தவும்</string>
+  <string name="preferences__use_signal_for_viewing_and_storing_all_incoming_multimedia_messages">உள்வரும் அனைத்து மல்டிமீடியா செய்திகளுக்கும் சிக்னல் பயன்படுத்தவும்</string>
   <string name="preferences__pref_enter_sends_title">பதிவு விசை அனுப்பும்</string>
   <string name="preferences__pressing_the_enter_key_will_send_text_messages">உள்ளீட்டு விசையை அழுத்துவது செய்தியை அனுப்பும் </string>
   <string name="preferences__generate_link_previews">இணைப்பு மாதிரிக்காட்சிகளை உருவாக்கவும்</string>
@@ -1965,7 +1965,7 @@
   <string name="preferences__lock_signal_and_message_notifications_with_a_passphrase">கடவுச்சொல் மூலம் திரை மற்றும் அறிவிப்புகளைப் பூட்டு</string>
   <string name="preferences__screen_security">திரை பாதுகாப்பு</string>
   <string name="preferences__disable_screen_security_to_allow_screen_shots">அண்மை பட்டியல் மற்றும் மென்பொருளுக்கு உள்ளே திரையை படம் எடுப்பதை தடுக்கவும்</string>
-  <string name="preferences__auto_lock_signal_after_a_specified_time_interval_of_inactivity">செயலற்ற ஒரு குறிப்பிட்ட நேர இடைவெளிக்குப் பிறகு தானாக Signal ஐ பூட்டு</string>
+  <string name="preferences__auto_lock_signal_after_a_specified_time_interval_of_inactivity">செயலற்ற ஒரு குறிப்பிட்ட நேர இடைவெளிக்குப் பிறகு தானாக சிக்னல்-ஐ பூட்டு</string>
   <string name="preferences__inactivity_timeout_passphrase">செயலற்ற நேரம் முடிந்தது கடவுச்சொல்</string>
   <string name="preferences__inactivity_timeout_interval">செயலற்ற காலக்கெடு இடைவெளி</string>
   <string name="preferences__notifications">அறிவிப்புகள்</string>
@@ -2019,14 +2019,14 @@
   <string name="preferences__theme">நிறவடிவமைப்பு</string>
   <string name="preferences__disable_pin">கடவு எண்-ஐ முடக்கு</string>
   <string name="preferences__enable_pin">பின்னை மீண்டும் திறக்கவும்</string>
-  <string name="preferences__if_you_disable_the_pin_you_will_lose_all_data">நீங்கள் Signal கடவு எண்-ஐ முடக்கினால், நீங்கள் கைமுறையாக காப்புப்பிரதி எடுத்து மீட்டெடுக்காவிட்டால் Signal-ஐ மீண்டும் பதிவுசெய்யும்போது எல்லா தரவையும் இழப்பீர்கள். கடவு எண் முடக்கப்பட்டிருக்கும் போது நீங்கள் பதிவு பூட்டை இயக்க முடியாது.</string>
-  <string name="preferences__pins_keep_information_stored_with_signal_encrypted_so_only_you_can_access_it">Signal இடம் சேமிக்கப்படும் தகவல்களை மறையாக்கி நீங்கள் மட்டும் அணுகும் வகையில் கடவு எண்-கள் வைக்கும். நீங்கள் மீண்டும் நிறுவும்போது உங்கள் சுயவிவரம், அமைப்புகள் மற்றும் தொடர்புகள் மீட்டமைக்கப்படும். பயன்பாட்டைத் திறக்க உங்கள் கடவு எண் தேவைப்படாது.</string>
+  <string name="preferences__if_you_disable_the_pin_you_will_lose_all_data">நீங்கள் சிக்னல் கடவு எண்-ஐ முடக்கினால், நீங்கள் கைமுறையாக காப்புப்பிரதி எடுத்து மீட்டெடுக்காவிட்டால் Signal-ஐ மீண்டும் பதிவுசெய்யும்போது எல்லா தரவையும் இழப்பீர்கள். கடவு எண் முடக்கப்பட்டிருக்கும் போது நீங்கள் பதிவு பூட்டை இயக்க முடியாது.</string>
+  <string name="preferences__pins_keep_information_stored_with_signal_encrypted_so_only_you_can_access_it">சிக்னல்-இடம் சேமிக்கப்படும் தகவல்களை மறையாக்கி நீங்கள் மட்டும் அணுகும் வகையில் கடவு எண்-கள் வைக்கும். நீங்கள் மீண்டும் நிறுவும்போது உங்கள் சுயவிவரம், அமைப்புகள் மற்றும் தொடர்புகள் மீட்டமைக்கப்படும். பயன்பாட்டைத் திறக்க உங்கள் கடவு எண் தேவைப்படாது.</string>
   <string name="preferences__system_default">கருவி இயல்புநிலை</string>
   <string name="preferences__default">இயல்புநிலை</string>
   <string name="preferences__language">மொழி</string>
-  <string name="preferences__signal_messages_and_calls">Signal செய்திகள் மற்றும் அழைப்புகள்</string>
+  <string name="preferences__signal_messages_and_calls">சிக்னல் செய்திகள் மற்றும் அழைப்புகள்</string>
   <string name="preferences__advanced_pin_settings">மேம்பட்ட பின் அமைப்புகள்</string>
-  <string name="preferences__free_private_messages_and_calls">Signal பயனர்களுக்கு இலவச தனிப்பட்ட செய்திகள் மற்றும் அழைப்புகள்</string>
+  <string name="preferences__free_private_messages_and_calls">சிக்னல் பயனர்களுக்கு இலவச தனிப்பட்ட செய்திகள் மற்றும் அழைப்புகள்</string>
   <string name="preferences__submit_debug_log">பிழைத்திருத்த பதிவுகளை சமர்ப்பி</string>
   <string name="preferences__delete_account">கணக்குகணக்குகணக்கு</string>
   <string name="preferences__support_wifi_calling">\'WiFi அழைப்புகள்\' பொருந்தக்கூடிய முறை</string>
@@ -2065,8 +2065,8 @@
   <string name="preferences_storage__s_messages">%1$s செய்திகள்</string>
   <string name="preferences_storage__custom">விருப்பத்திர்க்கேர்ப்ப</string>
   <string name="preferences_advanced__use_system_emoji">கணினி ஈமோஜியைப் பயன்படுத்தவும்</string>
-  <string name="preferences_advanced__disable_signal_built_in_emoji_support">Signal  உள்ளமைக்கப்பட்ட ஈமோஜி ஆதரவை முடக்கு</string>
-  <string name="preferences_advanced__relay_all_calls_through_the_signal_server_to_avoid_revealing_your_ip_address">உங்கள் ஐபி முகவரியை உங்கள் தொடர்புக்கு வெளிப்படுத்தாமல் இருக்க Signal சேவையகம் மூலம் அனைத்து அழைப்புகளையும் ரிலே செய்யவும். இயக்குவது அழைப்பு தரத்தை குறைக்கும்.</string>
+  <string name="preferences_advanced__disable_signal_built_in_emoji_support">சிக்னல் உள்ளமைக்கப்பட்ட ஈமோஜி ஆதரவை முடக்கு</string>
+  <string name="preferences_advanced__relay_all_calls_through_the_signal_server_to_avoid_revealing_your_ip_address">உங்கள் ஐபி முகவரியை உங்கள் தொடர்புக்கு வெளிப்படுத்தாமல் இருக்க சிக்னல் சேவையகம் மூலம் அனைத்து அழைப்புகளையும் ரிலே செய்யவும். இயக்குவது அழைப்பு தரத்தை குறைக்கும்.</string>
   <string name="preferences_advanced__always_relay_calls">எப்போதும் அழைப்புகளை ரிலே செய்யவும் </string>
   <string name="preferences_app_protection__who_can">யாரால் முடியும்…</string>
   <string name="preferences_app_protection__app_access">பயன்பாடு அணுகல்</string>
@@ -2079,9 +2079,9 @@
   <string name="preferences_notifications__calls">அழைப்புகள்</string>
   <string name="preferences_notifications__ringtone">ரிங்டோன்</string>
   <string name="preferences_chats__show_invitation_prompts">உடனடி அழைப்புகளைக் காட்டு</string>
-  <string name="preferences_chats__display_invitation_prompts_for_contacts_without_signal">காட்சி அழைப்பிதழ் Signal இல்லாத  தொடர்புகளுக்கு கேட்கும்</string>
+  <string name="preferences_chats__display_invitation_prompts_for_contacts_without_signal">காட்சி அழைப்பிதழ் சிக்னல் இல்லாத  தொடர்புகளுக்கு கேட்கும்</string>
   <string name="preferences_chats__message_text_size">செய்தி எழுத்துரு அளவு</string>
-  <string name="preferences_events__contact_joined_signal">தொடர்பு  Signal இல் இணைந்தது </string>
+  <string name="preferences_events__contact_joined_signal">தொடர்பு  சிக்னலில் இணைந்தது </string>
   <string name="preferences_notifications__priority">முன்னுரிமை</string>
   <string name="preferences_communication__category_sealed_sender">சீல் அனுப்பியவர்</string>
   <string name="preferences_communication__sealed_sender_display_indicators">காட்சி குறிகாட்டிகள்</string>
@@ -2105,8 +2105,8 @@
   <!--conversation_callable_insecure-->
   <string name="conversation_callable_insecure__menu_call">அழை</string>
   <!--conversation_callable_secure-->
-  <string name="conversation_callable_secure__menu_call">Signal அழைப்பு</string>
-  <string name="conversation_callable_secure__menu_video">Signal காணொளி அழைப்பு</string>
+  <string name="conversation_callable_secure__menu_call">சிக்னல் அழைப்பு</string>
+  <string name="conversation_callable_secure__menu_video">சிக்னல் காணொளி அழைப்பு</string>
   <!--conversation_context-->
   <string name="conversation_context__menu_message_details">செய்தி விவரங்கள்</string>
   <string name="conversation_context__menu_copy_text">உரை நகலெடு</string>
@@ -2186,14 +2186,14 @@
   <!--reminder_header-->
   <string name="reminder_header_sms_import_title">தொலைபேசியிலுள்ள SMS-களை இறக்குமதி</string>
   <string name="reminder_header_sms_import_text">உங்கள் தொலைபேசியின் SMS செய்திகளை Signal-இன் மறைகுறியாக்கப்பட்ட தரவுத்தளக்கு நகலெடுக்க தட்டவும்.</string>
-  <string name="reminder_header_push_title">Signal செய்திகளையும் அழைப்புகளையும் இயக்கு</string>
+  <string name="reminder_header_push_title">சிக்னல் செய்திகளையும் அழைப்புகளையும் இயக்கு</string>
   <string name="reminder_header_push_text">உங்கள் தொடர்பு அனுபவத்தை மேம்படுத்தவும்.</string>
   <string name="reminder_header_invite_title">Signalக்கு அழை</string>
   <string name="reminder_header_invite_text">உங்கள் உரையாடலை %1$s உடன் அடுத்த கட்டத்திற்கு கொண்டு செல்லுங்கள்.</string>
   <string name="reminder_header_share_title">நண்பர்களை அழைக்கவும்!</string>
-  <string name="reminder_header_share_text">அதிகமான நண்பர்கள் Signal ஐ பயன்படுத்தும் போது, அது அதிக சிறப்படைகிறது .</string>
-  <string name="reminder_header_service_outage_text">Signal தொழில்நுட்ப சிக்கல்களை எதிர்கொள்கிறது. சேவையை விரைவாக மீட்டெடுக்க நாங்கள் விரைவாக வேலை செய்து  வருகிறோம்.</string>
-  <string name="reminder_header_the_latest_signal_features_wont_work">அண்ட்ராய்டு இன் இந்த பதிப்பில் சமீபத்திய Signal அம்சங்கள் இயங்காது. எதிர்கால Signal புதுப்பிப்புகளைப் பெற இந்த சாதனத்தை மேம்படுத்தவும்.</string>
+  <string name="reminder_header_share_text">அதிகமான நண்பர்கள் சிக்னல்-ஐ பயன்படுத்தும் போது, அது அதிக சிறப்படைகிறது .</string>
+  <string name="reminder_header_service_outage_text">சிக்னல் தொழில்நுட்ப சிக்கல்களை எதிர்கொள்கிறது. சேவையை விரைவாக மீட்டெடுக்க நாங்கள் விரைவாக வேலை செய்து  வருகிறோம்.</string>
+  <string name="reminder_header_the_latest_signal_features_wont_work">அண்ட்ராய்டு இன் இந்த பதிப்பில் சமீபத்திய சிக்னல் அம்சங்கள் இயங்காது. எதிர்கால சிக்னல் புதுப்பிப்புகளைப் பெற இந்த சாதனத்தை மேம்படுத்தவும்.</string>
   <string name="reminder_header_progress">%1$d%%</string>
   <!--media_preview-->
   <string name="media_preview__save_title">சேமி</string>
@@ -2213,8 +2213,8 @@
   <string name="Insights__percent">%</string>
   <string name="Insights__title">நுண்ணறிவு</string>
   <string name="InsightsDashboardFragment__title">நுண்ணறிவு</string>
-  <string name="InsightsDashboardFragment__signal_protocol_automatically_protected">கடந்த %2$d நாட்களில் Signal நெறிமுறை தானாகவே உங்களின் %1$d%% வெளிச்செல்லும் செய்திகளை பாதுகாத்தது. Signal பயனர்களிடையேயான உரையாடல்கள் எப்போதும் முடிவிலிருந்து-முடிவுவரை மறையாக்கம் செய்யப்படுகின்றன.</string>
-  <string name="InsightsDashboardFragment__boost_your_signal">Signal பூஸ்ட்</string>
+  <string name="InsightsDashboardFragment__signal_protocol_automatically_protected">கடந்த %2$d நாட்களில் சிக்னல் நெறிமுறை தானாகவே உங்களின் %1$d%% வெளிச்செல்லும் செய்திகளை பாதுகாத்தது. சிக்னல் பயனர்களிடையேயான உரையாடல்கள் எப்போதும் முடிவிலிருந்து-முடிவுவரை மறையாக்கம் செய்யப்படுகின்றன.</string>
+  <string name="InsightsDashboardFragment__boost_your_signal">சிக்னல் பூஸ்ட்</string>
   <string name="InsightsDashboardFragment__not_enough_data">போதிய தரவு இல்லை</string>
   <string name="InsightsDashboardFragment__your_insights_percentage_is_calculated_based_on">கடந்த %1$d நாட்களில் காணாமல் போகாத அல்லது நீக்கப்படாத வெளிச்செல்லும் செய்திகளின் அடிப்படையில் உங்கள் நுண்ணறிவு சதவீதம் கணக்கிடப்படுகிறது.</string>
   <string name="InsightsDashboardFragment__start_a_conversation">புதிய உரையாடலை தொடங்கு</string>
@@ -2224,9 +2224,9 @@
   <string name="InsightsDashboardFragment__cancel">ரத்து</string>
   <string name="InsightsDashboardFragment__send">அனுப்புக</string>
   <string name="InsightsModalFragment__title">நுண்ணறிவுகளை அறிமுகப்படுத்துகிறது</string>
-  <string name="InsightsModalFragment__description">உங்கள் வெளிச்செல்லும் செய்திகளில் எத்தனை பாதுகாப்பாக அனுப்பப்பட்டன என்பதைக் கண்டுபிடி, பின்னர் உங்கள் Signal சதவீதத்தை அதிகரிக்க புதிய தொடர்புகளை விரைவாக அழைக்கவும்</string>
+  <string name="InsightsModalFragment__description">உங்கள் வெளிச்செல்லும் செய்திகளில் எத்தனை பாதுகாப்பாக அனுப்பப்பட்டன என்பதைக் கண்டுபிடி, பின்னர் உங்கள் சிக்னல் சதவீதத்தை அதிகரிக்க புதிய தொடர்புகளை விரைவாக அழைக்கவும்</string>
   <string name="InsightsModalFragment__view_insights">நுண்ணறிவுகளைக் காண்க</string>
-  <string name="FirstInviteReminder__title">Signal க்கு அழைக்கவும்</string>
+  <string name="FirstInviteReminder__title">சிக்னலுக்கு அழைக்கவும்</string>
   <string name="FirstInviteReminder__description">நீங்கள் அனுப்பும் மறையாக்கப்பட்ட செய்திகளின் எண்ணிக்கையை %1$d%% அதிகரிக்கலாம்</string>
   <string name="SecondInviteReminder__title">உங்கள் Signal Boost ஐ அதிகரிக்கவும்</string>
   <string name="SecondInviteReminder__description">அழைக்கவும் %1$s</string>
@@ -2249,7 +2249,7 @@
   <string name="CreateKbsPinFragment__create_a_new_pin">புதிய கடவு எண்ணை உருவாக்கவும்</string>
   <string name="CreateKbsPinFragment__you_can_choose_a_new_pin_as_long_as_this_device_is_registered">நீங்கள் முடியும் மாற்றம் உங்கள் கடவு எண் இந்த வரை சாதனம் பதிவு செய்யப்பட்டுள்ளது.</string>
   <string name="CreateKbsPinFragment__create_your_pin">உங்கள் பின்னை உருவாக்கவும்</string>
-  <string name="CreateKbsPinFragment__pins_keep_information_stored_with_signal_encrypted">Signal இடம் சேமிக்கப்படும் தகவல்களை மறையாக்கி நீங்கள் மட்டும் அணுகும் வகையில் கடவு எண்-கள் வைக்கும். நீங்கள் மீண்டும் நிறுவும்போது உங்கள் சுயவிவரம், அமைப்புகள் மற்றும் தொடர்புகள் மீட்டமைக்கப்படும். பயன்பாட்டைத் திறக்க உங்கள் கடவு எண் தேவைப்படாது.</string>
+  <string name="CreateKbsPinFragment__pins_keep_information_stored_with_signal_encrypted">சிக்னல் இடம் சேமிக்கப்படும் தகவல்களை மறையாக்கி நீங்கள் மட்டும் அணுகும் வகையில் கடவு எண்-கள் வைக்கும். நீங்கள் மீண்டும் நிறுவும்போது உங்கள் சுயவிவரம், அமைப்புகள் மற்றும் தொடர்புகள் மீட்டமைக்கப்படும். பயன்பாட்டைத் திறக்க உங்கள் கடவு எண் தேவைப்படாது.</string>
   <string name="CreateKbsPinFragment__choose_a_stronger_pin">வலுவானதைத் தேர்வுசெய்க பின்</string>
   <!--ConfirmKbsPinFragment-->
   <string name="ConfirmKbsPinFragment__pins_dont_match">கடவு எண்-கள் பொருந்தவில்லை. மீண்டும் முயற்சி செய்க.</string>
@@ -2261,7 +2261,7 @@
   <string name="ConfirmKbsPinFragment__creating_pin">கடவு எண் உருவாக்குகிறது…</string>
   <!--KbsSplashFragment-->
   <string name="KbsSplashFragment__introducing_pins">பின்களை  அறிமுகப்படுத்துகிறது</string>
-  <string name="KbsSplashFragment__pins_keep_information_stored_with_signal_encrypted">Signal இடம் சேமிக்கப்படும் தகவல்களை மறையாக்கி நீங்கள் மட்டும் அணுகும் வகையில் கடவு எண்-கள் வைக்கும். நீங்கள் மீண்டும் நிறுவும்போது உங்கள் சுயவிவரம், அமைப்புகள் மற்றும் தொடர்புகள் மீட்டமைக்கப்படும். பயன்பாட்டைத் திறக்க உங்கள் கடவு எண் தேவைப்படாது.</string>
+  <string name="KbsSplashFragment__pins_keep_information_stored_with_signal_encrypted">சிக்னல் இடம் சேமிக்கப்படும் தகவல்களை மறையாக்கி நீங்கள் மட்டும் அணுகும் வகையில் கடவு எண்-கள் வைக்கும். நீங்கள் மீண்டும் நிறுவும்போது உங்கள் சுயவிவரம், அமைப்புகள் மற்றும் தொடர்புகள் மீட்டமைக்கப்படும். பயன்பாட்டைத் திறக்க உங்கள் கடவு எண் தேவைப்படாது.</string>
   <string name="KbsSplashFragment__learn_more">மேலும் அறிக</string>
   <string name="KbsSplashFragment__registration_lock_equals_pin">பதிவு பூட்டு = கடவு எண்</string>
   <string name="KbsSplashFragment__your_registration_lock_is_now_called_a_pin">உங்கள் பதிவு பூட்டு இப்போது கடவு எண் என அழைக்கப்படுகிறது, மேலும் இது மேலும் செய்கிறது. இப்போது புதுப்பிக்கவும்.</string>
@@ -2271,12 +2271,12 @@
   <string name="KbsSplashFragment__learn_more_about_pins">பின்கள் பற்றி மேலும் அறிக</string>
   <string name="KbsSplashFragment__disable_pin">கடவு எண்-ஐ முடக்கு</string>
   <!--KBS Reminder Dialog-->
-  <string name="KbsReminderDialog__enter_your_signal_pin">உங்கள் Signal பின்னை உள்ளிடவும்</string>
-  <string name="KbsReminderDialog__to_help_you_memorize_your_pin">உங்கள் பின்னை மனப்பாடம் செய்ய உங்களுக்கு உதவ, அதை அவ்வப்போது உள்ளிடுமாறு கேட்டுக்கொள்கிறோம். காலப்போக்கில் நாங்கள் உங்களிடம் குறைவாகக் கேட்கிறோம்.</string>
+  <string name="KbsReminderDialog__enter_your_signal_pin">உங்கள் சிக்னல் கடவு எண்ணை உள்ளிடவும்</string>
+  <string name="KbsReminderDialog__to_help_you_memorize_your_pin">உங்கள் கடவு எண்ணை மனப்பாடம் செய்ய உங்களுக்கு உதவ, அதை அவ்வப்போது உள்ளிடுமாறு கேட்டுக்கொள்கிறோம். காலப்போக்கில் நாங்கள் உங்களிடம் குறைவாகக் கேட்கிறோம்.</string>
   <string name="KbsReminderDialog__skip">தவிர்</string>
   <string name="KbsReminderDialog__submit">சமர்ப்பி</string>
   <string name="KbsReminderDialog__forgot_pin">கடவு எண் மறந்துவிட்டீர்களா?</string>
-  <string name="KbsReminderDialog__incorrect_pin_try_again">தவறான பின். மீண்டும் முயற்சி செய்க.</string>
+  <string name="KbsReminderDialog__incorrect_pin_try_again">தவறான கடவு எண். மீண்டும் முயற்சி செய்க.</string>
   <!--AccountLockedFragment-->
   <string name="AccountLockedFragment__account_locked">கணக்கில் பூட்டப்பட்டுள்ளது</string>
   <string name="AccountLockedFragment__your_account_has_been_locked_to_protect_your_privacy">உங்கள் தனியுரிமை மற்றும் பாதுகாப்பைப் பாதுகாக்க உங்கள் கணக்கு பூட்டப்பட்டுள்ளது. உங்கள் கணக்கில் %1$dநாட்கள் செயலற்ற நிலையில் இருந்தபின், உங்கள் கடவு எண் தேவைப்படாமல் இந்த தொலைபேசி எண்ணை மீண்டும் பதிவு செய்ய முடியும். எல்லா உள்ளடக்கமும் நீக்கப்படும்.</string>
@@ -2284,7 +2284,7 @@
   <string name="AccountLockedFragment__learn_more">மேலும் அறிக</string>
   <!--KbsLockFragment-->
   <string name="RegistrationLockFragment__enter_your_pin">உங்கள் கடவு எண்ணை உள்ளிடவும்</string>
-  <string name="RegistrationLockFragment__enter_the_pin_you_created">உங்கள் கணக்கிற்கு நீங்கள் உருவாக்கிய பின்னை உள்ளிடவும். இது உங்கள் SMS சரிபார்ப்புக் குறியீட்டிலிருந்து வேறுபட்டது.</string>
+  <string name="RegistrationLockFragment__enter_the_pin_you_created">உங்கள் கணக்கிற்கு நீங்கள் உருவாக்கிய கடவு எண்ணை உள்ளிடவும். இது உங்கள் SMS சரிபார்ப்புக் குறியீட்டிலிருந்து வேறுபட்டது.</string>
   <string name="RegistrationLockFragment__enter_alphanumeric_pin">எண்ணெழுத்துக்கள் உள்ளடக்கிய கடவு எண் உள்ளிடவும்</string>
   <string name="RegistrationLockFragment__enter_numeric_pin">எண்கள் உள்ளடக்கிய கடவு எண் உள்ளிடவும்</string>
   <string name="RegistrationLockFragment__next">அடுத்தது</string>
@@ -2318,14 +2318,14 @@
   <string name="CalleeMustAcceptMessageRequestDialogFragment__s_will_get_a_message_request_from_you">%1$s உங்களிடமிருந்து செய்தி கோரிக்கையைப் பெறும். உங்கள் செய்தி கோரிக்கை ஏற்றுக்கொள்ளப்பட்டவுடன் நீங்கள் அழைக்கலாம்.</string>
   <!--KBS Megaphone-->
   <string name="KbsMegaphone__create_a_pin">கடவு எண்ணை உருவாக்கவும்</string>
-  <string name="KbsMegaphone__pins_keep_information_thats_stored_with_signal_encrytped">Signal இடம் சேமிக்கப்படும் தகவல்களை மறையாக்கி நீங்கள் மட்டும் அணுகும் வகையில் கடவு எண்-கள் வைக்கும்.</string>
+  <string name="KbsMegaphone__pins_keep_information_thats_stored_with_signal_encrytped">சிக்னலிடம் சேமிக்கப்படும் தகவல்களை மறையாக்கி நீங்கள் மட்டும் அணுகும் வகையில் கடவு எண்-கள் வைக்கும்.</string>
   <string name="KbsMegaphone__create_pin">கடவு எண் உருவாக்கவும்</string>
   <string name="KbsMegaphone__introducing_pins">கடவு எண்களை  அறிமுகப்படுத்துகிறது</string>
   <string name="KbsMegaphone__update_pin">கடவு எண்ணைப் புதுப்பிக்கவும்</string>
   <string name="KbsMegaphone__well_remind_you_later_creating_a_pin">நாங்கள் உங்களுக்கு பின்னர் நினைவூட்டுவோம். கடவு எண்ணை ஐ உருவாக்குவது %1$dநாட்களில் கட்டாயமாகிவிடும்.</string>
   <string name="KbsMegaphone__well_remind_you_later_confirming_your_pin">நாங்கள் உங்களுக்கு பின்னர் நினைவூட்டுவோம்.%1$dநாட்களில் உங்கள் கடவு எண்ணை உறுதிப்படுத்துவது கட்டாயமாகிவிடும்.</string>
   <!--Research Megaphone-->
-  <string name="ResearchMegaphone_tell_signal_what_you_think">நீங்கள் என்ன நினைக்கிறீர்கள் என்று Signal லிடம் சொல்லுங்கள்</string>
+  <string name="ResearchMegaphone_tell_signal_what_you_think">நீங்கள் என்ன நினைக்கிறீர்கள் என்று சிக்னலிடம் சொல்லுங்கள்</string>
   <string name="ResearchMegaphone_to_make_signal_the_best_messaging_app_on_the_planet">சிக்னலை உலகின் சிறந்த செய்தியிடல் பயன்பாடாக மாற்ற, உங்கள் கருத்தைக் கேட்க நாங்கள் விரும்புகிறோம்.</string>
   <string name="ResearchMegaphone_learn_more">மேலும் அறிக</string>
   <string name="ResearchMegaphone_dismiss">நிராகரி</string>
@@ -2342,9 +2342,9 @@
   <string name="ConversationActivity_signal_needs_sms_permission_in_order_to_send_an_sms">ஒர் SMS அனுப்ப Signal-க்கு SMS அனுமதி தேவை, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாட்டின் அமைப்புகளுக்கு தொடரந்து, \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து \"SMS\" ஐ இயக்கவும்.</string>
   <string name="Permissions_continue">தொடர்</string>
   <string name="Permissions_not_now">இப்போது இல்லை</string>
-  <string name="ConversationListActivity_signal_needs_contacts_permission_in_order_to_search_your_contacts_but_it_has_been_permanently_denied">உங்கள் தொடர்புகளைத் தேட Signal கு தொடர்புகளின் அனுமதி தேவை, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகளைத் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து, \"தொடர்புகளை\" இயக்கவும்.</string>
-  <string name="conversation_activity__enable_signal_messages">Signal செய்திகளை இயக்கவும்</string>
-  <string name="SQLCipherMigrationHelper_migrating_signal_database">Signal தரவுத்தளத்தை மாற்றுதல்</string>
+  <string name="ConversationListActivity_signal_needs_contacts_permission_in_order_to_search_your_contacts_but_it_has_been_permanently_denied">உங்கள் தொடர்புகளைத் தேட சிக்னலுக்கு தொடர்புகளின் அனுமதி தேவை, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகளைத் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து, \"தொடர்புகளை\" இயக்கவும்.</string>
+  <string name="conversation_activity__enable_signal_messages">சிக்னல் செய்திகளை இயக்கவும்</string>
+  <string name="SQLCipherMigrationHelper_migrating_signal_database">சிக்னல் தரவுத்தளத்தை மாற்றுதல்</string>
   <string name="PushDecryptJob_new_locked_message">பூட்டப்பட்ட புதிய செய்தி</string>
   <string name="PushDecryptJob_unlock_to_view_pending_messages">நிலுவையிலுள்ள செய்திகளைக் காண திறக்கவும்</string>
   <string name="enter_backup_passphrase_dialog__backup_passphrase">கடவுச்சொல்லை காப்புப்பிரதி  செய்க </string>
@@ -2362,7 +2362,7 @@
   <string name="preferences_chats__test_your_backup_passphrase_and_verify_that_it_matches">உங்கள் காப்புப்பிரதி கடவுச்சொற்றொடரைச் சோதித்து, அது பொருந்துமா என்பதைச் சரிபார்க்கவும்</string>
   <string name="RegistrationActivity_enter_backup_passphrase">காப்புப்பதிவு பயனர் தரவு கடவுச்சொற்றொடரை உள்ளிடவும்</string>
   <string name="RegistrationActivity_restore">மீட்க</string>
-  <string name="RegistrationActivity_backup_failure_downgrade">Signal லின் புதிய பதிப்புகளிலிருந்து காப்புப்பிரதிகளை இறக்குமதி செய்ய முடியாது</string>
+  <string name="RegistrationActivity_backup_failure_downgrade">சிக்னலின் புதிய பதிப்புகளிலிருந்து காப்புப்பிரதிகளை இறக்குமதி செய்ய முடியாது</string>
   <string name="RegistrationActivity_incorrect_backup_passphrase">தவறான காப்புப்பதிவு பயனர் தரவு கடவுச்சொல்</string>
   <string name="RegistrationActivity_checking">சரிபார்க்கிறது…</string>
   <string name="RegistrationActivity_d_messages_so_far">இதுவரை %d செய்திகள் …</string>
@@ -2383,7 +2383,7 @@
   <string name="BackupDialog_verify">சரிபார்க்கவும்</string>
   <string name="BackupDialog_you_successfully_entered_your_backup_passphrase">உங்கள் காப்புப்பிரதி கடவுச்சொற்றொடரை வெற்றிகரமாக உள்ளிட்டுள்ளீர்கள்</string>
   <string name="BackupDialog_passphrase_was_not_correct">கடவுச்சொல் சரியாக இல்லை</string>
-  <string name="ChatsPreferenceFragment_signal_requires_external_storage_permission_in_order_to_create_backups">காப்புப்பிரதிகளை உருவாக்க Signal கு வெளிப்புற சேமிப்பக அனுமதி தேவைப்படுகிறது, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகளைத் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து \"சேமிப்பகத்தை\" இயக்கவும்.</string>
+  <string name="ChatsPreferenceFragment_signal_requires_external_storage_permission_in_order_to_create_backups">காப்புப்பிரதிகளை உருவாக்க சிக்னலுக்கு வெளிப்புற சேமிப்பக அனுமதி தேவைப்படுகிறது, ஆனால் அது நிரந்தரமாக மறுக்கப்பட்டது. பயன்பாடு அமைப்புகளைத் தொடரவும், \"அனுமதிகள்\" என்பதைத் தேர்ந்தெடுத்து \"சேமிப்பகத்தை\" இயக்கவும்.</string>
   <string name="ChatsPreferenceFragment_last_backup_s">கடைசி காப்புப்பதிவு பயனர் தரவு: %s</string>
   <string name="ChatsPreferenceFragment_in_progress">நடந்து கொண்டிருக்கிறது</string>
   <string name="LocalBackupJob_creating_backup">காப்புப்பதிவு பயனர் தரவு உருவாக்குகிறது …</string>
@@ -2396,8 +2396,8 @@
   <string name="RegistrationActivity_please_enter_the_verification_code_sent_to_s">%s க்கு அனுப்பப்பட்ட சரிபார்ப்புக் குறியீட்டை உள்ளிடவும்.</string>
   <string name="RegistrationActivity_wrong_number">தவறான எண்</string>
   <string name="RegistrationActivity_call_me_instead_available_in">அதற்கு பதிலாக என்னை அழைக்கவும் \ n ( %1$02d :%2$02d இல் கிடைக்கும்)</string>
-  <string name="RegistrationActivity_contact_signal_support">Signal ஆதரவைத் தொடர்பு கொள்ளுங்கள்</string>
-  <string name="RegistrationActivity_code_support_subject">Signal பதிவு - அண்ட்ராய்டு க்கான சரிபார்ப்புக் குறியீடு</string>
+  <string name="RegistrationActivity_contact_signal_support">சிக்னல் ஆதரவைத் தொடர்பு கொள்ளுங்கள்</string>
+  <string name="RegistrationActivity_code_support_subject">சிக்னல் பதிவு - அண்ட்ராய்டு க்கான சரிபார்ப்புக் குறியீடு</string>
   <string name="BackupUtil_never">ஒருபோதுமில்லை</string>
   <string name="BackupUtil_unknown">முன் தெரிந்திராத</string>
   <string name="preferences_app_protection__see_my_phone_number">எனது தொலைபேசி எண்ணைக் காண்க</string>
@@ -2406,21 +2406,21 @@
   <string name="PhoneNumberPrivacy_my_contacts">எனது தொடர்புகள்</string>
   <string name="PhoneNumberPrivacy_nobody">ஒருவருமில்லை</string>
   <string name="PhoneNumberPrivacy_everyone_see_description">நீங்கள் செய்தி அனுப்பும் அனைத்து நபர்களுக்கும் குழுக்களுக்கும் உங்கள் தொலைபேசி எண் தெரியும்.</string>
-  <string name="PhoneNumberPrivacy_everyone_find_description">உங்கள் தொலைபேசி எண்ணை தங்கள் தொடர்புகளில் வைத்திருக்கும் எவரும் உங்களை Signal சிக்னலில் ஒரு தொடர்பாகப் பார்ப்பார்கள். மற்றவர்கள் உங்களை தேடலில் கண்டுபிடிக்க முடியும்.</string>
-  <string name="PhoneNumberPrivacy_my_contacts_see_description">உங்கள் தொடர்புகள் மட்டுமே உங்கள் தொலைபேசி எண்ணை சிக்னலில் Signal பார்க்கும்.</string>
+  <string name="PhoneNumberPrivacy_everyone_find_description">உங்கள் தொலைபேசி எண்ணை தங்கள் தொடர்புகளில் வைத்திருக்கும் எவரும் உங்களை சிக்னலில் ஒரு தொடர்பாகப் பார்ப்பார்கள். மற்றவர்கள் உங்களை தேடலில் கண்டுபிடிக்க முடியும்.</string>
+  <string name="PhoneNumberPrivacy_my_contacts_see_description">உங்கள் தொடர்புகள் மட்டுமே உங்கள் தொலைபேசி எண்ணை சிக்னலில் சிக்னல் பார்க்கும்.</string>
   <string name="preferences_app_protection__screen_lock">திரை பூட்டு</string>
-  <string name="preferences_app_protection__lock_signal_access_with_android_screen_lock_or_fingerprint">அண்ட்ராய்டு திரை பூட்டு அல்லது கைரேகையுடன் Signal அணுகலைப் பூட்டு</string>
+  <string name="preferences_app_protection__lock_signal_access_with_android_screen_lock_or_fingerprint">அண்ட்ராய்டு திரை பூட்டு அல்லது கைரேகையுடன் சிக்னல் அணுகலைப் பூட்டு</string>
   <string name="preferences_app_protection__screen_lock_inactivity_timeout">திரை பூட்டு செயலற்ற நேரம் முடிந்தது</string>
-  <string name="preferences_app_protection__signal_pin">Signal கடவு எண்</string>
+  <string name="preferences_app_protection__signal_pin">சிக்னல் கடவு எண்</string>
   <string name="preferences_app_protection__create_a_pin">பின்னை உருவாக்கவும்</string>
   <string name="preferences_app_protection__change_your_pin">உங்கள் கடவு எண்ணை மாற்றவும்</string>
   <string name="preferences_app_protection__pin_reminders">கடவு எண் நினைவூட்டல்கள்</string>
-  <string name="preferences_app_protection__pins_keep_information_stored_with_signal_encrypted">Signal இடம் சேமிக்கப்படும் தகவல்களை மறையாக்கி நீங்கள் மட்டும் அணுகும் வகையில் கடவு எண்-கள் வைக்கும். நீங்கள் மீண்டும் நிறுவும்போது உங்கள் சுயவிவரம், அமைப்புகள் மற்றும் தொடர்புகள் மீட்டமைக்கப்படும்.</string>
+  <string name="preferences_app_protection__pins_keep_information_stored_with_signal_encrypted">சிக்னலிடம் சேமிக்கப்படும் தகவல்களை மறையாக்கி நீங்கள் மட்டும் அணுகும் வகையில் கடவு எண்-கள் வைக்கும். நீங்கள் மீண்டும் நிறுவும்போது உங்கள் சுயவிவரம், அமைப்புகள் மற்றும் தொடர்புகள் மீட்டமைக்கப்படும்.</string>
   <string name="preferences_app_protection__add_extra_security_by_requiring_your_signal_pin_to_register">உங்கள் தொலைபேசி எண்ணை மீண்டும் சிக்னலுடன் பதிவு செய்ய உங்கள் சிக்னல் கடவு எண் தேவைப்படுவதன் மூலம் கூடுதல் பாதுகாப்பைச் சேர்க்கவும்.</string>
   <string name="preferences_app_protection__reminders_help_you_remember_your_pin">உங்கள் பின்னை மீட்டெடுக்க முடியாததால் நினைவூட்டல்கள் உங்களுக்கு உதவுகின்றன. காலப்போக்கில் உங்களிடம் குறைவாகவே கேட்கப்படும்.</string>
   <string name="preferences_app_protection__turn_off">அணைக்க</string>
   <string name="preferences_app_protection__confirm_pin">கடவு எண்ணை உறுதிப்படுத்தவும்</string>
-  <string name="preferences_app_protection__confirm_your_signal_pin">உறுதிப்படுத்தவும் உங்கள் Signal கடவு எண்</string>
+  <string name="preferences_app_protection__confirm_your_signal_pin">உறுதிப்படுத்தவும் உங்கள் சிக்னல் கடவு எண்</string>
   <string name="preferences_app_protection__make_sure_you_memorize_or_securely_store_your_pin">உங்கள் கடவு எண்-ஐ மீட்டெடுக்க முடியாததால் அதை நினைவில் வைத்துக் கொள்ளுங்கள் அல்லது பாதுகாப்பாக சேமித்து வைக்கவும். உங்கள் பின்னை மறந்துவிட்டால், உங்கள் சிக்னல் கணக்கை மீண்டும் பதிவு செய்யும் போது தரவை இழக்க நேரிடும்.</string>
   <string name="preferences_app_protection__incorrect_pin_try_again">தவறான கடவு எண். மீண்டும் முயற்சி செய்க.</string>
   <string name="preferences_app_protection__failed_to_enable_registration_lock">பதிவு பூட்டை இயக்குவதில் தோல்வி.</string>
@@ -2434,7 +2434,7 @@
   <string name="registration_lock_dialog_view__confirm_pin">கடவு எண் உறுதிப்படுத்தவும்</string>
   <string name="registration_lock_reminder_view__enter_your_registration_lock_pin">உங்கள் பதிவு பூட்டு கடவு எண்ணை உள்ளிடவும்</string>
   <string name="registration_lock_reminder_view__enter_pin">கடவு எண்ணை உள்ளிடவும்</string>
-  <string name="preferences_app_protection__enable_a_registration_lock_pin_that_will_be_required">இந்த தொலைபேசி எண்ணை மீண்டும் Signal லுடன் பதிவு செய்ய வேண்டிய பதிவு பூட்டு கடவு எண்ணை இயக்கவும்.</string>
+  <string name="preferences_app_protection__enable_a_registration_lock_pin_that_will_be_required">இந்த தொலைபேசி எண்ணை மீண்டும் சிக்னலுடன் பதிவு செய்ய வேண்டிய பதிவு பூட்டு கடவு எண்ணை இயக்கவும்.</string>
   <string name="preferences_app_protection__registration_lock_pin">பதிவு பூட்டு கடவு எண்</string>
   <string name="preferences_app_protection__registration_lock">பதிவு பூட்டு</string>
   <string name="RegistrationActivity_you_must_enter_your_registration_lock_PIN">உங்கள் பதிவு பூட்டு கடவு எண்ணை உள்ளிட வேண்டும்</string>
@@ -2448,10 +2448,10 @@
   <string name="RegistrationActivity_registration_of_this_phone_number_will_be_possible_without_your_registration_lock_pin_after_seven_days_have_passed">பதிவு பூட்டு கடவு எண் இல்லாமல் இந்த தொலைபேசி எண்ணை பதிவு செய்ய, Signal-இல் இந்த தொலைபேசி எண் கடைசியாக செயலில் இருந்து 7 நாட்கள் கடந்துவிட்ட பின் சாத்தியமாகும். உங்களுக்கு %d நாட்கள் மீதம் உள்ளன.</string>
   <string name="RegistrationActivity_registration_lock_pin">பதிவு பூட்டு பின்</string>
   <string name="RegistrationActivity_this_phone_number_has_registration_lock_enabled_please_enter_the_registration_lock_pin">இந்த தொலைபேசி எண்ணில் பதிவு பூட்டு இயக்கப்பட்டுள்ளது. பதிவு பூட்டு பின்னை உள்ளிடவும்.</string>
-  <string name="RegistrationLockDialog_registration_lock_is_enabled_for_your_phone_number">உங்கள் தொலைபேசி எண்ணுக்கு பதிவு பூட்டு இயக்கப்பட்டது. உங்கள் பதிவு பூட்டு கடவு எண்-ஐ மனப்பாடம் செய்ய உங்களுக்கு உதவ, Signal அவ்வப்போது அதை உறுதிப்படுத்தும்படி கேட்கும்.</string>
+  <string name="RegistrationLockDialog_registration_lock_is_enabled_for_your_phone_number">உங்கள் தொலைபேசி எண்ணுக்கு பதிவு பூட்டு இயக்கப்பட்டது. உங்கள் பதிவு பூட்டு கடவு எண்-ஐ மனப்பாடம் செய்ய உங்களுக்கு உதவ, சிக்னல் அவ்வப்போது அதை உறுதிப்படுத்தும்படி கேட்கும்.</string>
   <string name="RegistrationLockDialog_i_forgot_my_pin">எனது பின்னை மறந்துவிட்டேன்.</string>
   <string name="RegistrationLockDialog_forgotten_pin">பின்னை மறந்துவிட்டர்களா?</string>
-  <string name="RegistrationLockDialog_registration_lock_helps_protect_your_phone_number_from_unauthorized_registration_attempts">பதிவு பூட்டு உங்கள் தொலைபேசி எண்ணை அங்கீகரிக்கப்படாத பதிவு முயற்சிகளிலிருந்து பாதுகாக்க உதவுகிறது. உங்கள் Signal தனியுரிமை அமைப்புகளில் எந்த நேரத்திலும் இந்த அம்சத்தை முடக்கலாம்</string>
+  <string name="RegistrationLockDialog_registration_lock_helps_protect_your_phone_number_from_unauthorized_registration_attempts">பதிவு பூட்டு உங்கள் தொலைபேசி எண்ணை அங்கீகரிக்கப்படாத பதிவு முயற்சிகளிலிருந்து பாதுகாக்க உதவுகிறது. உங்கள் சிக்னல் தனியுரிமை அமைப்புகளில் எந்த நேரத்திலும் இந்த அம்சத்தை முடக்கலாம்</string>
   <string name="RegistrationLockDialog_registration_lock">பதிவு பூட்டு</string>
   <string name="RegistrationLockDialog_enable">செயல்படுத்து</string>
   <string name="RegistrationLockDialog_the_registration_lock_pin_must_be_at_least_d_digits">பதிவு பூட்டு கடவு எண் குறைந்தபட்சம்  %d இலக்கங்கள் இருக்க வேண்டும்.</string>
@@ -2462,7 +2462,7 @@
   <string name="RegistrationActivity_pin_incorrect">கடவு எண் தவறானது</string>
   <string name="RegistrationActivity_you_have_d_tries_remaining">உங்களிடம் %d முயற்சிகள் மீதமுள்ளது </string>
   <string name="preferences_chats__backups">காப்புப் பிரதிகள்</string>
-  <string name="prompt_passphrase_activity__signal_is_locked">Signal பூட்டப்பட்டுள்ளது</string>
+  <string name="prompt_passphrase_activity__signal_is_locked">சிக்னல் பூட்டப்பட்டுள்ளது</string>
   <string name="prompt_passphrase_activity__tap_to_unlock">திறக்க தட்டவும் </string>
   <string name="RegistrationLockDialog_reminder">நினைவூட்டல்:</string>
   <string name="recipient_preferences__about">அறிமுகம்</string>
@@ -2495,9 +2495,9 @@
   <string name="GroupsLearnMore_paragraph_1">பழைய மரபு குழுக்கள் என்பது நிர்வாகிகள் மற்றும் மேம்பட்ட குழு புதுப்பிப்பு விளக்கங்கள் போன்ற புதிய குழு அம்சங்களுடன் பொருந்தாத குழுக்கள்.</string>
   <string name="GroupsLearnMore_can_i_upgrade_a_legacy_group">நான் ஒரு மரபு குழுவை மேம்படுத்த முடியுமா?</string>
   <string name="GroupsLearnMore_paragraph_2">மரபு குழுக்களை புதிய குழுக்களாக மேம்படுத்த முடியாது, ஆனால் குழு உறுப்பினர்கள் சிக்னலின் சமீபத்திய பதிப்பில் இருந்தால் அதே உறுப்பினர்களுடன் புதிய குழுவை உருவாக்கலாம்.</string>
-  <string name="GroupsLearnMore_paragraph_3">Signal எதிர்காலத்தில் மரபு குழுக்களை மேம்படுத்த ஒரு வழியை வழங்கும்.</string>
+  <string name="GroupsLearnMore_paragraph_3">சிக்னல் எதிர்காலத்தில் மரபு குழுக்களை மேம்படுத்த ஒரு வழியை வழங்கும்.</string>
   <!--GroupLinkBottomSheetDialogFragment-->
-  <string name="GroupLinkBottomSheet_share_via_signal">சிக்னல் Signal வழியாக பகிரவும்</string>
+  <string name="GroupLinkBottomSheet_share_via_signal">சிக்னல் சிக்னல் வழியாக பகிரவும்</string>
   <string name="GroupLinkBottomSheet_copy">நகல்</string>
   <string name="GroupLinkBottomSheet_qr_code">QR குறியீடு</string>
   <string name="GroupLinkBottomSheet_share">பகிர்</string>
@@ -2561,7 +2561,7 @@
   <string name="DeleteAccountFragment__no_number">இல்லை எண் குறிப்பிடப்பட்டுள்ளது</string>
   <string name="DeleteAccountFragment__the_phone_number">தி தொலைபேசி நீங்கள் உள்ளிட்ட எண் உங்களுடன் பொருந்தவில்லை கணக்கு.</string>
   <string name="DeleteAccountFragment__are_you_sure">உங்கள் கணக்கு நீக்க விரும்புகிறீர்களா?</string>
-  <string name="DeleteAccountFragment__this_will_delete_your_signal_account">இது உங்கள் நீக்கும் Signal கணக்கு மற்றும் மீட்டமைக்கவும் விண்ணப்பம். செயல்முறை முடிந்ததும் பயன்பாடு மூடப்படும்.</string>
+  <string name="DeleteAccountFragment__this_will_delete_your_signal_account">இது உங்கள் நீக்கும் சிக்னல் கணக்கு மற்றும் மீட்டமைக்கவும் விண்ணப்பம். செயல்முறை முடிந்ததும் பயன்பாடு மூடப்படும்.</string>
   <string name="DeleteAccountFragment__failed_to_delete_account">நீக்குவதில் தோல்வி கணக்கு. உங்களிடம் பிணைய இணைப்பு உள்ளதா?</string>
   <string name="DeleteAccountFragment__failed_to_delete_local_data">உள்ளூர் தரவை நீக்குவதில் தோல்வி. நீங்கள் அதை கணினியில் கைமுறையாக அழிக்கலாம்விண்ணப்பம் அமைப்புகள்.</string>
   <string name="DeleteAccountFragment__launch_app_settings">பயன்பாட்டைத் தொடங்கவும் அமைப்புகள்</string>


### PR DESCRIPTION
Translation of display strings in Tamil is not complete Fixes #10472

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

- Signal word is not "transliterated" as name in Tamil, while in other languages that show 100% in transifex is transliterated
- Are the following texts needs to stay in English:
   * Signal needs permission to your microphone and camera.
   * Signal version: 
   * Signal package: 
   * Signal settings

This is change is not 100% complete. 
Also who is the owner /contributor for Tamil Language
Also, I am unable to choose Tamil language in transifex translation to JOIN