### PR TITLE
Remove ~200 unused English strings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,16 +25,6 @@
     <!-- ApplicationPreferencesActivity -->
     <string name="ApplicationPreferencesActivity_currently_s">Currently: %s</string>
     <string name="ApplicationPreferenceActivity_you_havent_set_a_passphrase_yet">You haven\'t set a passphrase yet!</string>
-    <plurals name="ApplicationPreferencesActivity_messages_per_conversation">
-        <item quantity="one">%d message per conversation</item>
-        <item quantity="other">%d messages per conversation</item>
-    </plurals>
-    <string name="ApplicationPreferencesActivity_delete_all_old_messages_now">Delete all old messages now?</string>
-    <plurals name="ApplicationPreferencesActivity_this_will_immediately_trim_all_conversations_to_the_d_most_recent_messages">
-        <item quantity="one">This will immediately trim all conversations to the most recent message.</item>
-        <item quantity="other">This will immediately trim all conversations to the %d most recent messages.</item>
-    </plurals>
-    <string name="ApplicationPreferencesActivity_delete">Delete</string>
     <string name="ApplicationPreferencesActivity_disable_passphrase">Disable passphrase?</string>
     <string name="ApplicationPreferencesActivity_this_will_permanently_unlock_signal_and_message_notifications">This will permanently unlock Signal and message notifications.</string>
     <string name="ApplicationPreferencesActivity_disable">Disable</string>
@@ -53,7 +43,6 @@
     <string name="ApplicationPreferencesActivity_Off">Off</string>
     <string name="ApplicationPreferencesActivity_sms_mms_summary">SMS %1$s, MMS %2$s</string>
     <string name="ApplicationPreferencesActivity_privacy_summary">Screen lock %1$s, Registration lock %2$s</string>
-    <string name="ApplicationPreferencesActivity_privacy_summary_screen_lock">Screen lock %1$s</string>
     <string name="ApplicationPreferencesActivity_appearance_summary">Theme %1$s, Language %2$s</string>
     <string name="ApplicationPreferencesActivity_pins_are_required_for_registration_lock">PINs are required for registration lock. To disable PINs, please first disable registration lock.</string>
     <string name="ApplicationPreferencesActivity_pin_created">PIN created.</string>
@@ -88,14 +77,10 @@
     <string name="AttachmentManager_signal_requires_the_external_storage_permission_in_order_to_attach_photos_videos_or_audio">Signal requires the Storage permission in order to attach photos, videos, or audio, but it has been permanently denied. Please continue to the app settings menu, select \"Permissions\", and enable \"Storage\".</string>
     <string name="AttachmentManager_signal_requires_contacts_permission_in_order_to_attach_contact_information">Signal requires Contacts permission in order to attach contact information, but it has been permanently denied. Please continue to the app settings menu, select \"Permissions\", and enable \"Contacts\".</string>
     <string name="AttachmentManager_signal_requires_location_information_in_order_to_attach_a_location">Signal requires Location permission in order to attach a location, but it has been permanently denied. Please continue to the app settings menu, select \"Permissions\", and enable \"Location\".</string>
-    <string name="AttachmentManager_signal_requires_the_camera_permission_in_order_to_take_photos_but_it_has_been_permanently_denied">Signal requires the Camera permission in order to take photos, but it has been permanently denied. Please continue to the app settings menu, select \"Permissions\", and enable \"Camera\".</string>
 
     <!-- AttachmentUploadJob -->
     <string name="AttachmentUploadJob_uploading_media">Uploading media…</string>
     <string name="AttachmentUploadJob_compressing_video_start">Compressing video…</string>
-
-    <!-- AudioSlidePlayer -->
-    <string name="AudioSlidePlayer_error_playing_audio">Error playing audio!</string>
 
     <!-- BlockedUsersActivity -->
     <string name="BlockedUsersActivity__blocked_users">Blocked users</string>
@@ -119,7 +104,6 @@
     <string name="BlockUnblockDialog_you_will_be_able_to_call_and_message_each_other">You will be able to message and call each other and your name and photo will be shared with them.</string>
     <string name="BlockUnblockDialog_blocked_people_wont_be_able_to_call_you_or_send_you_messages">Blocked people won\'t be able to call you or send you messages.</string>
     <string name="BlockUnblockDialog_unblock_s">Unblock %1$s?</string>
-    <string name="BlockUnblockDialog_unblock">Unblock</string>
     <string name="BlockUnblockDialog_block">Block</string>
     <string name="BlockUnblockDialog_block_and_leave">Block and Leave</string>
     <string name="BlockUnblockDialog_block_and_delete">Block and Delete</string>
@@ -132,12 +116,6 @@
     <string name="BucketedThreadMedia_Large">Large</string>
     <string name="BucketedThreadMedia_Medium">Medium</string>
     <string name="BucketedThreadMedia_Small">Small</string>
-
-    <!-- CallScreen -->
-    <string name="CallScreen_Incoming_call">Incoming call</string>
-
-    <!-- CameraActivity -->
-    <string name="CameraActivity_image_save_failure">Failed to save image.</string>
 
     <!-- CameraXFragment -->
     <string name="CameraXFragment_tap_for_photo_hold_for_video">Tap for photo, hold for video</string>
@@ -172,10 +150,8 @@
 
     <!-- CommunicationActions -->
     <string name="CommunicationActions_no_browser_found">No web browser found.</string>
-    <string name="CommunicationActions_no_email_app_found">No email app found.</string>
     <string name="CommunicationActions_send_email">Send email</string>
     <string name="CommunicationActions_a_cellular_call_is_already_in_progress">A cellular call is already in progress.</string>
-    <string name="CommunicationActions_start_video_call">Start video call?</string>
     <string name="CommunicationActions_start_voice_call">Start voice call?</string>
     <string name="CommunicationActions_cancel">Cancel</string>
     <string name="CommunicationActions_call">Call</string>
@@ -254,13 +230,8 @@
     <string name="ConversationActivity_transport_signal">Signal</string>
     <string name="ConversationActivity_lets_switch_to_signal">Let\'s switch to Signal %1$s</string>
     <string name="ConversationActivity_specify_recipient">Please choose a contact</string>
-    <string name="ConversationActivity_unblock_this_contact_question">Unblock this contact?</string>
-    <string name="ConversationActivity_unblock_this_group_question">Unblock this group?</string>
-    <string name="ConversationActivity_you_will_once_again_be_able_to_receive_messages_and_calls_from_this_contact">You will once again be able to receive messages and calls from this contact.</string>
-    <string name="ConversationActivity_unblock_this_group_description">Existing members will be able to add you to the group again.</string>
     <string name="ConversationActivity_unblock">Unblock</string>
     <string name="ConversationActivity_attachment_exceeds_size_limits">Attachment exceeds size limits for the type of message you\'re sending.</string>
-    <string name="ConversationActivity_quick_camera_unavailable">Camera unavailable</string>
     <string name="ConversationActivity_unable_to_record_audio">Unable to record audio!</string>
     <string name="ConversationActivity_you_cant_send_messages_to_this_group">You can\'t send messages to this group because you\'re no longer a member.</string>
     <string name="ConversationActivity_there_is_no_app_available_to_handle_this_link_on_your_device">There is no app available to handle this link on your device.</string>
@@ -295,7 +266,6 @@
     <string name="ConversationActivity_delete">Delete</string>
     <string name="ConversationActivity_delete_and_leave">Delete and leave</string>
     <string name="ConversationActivity__to_call_s_signal_needs_access_to_your_microphone">To call %1$s, Signal needs access to your microphone</string>
-    <string name="ConversationActivity__to_call_s_signal_needs_access_to_your_microphone_and_camera">To call %1$s, Signal needs access to your microphone and camera.</string>
 
     <string name="ConversationActivity__more_options_now_in_group_settings">More options now in \"Group settings\"</string>
 
@@ -312,10 +282,6 @@
     <plurals name="ConversationFragment_delete_selected_messages">
         <item quantity="one">Delete selected message?</item>
         <item quantity="other">Delete selected messages?</item>
-    </plurals>
-    <plurals name="ConversationFragment_this_will_permanently_delete_all_n_selected_messages">
-        <item quantity="one">This will permanently delete the selected message.</item>
-        <item quantity="other">This will permanently delete all %1$d selected messages.</item>
     </plurals>
     <string name="ConversationFragment_save_to_sd_card">Save to storage?</string>
     <plurals name="ConversationFragment_saving_n_media_to_storage_warning">
@@ -362,12 +328,6 @@
     <string name="ConversationFragment_your_safety_number_with_s_changed">Your safety number with %s changed</string>
     <string name="ConversationFragment_your_safety_number_with_s_changed_likey_because_they_reinstalled_signal">Your safety number with %s changed, likely because they reinstalled Signal or changed devices. Tap Verify to confirm the new safety number. This is optional.</string>
 
-    <!-- ConversationListActivity -->
-    <string name="ConversationListActivity_there_is_no_browser_installed_on_your_device">There is no browser installed on your device.</string>
-
-    <!-- ConversationListFragment -->
-    <string name="ConversationListFragment_no_results_found_for_s_">No results found for \'%s\'</string>
-
     <plurals name="ConversationListFragment_delete_selected_conversations">
         <item quantity="one">Delete selected conversation?</item>
         <item quantity="other">Delete selected conversations?</item>
@@ -405,7 +365,6 @@
     <string name="CreateProfileActivity__profile">Profile</string>
     <string name="CreateProfileActivity_error_setting_profile_photo">Error setting profile photo</string>
     <string name="CreateProfileActivity_problem_setting_profile">Problem setting profile</string>
-    <string name="CreateProfileActivity_profile_photo">Profile photo</string>
     <string name="CreateProfileActivity_set_up_your_profile">Set up your profile</string>
     <string name="CreateProfileActivity_signal_profiles_are_end_to_end_encrypted">Your profile is end-to-end encrypted. Your profile and changes to it will be visible to your contacts, when you initiate or accept new conversations, and when you join new groups.</string>
     <string name="CreateProfileActivity_set_avatar_description">Set avatar</string>
@@ -463,12 +422,6 @@
     <string name="DecryptionFailedDialog_chat_session_refreshed">Chat session refreshed</string>
     <string name="DecryptionFailedDialog_signal_uses_end_to_end_encryption">Signal uses end-to-end encryption and it may need to refresh your chat session sometimes. This doesn\'t affect your chat\'s security, but you may have missed a message from this contact, and you can ask them to resend it.</string>
 
-    <!-- DeliveryStatus -->
-    <string name="DeliveryStatus_sending">Sending</string>
-    <string name="DeliveryStatus_sent">Sent</string>
-    <string name="DeliveryStatus_delivered">Delivered</string>
-    <string name="DeliveryStatus_read">Read</string>
-
     <!-- DeviceListActivity -->
     <string name="DeviceListActivity_unlink_s">Unlink \'%s\'?</string>
     <string name="DeviceListActivity_by_unlinking_this_device_it_will_no_longer_be_able_to_send_or_receive">By unlinking this device, it will no longer be able to send or receive messages.</string>
@@ -517,9 +470,6 @@
     <string name="ShareActivity_share_with">Share with</string>
     <string name="ShareActivity_multiple_attachments_are_only_supported">Multiple attachments are only supported for images and videos</string>
 
-    <!-- GcmBroadcastReceiver -->
-    <string name="GcmBroadcastReceiver_retrieving_a_message">Retrieving a message…</string>
-
     <!-- GcmRefreshJob -->
     <string name="GcmRefreshJob_Permanent_Signal_communication_failure">Permanent Signal communication failure!</string>
     <string name="GcmRefreshJob_Signal_was_unable_to_register_with_Google_Play_Services">Signal was unable to register with Google Play Services. Signal messages and calls have been disabled, please try re-registering in Settings &gt; Advanced.</string>
@@ -546,11 +496,6 @@
     <string name="ChooseNewAdminActivity_done">Done</string>
     <string name="ChooseNewAdminActivity_you_left">You left \"%1$s.\"</string>
 
-    <!-- GroupShareProfileView -->
-    <string name="GroupShareProfileView_share_your_profile_name_and_photo_with_this_group">Share your profile name and photo with this group?</string>
-    <string name="GroupShareProfileView_do_you_want_to_make_your_profile_name_and_photo_visible_to_all_current_and_future_members_of_this_group">Do you want to make your profile name and photo visible to all current and future members of this group?</string>
-    <string name="GroupShareProfileView_make_visible">Make visible</string>
-
     <!-- GroupMembersDialog -->
     <string name="GroupMembersDialog_you">You</string>
 
@@ -575,7 +520,6 @@
         <item quantity="other">%d invitations sent</item>
     </plurals>
     <string name="GroupManagement_invite_single_user">“%1$s” can’t be automatically added to this group by you.\n\nThey’ve been invited to join, and won’t see any group messages until they accept.</string>
-    <string name="GroupManagement_learn_more">Learn more</string>
     <string name="GroupManagement_invite_multiple_users">These users can’t be automatically added to this group by you.\n\nThey’ve been invited to join the group, and won’t see any group messages until they accept.</string>
 
     <!-- GroupsV1MigrationLearnMoreBottomSheetDialogFragment -->
@@ -716,7 +660,6 @@
     <string name="AddGroupDetailsFragment__group_name_required">Group name (required)</string>
     <string name="AddGroupDetailsFragment__group_name_optional">Group name (optional)</string>
     <string name="AddGroupDetailsFragment__this_field_is_required">This field is required.</string>
-    <string name="AddGroupDetailsFragment__groups_require_at_least_two_members">Groups require at least two members.</string>
     <string name="AddGroupDetailsFragment__group_creation_failed">Group creation failed.</string>
     <string name="AddGroupDetailsFragment__try_again_later">Try again later.</string>
     <string name="AddGroupDetailsFragment__youve_selected_a_contact_that_doesnt">You\'ve selected a contact that doesn\'t support Signal groups, so this group will be MMS.</string>
@@ -746,7 +689,6 @@
     </plurals>
 
     <!-- ManageGroupActivity -->
-    <string name="ManageGroupActivity_disappearing_messages">Disappearing messages</string>
     <string name="ManageGroupActivity_member_requests_and_invites">Member requests &amp; invites</string>
     <string name="ManageGroupActivity_add_members">Add members</string>
     <string name="ManageGroupActivity_edit_group_info">Edit group info</string>
@@ -765,11 +707,6 @@
     <string name="ManageGroupActivity_view_all_members">View all members</string>
     <string name="ManageGroupActivity_see_all">See all</string>
 
-    <string name="ManageGroupActivity_none">None</string>
-    <plurals name="ManageGroupActivity_invited">
-        <item quantity="one">%d invited</item>
-        <item quantity="other">%d invited</item>
-    </plurals>
     <plurals name="ManageGroupActivity_added">
         <item quantity="one">%d member added.</item>
         <item quantity="other">%d members added.</item>
@@ -798,8 +735,6 @@
     <!-- GroupMentionSettingDialog -->
     <string name="GroupMentionSettingDialog_notify_me_for_mentions">Notify me for Mentions</string>
     <string name="GroupMentionSettingDialog_receive_notifications_when_youre_mentioned_in_muted_chats">Receive notifications when you’re mentioned in muted chats?</string>
-    <string name="GroupMentionSettingDialog_default_notify_me">Default (Notify me)</string>
-    <string name="GroupMentionSettingDialog_default_dont_notify_me">Default (Don\'t notify me)</string>
     <string name="GroupMentionSettingDialog_always_notify_me">Always notify me</string>
     <string name="GroupMentionSettingDialog_dont_notify_me">Don\'t notify me</string>
     
@@ -824,7 +759,6 @@
         <item quantity="one">%d group in common</item>
         <item quantity="other">%d groups in common</item>
     </plurals>
-    <string name="ManageRecipientActivity_edit_name_and_picture">Edit name and picture</string>
     <string name="ManageRecipientActivity_message_description">Message</string>
     <string name="ManageRecipientActivity_voice_call_description">Voice call</string>
     <string name="ManageRecipientActivity_insecure_voice_call_description">Insecure voice call</string>
@@ -855,10 +789,6 @@
     <string name="ShareableGroupLinkDialogFragment__reset_link">Reset link</string>
     <string name="ShareableGroupLinkDialogFragment__member_requests">Member requests</string>
     <string name="ShareableGroupLinkDialogFragment__approve_new_members">Approve new members</string>
-    <string name="ShareableGroupLinkDialogFragment__enabled">Enabled</string>
-    <string name="ShareableGroupLinkDialogFragment__disabled">Disabled</string>
-    <string name="ShareableGroupLinkDialogFragment__default">Default</string>
-    <string name="ShareableGroupLinkDialogFragment__group_link_reset">Group link reset</string>
     <string name="ShareableGroupLinkDialogFragment__require_an_admin_to_approve_new_members_joining_via_the_group_link">Require an admin to approve new members joining via the group link.</string>
     <string name="ShareableGroupLinkDialogFragment__are_you_sure_you_want_to_reset_the_group_link">Are you sure you want to reset the group link? People will no longer be able to join the group using the current link.</string>
 
@@ -891,7 +821,6 @@
     </plurals>
 
     <!-- GroupJoinUpdateRequiredBottomSheetDialogFragment -->
-    <string name="GroupJoinUpdateRequiredBottomSheetDialogFragment_group_links_coming_soon">Group links coming soon</string>
     <string name="GroupJoinUpdateRequiredBottomSheetDialogFragment_update_signal_to_use_group_links">Update Signal to use group links</string>
     <string name="GroupJoinUpdateRequiredBottomSheetDialogFragment_update_message">The version of Signal you’re using does not support this group link. Update to the latest version to join this group via link.</string>
     <string name="GroupJoinUpdateRequiredBottomSheetDialogFragment_update_signal">Update Signal</string>
@@ -916,10 +845,6 @@
     <string name="RequestConfirmationDialog_add">Add</string>
     <string name="RequestConfirmationDialog_deny">Deny</string>
 
-    <!-- CropImageActivity -->
-    <string name="CropImageActivity_group_avatar">Group avatar</string>
-    <string name="CropImageActivity_profile_avatar">Avatar</string>
-
     <!-- ImageEditorHud -->
     <string name="ImageEditorHud_blur_faces">Blur faces</string>
     <string name="ImageEditorHud_new_blur_faces_or_draw_anywhere_to_blur">New: Blur faces or draw anywhere to blur</string>
@@ -931,13 +856,11 @@
 
     <!-- InviteActivity -->
     <string name="InviteActivity_share">Share</string>
-    <string name="InviteActivity_choose_contacts">Choose contacts</string>
     <string name="InviteActivity_share_with_contacts">Share with contacts</string>
     <string name="InviteActivity_choose_how_to_share">Choose how to share</string>
 
     <string name="InviteActivity_cancel">Cancel</string>
     <string name="InviteActivity_sending">Sending…</string>
-    <string name="InviteActivity_heart_content_description">Heart</string>
     <string name="InviteActivity_invitations_sent">Invitations sent!</string>
     <string name="InviteActivity_invite_to_signal">Invite to Signal</string>
     <plurals name="InviteActivity_send_sms_to_friends">
@@ -951,9 +874,6 @@
     <string name="InviteActivity_lets_switch_to_signal">Let\'s switch to Signal: %1$s</string>
     <string name="InviteActivity_no_app_to_share_to">It looks like you don\'t have any apps to share to.</string>
     <string name="InviteActivity_friends_dont_let_friends_text_unencrypted">Friends don\'t let friends chat unencrypted.</string>
-
-    <!-- Job -->
-    <string name="Job_working_in_the_background">Working in the background…</string>
 
     <!-- LearnMoreTextView -->
     <string name="LearnMoreTextView_learn_more">Learn more</string>
@@ -1046,9 +966,6 @@
     <string name="MediaPickerActivity_send_to">Send to %s</string>
     <string name="MediaPickerActivity__menu_open_camera">Open camera</string>
 
-    <!-- MediaPickerItemFragment -->
-    <string name="MediaPickerItemFragment_tap_to_select">Tap to select</string>
-
     <!-- MediaSendActivity -->
     <string name="MediaSendActivity_add_a_caption">Add a caption…</string>
     <string name="MediaSendActivity_an_item_was_removed_because_it_exceeded_the_size_limit">An item was removed because it exceeded the size limit</string>
@@ -1080,7 +997,6 @@
     <string name="MessageRecord_missed_video_call_date">Missed video call · %1$s</string>
     <string name="MessageRecord_s_updated_group">%s updated the group.</string>
     <string name="MessageRecord_s_called_you_date">%1$s called you · %2$s</string>
-    <string name="MessageRecord_called_s">Called %s</string>
     <string name="MessageRecord_s_joined_signal">%s is on Signal!</string>
     <string name="MessageRecord_you_disabled_disappearing_messages">You disabled disappearing messages.</string>
     <string name="MessageRecord_s_disabled_disappearing_messages">%1$s disabled disappearing messages.</string>
@@ -1252,14 +1168,12 @@
     <string name="MessageRecord_s_is_in_the_group_call_s">%1$s is in the group call · %2$s</string>
     <string name="MessageRecord_you_are_in_the_group_call_s1">You are in the group call · %1$s</string>
     <string name="MessageRecord_s_and_s_are_in_the_group_call_s1">%1$s and %2$s are in the group call · %3$s</string>
-    <string name="MessageRecord_s_s_and_s_are_in_the_group_call_s">%1$s, %2$s, and %3$s are in the group call · %4$s</string>
     <string name="MessageRecord_group_call_s">Group call · %1$s</string>
 
     <string name="MessageRecord_s_started_a_group_call">%1$s started a group call</string>
     <string name="MessageRecord_s_is_in_the_group_call">%1$s is in the group call</string>
     <string name="MessageRecord_you_are_in_the_group_call">You are in the group call</string>
     <string name="MessageRecord_s_and_s_are_in_the_group_call">%1$s and %2$s are in the group call</string>
-    <string name="MessageRecord_s_s_and_s_are_in_the_group_call">%1$s, %2$s, and %3$s are in the group call</string>
     <string name="MessageRecord_group_call">Group call</string>
 
     <string name="MessageRecord_you">You</string>
@@ -1357,7 +1271,6 @@
     <!-- PlacePickerActivity -->
     <string name="PlacePickerActivity_title">Map</string>
 
-    <string name="PlacePickerActivity_not_a_valid_address">Not a valid Address</string>
     <string name="PlacePickerActivity_drop_pin">Drop pin</string>
     <string name="PlacePickerActivity_accept_address">Accept address</string>
 
@@ -1412,11 +1325,7 @@
 
     <!-- RecipientPreferencesActivity -->
     <string name="RecipientPreferenceActivity_block">Block</string>
-    <string name="RecipientPreferenceActivity_error_leaving_group">Error leaving group</string>
     <string name="RecipientPreferenceActivity_unblock">Unblock</string>
-    <string name="RecipientPreferenceActivity_enabled">Enabled</string>
-    <string name="RecipientPreferenceActivity_disabled">Disabled</string>
-    <string name="RecipientPreferenceActivity_available_once_a_message_has_been_sent_or_received">Available once a message has been sent or received.</string>
 
     <!-- RecipientProvider -->
     <string name="RecipientProvider_unnamed_group">Unnamed group</string>
@@ -1424,10 +1333,8 @@
     <!-- RedPhone -->
     <string name="RedPhone_answering">Answering…</string>
     <string name="RedPhone_ending_call">Ending call…</string>
-    <string name="RedPhone_dialing">Dialing…</string>
     <string name="RedPhone_ringing">Ringing…</string>
     <string name="RedPhone_busy">Busy</string>
-    <string name="RedPhone_connected">Connected</string>
     <string name="RedPhone_recipient_unavailable">Recipient unavailable</string>
     <string name="RedPhone_network_failed">Network failed!</string>
     <string name="RedPhone_number_not_registered">Number not registered!</string>
@@ -1439,7 +1346,6 @@
     <string name="WebRtcCallActivity__to_call_s_signal_needs_access_to_your_camera">To call %1$s, Signal needs access to your camera</string>
     <string name="WebRtcCallActivity__signal_s">Signal %1$s</string>
     <string name="WebRtcCallActivity__calling">Calling…</string>
-    <string name="WebRtcCallActivity__group_call">Group Call</string>
 
     <!-- WebRtcCallView -->
     <string name="WebRtcCallView__signal_voice_call">Signal voice call…</string>
@@ -1451,7 +1357,6 @@
     <string name="WebRtcCallView__s_group_call">\"%1$s\" Group Call</string>
     <string name="WebRtcCallView__view_participants_list">View participants</string>
     <string name="WebRtcCallView__your_video_is_off">Your video is off</string>
-    <string name="WebRtcCallView__connecting">Connecting…</string>
     <string name="WebRtcCallView__reconnecting">Reconnecting…</string>
     <string name="WebRtcCallView__joining">Joining…</string>
     <string name="WebRtcCallView__disconnected">Disconnected</string>
@@ -1501,27 +1406,19 @@
     <string name="RegistrationActivity_play_services_error">Play Services Error</string>
     <string name="RegistrationActivity_google_play_services_is_updating_or_unavailable">Google Play Services is updating or temporarily unavailable. Please try again.</string>
     <string name="RegistrationActivity_terms_and_privacy">Terms &amp; Privacy Policy</string>
-    <string name="RegistrationActivity_no_browser">Unable to open this link. No web browser found.</string>
-    <string name="RegistrationActivity_more_information">More information</string>
-    <string name="RegistrationActivity_less_information">Less information</string>
     <string name="RegistrationActivity_signal_needs_access_to_your_contacts_and_media_in_order_to_connect_with_friends">Signal needs access to your contacts and media in order to connect with friends, exchange messages, and make secure calls</string>
     <string name="RegistrationActivity_signal_needs_access_to_your_contacts_in_order_to_connect_with_friends">Signal needs access to your contacts in order to connect with friends, exchange messages, and make secure calls</string>
     <string name="RegistrationActivity_rate_limited_to_service">You\'ve made too many attempts to register this number. Please try again later.</string>
     <string name="RegistrationActivity_unable_to_connect_to_service">Unable to connect to service. Please check network connection and try again.</string>
-    <string name="RegistrationActivity_to_easily_verify_your_phone_number_signal_can_automatically_detect_your_verification_code">To easily verify your phone number, Signal can automatically detect your verification code if you allow Signal to view SMS messages.</string>
     <plurals name="RegistrationActivity_debug_log_hint">
         <item quantity="one">You are now %d step away from submitting a debug log.</item>
         <item quantity="other">You are now %d steps away from submitting a debug log.</item>
     </plurals>
     <string name="RegistrationActivity_we_need_to_verify_that_youre_human">We need to verify that you\'re human.</string>
-    <string name="RegistrationActivity_failed_to_verify_the_captcha">Failed to verify the CAPTCHA</string>
     <string name="RegistrationActivity_next">Next</string>
     <string name="RegistrationActivity_continue">Continue</string>
-    <string name="RegistrationActivity_continue_d_attempts_left">Continue (%d attempts left)</string>
-    <string name="RegistrationActivity_continue_last_attempt">Continue (last attempt!)</string>
     <string name="RegistrationActivity_take_privacy_with_you_be_yourself_in_every_message">Take privacy with you.\nBe yourself in every message.</string>
     <string name="RegistrationActivity_enter_your_phone_number_to_get_started">Enter your phone number to get started</string>
-    <string name="RegistrationActivity_enter_your_phone_number">Enter your phone number</string>
     <string name="RegistrationActivity_you_will_receive_a_verification_code">You will receive a verification code. Carrier rates may apply.</string>
     <string name="RegistrationActivity_enter_the_code_we_sent_to_s">Enter the code we sent to %s</string>
     <string name="RegistrationActivity_make_sure_your_phone_has_a_cellular_signal">Make sure your phone has a cellular signal to receive your SMS or call</string>
@@ -1542,9 +1439,6 @@
     <string name="RevealableMessageView_view_video">View Video</string>
     <string name="RevealableMessageView_viewed">Viewed</string>
     <string name="RevealableMessageView_media">Media</string>
-
-    <!-- ScribbleActivity -->
-    <string name="ScribbleActivity_save_failure">Failed to save image changes</string>
 
     <!-- Search -->
     <string name="SearchFragment_no_results">No results found for \'%s\'</string>
@@ -1627,13 +1521,11 @@
     <string name="SubmitDebugLogActivity_failed_to_submit_logs">Failed to submit logs</string>
     <string name="SubmitDebugLogActivity_success">Success!</string>
     <string name="SubmitDebugLogActivity_copy_this_url_and_add_it_to_your_issue">Copy this URL and add it to your issue report or support email:\n\n<b>%1$s</b></string>
-    <string name="SubmitDebugLogActivity_copied_to_clipboard">Copied to clipboard</string>
     <string name="SubmitDebugLogActivity_share">Share</string>
 
     <!-- SupportEmailUtil -->
     <string name="SupportEmailUtil_support_email" translatable="false">support@signal.org</string>
     <string name="SupportEmailUtil_subject">Subject:</string>
-    <string name="SupportEmailUtil_signal_android_support_request">Signal Android Support Request</string>
     <string name="SupportEmailUtil_device_info">Device info:</string>
     <string name="SupportEmailUtil_android_version">Android version:</string>
     <string name="SupportEmailUtil_signal_version">Signal version:</string>
@@ -1666,12 +1558,9 @@
     <string name="ThreadRecord_you_marked_unverified">You marked unverified</string>
     <string name="ThreadRecord_message_could_not_be_processed">Message could not be processed</string>
     <string name="ThreadRecord_message_request">Message Request</string>
-    <string name="ThreadRecord_s_added_you_to_the_group">%1$s added you to the group</string>
-    <string name="ThreadRecord_s_invited_you_to_the_group">%1$s invited you to the group</string>
     <string name="ThreadRecord_photo">Photo</string>
     <string name="ThreadRecord_gif">GIF</string>
     <string name="ThreadRecord_voice_message">Voice Message</string>
-    <string name="ThreadRecord_contact">Contact</string>
     <string name="ThreadRecord_file">File</string>
     <string name="ThreadRecord_video">Video</string>
     <string name="ThreadRecord_chat_session_refreshed">Chat session refreshed</string>
@@ -1743,7 +1632,6 @@
 
     <!-- KeyCachingService -->
     <string name="KeyCachingService_signal_passphrase_cached">Touch to open.</string>
-    <string name="KeyCachingService_signal_passphrase_cached_with_lock">Touch to open, or touch the lock to close.</string>
     <string name="KeyCachingService_passphrase_cached">Signal is unlocked</string>
     <string name="KeyCachingService_lock">Lock Signal</string>
 
@@ -1763,15 +1651,12 @@
     <string name="MessageNotifier_d_new_messages_in_d_conversations">%1$d new messages in %2$d conversations</string>
     <string name="MessageNotifier_most_recent_from_s">Most recent from: %1$s</string>
     <string name="MessageNotifier_locked_message">Locked message</string>
-    <string name="MessageNotifier_media_message_with_text">Media message: %s</string>
     <string name="MessageNotifier_message_delivery_failed">Message delivery failed.</string>
     <string name="MessageNotifier_failed_to_deliver_message">Failed to deliver message.</string>
     <string name="MessageNotifier_error_delivering_message">Error delivering message.</string>
     <string name="MessageNotifier_mark_all_as_read">Mark all as read</string>
     <string name="MessageNotifier_mark_read">Mark read</string>
     <string name="MessageNotifier_turn_off_these_notifications">Turn off these notifications</string>
-    <string name="MessageNotifier_media_message">Media message</string>
-    <string name="MessageNotifier_sticker">Sticker</string>
     <string name="MessageNotifier_view_once_photo">View-once photo</string>
     <string name="MessageNotifier_view_once_video">View-once video</string>
     <string name="MessageNotifier_reply">Reply</string>
@@ -1805,8 +1690,6 @@
     <string name="NotificationChannel_voice_notes">Voice Notes</string>
 
     <!-- ProfileEditNameFragment -->
-    <string name="ProfileEditNameFragment_successfully_set_profile_name">Successfully set profile name.</string>
-    <string name="ProfileEditNameFragment_encountered_a_network_error">Encountered a network error.</string>
 
     <!-- QuickResponseService -->
     <string name="QuickResponseService_quick_response_unavailable_when_Signal_is_locked">Quick response unavailable when Signal is locked!</string>
@@ -1841,9 +1724,6 @@
     <string name="UnauthorizedReminder_device_no_longer_registered">Device no longer registered</string>
     <string name="UnauthorizedReminder_this_is_likely_because_you_registered_your_phone_number_with_Signal_on_a_different_device">This is likely because you registered your phone number with Signal on a different device. Tap to re-register.</string>
 
-    <!-- VideoPlayer -->
-    <string name="VideoPlayer_error_playing_video">Error playing video</string>
-
     <!-- WebRtcCallActivity -->
     <string name="WebRtcCallActivity_to_answer_the_call_from_s_give_signal_access_to_your_microphone">To answer the call from %s, give Signal access to your microphone.</string>
     <string name="WebRtcCallActivity_signal_requires_microphone_and_camera_permissions_in_order_to_make_or_receive_calls">Signal requires Microphone and Camera permissions in order to make or receive calls, but they have been permanently denied. Please continue to app settings, select \"Permissions\", and enable \"Microphone\" and \"Camera\".</string>
@@ -1854,11 +1734,6 @@
     <string name="GroupCallSafetyNumberChangeNotification__someone_has_joined_this_call_with_a_safety_number_that_has_changed">Someone has joined this call with a safety number that has changed.</string>
 
     <!-- WebRtcCallScreen -->
-    <string name="WebRtcCallScreen_new_safety_numbers">The safety number for your conversation with %1$s has changed. This could either mean that someone is trying to intercept your communication, or that %2$s simply re-installed Signal.</string>
-    <string name="WebRtcCallScreen_you_may_wish_to_verify_this_contact">You may wish to verify your safety number with this contact.</string>
-    <string name="WebRtcCallScreen_new_safety_number_title">New safety number</string>
-    <string name="WebRtcCallScreen_accept">Accept</string>
-    <string name="WebRtcCallScreen_end_call">End call</string>
     <string name="WebRtcCallScreen_swipe_up_to_change_views">Swipe up to change views</string>
 
     <!-- WebRtcCallScreen V2 -->
@@ -1872,37 +1747,8 @@
     <string name="WebRtcAudioOutputToggle__speaker">Speaker</string>
     <string name="WebRtcAudioOutputToggle__bluetooth">Bluetooth</string>
 
-    <!-- WebRtcCallControls -->
-    <string name="WebRtcCallControls_tap_to_enable_your_video">Tap to enable your video</string>
-
-    <!-- WebRtcCallControls Content Descriptions -->
-    <string name="WebRtcCallControls_contact_photo_description">Contact photo</string>
-    <string name="WebRtcCallControls_speaker_button_description">Speaker</string>
-    <string name="WebRtcCallControls_bluetooth_button_description">Bluetooth</string>
-    <string name="WebRtcCallControls_mute_button_description">Mute</string>
-    <string name="WebRtcCallControls_your_camera_button_description">Your camera</string>
-    <string name="WebRtcCallControls_switch_to_rear_camera_button_description">Switch to rear camera</string>
-
     <string name="WebRtcCallControls_answer_call_description">Answer call</string>
     <string name="WebRtcCallControls_reject_call_description">Reject call</string>
-
-    <!-- attachment_type_selector -->
-    <string name="attachment_type_selector__audio">Audio</string>
-    <string name="attachment_type_selector__audio_description">Audio</string>
-    <string name="attachment_type_selector__contact">Contact</string>
-    <string name="attachment_type_selector__contact_description">Contact</string>
-    <string name="attachment_type_selector__camera">Camera</string>
-    <string name="attachment_type_selector__camera_description">Camera</string>
-    <string name="attachment_type_selector__location">Location</string>
-    <string name="attachment_type_selector__location_description">Location</string>
-    <string name="attachment_type_selector__gif">GIF</string>
-    <string name="attachment_type_selector__gif_description">Gif</string>
-    <string name="attachment_type_selector__gallery_description">Image or video</string>
-    <string name="attachment_type_selector__file_description">File</string>
-    <string name="attachment_type_selector__gallery">Gallery</string>
-    <string name="attachment_type_selector__file">File</string>
-
-    <string name="attachment_type_selector__drawer_description">Toggle attachment drawer</string>
 
     <!-- change_passphrase_activity -->
     <string name="change_passphrase_activity__old_passphrase">Old passphrase</string>
@@ -1940,9 +1786,6 @@
         <item quantity="one">%1$d member</item>
         <item quantity="other">%1$d members</item>
     </plurals>
-
-    <!-- blocked_contacts_fragment -->
-    <string name="blocked_contacts_fragment__no_blocked_contacts">No blocked contacts</string>
 
     <!-- contact_selection_list_fragment -->
     <string name="contact_selection_list_fragment__signal_needs_access_to_your_contacts_in_order_to_display_them">Signal needs access to your contacts in order to display them.</string>
@@ -2005,7 +1848,6 @@
     <string name="QuoteView_photo">Photo</string>
     <string name="QuoteView_view_once_media">View-once media</string>
     <string name="QuoteView_sticker">Sticker</string>
-    <string name="QuoteView_document">Document</string>
     <string name="QuoteView_you">You</string>
     <string name="QuoteView_original_missing">Original message not found</string>
 
@@ -2037,13 +1879,6 @@
     <!-- device_list_fragment -->
     <string name="device_list_fragment__no_devices_linked">No devices linked</string>
     <string name="device_list_fragment__link_new_device">Link new device</string>
-
-    <!-- experience_upgrade_activity -->
-    <string name="experience_upgrade_activity__continue">continue</string>
-
-    <string name="experience_upgrade_preference_fragment__read_receipts_are_here">Read receipts are here</string>
-    <string name="experience_upgrade_preference_fragment__optionally_see_and_share_when_messages_have_been_read">Optionally see and share when messages have been read</string>
-    <string name="experience_upgrade_preference_fragment__enable_read_receipts">Enable read receipts</string>
 
     <!-- expiration -->
     <string name="expiration_off">Off</string>
@@ -2109,20 +1944,7 @@
     <string name="giphy_fragment__nothing_found">Nothing found</string>
 
     <!-- log_submit_activity -->
-    <string name="log_submit_activity__log_fetch_failed">Could not read the log on your device. You can still use ADB to get a debug log instead.</string>
-    <string name="log_submit_activity__thanks">Thanks for your help!</string>
-    <string name="log_submit_activity__submitting">Submitting</string>
-    <string name="log_submit_activity__no_browser_installed">No browser installed</string>
-    <string name="log_submit_activity__button_dont_submit">Don\'t submit</string>
-    <string name="log_submit_activity__button_submit">Submit</string>
-    <string name="log_submit_activity__button_got_it">Got it</string>
-    <string name="log_submit_activity__button_compose_email">Compose email</string>
     <string name="log_submit_activity__this_log_will_be_posted_online">This log will be posted publicly online for contributors to view, you may examine and edit it before submitting.</string>
-    <string name="log_submit_activity__loading_logs">Loading logs…</string>
-    <string name="log_submit_activity__uploading_logs">Uploading logs…</string>
-    <string name="log_submit_activity__choose_email_app">Choose email app</string>
-    <string name="log_submit_activity__please_review_this_log_from_my_app">Please review this log from my app: %1$s</string>
-    <string name="log_submit_activity__network_failure">Network failure. Please try again.</string>
 
     <!-- database_migration_activity -->
     <string name="database_migration_activity__would_you_like_to_import_your_existing_text_messages">Would you like to import your existing text messages into Signal\'s encrypted database?</string>
@@ -2132,11 +1954,6 @@
     <string name="database_migration_activity__this_could_take_a_moment_please_be_patient">This could take a moment. Please be patient, we\'ll notify you when the import is complete.</string>
     <string name="database_migration_activity__importing">IMPORTING</string>
 
-
-    <string name="import_fragment__import_system_sms_database">Import system SMS database</string>
-    <string name="import_fragment__import_the_database_from_the_default_system">Import the database from the default system messenger app</string>
-    <string name="import_fragment__import_plaintext_backup">Import plaintext backup</string>
-    <string name="import_fragment__import_a_plaintext_backup_file">Import a plaintext backup file. Compatible with \'SMS Backup &amp; Restore.\'</string>
 
     <!-- load_more_header -->
     <string name="load_more_header__see_full_conversation">See full conversation</string>
@@ -2148,7 +1965,6 @@
     <!-- message_recipients_list_item -->
     <string name="message_recipients_list_item__view">VIEW</string>
     <string name="message_recipients_list_item__resend">RESEND</string>
-    <string name="message_recipients_list_item__resending">Resending…</string>
 
     <!-- GroupUtil -->
     <plurals name="GroupUtil_joined_the_group">
@@ -2180,24 +1996,8 @@
     <!-- recipient_preferences_activity -->
     <string name="recipient_preference_activity__shared_media">Shared media</string>
 
-    <!--- redphone_call_controls -->
-    <string name="redphone_call_card__signal_call">Signal Call</string>
-
-    <!-- registration_activity -->
-    <string name="registration_activity__phone_number">PHONE NUMBER</string>
-    <string name="registration_activity__registration_will_transmit_some_contact_information_to_the_server_temporariliy">Signal makes it easy to communicate by using your existing phone number and address book. Friends and contacts who already know how to contact you by phone will be able to easily get in touch by Signal.\n\nRegistration transmits some contact information to the server. It is not stored.</string>
-    <string name="registration_activity__verify_your_number">Verify Your Number</string>
-    <string name="registration_activity__please_enter_your_mobile_number_to_receive_a_verification_code_carrier_rates_may_apply">Please enter your mobile number to receive a verification code. Carrier rates may apply.</string>
-
     <!-- recipients_panel -->
     <string name="recipients_panel__to"><small>Enter a name or number</small></string>
-    <string name="recipients_panel__add_members">Add members</string>
-
-    <!-- unknown_sender_view -->
-    <string name="unknown_sender_view__the_sender_is_not_in_your_contact_list">The sender is not in your contact list</string>
-    <string name="unknown_sender_view__block">BLOCK</string>
-    <string name="unknown_sender_view__add_to_contacts">ADD TO CONTACTS</string>
-    <string name="unknown_sender_view__don_t_add_but_make_my_profile_visible">DON\'T ADD, BUT MAKE MY PROFILE VISIBLE</string>
 
     <!-- verify_display_fragment -->
     <string name="verify_display_fragment__if_you_wish_to_verify_the_security_of_your_end_to_end_encryption_with_s"><![CDATA[If you wish to verify the security of your encryption with %s, compare the number above with the number on their device. Alternatively, you can scan the code on their phone, or ask them to scan your code. <a href="https://signal.org/redirect/safety-numbers">Learn more.</a>]]></string>
@@ -2248,12 +2048,8 @@
     <string name="MessageRequestsMegaphone__message_requests">Message requests</string>
     <string name="MessageRequestsMegaphone__users_can_now_choose_to_accept">Users can now choose to accept a new conversation. Profile names let people know who\'s messaging them.</string>
     <string name="MessageRequestsMegaphone__add_profile_name">Add profile name</string>
-    <string name="MessageRequestsMegaphone__new_message_requests">New: Message requests</string>
-    <string name="MessageRequestsMegaphone__add_name">Add name</string>
-    <string name="MessageRequestsMegaphone__you_can_now_choose_whether_to_accept">You can now choose whether to accept a new conversation. You’ll see options to \"Accept,\" \"Delete,\" or \"Block.\"</string>
 
     <!-- HelpFragment -->
-    <string name="HelpFragment__help">Help</string>
     <string name="HelpFragment__have_you_read_our_faq_yet">Have you read our FAQ yet?</string>
     <string name="HelpFragment__next">Next</string>
     <string name="HelpFragment__contact_us">Contact us</string>
@@ -2271,11 +2067,8 @@
     <string name="HelpFragment__support_info">Support Info</string>
     <string name="HelpFragment__signal_android_support_request">Signal Android Support Request</string>
     <string name="HelpFragment__debug_log">Debug Log:</string>
-    <string name="HelpFragment__na">n/a</string>
     <string name="HelpFragment__could_not_upload_logs">Could not upload logs</string>
-    <string name="HelpFragment__signal_support">Signal Support</string>
     <string name="HelpFragment__please_be_as_descriptive_as_possible">Please be as descriptive as possible to help us understand the issue.</string>
-    <string name="HelpFragment__no_email_app_found">No email app found.</string>
 
     <!-- ReactWithAnyEmojiBottomSheetDialogFragment -->
     <string name="ReactWithAnyEmojiBottomSheetDialogFragment__this_message">This Message</string>
@@ -2291,7 +2084,6 @@
     <string name="ReactWithAnyEmojiBottomSheetDialogFragment__emoticons">Emoticons</string>
 
     <!-- arrays.xml -->
-    <string name="arrays__import_export">Import</string>
     <string name="arrays__use_default">Use default</string>
     <string name="arrays__use_custom">Use custom</string>
 
@@ -2353,7 +2145,6 @@
     <string name="preferences__inactivity_timeout_passphrase">Inactivity timeout passphrase</string>
     <string name="preferences__inactivity_timeout_interval">Inactivity timeout interval</string>
     <string name="preferences__notifications">Notifications</string>
-    <string name="preferences__system_notification_settings">System notification settings</string>
     <string name="preferences__led_color">LED color</string>
     <string name="preferences__led_color_unknown">Unknown</string>
     <string name="preferences__pref_led_blink_title">LED blink pattern</string>
@@ -2406,7 +2197,6 @@
     <string name="preferences__if_you_disable_the_pin_you_will_lose_all_data">If you disable the PIN, you will lose all data when you re-register Signal unless you manually back up and restore. You can not turn on Registration Lock while the PIN is disabled.</string>
     <string name="preferences__pins_keep_information_stored_with_signal_encrypted_so_only_you_can_access_it">PINs keep information stored with Signal encrypted so only you can access it. Your profile, settings, and contacts will restore when you reinstall. You won’t need your PIN to open the app.</string>
     <string name="preferences__system_default">System default</string>
-    <string name="preferences__default">Default</string>
     <string name="preferences__language">Language</string>
     <string name="preferences__signal_messages_and_calls">Signal messages and calls</string>
     <string name="preferences__advanced_pin_settings">Advanced PIN settings</string>
@@ -2480,9 +2270,6 @@
     <string name="preferences_communication__sealed_sender_allow_from_anyone">Allow from anyone</string>
     <string name="preferences_communication__sealed_sender_allow_from_anyone_description">Enable sealed sender for incoming messages from non-contacts and people with whom you have not shared your profile.</string>
     <string name="preferences_communication__sealed_sender_learn_more">Learn more</string>
-    <string name="preferences_notifications__mentions">Mentions</string>
-    <string name="preferences_notifications__notify_me">Notify me</string>
-    <string name="preferences_notifications__receive_notifications_when_youre_mentioned_in_muted_chats">Receive notifications when you’re mentioned in muted chats</string>
     <string name="preferences_setup_a_username">Setup a username</string>
 
     <string name="configurable_single_select__customize_option">Customize option</string>
@@ -2558,7 +2345,6 @@
     <string name="conversation_expiring_off__disappearing_messages">Disappearing messages</string>
 
     <!-- conversation_expiring_on -->
-    <string name="menu_conversation_expiring_on__messages_expiring">Messages expiring</string>
 
     <!-- conversation_insecure -->
     <string name="conversation_insecure__invite">Invite</string>
@@ -2570,7 +2356,6 @@
     <string name="conversation_list_batch__menu_select_all">Select all</string>
     <string name="conversation_list_batch_archive__menu_archive_selected">Archive selected</string>
     <string name="conversation_list_batch_unarchive__menu_unarchive_selected">Unarchive selected</string>
-    <string name="conversation_list_batch__menu_unarchive_selected">Unarchive selected</string>
     <string name="conversation_list_batch__menu_mark_as_read">Mark as read</string>
     <string name="conversation_list_batch__menu_mark_as_unread">Mark as unread</string>
 
@@ -2584,9 +2369,6 @@
     <!-- conversation_list_item_view -->
     <string name="conversation_list_item_view__contact_photo_image">Contact Photo Image</string>
     <string name="conversation_list_item_view__archived">Archived</string>
-
-    <string name="conversation_list_item_inbox_zero__inbox_zeeerrro">Inbox zeeerrro</string>
-    <string name="conversation_list_item_inbox_zero__zip_zilch_zero_nada_nyou_re_all_caught_up">Zip. Zilch. Zero. Nada.\nYou\'re all caught up!</string>
 
 
     <!-- conversation_list_fragment -->
@@ -2605,14 +2387,11 @@
     <string name="conversation_unmuted__mute_notifications">Mute notifications</string>
 
     <!-- conversation -->
-    <string name="conversation__menu_add_attachment">Add attachment</string>
-    <string name="conversation__menu_edit_group">Edit group</string>
     <string name="conversation__menu_group_settings">Group settings</string>
     <string name="conversation__menu_leave_group">Leave group</string>
     <string name="conversation__menu_view_all_media">All media</string>
     <string name="conversation__menu_conversation_settings">Conversation settings</string>
     <string name="conversation__menu_add_shortcut">Add to home screen</string>
-    <string name="conversation__menu_pending_members">Pending members</string>
     <string name="conversation__menu_create_bubble">Create bubble</string>
 
     <!-- conversation_popup -->
@@ -2633,7 +2412,6 @@
     <string name="text_secure_normal__menu_clear_passphrase">Lock</string>
     <string name="text_secure_normal__mark_all_as_read">Mark all read</string>
     <string name="text_secure_normal__invite_friends">Invite friends</string>
-    <string name="text_secure_normal__help">Help</string>
 
     <!-- verify_display_fragment -->
     <string name="verify_display_fragment_context_menu__copy_to_clipboard">Copy to clipboard</string>
@@ -2644,12 +2422,7 @@
     <string name="reminder_header_sms_import_text">Tap to copy your phone\'s SMS messages into Signal\'s encrypted database.</string>
     <string name="reminder_header_push_title">Enable Signal messages and calls</string>
     <string name="reminder_header_push_text">Upgrade your communication experience.</string>
-    <string name="reminder_header_invite_title">Invite to Signal</string>
-    <string name="reminder_header_invite_text">Take your conversation with %1$s to the next level.</string>
-    <string name="reminder_header_share_title">Invite your friends!</string>
-    <string name="reminder_header_share_text">The more friends use Signal, the better it gets.</string>
     <string name="reminder_header_service_outage_text">Signal is experiencing technical difficulties. We are working hard to restore service as quickly as possible.</string>
-    <string name="reminder_header_the_latest_signal_features_wont_work">The latest Signal features won\'t work on this version of Android. Please upgrade this device to receive future Signal updates.</string>
     <string name="reminder_header_progress">%1$d%%</string>
 
     <!-- media_preview -->
@@ -2664,11 +2437,6 @@
     <!-- new_conversation_activity -->
     <string name="new_conversation_activity__refresh">Refresh</string>
     <!-- redphone_audio_popup_menu -->
-
-    <!-- Trimmer -->
-    <string name="trimmer__deleting">Deleting</string>
-    <string name="trimmer__deleting_old_messages">Deleting old messages…</string>
-    <string name="trimmer__old_messages_successfully_deleted">Old messages successfully deleted</string>
 
     <!-- Insights -->
     <string name="Insights__percent">%</string>
@@ -2734,7 +2502,6 @@
     <string name="KbsSplashFragment__learn_more_link" translatable="false">https://support.signal.org/hc/articles/360007059792</string>
     <string name="KbsSplashFragment__registration_lock_equals_pin">Registration Lock = PIN</string>
     <string name="KbsSplashFragment__your_registration_lock_is_now_called_a_pin">Your Registration Lock is now called a PIN, and it does more. Update it now.</string>
-    <string name="KbsSplashFragment__read_more_about_pins">Read more about PINs.</string>
     <string name="KbsSplashFragment__update_pin">Update PIN</string>
     <string name="KbsSplashFragment__create_your_pin">Create your PIN</string>
     <string name="KbsSplashFragment__learn_more_about_pins">Learn more about PINs</string>
@@ -2760,7 +2527,6 @@
     <string name="RegistrationLockFragment__enter_the_pin_you_created">Enter the PIN you created for your account. This is different from your SMS verification code.</string>
     <string name="RegistrationLockFragment__enter_alphanumeric_pin">Enter alphanumeric PIN</string>
     <string name="RegistrationLockFragment__enter_numeric_pin">Enter numeric PIN</string>
-    <string name="RegistrationLockFragment__next">Next</string>
     <string name="RegistrationLockFragment__incorrect_pin_try_again">Incorrect PIN. Try again.</string>
     <string name="RegistrationLockFragment__forgot_pin">Forgot PIN?</string>
     <string name="RegistrationLockFragment__incorrect_pin">Incorrect PIN</string>
@@ -2793,17 +2559,12 @@
     </plurals>
 
     <!-- CalleeMustAcceptMessageRequestDialogFragment -->
-    <string name="CalleeMustAcceptMessageRequestDialogFragment__okay">Okay</string>
     <string name="CalleeMustAcceptMessageRequestDialogFragment__s_will_get_a_message_request_from_you">%1$s will get a message request from you. You can call once your message request is accepted.</string>
 
     <!-- KBS Megaphone -->
     <string name="KbsMegaphone__create_a_pin">Create a PIN</string>
     <string name="KbsMegaphone__pins_keep_information_thats_stored_with_signal_encrytped">PINs keep information that’s stored with Signal encrypted.</string>
     <string name="KbsMegaphone__create_pin">Create PIN</string>
-    <string name="KbsMegaphone__introducing_pins">Introducing PINs</string>
-    <string name="KbsMegaphone__update_pin">Update PIN</string>
-    <string name="KbsMegaphone__well_remind_you_later_creating_a_pin">We\'ll remind you later. Creating a PIN will become mandatory in %1$d days.</string>
-    <string name="KbsMegaphone__well_remind_you_later_confirming_your_pin">We\'ll remind you later. Confirming your PIN will become mandatory in %1$d days.</string>
 
     <!-- Research Megaphone -->
     <string name="ResearchMegaphone_tell_signal_what_you_think">Tell Signal what you think</string>
@@ -2825,7 +2586,6 @@
     <string name="ConversationActivity_signal_needs_sms_permission_in_order_to_send_an_sms">Signal needs SMS permission in order to send an SMS, but it has been permanently denied. Please continue to app settings, select \"Permissions\" and enable \"SMS\".</string>
     <string name="Permissions_continue">Continue</string>
     <string name="Permissions_not_now">Not now</string>
-    <string name="ConversationListActivity_signal_needs_contacts_permission_in_order_to_search_your_contacts_but_it_has_been_permanently_denied">Signal needs Contacts permission in order to search your contacts, but it has been permanently denied. Please continue to app settings, select \"Permissions\", and enable \"Contacts\".</string>
     <string name="conversation_activity__enable_signal_messages">ENABLE SIGNAL MESSAGES</string>
     <string name="SQLCipherMigrationHelper_migrating_signal_database">Migrating Signal database</string>
     <string name="PushDecryptJob_new_locked_message">New locked message</string>
@@ -2837,12 +2597,8 @@
     <string name="backup_enable_dialog__i_have_written_down_this_passphrase">I have written down this passphrase. Without it, I will be unable to restore a backup.</string>
     <string name="registration_activity__restore_backup">Restore backup</string>
     <string name="registration_activity__skip">Skip</string>
-    <string name="registration_activity__register">Register</string>
     <string name="preferences_chats__chat_backups">Chat backups</string>
     <string name="preferences_chats__backup_chats_to_external_storage">Backup chats to external storage</string>
-    <string name="preferences_chats__create_backup">Create backup</string>
-    <string name="preferences_chats__verify_backup_passphrase">Verify backup passphrase</string>
-    <string name="preferences_chats__test_your_backup_passphrase_and_verify_that_it_matches">Test your backup passphrase and verify that it matches</string>
     <string name="RegistrationActivity_enter_backup_passphrase">Enter backup passphrase</string>
     <string name="RegistrationActivity_restore">Restore</string>
     <string name="RegistrationActivity_backup_failure_downgrade">Cannot import backups from newer versions of Signal</string>
@@ -2867,9 +2623,6 @@
     <string name="BackupDialog_verify">Verify</string>
     <string name="BackupDialog_you_successfully_entered_your_backup_passphrase">You successfully entered your backup passphrase</string>
     <string name="BackupDialog_passphrase_was_not_correct">Passphrase was not correct</string>
-    <string name="ChatsPreferenceFragment_signal_requires_external_storage_permission_in_order_to_create_backups">Signal requires external storage permission in order to create backups, but it has been permanently denied. Please continue to app settings, select \"Permissions\" and enable \"Storage\".</string>
-    <string name="ChatsPreferenceFragment_last_backup_s">Last backup: %s</string>
-    <string name="ChatsPreferenceFragment_in_progress">In progress</string>
     <string name="LocalBackupJob_creating_backup">Creating backup…</string>
     <string name="LocalBackupJobApi29_backup_failed">Backup failed</string>
     <string name="LocalBackupJobApi29_your_backup_directory_has_been_deleted_or_moved">Your backup directory has been deleted or moved.</string>
@@ -2877,7 +2630,6 @@
     <string name="LocalBackupJobApi29_there_is_not_enough_space">There is not enough space to store your backup.</string>
     <string name="LocalBackupJobApi29_tap_to_manage_backups">Tap to manage backups.</string>
     <string name="ProgressPreference_d_messages_so_far">%d messages so far</string>
-    <string name="RegistrationActivity_please_enter_the_verification_code_sent_to_s">Please enter the verification code sent to %s.</string>
     <string name="RegistrationActivity_wrong_number">Wrong number</string>
     <string name="RegistrationActivity_call_me_instead_available_in">Call me instead \n (Available in %1$02d:%2$02d)</string>
     <string name="RegistrationActivity_contact_signal_support">Contact Signal Support</string>
@@ -2891,7 +2643,6 @@
     <string name="PhoneNumberPrivacy_nobody">Nobody</string>
     <string name="PhoneNumberPrivacy_everyone_see_description">Your phone number will be visible to all people and groups you message.</string>
     <string name="PhoneNumberPrivacy_everyone_find_description">Anyone who has your phone number in their contacts will see you as a contact on Signal. Others will be able to find you in search.</string>
-    <string name="PhoneNumberPrivacy_my_contacts_see_description">Only your contacts will see your phone number on Signal.</string>
     <string name="preferences_app_protection__screen_lock">Screen lock</string>
     <string name="preferences_app_protection__lock_signal_access_with_android_screen_lock_or_fingerprint">Lock Signal access with Android screen lock or fingerprint</string>
     <string name="preferences_app_protection__screen_lock_inactivity_timeout">Screen lock inactivity timeout</string>
@@ -2910,46 +2661,16 @@
     <string name="preferences_app_protection__failed_to_enable_registration_lock">Failed to enable registration lock.</string>
     <string name="preferences_app_protection__failed_to_disable_registration_lock">Failed to disable registration lock.</string>
     <string name="AppProtectionPreferenceFragment_none">None</string>
-    <string name="registration_activity__the_registration_lock_pin_is_not_the_same_as_the_sms_verification_code_you_just_received_please_enter_the_pin_you_previously_configured_in_the_application">The Registration Lock PIN is not the same as the SMS verification code you just received. Please enter the PIN you previously configured in the application.</string>
-    <string name="registration_activity__registration_lock_pin">Registration Lock PIN</string>
-    <string name="registration_activity__forgot_pin">Forgot PIN?</string>
-    <string name="registration_lock_dialog_view__the_pin_can_consist_of_four_or_more_digits_if_you_forget_your_pin_you_could_be_locked_out_of_your_account_for_up_to_seven_days">The PIN can consist of four or more digits. If you forget your PIN, you could be locked out of your account for up to seven days.</string>
-    <string name="registration_lock_dialog_view__enter_pin">Enter PIN</string>
-    <string name="registration_lock_dialog_view__confirm_pin">Confirm PIN</string>
-    <string name="registration_lock_reminder_view__enter_your_registration_lock_pin">Enter your Registration Lock PIN</string>
-    <string name="registration_lock_reminder_view__enter_pin">Enter PIN</string>
-    <string name="preferences_app_protection__enable_a_registration_lock_pin_that_will_be_required">Enable a Registration Lock PIN that will be required to register this phone number with Signal again.</string>
-    <string name="preferences_app_protection__registration_lock_pin">Registration Lock PIN</string>
     <string name="preferences_app_protection__registration_lock">Registration Lock</string>
     <string name="RegistrationActivity_you_must_enter_your_registration_lock_PIN">You must enter your Registration Lock PIN</string>
     <string name="RegistrationActivity_your_pin_has_at_least_d_digits_or_characters">Your PIN has at least %d digits or characters</string>
-    <string name="RegistrationActivity_incorrect_registration_lock_pin">Incorrect Registration Lock PIN</string>
     <string name="RegistrationActivity_too_many_attempts">Too many attempts</string>
     <string name="RegistrationActivity_you_have_made_too_many_incorrect_registration_lock_pin_attempts_please_try_again_in_a_day">You\'ve made too many incorrect Registration Lock PIN attempts. Please try again in a day.</string>
     <string name="RegistrationActivity_you_have_made_too_many_attempts_please_try_again_later">You\'ve made too many attempts. Please try again later.</string>
     <string name="RegistrationActivity_error_connecting_to_service">Error connecting to service</string>
-    <string name="RegistrationActivity_oh_no">Oh no!</string>
-    <string name="RegistrationActivity_registration_of_this_phone_number_will_be_possible_without_your_registration_lock_pin_after_seven_days_have_passed">Registration of this phone number will be possible without your Registration Lock PIN after 7 days have passed since this phone number was last active on Signal. You have %d days remaining.</string>
-    <string name="RegistrationActivity_registration_lock_pin">Registration lock PIN</string>
-    <string name="RegistrationActivity_this_phone_number_has_registration_lock_enabled_please_enter_the_registration_lock_pin">This phone number has Registration Lock enabled. Please enter the Registration Lock PIN.</string>
-    <string name="RegistrationLockDialog_registration_lock_is_enabled_for_your_phone_number">Registration Lock is enabled for your phone number. To help you memorize your Registration Lock PIN, Signal will periodically ask you to confirm it.</string>
-    <string name="RegistrationLockDialog_i_forgot_my_pin">I forgot my PIN.</string>
-    <string name="RegistrationLockDialog_forgotten_pin">Forgotten PIN?</string>
-    <string name="RegistrationLockDialog_registration_lock_helps_protect_your_phone_number_from_unauthorized_registration_attempts">Registration Lock helps protect your phone number from unauthorized registration attempts. This feature can be disabled at any time in your Signal privacy settings</string>
-    <string name="RegistrationLockDialog_registration_lock">Registration lock</string>
-    <string name="RegistrationLockDialog_enable">Enable</string>
-    <string name="RegistrationLockDialog_the_registration_lock_pin_must_be_at_least_d_digits">The Registration Lock PIN must be at least %d digits.</string>
-    <string name="RegistrationLockDialog_the_two_pins_you_entered_do_not_match">The two PINs you entered do not match.</string>
-    <string name="RegistrationLockDialog_error_connecting_to_the_service">Error connecting to the service</string>
-    <string name="RegistrationLockDialog_disable_registration_lock_pin">Disable Registration Lock PIN?</string>
-    <string name="RegistrationLockDialog_disable">Disable</string>
-    <string name="RegistrationActivity_pin_incorrect">PIN Incorrect</string>
-    <string name="RegistrationActivity_you_have_d_tries_remaining">You have %d tries remaining</string>
     <string name="preferences_chats__backups">Backups</string>
     <string name="prompt_passphrase_activity__signal_is_locked">Signal is locked</string>
     <string name="prompt_passphrase_activity__tap_to_unlock">TAP TO UNLOCK</string>
-    <string name="RegistrationLockDialog_reminder">Reminder:</string>
-    <string name="recipient_preferences__about">About</string>
     <string name="Recipient_unknown">Unknown</string>
 
     <!-- RecipientBottomSheet -->
@@ -2996,7 +2717,6 @@
     <string name="GroupLinkBottomSheet_the_link_is_not_currently_active">The link is not currently active</string>
 
     <!-- VoiceNotePlaybackPreparer -->
-    <string name="VoiceNotePlaybackPreparer__could_not_start_playback">Could not start playback.</string>
 
     <!-- VoiceNoteMediaDescriptionCompatFactory -->
     <string name="VoiceNoteMediaDescriptionCompatFactory__voice_message">Voice message &#183; %1$s</string>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Grand Prime, Android 5.1.1, English
 * Samsung Grand Prime, Android 5.1.1, French
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Expected Benefits

The objective is to make the job of translators a little bit easier. This deletion represents ~9% of all strings that have to be translated to new languages. Languages that reached 100% completeness will have a little less to maintain, but that's negligible.

### Description of change
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

This commit will remove around 220 English strings that have been identified by Android Studio as unused. It was generated by running the tool (Menu > Refactor > Remove Unused Resources...), then applying the changes only to the English file.

To double check, I have read the key and value of each string quickly. And I have searched for a few of them in the codebase manually. But I am very much new to the codebase so there is a slight risk of error if some code somewhere accesses the strings in a funny way.

I tested this by opening the app and moving around, opening as many activites as I could. This was NOT exhaustive.
I did that when the app was in French, and when the app was in English.

Note that Android Studio detects a lot of other unused resource types (ex: tens of icons, one fragment, some IDs in fragments...) but cleaning them might be worthless.

### Open questions 

1. Are there other tests that should be performed for this change?
2. Should I also remove the corresponding strings in other languages? I expect that they will just be marked as deprecated by Transifex, and removed the next time that translations are imported.

### Screenshot of the tool

![Android Studio Inspector](https://user-images.githubusercontent.com/242172/104853977-ad780f80-5904-11eb-9ea0-64855c3edff7.png)
