### PR TITLE
Fixed - app crash on scanning invalid QR Code #10805

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/VerifyIdentityActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/VerifyIdentityActivity.java
@@ -431,7 +431,7 @@ public class VerifyIdentityActivity extends PassphraseRequiredActivity implement
       }
       catch (RuntimeException e){
         Log.w(TAG, e);
-        Toast.makeText(getActivity(), "Invalid QR Code", Toast.LENGTH_SHORT).show();
+        Toast.makeText(getActivity(), R.string.VerifyIdentityActivity_the_scanned_qr_code_is_invalid, Toast.LENGTH_SHORT).show();
       }
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/VerifyIdentityActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/VerifyIdentityActivity.java
@@ -429,6 +429,10 @@ public class VerifyIdentityActivity extends PassphraseRequiredActivity implement
       } catch (UnsupportedEncodingException e) {
         throw new AssertionError(e);
       }
+      catch (RuntimeException e){
+        Log.w(TAG, e);
+        Toast.makeText(getActivity(), "Invalid QR Code", Toast.LENGTH_SHORT).show();
+      }
     }
 
     public void setClickListener(View.OnClickListener listener) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1611,6 +1611,7 @@
     <string name="VerifyIdentityActivity_your_contact_is_running_an_old_version_of_signal">Your contact is running an old version of Signal. Please ask them to update before verifying your safety number.</string>
     <string name="VerifyIdentityActivity_your_contact_is_running_a_newer_version_of_Signal">Your contact is running a newer version of Signal with an incompatible QR code format. Please update to compare.</string>
     <string name="VerifyIdentityActivity_the_scanned_qr_code_is_not_a_correctly_formatted_safety_number">The scanned QR code is not a correctly formatted safety number verification code. Please try scanning again.</string>
+    <string name="VerifyIdentityActivity_the_scanned_qr_code_is_invalid">Invalid QR Code</string>
     <string name="VerifyIdentityActivity_share_safety_number_via">Share safety number via…</string>
     <string name="VerifyIdentityActivity_our_signal_safety_number">Our Signal safety number:</string>
     <string name="VerifyIdentityActivity_no_app_to_share_to">It looks like you don\'t have any apps to share to.</string>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nokia 5.3, Android 10 API 29
 * Samsung M01 Core, Android 10 API 29
 * Virtual device, Android 6.0 API 23
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #10805`

----------

### Description
Fixes #10805 
I have fixed the issue of the app crashing on scanning an invalid QR code. I added an additional catch block in the QR code scanning method.
I have tested it using different valid and invalid QR codes in different devices with diverse API level.