### PR TITLE
Move friends invitation to the top

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/ContactSelectionListFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ContactSelectionListFragment.java
@@ -132,7 +132,6 @@ public final class ContactSelectionListFragment extends LoggingFragment
 
 
   @Nullable private FixedViewsAdapter headerAdapter;
-  @Nullable private FixedViewsAdapter footerAdapter;
   @Nullable private ListCallback      listCallback;
   @Nullable private ScrollCallback    scrollCallback;
             private GlideRequests     glideRequests;
@@ -295,18 +294,12 @@ public final class ContactSelectionListFragment extends LoggingFragment
     RecyclerViewConcatenateAdapterStickyHeader concatenateAdapter = new RecyclerViewConcatenateAdapterStickyHeader();
 
     if (listCallback != null) {
-      headerAdapter = new FixedViewsAdapter(createNewGroupItem(listCallback));
+      headerAdapter = new FixedViewsAdapter(createNewGroupItem(listCallback), createInviteActionView(listCallback));
       headerAdapter.hide();
       concatenateAdapter.addAdapter(headerAdapter);
     }
 
     concatenateAdapter.addAdapter(cursorRecyclerViewAdapter);
-
-    if (listCallback != null) {
-      footerAdapter = new FixedViewsAdapter(createInviteActionView(listCallback));
-      footerAdapter.hide();
-      concatenateAdapter.addAdapter(footerAdapter);
-    }
 
     recyclerView.setAdapter(concatenateAdapter);
     recyclerView.addItemDecoration(new StickyHeaderDecoration(concatenateAdapter, true, true, 0));
@@ -398,10 +391,6 @@ public final class ContactSelectionListFragment extends LoggingFragment
     showContactsLayout.setVisibility(View.GONE);
 
     cursorRecyclerViewAdapter.changeCursor(data);
-
-    if (footerAdapter != null) {
-      footerAdapter.show();
-    }
 
     if (headerAdapter != null) {
       if (TextUtils.isEmpty(cursorFilter)) {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * OnePlus 7, Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
==> There are none that I'm aware of.

----------

### Description

This PR moves the "Invite friends" button to the top of the contact list.

Reasoning:
- streamline it with what iOS has
- give it more visibility. Because really, nobody scrolls down 100+ contacts. So previously, only when searching for someone you would come across the button.
