### PR TITLE
Fixed - Typing indicator showing as unread message #10833

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationAdapter.java
@@ -359,7 +359,10 @@ public class ConversationAdapter
   }
 
   void onBindLastSeenViewHolder(StickyHeaderViewHolder viewHolder, int position) {
-    viewHolder.setText(viewHolder.itemView.getContext().getResources().getQuantityString(R.plurals.ConversationAdapter_n_unread_messages, (position + 1), (position + 1)));
+    if (ConversationFragment.staticReference.isTypingIndicatorShowing())
+      viewHolder.setText(viewHolder.itemView.getContext().getResources().getQuantityString(R.plurals.ConversationAdapter_n_unread_messages, (position), (position)));
+    else
+      viewHolder.setText(viewHolder.itemView.getContext().getResources().getQuantityString(R.plurals.ConversationAdapter_n_unread_messages, (position + 1), (position + 1)));
 
     if (hasWallpaper) {
       viewHolder.setBackgroundRes(R.drawable.wallpaper_bubble_background_8);

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
@@ -165,6 +165,7 @@ public class ConversationFragment extends LoggingFragment {
 
   private ConversationFragmentListener listener;
 
+  public static ConversationFragment  staticReference;
   private LiveRecipient               recipient;
   private long                        threadId;
   private boolean                     isReacting;
@@ -1006,7 +1007,8 @@ public class ConversationFragment extends LoggingFragment {
     return firstVisiblePosition == 0 && list.getChildAt(0).getBottom() <= list.getHeight();
   }
 
-  private boolean isTypingIndicatorShowing() {
+  public boolean isTypingIndicatorShowing() {
+    staticReference = this;
     return getListAdapter().getHeaderView() == typingView;
   }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nokia 5.3, Android 10
 * Realme C2, Android 9
 *  Samsung M01 Core, Android 10
 * Virtual device, Android 6.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #10833`

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
I created a static reference in ConversationFragment and used it to check whether the typing indicator is showing or not using an if block and handled the number of unread message header accordingly in ConversationAdapter. About the wallpaper issue stated above, I believe that behaviour is intentional. That line has been intentionally put there to distinguish between read and unread section. So, that is not an issue.
Fixes #10833