### PR TITLE
Fix the unusable keyboard in landscape screen

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/AttachmentKeyboard.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/AttachmentKeyboard.java
@@ -3,8 +3,6 @@ package org.thoughtcrime.securesms.conversation;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.view.View;
-import android.view.ViewGroup;
-import android.widget.FrameLayout;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -14,6 +12,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.InputAwareLayout;
+import org.thoughtcrime.securesms.components.KeyboardAwareLinearLayout;
 import org.thoughtcrime.securesms.mediasend.Media;
 import org.thoughtcrime.securesms.mms.GlideApp;
 import org.thoughtcrime.securesms.util.StorageUtil;
@@ -21,7 +20,7 @@ import org.thoughtcrime.securesms.util.StorageUtil;
 import java.util.Arrays;
 import java.util.List;
 
-public class AttachmentKeyboard extends FrameLayout implements InputAwareLayout.InputView {
+public class AttachmentKeyboard extends KeyboardAwareLinearLayout implements InputAwareLayout.InputView {
 
   private AttachmentKeyboardMediaAdapter  mediaAdapter;
   private AttachmentKeyboardButtonAdapter buttonAdapter;
@@ -99,11 +98,32 @@ public class AttachmentKeyboard extends FrameLayout implements InputAwareLayout.
   }
 
   @Override
-  public void show(int height, boolean immediate) {
-    ViewGroup.LayoutParams params = getLayoutParams();
-    params.height = height;
-    setLayoutParams(params);
+  protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+    super.onMeasure(widthMeasureSpec, heightMeasureSpec);
 
+    int width      = MeasureSpec.getSize(widthMeasureSpec);
+    int height     = MeasureSpec.getSize(heightMeasureSpec);
+    int kbHeight   = getKeyboardHeight();
+    int heightMode = MeasureSpec.getMode(heightMeasureSpec);
+
+    int newHeight;
+    switch (heightMode) {
+      case MeasureSpec.EXACTLY:
+        newHeight = height;
+        break;
+      case MeasureSpec.AT_MOST:
+        newHeight = Math.min(height, kbHeight);
+        break;
+      default:
+        newHeight = kbHeight;
+        break;
+    }
+
+    setMeasuredDimension(width, newHeight);
+  }
+
+  @Override
+  public void show(int height, boolean immediate) {
     setVisibility(VISIBLE);
   }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Pixel 3a API 30
 * AVD Pixel API 23
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
The attachment keyboard covers all area of the landscape screen of smaller screen smartphones so that it becomes impossible to enter a message in the input area. The cause was because the height was not re-calculated when the available screen height changed.

The fix is to respond to Android's onMeasure call and measure the height every time the layout needs to be updated to properly occupy the area both in portrait and in landscape mode.

The bug was reported in the [beta forum](https://community.signalusers.org/t/beta-feedback-for-the-upcoming-android-5-3-release/25088/220)

### Screenrecords
**Bug**

https://user-images.githubusercontent.com/28482/107152501-4c0cf480-6936-11eb-8d6c-e9473fe6a2f9.mp4

**Fixed**

https://user-images.githubusercontent.com/28482/107152526-6cd54a00-6936-11eb-8dfc-1eb09e5d6f63.mp4



