### PR TITLE
Recommend Docker have 8GB memory available

### DIFF
--- a/reproducible-builds/README.md
+++ b/reproducible-builds/README.md
@@ -134,6 +134,13 @@ Your platform might also have its own preferred way of installing Docker. E.g. U
 
 In the following sections we will assume that your Docker installation works without issues. So after installing, please make sure that everything is running smoothly before continuing.
 
+### Configuring Docker runtime memory
+
+Docker seems to require about 8GB runtime memory to be able to build the APK successfully. Docker behaves differently on each platform - please consult Docker documentation for the platform of choice to confgure runtime memory settings
+
+ * https://docs.docker.com/config/containers/resource_constraints/
+ * OS X https://docs.docker.com/docker-for-mac/#resources
+ * Windows https://docs.docker.com/docker-for-windows/#resources
 
 ## Building a Docker image for Signal
 First, you need to pull down the source for Signal-Android, which contains everything you need to build the project, including the `Dockerfile`. The `Dockerfile` contains instructions on how to automatically build a Docker image for Signal. It's located in the `reproducible-builds` directory of the repository. To get it, clone the project:


### PR DESCRIPTION
And add links to Docker runtime memory documentation.

### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

This is a build documentation change only.
Changes should not affect build output so this was not tested on any device.
The reproducible build process was tested on my Mac build machine

Following the reproducible build instructions resulted in the build failing with somewhat cryptic errors :

```
> Task :Signal-Android:mergePlayProdReleaseNativeLibs

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':Signal-Android:processPlayProdReleaseResources'.
> Multiple task action failures occurred:
   > A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
      > AAPT2 aapt2-4.1.1-6503028-linux Daemon #1: Unexpected error during link, attempting to stop daemon.
        This should not happen under normal circumstances, please file an issue if it does.
   > A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
      > AAPT2 aapt2-4.1.1-6503028-linux Daemon #2: Unexpected error during link, attempting to stop daemon.
        This should not happen under normal circumstances, please file an issue if it does.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.5/userguide/command_line_interface.html#sec:command_line_warnings
BUILD FAILED in 4m 40s

117 actionable tasks: 107 executed, 10 up-to-date
```

This indicates AAPT2 running out of memory.

On my Mac, Docker was configured by default to use a max of 2GB of runtime memory. Docker on Mac cannot change the runtime memory available via command line. It needs to be set via `Docker Desktop`'s preferences GUI.

I played around with different settings and 8GB seems to be the minimum amount of memory that results in a successful APK build.

Updated build instructions to match.
