### PR TITLE
Changed padding from 8 to 16dp in country_list_item.xml and textColor of  composeText to White in mediasend_activity.xml due to readabibility problem 

### DIFF
--- a/app/src/main/res/layout/country_list_item.xml
+++ b/app/src/main/res/layout/country_list_item.xml
@@ -4,7 +4,7 @@
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal"
-    android:padding="8dp">
+    android:padding="16dp">
 
     <TextView
         android:id="@+id/country_name"

--- a/app/src/main/res/layout/mediasend_activity.xml
+++ b/app/src/main/res/layout/mediasend_activity.xml
@@ -25,7 +25,7 @@
             android:layout_gravity="bottom"
             android:orientation="vertical"
             android:clickable="true"
-            android:background="@color/transparent_black_40">
+            android:background="@color/transparent_black_60">
 
             <org.thoughtcrime.securesms.components.emoji.EmojiEditText
                 android:id="@+id/mediasend_caption"

--- a/app/src/main/res/layout/mediasend_activity.xml
+++ b/app/src/main/res/layout/mediasend_activity.xml
@@ -102,6 +102,7 @@
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_vertical"
                         android:layout_weight="1"
+                        android:textColor="@color/core_white"
                         android:nextFocusForward="@+id/send_button"
                         android:nextFocusRight="@+id/send_button"
                         tools:hint="Send TextSecure message" >


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Emulator, Android 10
 * OnePlus 7, Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Changed padding from 8dp to 16dp in country_list_item.xml for a better look .
8dp padding also clips parts of text on the bottom corners of the curved edge screens

This pull request also fix the readability issue  while entering caption in the issue #10828 by using white text color and reducing alpha