### PR TITLE
Use the theme-aware background color when drawing the background of a swiped item

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
@@ -1108,7 +1108,7 @@ public class ConversationListFragment extends MainFragment implements ActionMode
           canvas.save();
           canvas.clipRect(itemView.getLeft(), itemView.getTop(), dX, itemView.getBottom());
 
-          canvas.drawColor(alpha > 0 ? resources.getColor(R.color.green_500) : Color.WHITE);
+          canvas.drawColor(alpha > 0 ? resources.getColor(R.color.green_500) : resources.getColor(R.color.signal_background_primary));
 
           canvas.translate(itemView.getLeft() + resources.getDimension(R.dimen.conversation_list_fragment_archive_padding),
                            itemView.getTop() + (itemView.getBottom() - itemView.getTop() - archiveDrawable.getIntrinsicHeight()) / 2f);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Pixel 3a, API 29
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Replaces hard coded `Color.WHITE` with the background color that is aware of the theme (dark or light). Fixes #9258

### Screen records
**Before**

https://user-images.githubusercontent.com/28482/106065008-a8674d00-60c8-11eb-910f-80cf02751c7f.mp4


**After**

https://user-images.githubusercontent.com/28482/106065045-b4eba580-60c8-11eb-8512-70a3e795c38f.mp4


