### PR TITLE
Show picture-in-picture only when in video call

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/WebRtcCallActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/WebRtcCallActivity.java
@@ -178,7 +178,11 @@ public class WebRtcCallActivity extends BaseActivity implements SafetyNumberChan
 
   @Override
   public void onBackPressed() {
-    if (!enterPipModeIfPossible()) {
+    if (enableVideoIfAvailable) {
+      if (!enterPipModeIfPossible()) {
+        super.onBackPressed();
+      }
+    } else {
       super.onBackPressed();
     }
   }
@@ -194,10 +198,8 @@ public class WebRtcCallActivity extends BaseActivity implements SafetyNumberChan
       PictureInPictureParams params = new PictureInPictureParams.Builder()
               .setAspectRatio(new Rational(9, 16))
               .build();
-      enterPictureInPictureMode(params);
       CallParticipantsListDialog.dismiss(getSupportFragmentManager());
-
-      return true;
+      return enterPictureInPictureMode(params);
     }
     return false;
   }
@@ -328,6 +330,7 @@ public class WebRtcCallActivity extends BaseActivity implements SafetyNumberChan
   }
 
   private void handleSetMuteVideo(boolean muted) {
+    enableVideoIfAvailable = !muted;
     Recipient recipient = viewModel.getRecipient().get();
 
     if (!recipient.equals(Recipient.UNKNOWN)) {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Redmi Note 7 (lavender), Android 10 (Custom ROM DerpFest Official 20200907)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
I use video and voice calls alot, and that picture-in-picture was annoying, there's no need to show pip on voice calls, so i disabled the pip mode in the Android configurations, but i came across the bug that when i tried to close the call screen nothing happened, i had to use the home button. So i decide to fix it, now the code only enter in pip mode if the video call is enabled, and the user can leave the call screen if pip is disabled in the Android settings.