### PR TITLE
Allow sending message by pressing Ctrl+Enter on a physical keyboard

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationParentFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationParentFragment.java
@@ -3542,7 +3542,7 @@ public class ConversationParentFragment extends Fragment
     public boolean onKey(View v, int keyCode, KeyEvent event) {
       if (event.getAction() == KeyEvent.ACTION_DOWN) {
         if (keyCode == KeyEvent.KEYCODE_ENTER) {
-          if (SignalStore.settings().isEnterKeySends()) {
+          if (SignalStore.settings().isEnterKeySends() || event.isCtrlPressed()) {
             sendButton.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER));
             sendButton.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER));
             return true;


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Xiaomi Redmi 8, Android 9
 * Moto C Plus, Android 7
 * Virtual device, Android 9
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

This commit allows the user to send a message by pressing Ctrl+Enter on a physical keyboard.

Sending messages using only a physical keyboard is a relevant use case for accessibility (people who can't or have difficulties touching the screen) or UX (faster typing), but currently Signal does not _really_ allow this. The alternative of enabling option "Enter key sends" has the side effect of preventing the user from entering line breaks in the message. It is also possible to use tab-cycling as a workaround, but it is not very practical for now (see [#2](#2-sending-messages-and-tab-cycling)).

While Android apps don't have an universal standard for this use case (see [#1](#1-behavior-of-other-messaging-and-related-apps)), Ctrl+Enter seems to be the best approach because:

- It does not break any existing behavior (even undocumented ones) or user expectations;
- Allows the user to have both behaviors and can be overridden by "Enter to send" option if the user wants;
- Same keybinding used by Telegram, Gmail and possibly others;
- Does not require new settings;
- Does not seem to have any negative impact on a11y;
- Among the options, it seems to have the lowest impact on code (a single line changed, seriously);
- No perceivable impact on performance;
- No new requirements for API levels (`KeyEvent.isCtrlPressed()`is stable since API Level 11, Android 3).


Of course, comments are welcome. 





----------


### Footnotes

#### 1. Behavior of other messaging and related apps

For reference, follow the behaviors I tested in a few other communication apps (all on Android). 

- Telegram: Enter adds a new line, Ctrl+Enter sends the message. Tab changes focus to the message history, so user the scroll through them with the keyboard, but focus never reaches the send button.
- Gmail:  Enter adds a new line, Ctrl+Enter sends the email.
- Android 7 SMS app (ver 2.1.163): Enter adds a new line, Ctrl+Enter and Shift+Enter does nothing. Tab sends focus to "Add MMS media", a second Tab to the emoji button, focus never reaches the send button.
- Android 9 SMS app (ver 5.0.052): Enter adds a new line, Ctrl+Enter and Shift+Enter does nothing. Tab sends focus to "Add Contact", a second tab puts the focus on send button; Pressing Enter with the send button in focus sends the SMS and put focus back to input line automatically.
- Skype: Enter sends the message, Ctrl+Enter adds a new line.
- Google Meet: Enter always adds a new line (Ctrl+Enter does nothing). Send by keyboard requires a tab to focus in the send button, after that the user needs to tab-cycle through to all other controls to get back to the input line.
- Jitsi Meet: Enter always sends the message, Ctrl+Enter does nothing. Tab puts the send button on focus, once user presses Enter the message is sent and focus is lost (the only way to put the focus on the input line again is touching the screen).
- Mattermost: Both Enter and Ctrl+Enter sends the message. Shift+Enter adds a newline.


#### 2. Sending messages and tab cycling

On Signal 5.3.12, pressing tab from the input line will put a invisible focus in the send button so user can send the message with Enter after that. However, focus does not return to the input line automatically and user needs to tab-cycle through all other controls to get it back there, and not all controls give feedback on their focus. An advanced user may notice that after the Enter to send the message, focus will fall (invisibly) in the return button and pressing it will back to the chat list with the most recently used one pre-selected, and pressing Enter again will open this chat with the input line in focus. There is a bit of timing for this as the end button takes a few milliseconds to give focus up and, so, two immediate Enters will cause the second one to try to send an empty message, so user must stay aware to this. However, "Type message → Tab → Enter → Enter → Enter" is still the fastest keyboard-only way to write and get ready to answer (but a bit awkward). Restoring focus to input line after sending from the keyboard may be a nice improvement, but that's a thing for another PR.



