### PR TITLE
Fix #10971 You can Initiate Video/Audio Calls with Blocked Users

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/bottomsheet/RecipientBottomSheetDialogFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/bottomsheet/RecipientBottomSheetDialogFragment.java
@@ -183,22 +183,14 @@ public final class RecipientBottomSheetDialogFragment extends BottomSheetDialogF
 
       noteToSelfDescription.setVisibility(recipient.isSelf() ? View.VISIBLE : View.GONE);
 
-      if (RecipientUtil.isBlockable(recipient)) {
-        boolean blocked = recipient.isBlocked();
+      blockButton          .setVisibility(!recipient.isMmsGroup()   && !recipient.isBlocked() && !recipient.isSelf() ? View.VISIBLE : View.GONE);
+      unblockButton        .setVisibility(!recipient.isMmsGroup()   &&  recipient.isBlocked() && !recipient.isSelf() ? View.VISIBLE : View.GONE);
+      messageButton        .setVisibility(!recipient.isMmsGroup()   && !recipient.isBlocked() && !recipient.isSelf() ? View.VISIBLE : View.GONE);
+      secureCallButton     .setVisibility( recipient.isRegistered() && !recipient.isBlocked() && !recipient.isSelf() ? View.VISIBLE : View.GONE);
+      insecureCallButton   .setVisibility(!recipient.isRegistered() && !recipient.isBlocked() && !recipient.isSelf() ? View.VISIBLE : View.GONE);
+      secureVideoCallButton.setVisibility( recipient.isRegistered() && !recipient.isBlocked() && !recipient.isSelf() ? View.VISIBLE : View.GONE);
 
-        blockButton  .setVisibility(recipient.isSelf() ||  blocked ? View.GONE : View.VISIBLE);
-        unblockButton.setVisibility(recipient.isSelf() || !blocked ? View.GONE : View.VISIBLE);
-      } else {
-        blockButton  .setVisibility(View.GONE);
-        unblockButton.setVisibility(View.GONE);
-      }
-
-      messageButton.setVisibility(!recipient.isSelf() ? View.VISIBLE : View.GONE);
-      secureCallButton.setVisibility(recipient.isRegistered() && !recipient.isSelf() ? View.VISIBLE : View.GONE);
-      insecureCallButton.setVisibility(!recipient.isRegistered() && !recipient.isSelf() ? View.VISIBLE : View.GONE);
-      secureVideoCallButton.setVisibility(recipient.isRegistered() && !recipient.isSelf() ? View.VISIBLE : View.GONE);
-
-      if (recipient.isSystemContact() || recipient.isGroup() || recipient.isSelf()) {
+      if (recipient.isSystemContact() || recipient.isGroup() || recipient.isBlocked() || recipient.isSelf()) {
         addContactButton.setVisibility(View.GONE);
       } else {
         addContactButton.setVisibility(View.VISIBLE);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Moto X Play, Android 7.1.1
 * Virtual Pixel 2, Android 11.0
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Fixes #10971 

Prevent displaying the button for "text message", "voice call" and "video call" when recipient is blocked.
Additional also the option to add the recipient to the contacts, when contact is unsaved and blocked.

Tested with Signal contacts, Signal groups and SMS contacts. Not tested for MMS groups.


![signal-2021-02-15-210934](https://user-images.githubusercontent.com/49990901/107989607-ec1beb00-6fd2-11eb-9dd2-d82fb58670a9.jpg)

