### PR TITLE
Adds some breathing space in the button caption for a language

### DIFF
--- a/app/src/main/res/layout/edit_about_fragment.xml
+++ b/app/src/main/res/layout/edit_about_fragment.xml
@@ -86,6 +86,8 @@
       android:layout_gravity="bottom|end"
       android:layout_marginEnd="16dp"
       android:layout_marginBottom="16dp"
+      android:paddingStart="16dp"
+      android:paddingEnd="16dp"
       android:textColor="@color/white"
       android:text="@string/EditProfileNameFragment_save"
       app:cornerRadius="80dp"


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Pixel API 23
 * AVD Pixel 3a API 30
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Adds some padding in a button to give its caption some breathing space. This is a fix to a bug reported in the [beta forum](https://community.signalusers.org/t/beta-feedback-for-the-upcoming-android-5-3-release/25088/353). 

### Screenshot
|Locale|Before|After|
|---|---|---|
|fr|![Screenshot_1612713116](https://user-images.githubusercontent.com/28482/107152015-ae182a80-6933-11eb-8893-a89308380cab.png)|![Screenshot_1612713344](https://user-images.githubusercontent.com/28482/107151997-9e98e180-6933-11eb-9124-180c4f3b9b0e.png)|
|en|![Screenshot_1612713497](https://user-images.githubusercontent.com/28482/107152031-c5efae80-6933-11eb-8d8f-99de478ce8c5.png)|![Screenshot_1612713379](https://user-images.githubusercontent.com/28482/107152039-ca1bcc00-6933-11eb-8904-cca8f034208a.png)|

