### PR TITLE
Minor: Fix sameEraId check in insertOrUpdateGroupCall in SmsDatabase

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/SmsDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/SmsDatabase.java
@@ -767,7 +767,7 @@ public class SmsDatabase extends MessageDatabase {
 
           sameEraId = groupCallUpdateDetails.getEraId().equals(messageGroupCallEraId) && !Util.isEmpty(messageGroupCallEraId);
 
-          if (!sameEraId) {
+          if (sameEraId) {
             String body = GroupCallUpdateDetailsUtil.createUpdatedBody(groupCallUpdateDetails, Collections.emptyList(), false);
 
             ContentValues contentValues = new ContentValues();


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * OnePlus 8T, Android 11
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
The insertOrUpdateGroupCall method should update the latest group call entry
if it has the same eraId, otherwise it should add a new entry.

But currently the check is the wrong way round, if a new eraId was received
 a new entry is inserted AND the previous call entry is updated.

As far as I can see, this has no negative consequences, but it's just wrong
and does more work than necessary.

(And just out of curiosity, what does era stand for?)
