### PR TITLE
PushMediaConstraints.java: Tweak image dimensions (maximum to 2160 pixels)

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/mms/PushMediaConstraints.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/PushMediaConstraints.java
@@ -6,13 +6,13 @@ import org.thoughtcrime.securesms.util.Util;
 
 public class PushMediaConstraints extends MediaConstraints {
 
-  private static final int MAX_IMAGE_DIMEN_LOWMEM = 768;
-  private static final int MAX_IMAGE_DIMEN        = 1600;
+  private static final int MAX_IMAGE_DIMEN_LOWMEM = 1080;
+  private static final int MAX_IMAGE_DIMEN        = 2160;
   private static final int KB                     = 1024;
   private static final int MB                     = 1024 * KB;
 
-  private static final int[] FALLBACKS        = { MAX_IMAGE_DIMEN, 1024, 768, 512 };
-  private static final int[] FALLBACKS_LOWMEM = { MAX_IMAGE_DIMEN_LOWMEM, 512 };
+  private static final int[] FALLBACKS        = { MAX_IMAGE_DIMEN, 1440, 1080, 720, 540 };
+  private static final int[] FALLBACKS_LOWMEM = { MAX_IMAGE_DIMEN_LOWMEM, 720, 540, 360 };
 
   @Override
   public int getImageMaxWidth(Context context) {


### PR DESCRIPTION
This PR tweaks the maximum image dimensions to fall in line with screen resolutions and video standards.

This is not a perfect solution, make image compression slightly less worse than without it.

Recently the maximum image width was reduced from 4096 pixels to 1600 pixels, the same number WhatsApp uses for years. 1600 isn't the most logical number. In this PR I used standard video formats as baseline, which most smartphone displays also use.

The maximum of 2160 is both the vertical resolution of a regular 4K-screen (3840x2160), but also the vertical resolution of a 18:9 1080p display (1080x2160). So it's high enough to share 1080p screenshots, even in the 18:9 ratio.

Another advantage that for pictures in the 3:2 aspect ratio 2160 is perfectly dividable: 2160/3*2 = 1440 pixels on the short side, while 1600 pixels tries to reduce it to 1066.67 pixels, mostly rounded to 1067.

The max resolution is a little higher and so will the file-size be, but that's were the fall-backs are for. These are also adjusted to common screen and video format resolutions.

------

Talking about fall-backs: Currently the encoder tries (as far as I understand it) to drop resolution when the maximum file size is exceeded. I don't think this would be the best way, I would suggest dropping the quality parameter in the encoder. By default JPEG quality 70 now is used, instead of dropping resolution dropping encoder quality to 60 or 50 should first be tried.

@greyson-signal If you get the chance, please review.

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)