### PR TITLE
Fixes #10426: send delivery receipt even for ignored message 

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/PushProcessMessageJob.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/PushProcessMessageJob.java
@@ -340,6 +340,10 @@ public final class PushProcessMessageJob extends BaseJob {
 
       if (content == null || shouldIgnore(content)) {
         log(TAG, content != null ? String.valueOf(content.getTimestamp()) : "null", "Ignoring message.");
+        if (content.getDataMessage().isPresent() && content.isNeedsReceipt()) {
+          log(TAG, content != null ? String.valueOf(content.getTimestamp()) : "null", "Marking ignored message as delivered.");
+          handleNeedsDeliveryReceipt(content, content.getDataMessage().get());
+        }
         return;
       }
 


### PR DESCRIPTION

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 5, Android 11
 * Virtual device Pixel 3A, Android 11
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Fixes #10426.

Sends a delivery report even when a message is ignored, to be consistent with other Signal platforms.