### PR TITLE
Fix issue #9160

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/ConversationTypingView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/ConversationTypingView.java
@@ -40,7 +40,7 @@ public class ConversationTypingView extends LinearLayout {
       return;
     }
 
-    Recipient typist = typists.get(0);
+    Recipient typist = typists.get(0).fresh();
     bubble.getBackground().setColorFilter(typist.getColor().toConversationColor(getContext()), PorterDuff.Mode.MULTIPLY);
 
     if (isGroupThread) {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Oneplus 3T, Android 10 (Lineage 17.1 MicroG)
 * Virtual device Pixel_3a_API_30_x86, Android 11
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
This pull request fixes the typing indicator not changing color after a new chat color has been selected.
