### PR TITLE
Downscale link preview thumbnails to a maximum of 512x512 px

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/linkpreview/LinkPreviewRepository.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/linkpreview/LinkPreviewRepository.java
@@ -72,6 +72,7 @@ public class LinkPreviewRepository {
 
   private static final long FAILSAFE_MAX_TEXT_SIZE  = ByteUnit.MEGABYTES.toBytes(2);
   private static final long FAILSAFE_MAX_IMAGE_SIZE = ByteUnit.MEGABYTES.toBytes(2);
+  private static final int MAX_THUMBNAIL_CANVAS_SIZE = 512;
 
   private final OkHttpClient client;
 
@@ -173,6 +174,30 @@ public class LinkPreviewRepository {
     return new CallRequestController(call);
   }
 
+  private Optional<Attachment> makeThumbnailFromBytes(byte[] data) {
+    Bitmap bitmap = BitmapFactory.decodeByteArray(data, 0, data.length);
+    if (bitmap == null) {
+      return Optional.empty();
+    }
+
+    double maxImgDim = Math.max(1, Math.max(bitmap.getWidth(), bitmap.getHeight()));
+    double ratio = MAX_THUMBNAIL_CANVAS_SIZE / maxImgDim;
+
+    if (ratio < 1.0) {
+      int newWidth = Math.max(1, (int) Math.floor(ratio * bitmap.getWidth()));
+      int newHeight = Math.max(1, (int) Math.floor(ratio * bitmap.getHeight()));
+      Bitmap scaledBitmap = Bitmap.createScaledBitmap(bitmap, newWidth, newHeight, true);
+      bitmap.recycle();
+      bitmap = scaledBitmap;
+    }
+
+    Optional<Attachment> attachment = bitmapToAttachment(bitmap, Bitmap.CompressFormat.JPEG, MediaUtil.IMAGE_JPEG);
+    if (bitmap != null) {
+      bitmap.recycle();
+    }
+    return attachment;
+  }
+
   private @NonNull RequestController fetchThumbnail(@NonNull String imageUrl, @NonNull Consumer<Optional<Attachment>> callback) {
     Call                  call       = client.newCall(new Request.Builder().url(imageUrl).build());
     CallRequestController controller = new CallRequestController(call);
@@ -188,10 +213,7 @@ public class LinkPreviewRepository {
         controller.setStream(bodyStream);
 
         byte[]               data      = OkHttpUtil.readAsBytes(bodyStream, FAILSAFE_MAX_IMAGE_SIZE);
-        Bitmap               bitmap    = BitmapFactory.decodeByteArray(data, 0, data.length);
-        Optional<Attachment> thumbnail = bitmapToAttachment(bitmap, Bitmap.CompressFormat.JPEG, MediaUtil.IMAGE_JPEG);
-
-        if (bitmap != null) bitmap.recycle();
+        Optional<Attachment> thumbnail = makeThumbnailFromBytes(data);
 
         callback.accept(thumbnail);
       } catch (IOException | IllegalArgumentException e) {


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Xiaomi Redmi 8, Android 9
 * Moto C Plus, Android 7
 * Virtual device, Android 9
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
----------

### Description

This commit will make Signal scale large thumbnails generated for link previews to a size no larger than 512x512 pixels before saving or sending. 

Currently, when generating a link preview, Signal will load an image provided by a remote website and, if under a simple 2 MB file size limit, accept, recompress, store on local chat history and then send it to the receivers. These images can be much larger than actually required by the intended application, wasting storage and bandwidth. The problem is exacerbated when sending link previews to large groups due to amplification effects.

Limiting the size of these images is also important as they will accumulate on receiver's chat history and is not unrealistic to expect an user to collect a few thousand link previews on long lived chat sessions or, more commonly, on group chats. Deleting them from the media list, which a typical user may be tempted to do after seeing several large but apparently unused files there, will cause the original message to be deleted too, so this approach may not be always desired.

Taking the page https://commons.wikimedia.org/wiki/File:Oxford_Tolkien.JPG as an example: current stable version (v5.3.12) generates a 1200x1800px thumbnail of 359 KB. With the changes proposed here, this thumbnail is scaled down to 341x512px, resulting in a JPEG file of only 38 KB and still with enough quality to be used in the preview.

The 512x512 px limit is mostly based on the current recommendation for stickers and seems acceptable for this context. It gives enough resolution for a good presentation, while a larger image won't necessarily give more information to the user. Opinions on this are welcome, of course.




