### PR TITLE
Remove seconds from screen lock timeout input for coherence

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
@@ -70,6 +70,7 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import mobi.upod.timedurationpicker.TimeDurationPickerDialog;
+import mobi.upod.timedurationpicker.TimeDurationPicker;
 
 public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment {
 
@@ -184,11 +185,10 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
     long timeoutSeconds = TextSecurePreferences.getScreenLockTimeout(getContext());
     long hours          = TimeUnit.SECONDS.toHours(timeoutSeconds);
     long minutes        = TimeUnit.SECONDS.toMinutes(timeoutSeconds) - (TimeUnit.SECONDS.toHours(timeoutSeconds) * 60  );
-    long seconds        = TimeUnit.SECONDS.toSeconds(timeoutSeconds) - (TimeUnit.SECONDS.toMinutes(timeoutSeconds) * 60);
 
     findPreference(TextSecurePreferences.SCREEN_LOCK_TIMEOUT)
         .setSummary(timeoutSeconds <= 0 ? getString(R.string.AppProtectionPreferenceFragment_none) :
-                                          String.format(Locale.getDefault(), "%02d:%02d:%02d", hours, minutes, seconds));
+                                          String.format(Locale.getDefault(), "%02d:%02d:00", hours, minutes));
   }
 
   private void initializePhoneNumberPrivacyWhoCanSeeSummary() {
@@ -248,15 +248,11 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
     @Override
     public boolean onPreferenceClick(Preference preference) {
       new TimeDurationPickerDialog(getContext(), (view, duration) -> {
-        if (duration == 0) {
-          TextSecurePreferences.setScreenLockTimeout(getContext(), 0);
-        } else {
-          long timeoutSeconds = Math.max(TimeUnit.MILLISECONDS.toSeconds(duration), 60);
-          TextSecurePreferences.setScreenLockTimeout(getContext(), timeoutSeconds);
-        }
+        long timeoutSeconds = TimeUnit.MILLISECONDS.toSeconds(duration);
+        TextSecurePreferences.setScreenLockTimeout(getContext(), timeoutSeconds);
 
         initializeScreenLockTimeoutSummary();
-      }, 0).show();
+      }, 0, TimeDurationPicker.HH_MM).show();
 
       return true;
     }
@@ -392,7 +388,7 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
 
         initializePassphraseTimeoutSummary();
 
-      }, 0).show();
+      }, 0, TimeDurationPicker.HH_MM).show();
 
       return true;
     }


### PR DESCRIPTION

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Grand Prime, Android 5.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Configure the TimeDurationPickerDialog in the preferences to hide seconds.
Seconds were already ignored below 1min. This avoids the user expecting it to work.

Feature regression: after this change, seconds above 1min will also be impossible to input (ex: 1m30s).
But it makes little sense anyway to allow it: they are even less useful for longer durations.

Another possibility to reach a point where eveything is coherent would have been to just remove the Math.max(..., 60) that ignored seconds.

The duration will be displayed as "xx:xx:00" to make it clear that xx:xx represents minutes.

Fixes #10788.


Another evolution that would please some users: accept "0min" to mean "lock as soon as possible". It currently removes the autolock.