### PR TITLE
Create Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: gradle
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: monday
+    time: "06:00"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- I have tested my contribution on these devices (_not relevant as functional code doesn't change_)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Creates a Dependabot configuration to check for Java and Gradle dependency updates every Monday at 06:00 UTC. If any dependency is outdated, Dependabot opens a PR that can be merged at any moment convenient.

More information about Dependabot can be found [here](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/keeping-your-dependencies-updated-automatically).