### PR TITLE
Add ripple to contact selection list items

### DIFF
--- a/app/src/main/res/layout/contact_selection_invite_action_item.xml
+++ b/app/src/main/res/layout/contact_selection_invite_action_item.xml
@@ -5,6 +5,7 @@
     style="@style/Signal.Text.Body"
     android:layout_width="match_parent"
     android:layout_height="@dimen/contact_selection_item_height"
+    android:background="?selectableItemBackground"
     android:drawablePadding="16dp"
     android:ellipsize="marquee"
     android:fontFamily="sans-serif-medium"

--- a/app/src/main/res/layout/contact_selection_list_item.xml
+++ b/app/src/main/res/layout/contact_selection_list_item.xml
@@ -6,7 +6,7 @@
     android:orientation="horizontal"
     android:gravity="center_vertical"
     android:focusable="true"
-    android:background="@drawable/conversation_item_background"
+    android:background="?selectableItemBackground"
     android:paddingStart="@dimen/selection_item_header_width"
     android:paddingEnd="24dp">
 

--- a/app/src/main/res/layout/contact_selection_new_group_item.xml
+++ b/app/src/main/res/layout/contact_selection_new_group_item.xml
@@ -5,6 +5,7 @@
     style="@style/Signal.Text.Body"
     android:layout_width="match_parent"
     android:layout_height="@dimen/contact_selection_item_height"
+    android:background="?selectableItemBackground"
     android:drawablePadding="16dp"
     android:ellipsize="marquee"
     android:fontFamily="sans-serif-medium"


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * OnePlus 7, Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
==> There are none that I'm aware of.

----------

### Description

This PR adds touch states to the items in the contact selection list.

For the `contact_selection_list_item` it is safe to replace the `@drawable/conversation_item_background` I believe.
That drawable only contains `state_selected` and `state_focussed`, which don't seem to be used for the contacts list.
