### PR TITLE
Fixes #10678 - Discrepancies in source strings: WiFi or Wi-Fi

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Signal is a messaging app for simple private communication with friends.
 
-Signal uses your phone's data connection (WiFi/3G/4G) to communicate securely, optionally supports plain SMS/MMS to function as a unified messenger, and can also encrypt the stored messages on your phone.
+Signal uses your phone's data connection (Wi-Fi/3G/4G) to communicate securely, optionally supports plain SMS/MMS to function as a unified messenger, and can also encrypt the stored messages on your phone.
 
 Currently available on the Play store.
 

--- a/app/src/main/java/org/thoughtcrime/securesms/mms/LegacyMmsConnection.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/LegacyMmsConnection.java
@@ -95,7 +95,7 @@ public abstract class LegacyMmsConnection {
   }
 
   protected boolean isDirectConnect() {
-    // We think Sprint supports direct connection over wifi/data, but not Verizon
+    // We think Sprint supports direct connection over Wi-Fi/data, but not Verizon
     Set<String> sprintMccMncs = new HashSet<String>() {{
       add("312530");
       add("311880");

--- a/app/src/main/java/org/thoughtcrime/securesms/webrtc/locks/LockManager.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/webrtc/locks/LockManager.java
@@ -71,7 +71,7 @@ public class LockManager {
 
   private boolean isWifiPowerActiveModeEnabled(Context context) {
     int wifi_pwr_active_mode = Settings.Secure.getInt(context.getContentResolver(), "wifi_pwr_active_mode", -1);
-    Log.d(TAG, "Wifi Activity Policy: " + wifi_pwr_active_mode);
+    Log.d(TAG, "Wi-Fi Activity Policy: " + wifi_pwr_active_mode);
 
     if (wifi_pwr_active_mode == 0) {
       return false;

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -2365,7 +2365,7 @@
   <string name="preferences__submit_debug_log">إرسال سجل التصحيح</string>
   <string name="preferences__delete_account">حذف الحساب</string>
   <string name="preferences__support_wifi_calling">وضع التوافق مع \'مكالمات الواي فاي\'</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">يمكنك تفعيل الخاصية إذا كان هاتفك يدعم خاصية WiFi Calling لتسليم الرسائل القصيرة والرسائل متعددة الوسائط MMS/SMS ( قم بالتفعيل فقط في حال تفعيل WiFi Calling بهاتفك)</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">يمكنك تفعيل الخاصية إذا كان هاتفك يدعم خاصية Wi-Fi Calling لتسليم الرسائل القصيرة والرسائل متعددة الوسائط MMS/SMS ( قم بالتفعيل فقط في حال تفعيل Wi-Fi Calling بهاتفك)</string>
   <string name="preferences__incognito_keyboard">وضع التخفّي للوحة المفاتيح</string>
   <string name="preferences__read_receipts">قراءة وصولات القراءة</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">إن قمتِ بإلغاء تفعيل وصل قراءة الرسائل، فلن يمكنك كذلك رؤية وصل بأنّ الآخرين قاموا بقراءة  رسائلك.</string>
@@ -2411,7 +2411,7 @@
   <string name="preferences_data_and_storage__calls">المُكالمات</string>
   <string name="preferences_data_and_storage__use_less_data_for_calls">استخدام بيانات أقل أثناء المكالمات</string>
   <string name="preferences_data_and_storage__never">أبداً</string>
-  <string name="preferences_data_and_storage__wifi_and_cellular">شبكة WiFi والشبكة الخلوية</string>
+  <string name="preferences_data_and_storage__wifi_and_cellular">شبكة Wi-Fi والشبكة الخلوية</string>
   <string name="preferences_data_and_storage__cellular_only">الشبكة الخلوية فقط</string>
   <string name="preference_data_and_storage__using_less_data_may_improve_calls_on_bad_networks">يُحسِّن استخدام بيانات أقل جودة المكالمات في الشبكات الضعيفة</string>
   <string name="preferences_notifications__messages">الرسائل</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -1097,8 +1097,8 @@
   <string name="preferences__signal_messages_and_calls">Signal mesajları və zəngləri</string>
   <string name="preferences__free_private_messages_and_calls">Signal istifadəçilərinə ödənişsiz mesaj və zənglər</string>
   <string name="preferences__submit_debug_log">Xəta sorğusu təqdim et</string>
-  <string name="preferences__support_wifi_calling">\'WiFi Zəng\' uyğunluq rejimi</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Sənin cihazın WiFi üzərindən SMS/MMS çatdırılmasını həyata keçirə bilirsə, aktivləşdir (yalnız cihazında \'WiFi Zəng\' aktiv edildikdə istifadə et)</string>
+  <string name="preferences__support_wifi_calling">\'Wi-Fi Zəng\' uyğunluq rejimi</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Sənin cihazın Wi-Fi üzərindən SMS/MMS çatdırılmasını həyata keçirə bilirsə, aktivləşdir (yalnız cihazında \'Wi-Fi Zəng\' aktiv edildikdə istifadə et)</string>
   <string name="preferences__incognito_keyboard">Gözəgörünməz klaviatura</string>
   <string name="preferences__read_receipts">Oxunmuşlar haqqında məlumat</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Oxunmuşlar haqqında məlumat xidməti deaktiv edilsə, başqa şəxs mesajı oxuduqda məlumat almayacaqsan.</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -1138,8 +1138,8 @@
   <string name="preferences__signal_messages_and_calls">Signal съобщения и обаждания</string>
   <string name="preferences__free_private_messages_and_calls">Безплатни, лични съобщения и обаждания до Signal потребители</string>
   <string name="preferences__submit_debug_log">Изпращане на доклад</string>
-  <string name="preferences__support_wifi_calling">Съвместим режим \'WiFi Calling\'</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Включи ако устройството ти използва WiFi за SMS/MMS(само ако \'Wifi Calling\' е включен на устройството ти)</string>
+  <string name="preferences__support_wifi_calling">Съвместим режим \'Wi-Fi Calling\'</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Включи ако устройството ти използва Wi-Fi за SMS/MMS(само ако \'Wi-Fi Calling\' е включен на устройството ти)</string>
   <string name="preferences__incognito_keyboard">Тайна клавиатура</string>
   <string name="preferences__read_receipts">Потвърждения за прочитане</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Ако Вашите потвърждения за прочитане са деактивирани няма да можете да видите потвържденията за прочитане от други.</string>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -2135,8 +2135,8 @@
   <string name="preferences__free_private_messages_and_calls">Besplatne privatne poruke i pozivi za korisnike Signala</string>
   <string name="preferences__submit_debug_log">Pošaljite zapis za ispravljanje grešaka</string>
   <string name="preferences__delete_account">Izbriši račun</string>
-  <string name="preferences__support_wifi_calling">\'WiFi pozivanje\' kompatibilni način rada</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Aktivirajte ukoliko Vaš uređaj isporučuje SMS/MMS poruke preko WiFi-a (aktivirajte samo kad je na Vašem uređaju aktivno i \'WiFi pozivanje\')</string>
+  <string name="preferences__support_wifi_calling">\'Wi-Fi pozivanje\' kompatibilni način rada</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Aktivirajte ukoliko Vaš uređaj isporučuje SMS/MMS poruke preko Wi-Fi-a (aktivirajte samo kad je na Vašem uređaju aktivno i \'Wi-Fi pozivanje\')</string>
   <string name="preferences__incognito_keyboard">Inkognito tastatura</string>
   <string name="preferences__read_receipts">Potvrda čitanja</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Ako je potvrda čitanja onemogućena, nećete moći vidjeti potvrdu čitanja od drugih.</string>
@@ -2182,7 +2182,7 @@
   <string name="preferences_data_and_storage__calls">Pozivi</string>
   <string name="preferences_data_and_storage__use_less_data_for_calls">Koristi manju količinu podataka za pozive</string>
   <string name="preferences_data_and_storage__never">Nikad</string>
-  <string name="preferences_data_and_storage__wifi_and_cellular">WiFi i mobilna mreža</string>
+  <string name="preferences_data_and_storage__wifi_and_cellular">Wi-Fi i mobilna mreža</string>
   <string name="preferences_data_and_storage__cellular_only">Samo mobilna mreža</string>
   <string name="preference_data_and_storage__using_less_data_may_improve_calls_on_bad_networks">Korištenjem manje količine podataka može se poboljšati kvalitet poziva na lošim mrežama</string>
   <string name="preferences_notifications__messages">Poruke</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -2050,8 +2050,8 @@ S\'ha rebut un missatge d\'intercanvi de claus per a una versió del protocol no
   <string name="preferences__free_private_messages_and_calls">Missatges i trucades privades gratuïtes per als usuaris del Signal </string>
   <string name="preferences__submit_debug_log">Envia un registre de depuració</string>
   <string name="preferences__delete_account">Suprimeix el compte</string>
-  <string name="preferences__support_wifi_calling">Compatibilitat «Trucada per WiFi»</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Activeu-ho si el dispositiu fa servir SMS / MMS per WiFi (feu-ho només si la «Trucada per WiFi» està activada al dispositiu)</string>
+  <string name="preferences__support_wifi_calling">Compatibilitat «Trucada per Wi-Fi»</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Activeu-ho si el dispositiu fa servir SMS / MMS per Wi-Fi (feu-ho només si la «Trucada per Wi-Fi» està activada al dispositiu)</string>
   <string name="preferences__incognito_keyboard">Teclat d\'incògnit</string>
   <string name="preferences__read_receipts">Confirmació de lectura</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Si les confirmacions de recepció estan desactivbades, no podreu veure les dels altres.</string>
@@ -2097,7 +2097,7 @@ S\'ha rebut un missatge d\'intercanvi de claus per a una versió del protocol no
   <string name="preferences_data_and_storage__calls">Trucades</string>
   <string name="preferences_data_and_storage__use_less_data_for_calls">Usa menys dades per a les trucades</string>
   <string name="preferences_data_and_storage__never">Mai</string>
-  <string name="preferences_data_and_storage__wifi_and_cellular">WiFi i dades mòbils</string>
+  <string name="preferences_data_and_storage__wifi_and_cellular">Wi-Fi i dades mòbils</string>
   <string name="preferences_data_and_storage__cellular_only">Només dades mòbils</string>
   <string name="preference_data_and_storage__using_less_data_may_improve_calls_on_bad_networks">L\'ús de menys dades pot millorar les trucades en xarxes amb poca capacitat.</string>
   <string name="preferences_notifications__messages">Missatges</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -2211,8 +2211,8 @@ Obdržen požadavek na výměnu klíčů pro neplatnou verzi protokolu.
   <string name="preferences__free_private_messages_and_calls">Svobodné šifrované zprávy a volání uživatelům Signal</string>
   <string name="preferences__submit_debug_log">Odeslat ladicí log</string>
   <string name="preferences__delete_account">Smazat účet</string>
-  <string name="preferences__support_wifi_calling">Režim kompatibility \"WiFi volání\"</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Povolit, pokud vaše zařízení používá doručování SMS/MMS přes WiFi (povolte pouze, když vaše zařízení umožňuje \"WiFi volání\")</string>
+  <string name="preferences__support_wifi_calling">Režim kompatibility \"Wi-Fi volání\"</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Povolit, pokud vaše zařízení používá doručování SMS/MMS přes Wi-Fi (povolte pouze, když vaše zařízení umožňuje \"Wi-Fi volání\")</string>
   <string name="preferences__incognito_keyboard">Inkognito klávesnice</string>
   <string name="preferences__read_receipts">Potvrzení o přečtení</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Jestliže zakážete posílání potvrzení o přečtení zpráv, nebudete vidět tato potvrzení ani od ostatních.</string>
@@ -2221,7 +2221,7 @@ Obdržen požadavek na výměnu klíčů pro neplatnou verzi protokolu.
   <string name="preferences__request_keyboard_to_disable_personalized_learning">Vyžádat klávesnici s vypnutým učením</string>
   <string name="preferences_app_protection__blocked_users">Zablokovaní uživatelé</string>
   <string name="preferences_chats__when_using_mobile_data">Při použití mobilních datových přenosů</string>
-  <string name="preferences_chats__when_using_wifi">Při použití WiFi</string>
+  <string name="preferences_chats__when_using_wifi">Při použití Wi-Fi</string>
   <string name="preferences_chats__when_roaming">Při roamingu</string>
   <string name="preferences_chats__media_auto_download">Automatické stahování multimédií</string>
   <string name="preferences_chats__message_history">Historie zpráv</string>
@@ -2258,7 +2258,7 @@ Obdržen požadavek na výměnu klíčů pro neplatnou verzi protokolu.
   <string name="preferences_data_and_storage__calls">Volání</string>
   <string name="preferences_data_and_storage__use_less_data_for_calls">Šetřit data při hovorech</string>
   <string name="preferences_data_and_storage__never">Nikdy</string>
-  <string name="preferences_data_and_storage__wifi_and_cellular">WiFi a mobilní připojení</string>
+  <string name="preferences_data_and_storage__wifi_and_cellular">Wi-Fi a mobilní připojení</string>
   <string name="preferences_data_and_storage__cellular_only">Pouze mobilní připojení</string>
   <string name="preference_data_and_storage__using_less_data_may_improve_calls_on_bad_networks">Úspora dat může vylepšit kvalitu hovoru při špatném signálu</string>
   <string name="preferences_notifications__messages">Zprávy</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -2105,7 +2105,7 @@ Modtog en nøgle besked, for en ugyldig protokol-version
   <string name="preferences_data_and_storage__calls">Opkald</string>
   <string name="preferences_data_and_storage__use_less_data_for_calls">Brug færre data til opkald</string>
   <string name="preferences_data_and_storage__never">Aldrig</string>
-  <string name="preferences_data_and_storage__wifi_and_cellular">Wifi og mobildata</string>
+  <string name="preferences_data_and_storage__wifi_and_cellular">Wi-Fi og mobildata</string>
   <string name="preferences_data_and_storage__cellular_only">Kun mobildata</string>
   <string name="preference_data_and_storage__using_less_data_may_improve_calls_on_bad_networks">Brug af færre data kan forbedre opkald på dårlige netværk</string>
   <string name="preferences_notifications__messages">Beskeder</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -2053,8 +2053,8 @@
   <string name="preferences__free_private_messages_and_calls">Δωρεάν προσωπικά μηνύματα και κλήσεις προς τους χρήστες και τις χρήστριες του Signal</string>
   <string name="preferences__submit_debug_log">Αποστολή αρχείου συμβάντων αποσφαλμάτωσης</string>
   <string name="preferences__delete_account">Διαγραφή λογαριασμού</string>
-  <string name="preferences__support_wifi_calling">Λειτουργία συμβατότητας \"WiFi Calling\' </string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Ενεργοποίησέ το αν η συσκευή σου χρησιμοποιεί παράδοση SMS/MMS μέσω WiFi (ενεργοποίηση μόνο αν το \'WiFi Calling\' είναι ενεργοποιημένο στη συσκευή σου)</string>
+  <string name="preferences__support_wifi_calling">Λειτουργία συμβατότητας \"Wi-Fi Calling\' </string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Ενεργοποίησέ το αν η συσκευή σου χρησιμοποιεί παράδοση SMS/MMS μέσω Wi-Fi (ενεργοποίηση μόνο αν το \'Wi-Fi Calling\' είναι ενεργοποιημένο στη συσκευή σου)</string>
   <string name="preferences__incognito_keyboard">Κρυφό πληκτρολόγιο</string>
   <string name="preferences__read_receipts">Αποδεικτικά ανάγνωσης</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Αν τα αποδεικτικά ανάγνωσης είναι απενεργοποιημένα, δε θα μπορείς να δεις αποδεικτικά ανάγνωσης από άλλους/ες.</string>
@@ -2063,7 +2063,7 @@
   <string name="preferences__request_keyboard_to_disable_personalized_learning">Αίτηση πληκτρολογίου για να απενεργοποιηθεί η προσωποποιημένη εκμάθηση</string>
   <string name="preferences_app_protection__blocked_users">Φραγμένοι χρήστες/τριες</string>
   <string name="preferences_chats__when_using_mobile_data">Όταν χρησιμοποιούνται δεδομένα</string>
-  <string name="preferences_chats__when_using_wifi">Όταν χρησιμοποιείται WiFi</string>
+  <string name="preferences_chats__when_using_wifi">Όταν χρησιμοποιείται Wi-Fi</string>
   <string name="preferences_chats__when_roaming">Κατά το roaming</string>
   <string name="preferences_chats__media_auto_download">Αυτόματη λήψη πολυμέσων</string>
   <string name="preferences_chats__message_history">Ιστορικό μηνυμάτων</string>
@@ -2100,7 +2100,7 @@
   <string name="preferences_data_and_storage__calls">Κλήσεις</string>
   <string name="preferences_data_and_storage__use_less_data_for_calls">Χρήση λιγότερων δεδομένων για τις κλήσεις</string>
   <string name="preferences_data_and_storage__never">Ποτέ</string>
-  <string name="preferences_data_and_storage__wifi_and_cellular">WiFi και δεδομένα κινητής</string>
+  <string name="preferences_data_and_storage__wifi_and_cellular">Wi-Fi και δεδομένα κινητής</string>
   <string name="preferences_data_and_storage__cellular_only">Μόνο δεδομένα κινητής</string>
   <string name="preference_data_and_storage__using_less_data_may_improve_calls_on_bad_networks">Η χρήση λιγότερων δεδομένων ίσως βελτιώσει τη ποιότητα των κλήσεων σε δίκτυα με κακή σύνδεση</string>
   <string name="preferences_notifications__messages">Μηνύματα</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -2058,8 +2058,8 @@ Se recibió un mensaje de intercambio de claves para una versión no válida del
   <string name="preferences__free_private_messages_and_calls">Llamadas y mensajes cifrados a través de Signal ¡gratis! </string>
   <string name="preferences__submit_debug_log">Enviar registro de depuración</string>
   <string name="preferences__delete_account">Eliminar cuenta</string>
-  <string name="preferences__support_wifi_calling">Modo de compatibilidad «Llamada por WiFi»</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Actívalo si tu dispositivo utiliza entrega de SMS/MMS vía WiFi (actívalo sólo cuando «Llamada por WiFi» esté activada en el dispositivo)</string>
+  <string name="preferences__support_wifi_calling">Modo de compatibilidad «Llamada por Wi-Fi»</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Actívalo si tu dispositivo utiliza entrega de SMS/MMS vía Wi-Fi (actívalo sólo cuando «Llamada por Wi-Fi» esté activada en el dispositivo)</string>
   <string name="preferences__incognito_keyboard">Teclado incógnito</string>
   <string name="preferences__read_receipts">Notificaciones de lectura</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Si las notificaciones de lectura están desactivadas, no podrás comprobar cuándo se han leído tus mensajes.</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -2056,8 +2056,8 @@
   <string name="preferences__free_private_messages_and_calls">Tasuta privaatsõnumid ja kõned Signali kasutajatele</string>
   <string name="preferences__submit_debug_log">Saada silumislogi</string>
   <string name="preferences__delete_account">Kustuta konto</string>
-  <string name="preferences__support_wifi_calling">\"WiFi kõnede\" ühilduvusrežiim</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Luba, kui su seade kasutab SMS/MMS kohaletoimetamist üle WiFi (luba ainult siis, kui \"WiFi kõned\" on sinu seadmes lubatud)</string>
+  <string name="preferences__support_wifi_calling">\"Wi-Fi kõnede\" ühilduvusrežiim</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Luba, kui su seade kasutab SMS/MMS kohaletoimetamist üle Wi-Fi (luba ainult siis, kui \"Wi-Fi kõned\" on sinu seadmes lubatud)</string>
   <string name="preferences__incognito_keyboard">Inkognito klaviatuur</string>
   <string name="preferences__read_receipts">Lugemiskinnitused</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Kui lugemiskinnitused on keelatud, siis pole sul võimalik teiste saadetud lugemiskinnitusi näha.</string>
@@ -2103,7 +2103,7 @@
   <string name="preferences_data_and_storage__calls">Kõned</string>
   <string name="preferences_data_and_storage__use_less_data_for_calls">Kasuta kõnede jaoks vähem andmesidet</string>
   <string name="preferences_data_and_storage__never">Mitte kunagi</string>
-  <string name="preferences_data_and_storage__wifi_and_cellular">WiFi ja mobiilside</string>
+  <string name="preferences_data_and_storage__wifi_and_cellular">Wi-Fi ja mobiilside</string>
   <string name="preferences_data_and_storage__cellular_only">Ainult mobiilside</string>
   <string name="preference_data_and_storage__using_less_data_may_improve_calls_on_bad_networks">Väiksema andmemahu kasutamine võib kehvades võrkudes parendada kõnekvaliteeti.</string>
   <string name="preferences_notifications__messages">Sõnumid</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -2059,8 +2059,8 @@ Gakoaren elkar-trukeraro mezua jaso da protokoloaren bertsio baliogabe baterako.
   <string name="preferences__free_private_messages_and_calls">Mezu eta dei pribatu doanak Signal erabiltzaileri.</string>
   <string name="preferences__submit_debug_log">Arazketaren informazioa bidali</string>
   <string name="preferences__delete_account">Ezabatu kontua</string>
-  <string name="preferences__support_wifi_calling">\'WiFi Calling\' bateragarritasunerako modua</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Aktibatu zure gailuak WiFi bidezko SMS/MMS banaketa erabiltzen badu (bakarrik aktibatu \'WiFi Calling\' aktibatuta badago zure gailuan).</string>
+  <string name="preferences__support_wifi_calling">\'Wi-Fi Calling\' bateragarritasunerako modua</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Aktibatu zure gailuak Wi-Fi bidezko SMS/MMS banaketa erabiltzen badu (bakarrik aktibatu \'Wi-Fi Calling\' aktibatuta badago zure gailuan).</string>
   <string name="preferences__incognito_keyboard">Ezkutuko teklatua</string>
   <string name="preferences__read_receipts">Irakurketaren hartu-agiriak</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Irakurketaren hartu-agiriak desaktibatuta badaude, ezingo dituzu besteenak ikusi</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -2054,8 +2054,8 @@
   <string name="preferences__free_private_messages_and_calls">تماس‌ها و پیام‌های خصوصی رایگان برای کاربران سیگنال</string>
   <string name="preferences__submit_debug_log">ارسال گزارش اشکال‌زدایی</string>
   <string name="preferences__delete_account">حذف حساب کاربری</string>
-  <string name="preferences__support_wifi_calling">حالت سازگاری «تماس WiFi»</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">اگر دستگاه شما از تحویل پیامک/فراپیام بر روی شبکهٔ WiFi استفاده می‌کند، این گزینه را فعال کنید (فقط زمانی فعال کنید، که «تماس WiFi» بر روی دستگاه شما فعال است)</string>
+  <string name="preferences__support_wifi_calling">حالت سازگاری «تماس Wi-Fi»</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">اگر دستگاه شما از تحویل پیامک/فراپیام بر روی شبکهٔ Wi-Fi استفاده می‌کند، این گزینه را فعال کنید (فقط زمانی فعال کنید، که «تماس Wi-Fi» بر روی دستگاه شما فعال است)</string>
   <string name="preferences__incognito_keyboard">صفحه‌کلید ناشناس</string>
   <string name="preferences__read_receipts">رسیدهای خوانده شدن</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">اگر رسیدهای خوانده شدن غیرفعال باشند، شما قادر به دیدن رسیدهای خوانده شدن دیگران نخواهید بود.</string>
@@ -2101,7 +2101,7 @@
   <string name="preferences_data_and_storage__calls">تماس‌ها</string>
   <string name="preferences_data_and_storage__use_less_data_for_calls">استفاده از کمتر از داده‌ها برای تماس‌ها</string>
   <string name="preferences_data_and_storage__never">هرگز</string>
-  <string name="preferences_data_and_storage__wifi_and_cellular">WiFi و شبکهٔ تلفن همراه</string>
+  <string name="preferences_data_and_storage__wifi_and_cellular">Wi-Fi و شبکهٔ تلفن همراه</string>
   <string name="preferences_data_and_storage__cellular_only">فقط شبکهٔ تلفن ‌همراه</string>
   <string name="preference_data_and_storage__using_less_data_may_improve_calls_on_bad_networks">استفاده کمتر از داده‌ها ممکن است کیفیت تماس‌ها را بر روی شبکه‌های ضعیف بهبود ببخشد </string>
   <string name="preferences_notifications__messages">پیام‌ها</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -2052,8 +2052,8 @@ Vastaanotetiin avaintenvaihtoviesti, joka kuuluu väärälle protokollaversiolle
   <string name="preferences__free_private_messages_and_calls">Ilmaiset ja yksityiset viestit sekä puhelut Signalin käyttäjille</string>
   <string name="preferences__submit_debug_log">Lähetä virheenkorjausloki</string>
   <string name="preferences__delete_account">Poista tili</string>
-  <string name="preferences__support_wifi_calling">\"WiFi Calling\" -yhteensopiva tila</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Ota käyttöön, jos laitteesi lähettää SMS- ja MMS-viestit WiFi-yhteyden kautta. (Ota käyttöön vain, kun \"WiFi Calling\" on käytössä laitteessasi.)</string>
+  <string name="preferences__support_wifi_calling">\"Wi-Fi Calling\" -yhteensopiva tila</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Ota käyttöön, jos laitteesi lähettää SMS- ja MMS-viestit Wi-Fi-yhteyden kautta. (Ota käyttöön vain, kun \"Wi-Fi Calling\" on käytössä laitteessasi.)</string>
   <string name="preferences__incognito_keyboard">Yksityinen näppäimistö</string>
   <string name="preferences__read_receipts">Lukukuittaukset</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Jos lukukuittauksia ei ole otettu käyttöön, et tule näkemään lukukuittauksia muilta.</string>
@@ -2099,7 +2099,7 @@ Vastaanotetiin avaintenvaihtoviesti, joka kuuluu väärälle protokollaversiolle
   <string name="preferences_data_and_storage__calls">Puhelut</string>
   <string name="preferences_data_and_storage__use_less_data_for_calls">Käytä vähemmän dataa puheluihin</string>
   <string name="preferences_data_and_storage__never">ei koskaan</string>
-  <string name="preferences_data_and_storage__wifi_and_cellular">WiFi ja mobiili</string>
+  <string name="preferences_data_and_storage__wifi_and_cellular">Wi-Fi ja mobiili</string>
   <string name="preferences_data_and_storage__cellular_only">Vain mobiili</string>
   <string name="preference_data_and_storage__using_less_data_may_improve_calls_on_bad_networks">Alempi datankäyttö voi parantaa puheluja heikoissa verkkoyhteyksissä</string>
   <string name="preferences_notifications__messages">Viestit</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -1804,8 +1804,8 @@
   <string name="preferences__free_private_messages_and_calls">Mensaxes e chamadas privadas e de balde para usuarios de Signal</string>
   <string name="preferences__submit_debug_log">Enviar rexistro de depuración</string>
   <string name="preferences__delete_account">Eliminar conta</string>
-  <string name="preferences__support_wifi_calling">Modo de compatibilidade \'Chamadas por wifi\'</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Actívao se o teu dispositivo envía SMS/MMS vía wifi (só cando as chamadas por wifi estean tamén activadas)</string>
+  <string name="preferences__support_wifi_calling">Modo de compatibilidade \'Chamadas por Wi-Fi\'</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Actívao se o teu dispositivo envía SMS/MMS vía Wi-Fi (só cando as chamadas por Wi-Fi estean tamén activadas)</string>
   <string name="preferences__incognito_keyboard">Teclado de incógnito</string>
   <string name="preferences__read_receipts">Confirmacións de lectura</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Se desactivas as confirmacións de lectura, non poderás ver as confirmacións dos demais.</string>
@@ -1814,7 +1814,7 @@
   <string name="preferences__request_keyboard_to_disable_personalized_learning">Solicitude de teclado para desactivar a aprendizaxe personalizada</string>
   <string name="preferences_app_protection__blocked_users">Usuarios bloqueados</string>
   <string name="preferences_chats__when_using_mobile_data">Usando datos móbiles</string>
-  <string name="preferences_chats__when_using_wifi">Usando conexión wifi</string>
+  <string name="preferences_chats__when_using_wifi">Usando conexión Wi-Fi</string>
   <string name="preferences_chats__when_roaming">En itinerancia</string>
   <string name="preferences_chats__media_auto_download">Descarga automática multimedia</string>
   <string name="preferences_chats__message_history">Historial das mensaxes</string>

--- a/app/src/main/res/values-gu/strings.xml
+++ b/app/src/main/res/values-gu/strings.xml
@@ -1310,7 +1310,7 @@
   <string name="preferences__free_private_messages_and_calls">મફત ખાનગી મેસેજ અને Signal વપરાશકર્તાઓને કૉલ્સ</string>
   <string name="preferences__submit_debug_log">ડિબગ લૉગ સબમિટ કરો</string>
   <string name="preferences__support_wifi_calling">\'વાઇફાઇ કૉલિંગ\' સુસંગતતા મોડ</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">જો તમારું ડિવાઇસ WiFi પર SMS/MMS ડિલિવરીનો ઉપયોગ કરે છે તો સક્ષમ કરો (ફક્ત ત્યારે જ સક્ષમ કરો જ્યારે તમારા ડિવાઇસ પર \'વાઇફાઇ કૉલિંગ\' સક્ષમ હોય)</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">જો તમારું ડિવાઇસ Wi-Fi પર SMS/MMS ડિલિવરીનો ઉપયોગ કરે છે તો સક્ષમ કરો (ફક્ત ત્યારે જ સક્ષમ કરો જ્યારે તમારા ડિવાઇસ પર \'વાઇફાઇ કૉલિંગ\' સક્ષમ હોય)</string>
   <string name="preferences__incognito_keyboard">ઈનકોગ્નિટો કીબોર્ડ</string>
   <string name="preferences__read_receipts">રિડ રિસિપ્ટ</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">જો રિડ રિસિપ્ટ અક્ષમ કરવામાં આવે છે, તો તમે અન્ય લોકો પાસેથી વાંચેલી રિડ રિસિપ્ટ જોઈ શકશો નહીં.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -2058,8 +2058,8 @@
   <string name="preferences__free_private_messages_and_calls">Messaggi e chiamate private e gratuite verso gli utenti Signal</string>
   <string name="preferences__submit_debug_log">Invia log di debug</string>
   <string name="preferences__delete_account">Elimina account</string>
-  <string name="preferences__support_wifi_calling">Modalità di compatibilità \'WiFi Calling\'</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Abilitare se il tuo device spedisce gli SMS/MMS via WiFi (abilita solo quando \"WiFi Calling\" è abilitato per il tuo dispositivo)</string>
+  <string name="preferences__support_wifi_calling">Modalità di compatibilità \'Wi-Fi Calling\'</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Abilitare se il tuo device spedisce gli SMS/MMS via Wi-Fi (abilita solo quando \"Wi-Fi Calling\" è abilitato per il tuo dispositivo)</string>
   <string name="preferences__incognito_keyboard">Tastiera in incognito</string>
   <string name="preferences__read_receipts">Conferme di lettura</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Se le conferme di lettura sono disabilitate, non sarai in grado di vedere le conferme di lettura da altri.</string>
@@ -2105,7 +2105,7 @@
   <string name="preferences_data_and_storage__calls">Chiamate</string>
   <string name="preferences_data_and_storage__use_less_data_for_calls">Utilizza meno dati per le chiamate</string>
   <string name="preferences_data_and_storage__never">Mai</string>
-  <string name="preferences_data_and_storage__wifi_and_cellular">WiFi e rete cellulare</string>
+  <string name="preferences_data_and_storage__wifi_and_cellular">Wi-Fi e rete cellulare</string>
   <string name="preferences_data_and_storage__cellular_only">Solo rete cellulare</string>
   <string name="preference_data_and_storage__using_less_data_may_improve_calls_on_bad_networks">L\'utilizzo di meno dati può migliorare le chiamate su reti lente</string>
   <string name="preferences_notifications__messages">Messaggi</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -2212,8 +2212,8 @@
   <string name="preferences__free_private_messages_and_calls">הודעות ושיחות פרטיות חינמיות אל משתמשי Signal</string>
   <string name="preferences__submit_debug_log">הגש יומן ניפוי תקלים</string>
   <string name="preferences__delete_account">מחק חשבון</string>
-  <string name="preferences__support_wifi_calling">מצב תאימות \'התקשרות WiFi\'</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">אפשר אם המכשיר שלך משתמש במשלוח של מסרונים או MMS על גבי WiFi (אפשר רק כאשר \'התקשרות WiFi\' מאופשרת במכשיר שלך)</string>
+  <string name="preferences__support_wifi_calling">מצב תאימות \'התקשרות Wi-Fi\'</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">אפשר אם המכשיר שלך משתמש במשלוח של מסרונים או MMS על גבי Wi-Fi (אפשר רק כאשר \'התקשרות Wi-Fi\' מאופשרת במכשיר שלך)</string>
   <string name="preferences__incognito_keyboard">מקלדת סמויה</string>
   <string name="preferences__read_receipts">אישורי קריאה</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">אם אישורי קריאה מושבתים, לא תוכל לראות אישורי קריאה מאחרים.</string>
@@ -2259,7 +2259,7 @@
   <string name="preferences_data_and_storage__calls">שיחות</string>
   <string name="preferences_data_and_storage__use_less_data_for_calls">השתמש בפחות נתונים עבור שיחות</string>
   <string name="preferences_data_and_storage__never">אף פעם</string>
-  <string name="preferences_data_and_storage__wifi_and_cellular">WiFi וסלולרי</string>
+  <string name="preferences_data_and_storage__wifi_and_cellular">Wi-Fi וסלולרי</string>
   <string name="preferences_data_and_storage__cellular_only">סלולרי בלבד</string>
   <string name="preference_data_and_storage__using_less_data_may_improve_calls_on_bad_networks">שימוש בפחות נתונים עשוי לשפר שיחות על רשתות גרועות</string>
   <string name="preferences_notifications__messages">הודעות</string>

--- a/app/src/main/res/values-ku/strings.xml
+++ b/app/src/main/res/values-ku/strings.xml
@@ -1445,7 +1445,7 @@
   <!--prompt_passphrase_activity-->
   <string name="prompt_passphrase_activity__unlock">Kilîde veke</string>
   <!--prompt_mms_activity-->
-  <string name="prompt_mms_activity__signal_requires_mms_settings_to_deliver_media_and_group_messages">Ji bo şandina medya û peyamên komê ser WiFi, Signal şikila MMS dixwaze. Vê agahî ser cihazê te bêfêde ye, belkî amûr biqif e, an şikil gelek astengker e.</string>
+  <string name="prompt_mms_activity__signal_requires_mms_settings_to_deliver_media_and_group_messages">Ji bo şandina medya û peyamên komê ser Wi-Fi, Signal şikila MMS dixwaze. Vê agahî ser cihazê te bêfêde ye, belkî amûr biqif e, an şikil gelek astengker e.</string>
   <string name="prompt_mms_activity__to_send_media_and_group_messages_tap_ok">Ji bo şandina medya û peyamên komê, \'OK\' lêxe û şikila pêwîst xelas bike. Şikila MMS ji bo şirketa torrê di normal de dikare bê peydakirin bi lêgerrina \'your carrier APN\'. Pêwîst ku tu tenê carek wisa bikî.</string>
   <!--profile_create_activity-->
   <string name="CreateProfileActivity_first_name_required">Nav (hewce)</string>
@@ -1643,7 +1643,7 @@
   <string name="preferences__submit_debug_log">Tomara pînekirina çewtiyan bişîne</string>
   <string name="preferences__delete_account">Hesêb jê be</string>
   <string name="preferences__support_wifi_calling">Moda hevahengiya \'Bangewaziyên WiFiyê\'</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Eger amûra te gihandina SMS/MMSê ya ji ser \'WiFi\'yê bi kar bîne, rê bide (tenê dema \'Lêgerîna WiFiyê\' ser amûra te vekirî be bila çalak be)</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Eger amûra te gihandina SMS/MMSê ya ji ser \'Wi-Fi\'yê bi kar bîne, rê bide (tenê dema \'Lêgerîna WiFiyê\' ser amûra te vekirî be bila çalak be)</string>
   <string name="preferences__incognito_keyboard">Klavyeya veşartî</string>
   <string name="preferences__read_receipts">Hat xwendin</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Heger xwendina reçete qedexe be tu nikarî reçete ji kesên din bixwînî.</string>
@@ -1683,7 +1683,7 @@
   <string name="preferences_data_and_storage__manage_storage">Bîrgehê birêve bibe</string>
   <string name="preferences_data_and_storage__calls">Gerîn</string>
   <string name="preferences_data_and_storage__never">Qet</string>
-  <string name="preferences_data_and_storage__wifi_and_cellular">WiFi û Hucreyî</string>
+  <string name="preferences_data_and_storage__wifi_and_cellular">Wi-Fi û Hucreyî</string>
   <string name="preferences_data_and_storage__cellular_only">Tenê hucreyî</string>
   <string name="preferences_notifications__messages">Peyam</string>
   <string name="preferences_notifications__events">Çalakî</string>

--- a/app/src/main/res/values-lg/strings.xml
+++ b/app/src/main/res/values-lg/strings.xml
@@ -388,7 +388,7 @@ gy\'olonze (%s) sintuufu.</string>
   <string name="MessageNotifier_reply">ddamu</string>
   <string name="MessageNotifier_unknown_contact_message">Contact</string>
   <!--Notification Channels-->
-  <string name="NotificationChannel_messages">wifi calling compatiblity mode</string>
+  <string name="NotificationChannel_messages">Wi-Fi calling compatiblity mode</string>
   <string name="NotificationChannel_missing_display_name">Tekimanyikiddwa</string>
   <!--QuickResponseService-->
   <string name="QuickResponseService_quick_response_unavailable_when_Signal_is_locked">okudamu okwangu tekubawo nga amayengo gasibidwa</string>
@@ -644,13 +644,13 @@ gy\'olonze (%s) sintuufu.</string>
   <string name="preferences__dark_theme">Kizikiza</string>
   <string name="preferences__appearance">ndabika</string>
   <string name="preferences__theme">omulamwa</string>
-  <string name="preferences__default">wifi calling compatiblity mode</string>
+  <string name="preferences__default">Wi-Fi calling compatiblity mode</string>
   <string name="preferences__language">Lulimi</string>
   <string name="preferences__signal_messages_and_calls">Obubaka na massinu ga Signal</string>
   <string name="preferences__free_private_messages_and_calls">Obubaka obwekyama na massimu ku bakozesa ba Signal</string>
   <string name="preferences__submit_debug_log">Waayo olukalala bili kibaddewo</string>
-  <string name="preferences__support_wifi_calling">\'WiFi Calling\' compatibility mode</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Enable if your device uses SMS/MMS delivery over WiFi (only enable when \'WiFi Calling\' is enabled on your device)</string>
+  <string name="preferences__support_wifi_calling">\'Wi-Fi Calling\' compatibility mode</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Enable if your device uses SMS/MMS delivery over Wi-Fi (only enable when \'Wi-Fi Calling\' is enabled on your device)</string>
   <!-- Removed by excludeNonTranslatables <string name="preferences_app_protection__blocked_contacts">Kuziyiza contact</string> -->
   <string name="preferences_chats__when_using_mobile_data">Bwoba okozesa dat we ssimu</string>
   <string name="preferences_chats__when_using_wifi">Bwoba okozesa WI-Fi</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -2200,7 +2200,7 @@
   <string name="preferences__submit_debug_log">Pateikti derinimo žurnalą</string>
   <string name="preferences__delete_account">Ištrinti paskyrą</string>
   <string name="preferences__support_wifi_calling">„Wi-Fi skambučių“ suderinamumo veiksena</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Įjunkite, jeigu jūsų įrenginys siunčia SMS/MMS per belaidį (WiFi) tinklą (įjunkite tik tuo atveju, jeigu jūsų įrenginyje yra aktyvuota „WiFi skambučių“ funkcija)</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Įjunkite, jeigu jūsų įrenginys siunčia SMS/MMS per belaidį (Wi-Fi) tinklą (įjunkite tik tuo atveju, jeigu jūsų įrenginyje yra aktyvuota „Wi-Fi skambučių“ funkcija)</string>
   <string name="preferences__incognito_keyboard">Inkognito klaviatūra</string>
   <string name="preferences__read_receipts">Pranešimai apie žinučių skaitymą</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Jeigu pranešimai apie žinučių skaitymą yra išjungti, jūs negalėsite matyti kitų žmonių pranešimų apie žinučių skaitymą.</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -2048,8 +2048,8 @@
   <string name="preferences__free_private_messages_and_calls">സിഗ്നൽ ഉപയോക്താക്കൾക്ക് സൗജന്യ സ്വകാര്യ സന്ദേശങ്ങളും കോളുകളും</string>
   <string name="preferences__submit_debug_log">ഡീബഗ് ലോഗ് സമർപ്പിക്കുക</string>
   <string name="preferences__delete_account">അക്കൗണ്ട് ഇല്ലാതാക്കുക</string>
-  <string name="preferences__support_wifi_calling">\'WiFi കോളിംഗ്\' അനുയോജ്യത മോഡ്</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">നിങ്ങളുടെ ഉപകരണം WiFi വഴി SMS/MMS ഡെലിവറി ഉപയോഗിക്കുന്നുവെങ്കിൽ പ്രവർത്തനക്ഷമമാക്കുക (ഉപകരണത്തിൽ \'WiFi കോളിംഗ്\' പ്രാപ്‌തമാക്കിയാൽ മാത്രം ഇത് പ്രവർത്തനക്ഷമമാക്കുക)</string>
+  <string name="preferences__support_wifi_calling">\'Wi-Fi കോളിംഗ്\' അനുയോജ്യത മോഡ്</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">നിങ്ങളുടെ ഉപകരണം Wi-Fi വഴി SMS/MMS ഡെലിവറി ഉപയോഗിക്കുന്നുവെങ്കിൽ പ്രവർത്തനക്ഷമമാക്കുക (ഉപകരണത്തിൽ \'Wi-Fi കോളിംഗ്\' പ്രാപ്‌തമാക്കിയാൽ മാത്രം ഇത് പ്രവർത്തനക്ഷമമാക്കുക)</string>
   <string name="preferences__incognito_keyboard">ഇൻകോഗ്നിറ്റോ കീബോർഡ്</string>
   <string name="preferences__read_receipts">വായന രസീതുകൾ</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">വായന രസീതുകൾ അപ്രാപ്തമാക്കിയിട്ടുണ്ടെങ്കിൽ, മറ്റുള്ളവരിൽ നിന്നുള്ള വായന രസീതുകൾ നിങ്ങൾക്ക് കാണാൻ കഴിയില്ല.</string>

--- a/app/src/main/res/values-mr/strings.xml
+++ b/app/src/main/res/values-mr/strings.xml
@@ -1392,8 +1392,8 @@
   <string name="preferences__signal_messages_and_calls">Signal संदेश आणि कॉल</string>
   <string name="preferences__free_private_messages_and_calls">Signal वापरकर्त्यांना विनामुल्य खाजगी संदेश आणि कॉल</string>
   <string name="preferences__submit_debug_log">डीबग लॉग प्रविष्ट करा</string>
-  <string name="preferences__support_wifi_calling">\'WiFi कॉलिंग\' सुसंगतता मोड</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">जर आपला डिव्हाईस WiFi वर SMS/MMS पोहचवत असेल तर सक्षम करा(फक्त \'WiFi कॉलिंग\' सक्षम असल्यावरच सक्षम करा)</string>
+  <string name="preferences__support_wifi_calling">\'Wi-Fi कॉलिंग\' सुसंगतता मोड</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">जर आपला डिव्हाईस Wi-Fi वर SMS/MMS पोहचवत असेल तर सक्षम करा(फक्त \'Wi-Fi कॉलिंग\' सक्षम असल्यावरच सक्षम करा)</string>
   <string name="preferences__incognito_keyboard">इनकॉग्निटो कीबोर्ड</string>
   <string name="preferences__read_receipts">वाचले पावत्या</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">जर आपल्या वाचल्याचा पावत्या अक्षम असतील तर आपल्याला इतरांकडूनही त्या मिळणार नाहीत.</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1172,7 +1172,7 @@ Menerima mesej pertukaran kunci untuk versi protokol yang tidak sah.</string>
   <string name="preferences__free_private_messages_and_calls">Mesej dan panggilan sulit percuma kepada pengguna Signal</string>
   <string name="preferences__submit_debug_log">Menghantar log debug</string>
   <string name="preferences__support_wifi_calling">Mod keserasian \'Panggilan WiFI\' </string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Dayakan jika peranti anda menggunakan penghantaran SMS/MMS melalui WiFi (hanya dayakan apabila \'Panggilan WiFi\' diaktifkan pada peranti anda)</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Dayakan jika peranti anda menggunakan penghantaran SMS/MMS melalui Wi-Fi (hanya dayakan apabila \'Panggilan Wi-Fi\' diaktifkan pada peranti anda)</string>
   <string name="preferences__incognito_keyboard">Papan kekunci incognito</string>
   <string name="preferences__read_receipts">Resit dibaca</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Jika resit baca dinyahdayakan, anda tidak akan dapat melihat resit baca dari orang lain.</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -986,8 +986,8 @@
   <string name="preferences__signal_messages_and_calls">Signal စာများနှင့် ဖုန်းခေါ်ဆိုမှုများ</string>
   <string name="preferences__free_private_messages_and_calls">Signal အသုံးပြုသူများအတွက် အခမဲ့စာများနှင့် ဖုန်းခေါ်ဆိုမှုများ</string>
   <string name="preferences__submit_debug_log">Debug log ကို တင်ပြပါ</string>
-  <string name="preferences__support_wifi_calling">\'WiFi Calling\' လိုက်လျောညီထွေမှု ရှိသည့် ပုံစံ</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">သင့်ဖုန်းမှ ဝိုင်ဖိုင် အသုံးပြု၍ SMS/MMS ပေးပို့ခြင်းကို အသုံးပြုပါက လုပ်ဆောင်ချက်ကို ဖွင့်ပါ (\'WiFi Calling\'လုပ်ဆောင်ချက်ကို သင့်ဖုန်းက ဖွင့်ထားမှသာ လုပ်ဆောင်ပါ)</string>
+  <string name="preferences__support_wifi_calling">\'Wi-Fi Calling\' လိုက်လျောညီထွေမှု ရှိသည့် ပုံစံ</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">သင့်ဖုန်းမှ ဝိုင်ဖိုင် အသုံးပြု၍ SMS/MMS ပေးပို့ခြင်းကို အသုံးပြုပါက လုပ်ဆောင်ချက်ကို ဖွင့်ပါ (\'Wi-Fi Calling\'လုပ်ဆောင်ချက်ကို သင့်ဖုန်းက ဖွင့်ထားမှသာ လုပ်ဆောင်ပါ)</string>
   <string name="preferences__incognito_keyboard">နောက်ယောင်ခံမှု မရှိသည့် ကီးဘုတ်</string>
   <string name="preferences__read_receipts">ဖတ်ပြီးပြီ</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">စာဖတ်ပြီး​ကြောင်းပြသည်ကို ပိတ်ထားပါက တခြားသူများထံမှ ဖတ်ပြီး​ကြောင်းပြသည်ကိုလည်း မြင်ရမည်မဟုတ်ပါ။</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -2064,8 +2064,8 @@ Signal zal nu toestemming vragen om je contactenlijst te lezen, om na te gaan wi
   <string name="preferences__free_private_messages_and_calls">Gratis privéberichten en bellen met Signal-gebruikers</string>
   <string name="preferences__submit_debug_log">Foutopsporingslog indienen</string>
   <string name="preferences__delete_account">Al je gegevens wissen</string>
-  <string name="preferences__support_wifi_calling">‘Bellen via wifi’-compatibiliteitsmodus</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Schakel dit in als je gebruik wilt maken van sms/mms over wifi (schakel dit alleen in als ook ‘Bellen via wifi’ is ingeschakeld op je apparaat)</string>
+  <string name="preferences__support_wifi_calling">‘Bellen via Wi-Fi’-compatibiliteitsmodus</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Schakel dit in als je gebruik wilt maken van sms/mms over Wi-Fi (schakel dit alleen in als ook ‘Bellen via Wi-Fi’ is ingeschakeld op je apparaat)</string>
   <string name="preferences__incognito_keyboard">Incognito toetsenbord</string>
   <string name="preferences__read_receipts">Leesbevestigingen</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Als leesbevestigingen zijn uitgeschakeld kunnen anderen niet zien of je hun berichten hebt gelezen, maar je zult ook niet kunnen zien of anderen jouw berichten hebben gelezen.</string>
@@ -2074,7 +2074,7 @@ Signal zal nu toestemming vragen om je contactenlijst te lezen, om na te gaan wi
   <string name="preferences__request_keyboard_to_disable_personalized_learning">Voorkom gepersonaliseerd leren door het toetsenbord</string>
   <string name="preferences_app_protection__blocked_users">Geblokkeerde personen</string>
   <string name="preferences_chats__when_using_mobile_data">Bij mobielegegevensoverdracht</string>
-  <string name="preferences_chats__when_using_wifi">Bij wifi-verbinding</string>
+  <string name="preferences_chats__when_using_wifi">Bij Wi-Fi-verbinding</string>
   <string name="preferences_chats__when_roaming">Bij roaming</string>
   <string name="preferences_chats__media_auto_download">Media automatisch downloaden</string>
   <string name="preferences_chats__message_history">Gespreksgeschiedenis</string>
@@ -2111,7 +2111,7 @@ Signal zal nu toestemming vragen om je contactenlijst te lezen, om na te gaan wi
   <string name="preferences_data_and_storage__calls">Oproepen</string>
   <string name="preferences_data_and_storage__use_less_data_for_calls">Minder gegevensoverdracht bij oproepen</string>
   <string name="preferences_data_and_storage__never">Nooit</string>
-  <string name="preferences_data_and_storage__wifi_and_cellular">Bij wifi en mobiele-gegevensoverdracht</string>
+  <string name="preferences_data_and_storage__wifi_and_cellular">Bij Wi-Fi en mobiele-gegevensoverdracht</string>
   <string name="preferences_data_and_storage__cellular_only">Alleen bij mobiele-gegevensoverdracht</string>
   <string name="preference_data_and_storage__using_less_data_may_improve_calls_on_bad_networks">Gebruik maken van minder gegevensoverdracht bij oproepen kan de kwaliteit van oproepen verbeteren</string>
   <string name="preferences_notifications__messages">Berichten</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -2064,8 +2064,8 @@ Ved registrering sender me litt kontaktinformasjon til tenaren. Informasjonen ve
   <string name="preferences__free_private_messages_and_calls">Gratis privatmeldingar og -samtalar til Signal-brukarar</string>
   <string name="preferences__submit_debug_log">Send feilsøkingslogg</string>
   <string name="preferences__delete_account">Slett konto</string>
-  <string name="preferences__support_wifi_calling">«Wifi-samtale»-tilbakefallsmodus</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Bruk dette viss eininga leverer SMS / MMS over Wifi og «Wifi-samtale» er slått på)</string>
+  <string name="preferences__support_wifi_calling">«Wi-Fi-samtale»-tilbakefallsmodus</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Bruk dette viss eininga leverer SMS / MMS over Wi-Fi og «Wi-Fi-samtale» er slått på)</string>
   <string name="preferences__incognito_keyboard">Inkognitotastatur</string>
   <string name="preferences__read_receipts">Lesekvitteringar</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Viss du har skrudd av lesekvitteringar, får du heller ikkje sjå andre sine lesekvitteringar.</string>
@@ -2074,7 +2074,7 @@ Ved registrering sender me litt kontaktinformasjon til tenaren. Informasjonen ve
   <string name="preferences__request_keyboard_to_disable_personalized_learning">Spør om tastatur for å skru av persontilpassa læring</string>
   <string name="preferences_app_protection__blocked_users">Blokkerte brukarar</string>
   <string name="preferences_chats__when_using_mobile_data">Ved bruk av mobildata</string>
-  <string name="preferences_chats__when_using_wifi">Ved bruk av Wifi</string>
+  <string name="preferences_chats__when_using_wifi">Ved bruk av Wi-Fi</string>
   <string name="preferences_chats__when_roaming">I framandnett</string>
   <string name="preferences_chats__media_auto_download">Automatisk nedlasting av media</string>
   <string name="preferences_chats__message_history">Meldingshistorikk</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -1430,7 +1430,7 @@
   <string name="preferences__free_private_messages_and_calls">Signal ਉਪਭੋਗਤਾਵਾਂ ਨੂੰ ਮੁਫਤ ਗੁਪਤ ਸੰਦੇਸ਼ ਅਤੇ ਕਾਲਾਂ</string>
   <string name="preferences__submit_debug_log">ਡੀਬੱਗ ਲਾਗ ਜਮ੍ਹਾਂ ਕਰੋ</string>
   <string name="preferences__support_wifi_calling">\'ਵਾਈਫਾਈ ਕਾਲਿੰਗ\' ਅਨੁਕੂਲਤਾ ਮੋਡ</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">ਜੇਕਰ ਤੁਹਾਡੀ ਡਿਵਾਈਸ WiFi ਦੀ ਜਗਾਹ SMS / MMS ਡਿਲਵਰੀ ਵਰਤਦੀ ਹੈ ਤਾਂ ਸਮਰੱਥ ਬਣਾਓ (ਕੇਵਲ ਉਦੋਂ ਸਮਰੱਥ ਕਰੋ ਜਦੋਂ ਤੁਹਾਡੀ ਡਿਵਾਈਸ ਤੇ\' WiFi Calling \'ਸਮਰਥਿਤ ਹੋਵੇ)</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">ਜੇਕਰ ਤੁਹਾਡੀ ਡਿਵਾਈਸ Wi-Fi ਦੀ ਜਗਾਹ SMS / MMS ਡਿਲਵਰੀ ਵਰਤਦੀ ਹੈ ਤਾਂ ਸਮਰੱਥ ਬਣਾਓ (ਕੇਵਲ ਉਦੋਂ ਸਮਰੱਥ ਕਰੋ ਜਦੋਂ ਤੁਹਾਡੀ ਡਿਵਾਈਸ ਤੇ\' Wi-Fi Calling \'ਸਮਰਥਿਤ ਹੋਵੇ)</string>
   <string name="preferences__incognito_keyboard">ਗੁਮਨਾਮ ਕੀਬੋਰਡ</string>
   <string name="preferences__read_receipts">ਪੜ੍ਹੀਆਂ ਹੋਇਆਂ ਰਸੀਦਾਂ</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">ਜੇਕਰ ਰਸੀਦਾਂ ਦੀਆਂ ਰਸੀਦਾਂ ਅਯੋਗ ਹਨ, ਤਾਂ ਤੁਸੀਂ ਹੋਰਨਾਂ ਤੋਂ ਪੜ੍ਹੀਆਂ ਰਸੀਦਾਂ ਵੇਖ ਨਹੀਂ ਸਕੋਗੇ</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -2204,8 +2204,8 @@ Otrzymano wiadomość wymiany klucz dla niepoprawnej wersji protokołu.</string>
   <string name="preferences__free_private_messages_and_calls">Darmowe oraz prywatne wiadomości i połączenia do użytkowników Signal</string>
   <string name="preferences__submit_debug_log">Wyślij logi debugowania</string>
   <string name="preferences__delete_account">Usuń konto</string>
-  <string name="preferences__support_wifi_calling">Tryb zgodności \"WiFi Calling\"</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Włącz jeśli Twoje urządzenie używa dostarczania SMS/MMS przez WiFi (włącz tylko wtedy gdy \"WiFi Calling\" jest włączone na Twoim urządzeniu)</string>
+  <string name="preferences__support_wifi_calling">Tryb zgodności \"Wi-Fi Calling\"</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Włącz jeśli Twoje urządzenie używa dostarczania SMS/MMS przez Wi-Fi (włącz tylko wtedy gdy \"Wi-Fi Calling\" jest włączone na Twoim urządzeniu)</string>
   <string name="preferences__incognito_keyboard">Klawiatura w trybie prywatnym</string>
   <string name="preferences__read_receipts">Potwierdzenia przeczytania</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Gdy potwierdzenia przeczytania są wyłączone, Ty również nie będziesz otrzymywać potwierdzeń od innych użytkowników.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2206,7 +2206,7 @@
   <string name="preferences__submit_debug_log">Отправить журнал отладки</string>
   <string name="preferences__delete_account">Удалить учётную запись</string>
   <string name="preferences__support_wifi_calling">Совместимость с Wi-Fi звонками</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Включите, если ваше устройство отправляет и принимает SMS и MMS через WiFi (включайте, только если «Звонки по WiFi» включены на вашем устройстве)</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Включите, если ваше устройство отправляет и принимает SMS и MMS через Wi-Fi (включайте, только если «Звонки по Wi-Fi» включены на вашем устройстве)</string>
   <string name="preferences__incognito_keyboard">Инкогнито-клавиатура</string>
   <string name="preferences__read_receipts">Уведомления о прочтении</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Если уведомления о прочтении отключены, вы не сможете видеть уведомления о прочтении от других пользователей.</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -2209,8 +2209,8 @@ Bola prijatá správa výmeny kľúčov s neplatnou verziou protokolu.
   <string name="preferences__free_private_messages_and_calls">Bezplatné zabezpečené správy a hovory medzi užívateľmi Signalu</string>
   <string name="preferences__submit_debug_log">Odoslať ladiaci záznam</string>
   <string name="preferences__delete_account">Vymazať účet</string>
-  <string name="preferences__support_wifi_calling">Režim kompatibility \'WiFi volania\'</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Zapnite ak vaše zariadenie používa doručenie SMS/MMS cez WiFi (zapnite len ak sú \"WiFi volania\" zapnuté na vašom zariadení)</string>
+  <string name="preferences__support_wifi_calling">Režim kompatibility \'Wi-Fi volania\'</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Zapnite ak vaše zariadenie používa doručenie SMS/MMS cez Wi-Fi (zapnite len ak sú \"Wi-Fi volania\" zapnuté na vašom zariadení)</string>
   <string name="preferences__incognito_keyboard">Inkognito klávesnica</string>
   <string name="preferences__read_receipts">Potvrdenia o prečítaní</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Keď máte vypnuté potvrdenia o prečítaní, nebudete dostávať potvrdenia ani od ostatných.</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -2203,8 +2203,8 @@ Prejeto sporočilo za izmenjavo ključev za napačno različico protokola.</stri
   <string name="preferences__free_private_messages_and_calls">Brezplačna zasebna sporočila in klici uporabnikom/cam aplikacije Signal</string>
   <string name="preferences__submit_debug_log">Oddaj sistemsko zabeležbo</string>
   <string name="preferences__delete_account">Izbris računa</string>
-  <string name="preferences__support_wifi_calling">\'WiFi calling\' združljivostni način</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Aktivirajte, če dostava SMS/MMS sporočil na vaši napravi poteka preko povezave WiFi (samo, če imate vklopljeno WiFi klicanje/WiFi Calling)</string>
+  <string name="preferences__support_wifi_calling">\'Wi-Fi calling\' združljivostni način</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Aktivirajte, če dostava SMS/MMS sporočil na vaši napravi poteka preko povezave Wi-Fi (samo, če imate vklopljeno Wi-Fi klicanje/Wi-Fi Calling)</string>
   <string name="preferences__incognito_keyboard">Inkognito tipkovnica</string>
   <string name="preferences__read_receipts">Potrdila o ogledu</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Če izklopite poročila o ogledu, tudi sami ne boste obveščeni, ko bo prejemnik prebral vaše sporočilo.</string>
@@ -2250,7 +2250,7 @@ Prejeto sporočilo za izmenjavo ključev za napačno različico protokola.</stri
   <string name="preferences_data_and_storage__calls">Klici</string>
   <string name="preferences_data_and_storage__use_less_data_for_calls">Porabi manj podatkov za klice</string>
   <string name="preferences_data_and_storage__never">Nikoli</string>
-  <string name="preferences_data_and_storage__wifi_and_cellular">WiFi in mobilni podatki</string>
+  <string name="preferences_data_and_storage__wifi_and_cellular">Wi-Fi in mobilni podatki</string>
   <string name="preferences_data_and_storage__cellular_only">Samo mobilni podatki</string>
   <string name="preference_data_and_storage__using_less_data_may_improve_calls_on_bad_networks">Poraba manj podatkov pri klicih lahko izboljša zanesljivost klicov v slabih omrežjih</string>
   <string name="preferences_notifications__messages">Sporočila</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -2060,8 +2060,8 @@ aktivizoni Kyçje Regjistrimi, teksa PIN-i është i çaktivizuar.</string>
   <string name="preferences__free_private_messages_and_calls">Mesazhe dhe thirrje falas drejt përdoruesish të Signal-it</string>
   <string name="preferences__submit_debug_log">Parashtro regjistër diagnostikimi</string>
   <string name="preferences__delete_account">Fshije llogarinë</string>
-  <string name="preferences__support_wifi_calling">Mënyrë përputhshmëri me \'Thirrje Wifi\'</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Aktivizojeni nëse pajisja juaj përdor dërgim SMS/MMS-sh përmes WiFi (aktivizojeni vetëm kur \'Thirrje Wifi\' janë të aktivizuara në pajisjen tuaj).</string>
+  <string name="preferences__support_wifi_calling">Mënyrë përputhshmëri me \'Thirrje Wi-Fi\'</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Aktivizojeni nëse pajisja juaj përdor dërgim SMS/MMS-sh përmes WiFi (aktivizojeni vetëm kur \'Thirrje Wi-Fi\' janë të aktivizuara në pajisjen tuaj).</string>
   <string name="preferences__incognito_keyboard">Tastiera inkonjito</string>
   <string name="preferences__read_receipts">Dëftesa leximi</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Nëse dëftesat e leximit janë të çaktivizuara, s\’do të jeni në gjendje të shihni dëftesa leximi nga të tjerët.</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -1323,7 +1323,7 @@ nambari yako ya simu</string>
   <string name="preferences__free_private_messages_and_calls">Ujumbe wa faragha wa bure na simu kwa watumiaji wa Signal</string>
   <string name="preferences__submit_debug_log">Wasilisha tunzakumbukumbu ya ueuaji</string>
   <string name="preferences__support_wifi_calling">\'\'Simu ya Wi-Fi\' aina ya utangamano</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Wezesha iwapo kifaa chako kinatumia uwasilishaji wa SMS / MMS juu ya WiFi (wezesha tu wakati \"Simu ya WiFi\" imewezeshwa kwenye kifaa chako)</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Wezesha iwapo kifaa chako kinatumia uwasilishaji wa SMS / MMS juu ya Wi-Fi (wezesha tu wakati \"Simu ya Wi-Fi\" imewezeshwa kwenye kifaa chako)</string>
   <string name="preferences__incognito_keyboard">Baobonye isiyotambulika</string>
   <string name="preferences__read_receipts">Jumbe zilizosomwa</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Ikiwa jumbe zilizosomwa zimemalemezwa, hutaweza kuona jumbe zilizosomwa kutoka kwa wengine</string>
@@ -1332,7 +1332,7 @@ nambari yako ya simu</string>
   <string name="preferences__request_keyboard_to_disable_personalized_learning">Omba kibaobonye kulemaza kujifunza kwa kibinafsi</string>
   <!-- Removed by excludeNonTranslatables <string name="preferences_app_protection__blocked_contacts">Wawasiliani waliozuiliwa</string> -->
   <string name="preferences_chats__when_using_mobile_data">Wakati unatumia mtandao wa simu</string>
-  <string name="preferences_chats__when_using_wifi">Wakati unatumia WiFi</string>
+  <string name="preferences_chats__when_using_wifi">Wakati unatumia Wi-Fi</string>
   <string name="preferences_chats__when_roaming">Wakati unarandaranda </string>
   <string name="preferences_chats__media_auto_download">Media kupakua kiotomatiki</string>
   <!-- Removed by excludeNonTranslatables <string name="preferences_chats__message_trimming">Upunguzaji ujumbe </string> -->

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -1493,8 +1493,8 @@
   <string name="preferences__signal_messages_and_calls">ข้อความและการโทร Signal</string>
   <string name="preferences__free_private_messages_and_calls">โทรและส่งข้อความส่วนตัวถึงผู้ใช้ Signal ฟรี</string>
   <string name="preferences__submit_debug_log">ส่งปูมดีบัก</string>
-  <string name="preferences__support_wifi_calling">โหมดที่เข้ากันได้กับ \'โทรผ่าน WiFi\'</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">เปิดใช้งานถ้าอุปกรณ์ของคุณใช้การส่ง SMS/MMS ผ่าน WiFi (จะเปิดใช้งานได้ก็ต่อเมื่อ \'โทรผ่าน WiFi\' ถูกเปิดใช้งานบนอุปกรณ์ของคุณ)</string>
+  <string name="preferences__support_wifi_calling">โหมดที่เข้ากันได้กับ \'โทรผ่าน Wi-Fi\'</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">เปิดใช้งานถ้าอุปกรณ์ของคุณใช้การส่ง SMS/MMS ผ่าน Wi-Fi (จะเปิดใช้งานได้ก็ต่อเมื่อ \'โทรผ่าน Wi-Fi\' ถูกเปิดใช้งานบนอุปกรณ์ของคุณ)</string>
   <string name="preferences__incognito_keyboard">แป้นพิมพ์แบบลับ</string>
   <string name="preferences__read_receipts">ใบตอบรับเมื่ออ่าน</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">ถ้าใบตอบรับเมื่ออ่านถูกปิดใช้งาน คุณจะไม่เห็นใบตอบรับเมื่ออ่านที่ส่งมาจากผู้อื่น</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1101,8 +1101,8 @@
   <string name="preferences__signal_messages_and_calls">Повідомлення та виклики Signal</string>
   <string name="preferences__free_private_messages_and_calls">Безкоштовні приватні повідомлення та виклики для користувачів Signal</string>
   <string name="preferences__submit_debug_log">Надіслати журнал відлагодження</string>
-  <string name="preferences__support_wifi_calling">Режим сумісності \'WiFi Calling\'</string>
-  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Увімкніть, якщо ваш пристрій використовує доставку SMS/MMS через WiFi (вмикайте лише якщо «WiFi Calling» увімкнені на вашому пристрої)</string>
+  <string name="preferences__support_wifi_calling">Режим сумісності \'Wi-Fi Calling\'</string>
+  <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Увімкніть, якщо ваш пристрій використовує доставку SMS/MMS через Wi-Fi (вмикайте лише якщо «Wi-Fi Calling» увімкнені на вашому пристрої)</string>
   <string name="preferences__incognito_keyboard">Клавіатура в режимі \"інкогніто\"</string>
   <string name="preferences__read_receipts">Звіти про прочитання</string>
   <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">Якщо звіти про прочитання вимкнено, ви не зможете отримувати звіти від інших.</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -2022,7 +2022,7 @@ Nhận thông tin trao đổi mã khóa về phiên bản giao thức không h�
   <string name="preferences_data_and_storage__calls">Cuộc gọi</string>
   <string name="preferences_data_and_storage__use_less_data_for_calls">Sử dụng ít lưu lượng data hơn khi gọi</string>
   <string name="preferences_data_and_storage__never">Không bao giờ</string>
-  <string name="preferences_data_and_storage__wifi_and_cellular">Wifi và Mạng di động</string>
+  <string name="preferences_data_and_storage__wifi_and_cellular">Wi-Fi và Mạng di động</string>
   <string name="preferences_data_and_storage__cellular_only">Chỉ dùng mạng di động</string>
   <string name="preference_data_and_storage__using_less_data_may_improve_calls_on_bad_networks">Sử dụng ít lưu lượng data có thể cải thiện chất lượng cuộc gọi trong môi trường mạng kém</string>
   <string name="preferences_notifications__messages">Tin nhắn</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2413,8 +2413,8 @@
     <string name="preferences__free_private_messages_and_calls">Free private messages and calls to Signal users</string>
     <string name="preferences__submit_debug_log">Submit debug log</string>
     <string name="preferences__delete_account">Delete account</string>
-    <string name="preferences__support_wifi_calling">\'WiFi Calling\' compatibility mode</string>
-    <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Enable if your device uses SMS/MMS delivery over WiFi (only enable when \'WiFi Calling\' is enabled on your device)</string>
+    <string name="preferences__support_wifi_calling">\'Wi-Fi Calling\' compatibility mode</string>
+    <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Enable if your device uses SMS/MMS delivery over Wi-Fi (only enable when \'Wi-Fi Calling\' is enabled on your device)</string>
     <string name="preferences__incognito_keyboard">Incognito keyboard</string>
     <string name="preferences__read_receipts">Read receipts</string>
     <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">If read receipts are disabled, you won\'t be able to see read receipts from others.</string>
@@ -2460,7 +2460,7 @@
     <string name="preferences_data_and_storage__calls">Calls</string>
     <string name="preferences_data_and_storage__use_less_data_for_calls">Use less data for calls</string>
     <string name="preferences_data_and_storage__never">Never</string>
-    <string name="preferences_data_and_storage__wifi_and_cellular">WiFi and Cellular</string>
+    <string name="preferences_data_and_storage__wifi_and_cellular">Wi-Fi and Cellular</string>
     <string name="preferences_data_and_storage__cellular_only">Cellular only</string>
     <string name="preference_data_and_storage__using_less_data_may_improve_calls_on_bad_networks">Using less data may improve calls on bad networks</string>
     <string name="preferences_notifications__messages">Messages</string>


### PR DESCRIPTION
Replaced all text occurrences like 'wifi', 'Wifi' and 'WiFi' to 'Wi-Fi'.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
