### PR TITLE
CI: Speedups, run tests, upload APK and cleanup

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,5 +1,4 @@
 name: Android CI
-
 on:
   pull_request:
   push:
@@ -10,22 +9,14 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v1
-
+    - uses: actions/checkout@v2
     - name: set up JDK 1.8
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-
-    - name: Install NDK
-      run: echo "y" | sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager --install "ndk;21.0.6113669" --sdk_root=${ANDROID_SDK_ROOT}
-
     - name: Validate Gradle Wrapper
       uses: gradle/wrapper-validation-action@v1
-
     - name: Build with Gradle
       run: ./gradlew qa

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,14 +21,14 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew qa
     - name: Upload APK
-      if: ${{ github.repository_owner == "signalapp" }}
+      if: ${{ github.repository_owner == 'signalapp' }}
       uses: actions/upload-artifact@v2
       with:
         name: Signal-Android-app
         path: app/build/outputs/apk/playProd/debug/Signal-Android-play-prod-arm64-v8a*.apk
 
   test:
-    if: ${{ github.repository_owner == "signalapp" }}
+    if: ${{ github.repository_owner == 'signalapp' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -26,17 +26,3 @@ jobs:
       with:
         name: Signal-Android-app
         path: app/build/outputs/apk/playProd/debug/Signal-Android-play-prod-arm64-v8a*.apk
-
-  test:
-    if: ${{ github.repository_owner == 'signalapp' }}
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
-    - name: Validate Gradle Wrapper
-      uses: gradle/wrapper-validation-action@v1
-    - name: Test with Gradle
-      run: ./gradlew test

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,3 +20,15 @@ jobs:
       uses: gradle/wrapper-validation-action@v1
     - name: Build with Gradle
       run: ./gradlew qa
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Validate Gradle Wrapper
+      uses: gradle/wrapper-validation-action@v1
+    - name: Test with Gradle
+      run: ./gradlew test

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,14 +21,14 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew qa
     - name: Upload APK
-      if: ${{ github.repository_owner == signalapp }}
+      if: ${{ github.repository_owner == "signalapp" }}
       uses: actions/upload-artifact@v2
       with:
         name: Signal-Android-app
         path: app/build/outputs/apk/playProd/debug/Signal-Android-play-prod-arm64-v8a*.apk
 
   test:
-    if: ${{ github.repository_owner == signalapp }}
+    if: ${{ github.repository_owner == "signalapp" }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,7 +20,15 @@ jobs:
       uses: gradle/wrapper-validation-action@v1
     - name: Build with Gradle
       run: ./gradlew qa
+    - name: Upload APK
+      if: ${{ github.repository_owner == signalapp }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: Signal-Android-app
+        path: app/build/outputs/apk/playProd/debug/Signal-Android-play-prod-arm64-v8a*.apk
+
   test:
+    if: ${{ github.repository_owner == signalapp }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Galaxy S10, Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Updates and extends the GitHub Actions workflow with the following aspects:
 - Updates to action/checkout v2, which is faster
 - Remove install NDK step, since it's installed by default and speeds up the build
 - Adds an extensive Gradle test job
 - Uploads Arm64 APKs as artifacts on PRs and pushes on Signal's repo, for quick testing
 - Removes a few empty lines

I split up the PR in 3 commits for readability. See the description of each commit for details.