### PR TITLE
Configure keep alive duration for okhttp connection pool to 1 minute

### DIFF
--- a/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java
+++ b/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java
@@ -135,6 +135,7 @@ import javax.net.ssl.X509TrustManager;
 
 import okhttp3.Call;
 import okhttp3.Callback;
+import okhttp3.ConnectionPool;
 import okhttp3.ConnectionSpec;
 import okhttp3.Credentials;
 import okhttp3.Dns;
@@ -1797,6 +1798,8 @@ public class PushServiceSocket {
       builder.sslSocketFactory(new Tls12SocketFactory(context.getSocketFactory()), (X509TrustManager)trustManagers[0])
              .connectionSpecs(url.getConnectionSpecs().or(Util.immutableList(ConnectionSpec.RESTRICTED_TLS)))
              .build();
+
+      builder.connectionPool(new ConnectionPool(5, 1, TimeUnit.MINUTES));
 
       for (Interceptor interceptor : interceptors) {
         builder.addInterceptor(interceptor);


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * OnePlus 8T, Android 11
 * Honor 5C, Android 7
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
The signal http server supports http keep alive, but seems to close idle connections after 1 minute.
The default OkHttp connection pool will keep idle connections in the pool for 5 minutes and doesn't notice it when the server closes connections.
As currently the automatic okhttp retries are disabled, reusing such a stale connection will be fatal.

This issue is especially severe for incoming calls, which fail because the request to retrieve the turn servers fails and isn't retried, see for example #10787

This PR configures a custom okhttp connection pool with keep alive of 1 minute, so no stale connections should be reused, under stable network conditions.
Adding some additional retry logic, which might make sense in case of other network issues, is out of scope for this PR.