### PR TITLE
Fixes #10684 - Links won't open in new tabs on stock chrome

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/CommunicationActions.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/CommunicationActions.java
@@ -142,6 +142,9 @@ public class CommunicationActions {
   public static void openBrowserLink(@NonNull Context context, @NonNull String link) {
     try {
       Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(link));
+      Bundle b = new Bundle();
+      b.putBoolean("new_window", true); //sets new window
+      intent.putExtras(b);
       context.startActivity(intent);
     } catch (ActivityNotFoundException e) {
       Toast.makeText(context, R.string.CommunicationActions_no_browser_found, Toast.LENGTH_SHORT).show();


### PR DESCRIPTION
Fixes #10684

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
It fixes an issue where links wouln't open new tabs. I copied enough code to replicate the issue in Android Studio and then applied the fix.
-->
