### PR TITLE
Fixed - app crash on scanning invalid QR Code #10805

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/VerifyIdentityActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/VerifyIdentityActivity.java
@@ -429,6 +429,10 @@ public class VerifyIdentityActivity extends PassphraseRequiredActivity implement
       } catch (UnsupportedEncodingException e) {
         throw new AssertionError(e);
       }
+      catch (RuntimeException e){
+        Log.w(TAG, e);
+        Toast.makeText(getActivity(), "Invalid QR Code", Toast.LENGTH_SHORT).show();
+      }
     }
 
     public void setClickListener(View.OnClickListener listener) {


### PR DESCRIPTION
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [ x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ x] I have tested my contribution on these devices:
 * Nokia 5.3, Android 10 API 29
 * Samsung M01 Core, Android 10 API 29
 * Virtual device, Android 6.0 API 23
- [ x] My contribution is fully baked and ready to be merged as is
- [ x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #10805`

----------

### Description
I have fixed the issue of the app crashing on scanning an invalid QR code. I added an additional catch block in the QR code scanning method.
I have tested it using different valid and invalid QR codes in different devices with diverse API level.