### PR TITLE
Center the terms link on the welcome fragment for all translations

### DIFF
--- a/app/src/main/res/layout/fragment_registration_welcome.xml
+++ b/app/src/main/res/layout/fragment_registration_welcome.xml
@@ -36,6 +36,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="24dp"
         android:text="@string/RegistrationActivity_terms_and_privacy"
+        android:gravity="center"
         android:textColor="@color/core_ultramarine"
         app:layout_constraintBottom_toTopOf="@+id/welcome_continue_button"
         app:layout_constraintEnd_toEndOf="@+id/welcome_continue_button"


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Grand Prime, Android 5.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
The translation for `@string/RegistrationActivity_terms_and_privacy` can span mutiple lines.

When the text spans multiple lines, the centering is broken compared to the English version. This PR fixes this.

### Before French+English
<div>
<img src="https://user-images.githubusercontent.com/242172/104849004-c9b98380-58e7-11eb-8ba3-22a190f649bc.jpg" width="250" />
<img src="https://user-images.githubusercontent.com/242172/104849009-d1792800-58e7-11eb-975b-7ceb908a50fc.jpg" width=250" />
</div>

### After French (English unchanged)
<div>
<img src="https://user-images.githubusercontent.com/242172/104849008-d047fb00-58e7-11eb-8607-fa3ab4cfc59f.jpg" width=250" />
</div>
