### PR TITLE
Clean the Glide target after use to prevent onResume to resume the Glide task again

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationActivity.java
@@ -1240,10 +1240,10 @@ public class ConversationActivity extends PassphraseRequiredActivity
   private void handleAddShortcut() {
     Log.i(TAG, "Creating home screen shortcut for recipient " + recipient.get().getId());
 
-    final Context context = getApplicationContext();
-    final Recipient recipient = this.recipient.get();
-
-    GlideApp.with(this)
+    final Context       context   = getApplicationContext();
+    final Recipient     recipient = this.recipient.get();
+    final GlideRequests requests  = GlideApp.with(this);
+    requests
             .asBitmap()
             .load(recipient.getContactPhoto())
             .error(recipient.getFallbackContactPhoto().asDrawable(this, recipient.getColor().toAvatarColor(this), false))
@@ -1256,14 +1256,18 @@ public class ConversationActivity extends PassphraseRequiredActivity
 
                 Log.w(TAG, "Utilizing fallback photo for shortcut for recipient " + recipient.getId());
 
+                final CustomTarget<Bitmap> target = this;
                 SimpleTask.run(() -> DrawableUtil.toBitmap(errorDrawable, SHORTCUT_ICON_SIZE, SHORTCUT_ICON_SIZE),
-                               bitmap -> addIconToHomeScreen(context, bitmap, recipient));
+                               bitmap -> addIconToHomeScreen(context, bitmap, recipient),
+                               () -> requests.clear(target));
               }
 
               @Override
               public void onResourceReady(@NonNull Bitmap resource, @Nullable Transition<? super Bitmap> transition) {
+                final CustomTarget<Bitmap> target = this;
                 SimpleTask.run(() -> BitmapUtil.createScaledBitmap(resource, SHORTCUT_ICON_SIZE, SHORTCUT_ICON_SIZE),
-                               bitmap -> addIconToHomeScreen(context, bitmap, recipient));
+                               bitmap -> addIconToHomeScreen(context, bitmap, recipient),
+                               () -> requests.clear(target));
               }
 
               @Override


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Pixel 3a API 30
 * AVD Nexus 6P API 27
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Steps to reproduce the issue
1. Prepare a group chat that does not have its own profile picture
2. Open Signal, go to the chat
3. In the toolbar menu, select "Add to homescreen"
4. Confirm that the dialog pops up
5. Cancel the dialog.
6. Open the Android's system "recent apps" by tapping on the square button of the Android's system navigation bar
7. In the list of recent apps, select Signal again

**Expected behavior**:

Signal opens the chat and nothing else happens

**Actual behavior**:

Signal opens the chat and the "Add to homescreen" dialog pops up again

### Description of the issue
Glide's task automatically resumes upon `onStart` or `onResume` of the activity when the last state was an error. It is an error for Signal to be unable to load a profile picture from a URL so `onLoadFailed` callback is called in the steps above.

Opening the recent apps list puts the activity to paused state and selecting Signal again resumes the activity and it is when Glide kicks in and resumes the task that *failed* the last time.

The solution is to clear Glide's target when either of the callback was called so Glide won't resume requests again on onStart/onResume.

### Screenrecords
|Before|After|
|---|---|
|https://user-images.githubusercontent.com/28482/105636459-7fc82480-5e36-11eb-98c0-14421e7e1564.mp4|https://user-images.githubusercontent.com/28482/105636468-85256f00-5e36-11eb-97b0-1c175ab54536.mp4|






