### PR TITLE
Automatically retry when there is connection issue

### DIFF
--- a/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java
+++ b/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java
@@ -1480,7 +1480,7 @@ public class PushServiceSocket {
     return baseClient.newBuilder()
                      .connectTimeout(soTimeoutMillis, TimeUnit.MILLISECONDS)
                      .readTimeout(soTimeoutMillis, TimeUnit.MILLISECONDS)
-                     .retryOnConnectionFailure(automaticNetworkRetry)
+                     .retryOnConnectionFailure(true)
                      .build();
   }
 


### PR DESCRIPTION
Fixes #7733 

Always retry when connection fails. PushServiceSocket -> buildOkHttpClient call is made by getServiceConnection() and submitServiceRequest(). There is a scenario where app is in background and when a incoming call notification is received, user gets a missed call notification instead of call ringing

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * OnePlus 6: Android 10.0 
 * Virtual device: Pixel XL API 30,Android 11.0
- [ ] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
 This PR attempts to fix the issue where a user receives a missed call notification instead of the call ringing. I am aware this is a very old issue with multiple variations/scenarios reported. 
Following is a list of steps for repro:
For this test FCM should be enabled.(All notifications are enabled for app)

1. Debug the latest code in AVD(Android Virtual Device) and wait for app launch
**Keep the Debugger Console open**
2. Make a test call from a phone to AVD. This call should ring on the AVD as expected.
3. Press the power button on AVD to push app to background
4. After some time websockets are disconnected (since FCM is enabled). This usually takes ~ 1 min. 
**Look out for this log in Console to confirm connections have been torn down:**

> I/ApplicationContext: App is no longer visible.
D/WebSocketConnection: Sending keep alive...
D/WebSocketConnection: Sending keep alive...
W/IncomingMessageObserver: Application level read timeout...
D/IncomingMessageObserver: Network: true, Foreground: false, FCM: true, Censored: false, Registered: true, Websocket Registered: true
W/IncomingMessageObserver: Shutting down pipe...
I/WebSocketConnection: disconnect()
    disconnect()
I/IncomingMessageObserver: Looping...
    Waiting for websocket state change....
D/IncomingMessageObserver: Network: true, Foreground: false, FCM: true, Censored: false, Registered: true, Websocket Registered: true
I/WebSocketConnection: onClosing()
    onClose()
W/ApplicationDependencyPr: onDisconnected()
I/WebSocketConnection: onClosing()
    onClose()
W/ApplicationDependencyPr: onDisconnected()


5. Now immediately make a test call from a phone to AVD. You will see 'Network Failed!'  on your phone
6. Now try to call again. A connection error gets thrown :
org.whispersystems.signalservice.api.push.exceptions.PushNetworkException: java.io.IOException: unexpected end of stream on Connection{textsecure-service.whispersystems.org:443, proxy=DIRECT hostAddress=textsecure-service.whispersystems.org/<some ip>:443 cipherSuite=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 protocol=http/1.1}
in RestStrategy -> execute call

The fix was to enable automatic retry in buildOkHttpClient. From what I could find in the code, this call is only made from submitServiceRequest and getServiceConnection. Based on https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html, retries should not be an issue for idempotent verbs. 

After my fix, I still get 'Network Failed!' on first call attempt, But the AVD rings on second call attempt
