### PR TITLE
Add sticker preview for sticker suggestion bar

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationStickerSuggestionAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationStickerSuggestionAdapter.java
@@ -6,6 +6,7 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions;
@@ -56,9 +57,11 @@ public class ConversationStickerSuggestionAdapter extends RecyclerView.Adapter<C
     notifyDataSetChanged();
   }
 
-  static class StickerSuggestionViewHolder extends RecyclerView.ViewHolder {
+  public static class StickerSuggestionViewHolder extends RecyclerView.ViewHolder {
 
     private final ImageView image;
+
+    private StickerRecord currentSticker;
 
     StickerSuggestionViewHolder(@NonNull View itemView) {
       super(itemView);
@@ -66,6 +69,7 @@ public class ConversationStickerSuggestionAdapter extends RecyclerView.Adapter<C
     }
 
     void bind(@NonNull GlideRequests glideRequests, @NonNull EventListener eventListener, @NonNull StickerRecord sticker) {
+      currentSticker = sticker;
       glideRequests.load(new DecryptableUri(sticker.getUri()))
                    .transition(DrawableTransitionOptions.withCrossFade())
                    .into(image);
@@ -73,14 +77,24 @@ public class ConversationStickerSuggestionAdapter extends RecyclerView.Adapter<C
       itemView.setOnClickListener(v -> {
         eventListener.onStickerSuggestionClicked(sticker);
       });
+      itemView.setOnLongClickListener(v -> {
+        eventListener.onStickerLongPress(v);
+        return true;
+      });
     }
 
     void recycle() {
       itemView.setOnClickListener(null);
     }
+
+    @Nullable
+    public StickerRecord getCurrentSticker() {
+      return currentSticker;
+    }
   }
 
   public interface EventListener {
     void onStickerSuggestionClicked(@NonNull StickerRecord sticker);
+    void onStickerLongPress(@NonNull View view);
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/stickers/StickerRolloverTouchListener.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/stickers/StickerRolloverTouchListener.java
@@ -24,7 +24,7 @@ public class StickerRolloverTouchListener implements RecyclerView.OnItemTouchLis
   private WeakReference<View> currentView;
   private boolean             hoverMode;
 
-  StickerRolloverTouchListener(@NonNull Context context,
+  public StickerRolloverTouchListener(@NonNull Context context,
                                @NonNull GlideRequests glideRequests,
                                @NonNull RolloverEventListener eventListener,
                                @NonNull RolloverStickerRetriever stickerRetriever)
@@ -72,7 +72,7 @@ public class StickerRolloverTouchListener implements RecyclerView.OnItemTouchLis
   public void onRequestDisallowInterceptTouchEvent(boolean b) {
   }
 
-  void enterHoverMode(@NonNull RecyclerView recyclerView, View targetView) {
+  public void enterHoverMode(@NonNull RecyclerView recyclerView, View targetView) {
     this.hoverMode = true;
     showStickerForView(recyclerView, targetView);
   }


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S9, Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Currently there are two places where the sticker preview popup (on long press) works:
- Sticker keyboard in conversations (`StickerKeyboardPageFragment`)
- Sticker pack preview screen for installing/uninstalling stickers (`StickerPackPreviewActivity`)

With these changes the sticker preview popup works additionally in the "suggested stickers bar" (when you enter a single emoji into the input field the stickers shows up in the bar above).
On the device specified above I confirmed the expected behavior with touch input using a `playProdDebug` build.
