### PR TITLE
Fix too much margins in group chats for RTL languages

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
@@ -201,6 +201,19 @@ public final class ConversationItem extends RelativeLayout implements BindableCo
 
   private final Context context;
 
+  private OnLayoutChangeListener newOnLayoutChangedListener(Optional<MessageRecord> previousMessageRecord,
+                                                            Optional<MessageRecord> nextMessageRecord)
+  {
+    return new OnLayoutChangeListener() {
+      @Override
+      public void onLayoutChange(View view, int i, int i1, int i2, int i3, int i4, int i5, int i6, int i7) {
+        setGutterSizes(messageRecord, groupThread);
+        setMessageSpacing(view.getContext(), messageRecord, previousMessageRecord, nextMessageRecord, groupThread);
+        removeOnLayoutChangeListener(this);
+      }
+    };
+  }
+
   public ConversationItem(Context context) {
     this(context, null);
   }
@@ -279,7 +292,6 @@ public final class ConversationItem extends RelativeLayout implements BindableCo
     this.recipient.observeForever(this);
     this.conversationRecipient.observeForever(this);
 
-    setGutterSizes(messageRecord, groupThread);
     setMessageShape(messageRecord, previousMessageRecord, nextMessageRecord, groupThread);
     setMediaAttributes(messageRecord, previousMessageRecord, nextMessageRecord, groupThread, hasWallpaper, isMessageRequestAccepted);
     setBodyText(messageRecord, searchQuery, isMessageRequestAccepted);
@@ -291,9 +303,10 @@ public final class ConversationItem extends RelativeLayout implements BindableCo
     setGroupAuthorColor(messageRecord, hasWallpaper);
     setAuthor(messageRecord, previousMessageRecord, nextMessageRecord, groupThread, hasWallpaper);
     setQuote(messageRecord, previousMessageRecord, nextMessageRecord, groupThread);
-    setMessageSpacing(context, messageRecord, previousMessageRecord, nextMessageRecord, groupThread);
     setReactions(messageRecord);
     setFooter(messageRecord, nextMessageRecord, locale, groupThread, hasWallpaper);
+
+    addOnLayoutChangeListener(newOnLayoutChangedListener(previousMessageRecord, nextMessageRecord));
   }
 
   @Override


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Pixel 3a API 30
 * AVD Nexus 6 AP 27
 * AVD Pixel API 23
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Set paddings whose values may vary depending on the view's layout direction after the layout direction is determined.

Fixes a bug reported first in [the beta forum](https://community.signalusers.org/t/beta-feedback-for-the-upcoming-android-5-3-release/25088/122)

### Screenshots
|Dir|Before|After|
|---|---|---|
|RTL|![Screenshot_1612715824](https://user-images.githubusercontent.com/28482/107155778-4f10e080-6948-11eb-889d-6ce9d2941e2f.png)|![Screenshot_1612721583](https://user-images.githubusercontent.com/28482/107155787-589a4880-6948-11eb-9502-a59f09768e96.png)|
|LTR|![Screenshot_1612721624](https://user-images.githubusercontent.com/28482/107155798-664fce00-6948-11eb-941e-3c1c4f71da1f.png)|![Screenshot_1612721615](https://user-images.githubusercontent.com/28482/107155802-6b148200-6948-11eb-9cec-513419459c63.png)|



