### PR TITLE
Fix issue with Rate me dialog showing every minute or more

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/RatingManager.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/RatingManager.java
@@ -60,6 +60,7 @@ public class RatingManager {
            TextSecurePreferences.setRatingLaterTimestamp(context, waitUntil);
          }
        })
+       .setCancelable(false)
        .show();
   }
 


### PR DESCRIPTION
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 
 * Samsung S10, Android 10.0
 * Samsung Galaxy A51, Android 9.0

- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

If Screen Lock is enabled, the Rate me dialog will appear as soon as the screen is unlocked instead of the expected `RatingManager.DAYS_UNTIL_REPROMPT_THRESHOLD`.  With screen lock inactivity timeout set to its smallest alllowable number, and the user dismissing the Rate me dialog by tapping outside of the dialog, this could mean that the Rate me dialog is displayed  every minute.   
The dialog will also show up whenever the user taps on a contact from the home screen, views the conversation screen for that contact, and then returns back to home screen.

This PR fixes the above problem by preventing the Rate Me dialog from being dismissed when tapping outside of the dialog.  By doing so, the user is forced to select one of the Rate me dialog buttons.

This fix was tested by actually attempting to dismiss the Rate me dialog by tapping outside of the dialog.

