### PR TITLE
Fix to the issue that a chat jumps to the latest message suddenly when reading older messages

### DIFF
--- a/paging/lib/src/main/java/org/signal/paging/FixedSizePagingController.java
+++ b/paging/lib/src/main/java/org/signal/paging/FixedSizePagingController.java
@@ -84,6 +84,11 @@ class FixedSizePagingController<E> implements PagingController {
       return;
     }
 
+    if (loadStart > aroundIndex || loadEnd < aroundIndex) {
+      if (DEBUG) Log.i(TAG, buildLog(aroundIndex, "loadStart > aroundIndex || loadEnd < aroundIndex, loadStart: " + loadStart + ", aroundIndex: " + aroundIndex + ", loadEnd: " + loadEnd));
+      return;
+    }
+
     int totalSize = loadState.size();
 
     loadState.markRange(loadStart, loadEnd);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Pixel 3a API 30
 * AVD Nexus 6P API 27 (w/o Google API)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
#### Tl;dr;
Fixes the issue of a chat jumping to the more recent message, by ignoring an execution that would have loaded data in a range that does not include the index that are needed to be loaded by the method call. Fixes #10332 

#### Longer description of the issue and the fix
It happens in v5.2.1 and older when you are scrolling down and reading older messages in a fairly long conversation, the view suddenly scrolls to the latest message. See the screen record below how it looks like.

The issue is because of some threading glitches; when we scroll RecyclerView, at some point it calls [onDataNeededAroundIndex(int aroundIndex)](https://github.com/signalapp/Signal-Android/blob/4b2366e537ef25d3489c08b1e9a508ef9fd37074/paging/lib/src/main/java/org/signal/paging/FixedSizePagingController.java#L55) to load data to add to the list. In the method it determines the range of the data to be loaded and first [mark the range as read](https://github.com/signalapp/Signal-Android/blob/4b2366e537ef25d3489c08b1e9a508ef9fd37074/paging/lib/src/main/java/org/signal/paging/FixedSizePagingController.java#L89), then [spawn a thread to actually load the data in the range](https://github.com/signalapp/Signal-Android/blob/4b2366e537ef25d3489c08b1e9a508ef9fd37074/paging/lib/src/main/java/org/signal/paging/FixedSizePagingController.java#L93). In there it loads data, and stuff them in to the (possibly) existing data according to the index of the data and post the array of data to UI to show them.

The problem here is that `onDataNeededAroundIndex` is called a lot of times when we scroll and read messages. Sometimes two or more calls to `onDataNeededAroundIndex` enter in the method before a thread that loads the data starts to execute. Because we use LIFO strategy to spawn threads and execute code, the later call to `onDataNeededAroundIndex` is executed before earlier calls. But the later one sometimes has very narrow range to load data that does not even include the `aroundIndex`, because the range around `aroundIndex` was already marked as read by the earlier calls (that have not been executed to load data yet). The result of the execution is an array that consist mostly of nulls.

When the array is posted to update the UI, RecyclerView adapter gets confused because most data is null but at the end of the array there are a few items. It calls `onItemRangeInserted` that calls [`snapToTopIfNecessary`](https://github.com/signalapp/Signal-Android/blob/2c1c6fab3560ef12996030cf7c84cc0d895e329e/app/src/main/java/org/thoughtcrime/securesms/util/SnapToTopDataObserver.java#L113) and we see the chat suddenly jumps to the more recent message all of the sudden.

The code in this PR fixes the issue simply by ignoring the execution that would have loaded data of a range that does not include `aroundIndex`. This works because this situation happens when two or more calls to `onDataNeededAroundIndex` happen very close to each other and one of those would likely have the data at the index we just ignored.

### Screen record
I'll attach screen records in comments below.

