### PR TITLE
Disable MMS Option

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/sms/MessageSender.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/sms/MessageSender.java
@@ -359,7 +359,9 @@ public class MessageSender {
     } else if (!forceSms && isPushMediaSend(context, recipient)) {
       sendMediaPush(context, recipient, messageId, uploadJobIds);
     } else {
-      sendMms(context, messageId);
+        if (!TextSecurePreferences.isMMSDisabled(context)) {
+              sendMms(context, messageId);
+        }
     }
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -93,6 +93,7 @@ public class TextSecurePreferences {
   private static final String LOCAL_REGISTRATION_ID_PREF       = "pref_local_registration_id";
   private static final String SIGNED_PREKEY_REGISTERED_PREF    = "pref_signed_prekey_registered";
   private static final String WIFI_SMS_PREF                    = "pref_wifi_sms";
+  private static final String DISABLE_MMS_PREF                 = "pref_disable_mms";
 
   private static final String GCM_DISABLED_PREF                = "pref_gcm_disabled";
   private static final String GCM_REGISTRATION_ID_PREF         = "pref_gcm_registration_id";
@@ -519,6 +520,10 @@ public class TextSecurePreferences {
 
   public static boolean isWifiSmsEnabled(Context context) {
     return getBooleanPreference(context, WIFI_SMS_PREF, false);
+  }
+
+  public static boolean isMMSDisabled(Context context) {
+    return getBooleanPreference(context, DISABLE_MMS_PREF, false);
   }
 
   public static int getRepeatAlertsCount(Context context) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2398,7 +2398,9 @@
     <string name="preferences__submit_debug_log">Submit debug log</string>
     <string name="preferences__delete_account">Delete account</string>
     <string name="preferences__support_wifi_calling">\'WiFi Calling\' compatibility mode</string>
+    <string name="preferences__disable_mms">Prevent Signal from sending MMS</string>
     <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Enable if your device uses SMS/MMS delivery over WiFi (only enable when \'WiFi Calling\' is enabled on your device)</string>
+    <string name="preferences__disable_mms_to_avoid_of_additional_expense">The mobile operators charge additional fees for MMS while not allowing you to disable the service. Enable this option to prevent Signal from accidentally sending MMS.</string>
     <string name="preferences__incognito_keyboard">Incognito keyboard</string>
     <string name="preferences__read_receipts">Read receipts</string>
     <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">If read receipts are disabled, you won\'t be able to see read receipts from others.</string>

--- a/app/src/main/res/xml/preferences_sms_mms.xml
+++ b/app/src/main/res/xml/preferences_sms_mms.xml
@@ -29,6 +29,12 @@
                         android:title="@string/preferences__support_wifi_calling"
                         android:summary="@string/preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi"/>
 
+    <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+                        android:defaultValue="false"
+                        android:key="pref_disable_mms"
+                        android:title="@string/preferences__disable_mms"
+                        android:summary="@string/preferences__disable_mms_to_avoid_of_additional_expense"/>
+
     <Preference android:key="pref_mms_preferences"
                 android:title="@string/preferences__advanced_mms_access_point_names"/>
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * OnePlus Pro 8, Android 11
- [] My contribution is fully baked and ready to be merged as is - not sure, how is the localization

----------
### Description

I would like to see this option in the Signal app. My mobile operator doesn’t allow me to deactivate the MMS service and it happened to me several times that I accidentally sent the MMS by Signal being charged an immoral fee.

It’s quite easy to implement, but I’m not an Android/iOS developer. Please, let me know if something was wrong with the patch, I'll fix it promply. 