### PR TITLE
Note-to-self catalan translation is a bit weird

### DIFF
--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -5,7 +5,7 @@
   <string name="delete">Suprimeix</string>
   <string name="please_wait">Espereu, si us plau…</string>
   <string name="save">Desa</string>
-  <string name="note_to_self">Notifica-m\'ho</string>
+  <string name="note_to_self">Notes personals</string>
   <!--AbstractNotificationBuilder-->
   <string name="AbstractNotificationBuilder_new_message">Missatge nou</string>
   <!--AlbumThumbnailView-->


### PR DESCRIPTION
Hello.

I'm a Spanish, Catalan and English speaker who uses Signal in Catalan.
I've noticed the "Note to self" translation "Notifica-m'ho" (literally "Notify me") is a little bit weird, meanwhile other romance languages like Spanish or Italian translate it to "Notas personales" or "Note personali", both meaning "Personal notes".

I've already tried to contribute using Transifex but the platform doesn't allow me to edit the already-completed Catalan translations, so I'm forced to do this Pull Request.

Greets, David.