### PR TITLE
Fix crash from incoming call without contacts permission

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/DoNotDisturbUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/DoNotDisturbUtil.java
@@ -1,5 +1,6 @@
 package org.thoughtcrime.securesms.notifications;
 
+import android.Manifest;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.database.Cursor;
@@ -12,6 +13,7 @@ import androidx.annotation.WorkerThread;
 
 import org.signal.core.util.logging.Log;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
+import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.util.ServiceUtil;
 
@@ -83,6 +85,10 @@ public final class DoNotDisturbUtil {
 
   private static boolean isContactStarred(@NonNull Context context, @NonNull Recipient recipient) {
     if (!recipient.resolve().isSystemContact()) return false;
+
+    if (!Permissions.hasAny(context, Manifest.permission.READ_CONTACTS, Manifest.permission.WRITE_CONTACTS)) {
+      return false;
+    }
 
     try (Cursor cursor = context.getContentResolver().query(recipient.resolve().getContactUri(), new String[]{ContactsContract.Contacts.STARRED}, null, null, null)) {
       if (cursor == null || !cursor.moveToFirst()) return false;


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * OnePlus 8T, Android 11
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
When the device is in Do Not Disturb mode and a call comes in from a
system contact, the app crashes if the user has revoked the contacts
permission.
The crash occurs because in Do Not Disturb mode Signal tries to check if
the contact is starred.

Visible behavior on callee side: The connecting notification is shown shortly and then disappears.

Fixes this crash:
```
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: java.lang.SecurityException: Permission Denial: opening provider com.android.providers.contacts.ContactsProvider2 from ProcessRecord{42bbb24 21870:org.thoughtcrime.securesms/u0a249} (pid=21870, uid=10249) requires android.permission.READ_CONTACTS or android.permission.WRITE_CONTACTS
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at android.os.Parcel.createExceptionOrNull(Parcel.java:2373)
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at android.os.Parcel.createException(Parcel.java:2357)
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at android.os.Parcel.readException(Parcel.java:2340)
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at android.os.Parcel.readException(Parcel.java:2282)
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at android.app.IActivityManager$Stub$Proxy.getContentProvider(IActivityManager.java:5855)
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at android.app.ActivityThread.acquireProvider(ActivityThread.java:7076)
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at android.app.ContextImpl$ApplicationContentResolver.acquireUnstableProvider(ContextImpl.java:2954)
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at android.content.ContentResolver.acquireUnstableProvider(ContentResolver.java:2525)
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at android.content.ContentResolver.query(ContentResolver.java:1186)
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at android.content.ContentResolver.query(ContentResolver.java:1126)
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at android.content.ContentResolver.query(ContentResolver.java:1082)
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at org.thoughtcrime.securesms.notifications.DoNotDisturbUtil.isContactStarred(DoNotDisturbUtil.java:87)
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at org.thoughtcrime.securesms.notifications.DoNotDisturbUtil.isContactPriority(DoNotDisturbUtil.java:77)
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at org.thoughtcrime.securesms.notifications.DoNotDisturbUtil.handlePriority(DoNotDisturbUtil.java:67)
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at org.thoughtcrime.securesms.notifications.DoNotDisturbUtil.shouldDisturbUserWithCall(DoNotDisturbUtil.java:35)
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at org.thoughtcrime.securesms.service.webrtc.IncomingCallActionProcessor.handleLocalRinging(IncomingCallActionProcessor.java:158)
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at org.thoughtcrime.securesms.service.webrtc.WebRtcActionProcessor.processAction(WebRtcActionProcessor.java:190)
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at org.thoughtcrime.securesms.service.WebRtcCallService.lambda$onStartCommand$0(WebRtcCallService.java:290)
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at org.thoughtcrime.securesms.service.WebRtcCallService.lambda$onStartCommand$0$WebRtcCallService(Unknown Source:0)
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at org.thoughtcrime.securesms.service.-$$Lambda$WebRtcCallService$Yh6A0UG5XRlf3T0gTOG7ZD8M4xo.run(Unknown Source:4)
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
[5.3.11] [4655] 2021-02-04 08:24:38.108 MEZ E SignalUncaughtExceptionHandler: 	at java.lang.Thread.run(Thread.java:923)
```