### PR TITLE
Rate limit on notifications unique to each conversation

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.java
@@ -71,10 +71,12 @@ import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.MessageRecordUtil;
 import org.thoughtcrime.securesms.util.ServiceUtil;
 import org.thoughtcrime.securesms.util.SpanUtil;
+import org.thoughtcrime.securesms.util.SoftHashMap;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.webrtc.CallNotificationBuilder;
 import org.whispersystems.signalservice.internal.util.Util;
 
+import java.util.Map;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -103,15 +105,18 @@ public class DefaultMessageNotifier implements MessageNotifier {
 
   private static final String EMOJI_REPLACEMENT_STRING  = "__EMOJI__";
   private static final long   MIN_AUDIBLE_PERIOD_MILLIS = TimeUnit.SECONDS.toMillis(2);
+  private static final long   MIN_AUDIBLE_GROUP_PERIOD_MILLIS = TimeUnit.MINUTES.toMillis(10);
   private static final long   DESKTOP_ACTIVITY_PERIOD   = TimeUnit.MINUTES.toMillis(1);
-
+  
   private volatile long                     visibleThread                = -1;
   private volatile long                     lastDesktopActivityTimestamp = -1;
   private volatile long                     lastAudibleNotification      = -1;
+  private static   final Map<Long, Long>    lastAudibleNotificationsPerThread = new SoftHashMap<>();
   private          final CancelableExecutor executor                     = new CancelableExecutor();
 
   @Override
   public void setVisibleThread(long threadId) {
+    lastAudibleNotificationsPerThread.remove(threadId);
     visibleThread = threadId;
   }
 
@@ -302,12 +307,19 @@ public class DefaultMessageNotifier implements MessageNotifier {
         if (Build.VERSION.SDK_INT >= 23) {
           for (long threadId : notificationState.getThreads()) {
             if (targetThread < 1 || targetThread == threadId) {
-              sendSingleThreadNotification(context,
-                                           new NotificationState(notificationState.getNotificationsForThread(threadId)),
-                                           signal && (threadId == targetThread),
-                                           true,
-                                           isReminder,
-                                           (threadId == targetThread) ? defaultBubbleState : BubbleUtil.BubbleState.HIDDEN);
+              Long lastNotificationTimestamp = lastAudibleNotificationsPerThread.get(threadId);
+
+              if (lastNotificationTimestamp != null && (System.currentTimeMillis() - lastNotificationTimestamp) < MIN_AUDIBLE_GROUP_PERIOD_MILLIS) {
+                signal = false;
+              } else {
+                lastAudibleNotificationsPerThread.put(threadId, System.currentTimeMillis());
+                sendSingleThreadNotification(context,
+                        new NotificationState(notificationState.getNotificationsForThread(threadId)),
+                        signal && (threadId == targetThread),
+                        true,
+                        isReminder,
+                        (threadId == targetThread) ? defaultBubbleState : BubbleUtil.BubbleState.HIDDEN);
+              }
             }
           }
         }
@@ -316,11 +328,16 @@ public class DefaultMessageNotifier implements MessageNotifier {
       } else {
         long                   thread      = notificationState.getNotifications().isEmpty() ? -1 : notificationState.getNotifications().get(0).getThreadId();
         BubbleUtil.BubbleState bubbleState = thread == targetThread ? defaultBubbleState : BubbleUtil.BubbleState.HIDDEN;
+        Long lastNotificationTimestamp = lastAudibleNotificationsPerThread.get(thread);
 
-        shouldScheduleReminder = sendSingleThreadNotification(context, notificationState, signal, false, isReminder, bubbleState);
-
-        if (isDisplayingSummaryNotification(context)) {
-          sendMultipleThreadNotification(context, notificationState, false);
+        if (lastNotificationTimestamp != null && (System.currentTimeMillis() - lastNotificationTimestamp) < MIN_AUDIBLE_GROUP_PERIOD_MILLIS) {
+          signal = false;
+        } else {
+          lastAudibleNotificationsPerThread.put(thread, System.currentTimeMillis());
+          shouldScheduleReminder = sendSingleThreadNotification(context, notificationState, signal, false, isReminder, bubbleState);
+          if (isDisplayingSummaryNotification(context)) {
+            sendMultipleThreadNotification(context, notificationState, false);
+          }
         }
       }
 


### PR DESCRIPTION
Modify notifications to only send you a new notification from each chat once every 10 minutes, or after opening the chat

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
  Moto Power G, Android 11.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This is a modified version of #8846 which attempted to add a rate limit to group conversations. I have not restricted mine to group notifications, as a rate limit is needed for all chats to stop notification spam. This existing PR is over a year old and far too out of date with the codebase to be adapted, so I've redone it.

I've made the notification rate limit once every 10 minutes, but if you open the chat it resets the rate limit allowing another notification through. I feel this strikes a balance between letting people know a conversation is ongoing without nagging them, but happy to take suggestions on modifying the 10 minute restriction. 