### PR TITLE
Hide content of disappearing messages

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListItem.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListItem.java
@@ -466,6 +466,8 @@ public final class ConversationListItem extends ConstraintLayout
       }
       String time = ExpirationUtil.getExpirationDisplayValue(context, seconds);
       return emphasisAdded(context, context.getString(R.string.ThreadRecord_disappearing_message_time_updated_to_s, time), defaultTint);
+    } else if (thread.getExpiresIn() > 0) {
+      return emphasisAdded(context, context.getString(R.string.ThreadRecord_new_disappearing_message_received), defaultTint);
     } else if (SmsDatabase.Types.isIdentityUpdate(thread.getType())) {
       return emphasisAdded(recipientToStringAsync(thread.getRecipient().getId(), r -> {
         if (r.isGroup()) {

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/AbstractNotificationBuilder.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/AbstractNotificationBuilder.java
@@ -76,9 +76,9 @@ public abstract class AbstractNotificationBuilder extends NotificationCompat.Bui
   }
 
   public void setTicker(@NonNull Recipient recipient, @Nullable CharSequence message) {
-    if (privacy.isDisplayMessage()) {
+    if (isDisplayMessage(recipient)) {
       setTicker(getStyledMessage(recipient, trimToDisplayLength(message)));
-    } else if (privacy.isDisplayContact()) {
+    } else if (isDisplayContact(recipient)) {
       setTicker(getStyledMessage(recipient, context.getString(R.string.AbstractNotificationBuilder_new_message)));
     } else {
       setTicker(context.getString(R.string.AbstractNotificationBuilder_new_message));
@@ -97,5 +97,13 @@ public abstract class AbstractNotificationBuilder extends NotificationCompat.Bui
 
     return text.length() <= MAX_DISPLAY_LENGTH ? text
                                                : text.subSequence(0, MAX_DISPLAY_LENGTH);
+  }
+
+  protected boolean isDisplayMessage(@NonNull Recipient recipient) {
+    return privacy.isDisplayMessage() && recipient.getExpireMessages() == 0;
+  }
+
+  protected boolean isDisplayContact(@NonNull Recipient recipient) {
+    return privacy.isDisplayContact() && recipient.getExpireMessages() == 0;
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/MultipleRecipientNotificationBuilder.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/MultipleRecipientNotificationBuilder.java
@@ -47,7 +47,7 @@ public class MultipleRecipientNotificationBuilder extends AbstractNotificationBu
   }
 
   public void setMostRecentSender(Recipient recipient) {
-    if (privacy.isDisplayContact()) {
+    if (isDisplayContact(recipient)) {
       setContentText(context.getString(R.string.MessageNotifier_most_recent_from_s,
                                        recipient.getDisplayName(context)));
     }
@@ -66,13 +66,13 @@ public class MultipleRecipientNotificationBuilder extends AbstractNotificationBu
   }
 
   public void addMessageBody(@NonNull Recipient sender, @Nullable CharSequence body) {
-    if (privacy.isDisplayMessage()) {
+    if (isDisplayMessage(sender)) {
       messageBodies.add(getStyledMessage(sender, body));
-    } else if (privacy.isDisplayContact()) {
+    } else if (isDisplayContact(sender)) {
       messageBodies.add(Util.getBoldedString(sender.getDisplayName(context)));
     }
 
-    if (privacy.isDisplayContact() && sender.getContactUri() != null) {
+    if (isDisplayContact(sender) && sender.getContactUri() != null) {
       addPerson(sender.getContactUri().toString());
     }
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
@@ -80,7 +80,7 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
     String channelId = recipient.getNotificationChannel();
     setChannelId(channelId != null ? channelId : NotificationChannels.getMessagesChannel(context));
 
-    if (privacy.isDisplayContact()) {
+    if (isDisplayContact(recipient)) {
       setContentTitle(recipient.getDisplayName(context));
 
       if (recipient.getContactUri() != null) {
@@ -134,7 +134,7 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
       stringBuilder.append(Util.getBoldedString(individualRecipient.getDisplayName(context) + ": "));
     }
 
-    if (privacy.isDisplayMessage()) {
+    if (isDisplayMessage(threadRecipients)) {
       setContentText(stringBuilder.append(message));
       this.slideDeck = slideDeck;
     } else {
@@ -243,7 +243,7 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
 
     this.threadRecipient = threadRecipient;
 
-    if (privacy.isDisplayContact()) {
+    if (isDisplayContact(threadRecipient)) {
       personBuilder.setName(individualRecipient.getDisplayName(context));
       personBuilder.setUri(individualRecipient.isSystemContact() ? individualRecipient.getContactUri().toString() : null);
 
@@ -256,7 +256,7 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
     }
 
     final CharSequence text;
-    if (privacy.isDisplayMessage()) {
+    if (isDisplayMessage(threadRecipient)) {
       text = messageBody == null ? "" : messageBody;
     } else {
       text = stringBuilder.append(context.getString(R.string.SingleRecipientNotificationBuilder_new_message));
@@ -314,7 +314,7 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
     NotificationCompat.MessagingStyle messagingStyle = new NotificationCompat.MessagingStyle(ConversationUtil.buildPersonCompat(context, Recipient.self()));
 
     if (threadRecipient.isGroup()) {
-      if (privacy.isDisplayContact()) {
+      if (isDisplayContact(threadRecipient)) {
         messagingStyle.setConversationTitle(threadRecipient.getDisplayName(context));
       } else {
         messagingStyle.setConversationTitle(context.getString(R.string.SingleRecipientNotificationBuilder_signal));

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1575,6 +1575,7 @@
     <string name="ThreadRecord_s_is_on_signal">%s is on Signal!</string>
     <string name="ThreadRecord_disappearing_messages_disabled">Disappearing messages disabled</string>
     <string name="ThreadRecord_disappearing_message_time_updated_to_s">Disappearing message time set to %s</string>
+    <string name="ThreadRecord_new_disappearing_message_received">New disappearing message received</string>
     <string name="ThreadRecord_safety_number_changed">Safety number changed</string>
     <string name="ThreadRecord_your_safety_number_with_s_has_changed">Your safety number with %s has changed.</string>
     <string name="ThreadRecord_you_marked_verified">You marked verified</string>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * OnePlus 5, Android 10
 * Sony Xperia XZ2 Compact, Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Motivation
I raised this [issue on the community forum](https://community.signalusers.org/t/privacy-issue-notifications-for-disappearing-messages-shouldnt-show-content-or-name-regardless-of-the-receivers-notification-settings/1868) three years ago. At that time, my intention was incorrectly interpreted. Later, there were more reports ([one](https://community.signalusers.org/t/privacy-issue-notifications-for-disappearing-messages-shouldnt-show-content-or-name-regardless-of-the-receivers-notification-settings/1868/8?u=agfngr), [two](https://community.signalusers.org/t/dont-show-disappearing-message-contents-in-the-conversation-list/6238), [three](https://github.com/signalapp/Signal-Android/issues/5781)) on this issue and finally I was able to convey my true intentions for this feature, simply put by [Meteor0id](https://community.signalusers.org/t/privacy-issue-notifications-for-disappearing-messages-shouldnt-show-content-or-name-regardless-of-the-receivers-notification-settings/1868/15?u=agfngr):

> _It is currently valentines day. Say I send my girlfriend, who is at work, a sexy message. I want to send the message in such a way that she doesn’t accidentally open it while her coworkers are sitting next to her in a meeting. And the notification should not automatically display on her lock screen as soon as the message is received._
>
> _A disappearing message should never show content of the message nor the name of the sender on its notification, regardless of the notification setting of the receiver._

I am aware of the fact that disappearing messages are [only intended to keep a tidy history](https://signal.org/blog/disappearing-messages/), but this feature would be so much more powerful and much more in line with a users expectation if the content isn't revealed in the notifications nor the conversation list. Especially these days where there's so much inflow of users coming from other applications. After all these years, I still think it's confusing that you set up a conversation where messages expire after a specific amount of time, which happens at the senders side, but the message is readable for an undefined amount of time in the notifications of the receiver or as a preview in the conversation list...

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
When applied, this pull request will 
* make notifications for disappearing messages behave as if the Notification Privacy setting would be set to _No name or message_: incoming messages are seen as "new message" and hides both incoming user as well as message content
* show "New disappearing message received" in the conversation list when the conversation contains one or more unread disappearing messages
