### PR TITLE
Fix #10970 You Can Add Blocked Users to Groups

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/bottomsheet/RecipientDialogViewModel.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/bottomsheet/RecipientDialogViewModel.java
@@ -84,7 +84,7 @@ final class RecipientDialogViewModel extends ViewModel {
     MutableLiveData<Integer> localGroupCount = new MutableLiveData<>(0);
 
     canAddToAGroup = LiveDataUtil.combineLatest(recipient, localGroupCount,
-                                                (r, count) -> count > 0 && r.isRegistered() && !r.isGroup() && !r.isSelf());
+                                                (r, count) -> count > 0 && r.isRegistered() && !r.isGroup() && !r.isSelf() && !r.isBlocked());
 
     recipientDialogRepository.getActiveGroupCount(localGroupCount::postValue);
   }


### PR DESCRIPTION
### Contributor checklist
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Moto X Play, Android 7.1.1
 * Virtual device Pixel 2, Android 11.0
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Fixes #10970 

Adding the condition "!r.isBlocked" to the boolean canAddToAGroup to prevent the selection "Add to a group / Add to another group" from being displayed for blocked recipients.

![Screenshot_1613418197](https://user-images.githubusercontent.com/49990901/107987599-95acad80-6fce-11eb-8a57-4678104fab90.png)

