### PR TITLE
Made input bar background transparent to show wallpaper

### DIFF
--- a/app/src/main/res/drawable/conversation_attachment_keyboard_background.xml
+++ b/app/src/main/res/drawable/conversation_attachment_keyboard_background.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <solid android:color="@color/signal_background_primary" />
-
-    <padding
-        android:left="1dp"
-        android:right="1dp"
-        android:bottom="1dp"
-        android:top="1dp" />
-
     <corners android:topLeftRadius="5dp" android:topRightRadius="5dp" />
 </shape>

--- a/app/src/main/res/drawable/conversation_attachment_keyboard_background.xml
+++ b/app/src/main/res/drawable/conversation_attachment_keyboard_background.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/signal_background_primary" />
+
+    <padding
+        android:left="1dp"
+        android:right="1dp"
+        android:bottom="1dp"
+        android:top="1dp" />
+
+    <corners android:topLeftRadius="5dp" android:topRightRadius="5dp" />
+</shape>

--- a/app/src/main/res/layout/conversation_activity_attachment_keyboard_stub.xml
+++ b/app/src/main/res/layout/conversation_activity_attachment_keyboard_stub.xml
@@ -5,6 +5,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:visibility="gone"
-        android:paddingTop="10dp"
+        android:paddingTop="6dp"
         android:paddingBottom="5dp"
         android:background="@drawable/conversation_attachment_keyboard_background"/>

--- a/app/src/main/res/layout/conversation_activity_attachment_keyboard_stub.xml
+++ b/app/src/main/res/layout/conversation_activity_attachment_keyboard_stub.xml
@@ -4,4 +4,7 @@
         android:id="@+id/attachment_keyboard"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:visibility="gone" />
+        android:visibility="gone"
+        android:paddingTop="10dp"
+        android:paddingBottom="5dp"
+        android:background="@drawable/conversation_attachment_keyboard_background"/>

--- a/app/src/main/res/layout/conversation_input_panel.xml
+++ b/app/src/main/res/layout/conversation_input_panel.xml
@@ -7,7 +7,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:background="@color/signal_background_primary"
     android:clipChildren="false"
     android:clipToPadding="false">
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * OnePlus 6T, Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
This pull request does a small design change to the new wallpaper feature.
The input bar background is made transparent such that the wallpaper can be seen.
The background of the attachment keyboard is changed to have rounded corners at the top.

Find a screenshot here with single color wallpaper:
![signalpull](https://user-images.githubusercontent.com/33359018/105490717-7a8f9c00-5cb5-11eb-99ff-03b249fe43f2.jpg)


It's a small request as I have been working on the chat functionality wallpaper myself but this is obsolete now.
