### PR TITLE
Fix #10973 You Can Set Disappearing Messages on Blocked Users

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/managerecipient/ManageRecipientFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/managerecipient/ManageRecipientFragment.java
@@ -288,26 +288,33 @@ public class ManageRecipientFragment extends LoggingFragment {
     colorCircle.setBounds(0, 0, ViewUtil.dpToPx(16), ViewUtil.dpToPx(16));
     TextViewCompat.setCompoundDrawablesRelative(chatWallpaperButton, null, null, colorCircle, null);
 
+    messageButton        .setVisibility(!recipient.isMmsGroup()   && !recipient.isBlocked() && !recipient.isSelf() ? View.VISIBLE : View.GONE);
+    secureCallButton     .setVisibility( recipient.isRegistered() && !recipient.isBlocked() && !recipient.isSelf() ? View.VISIBLE : View.GONE);
+    insecureCallButton   .setVisibility(!recipient.isRegistered() && !recipient.isBlocked() && !recipient.isSelf() ? View.VISIBLE : View.GONE);
+    secureVideoCallButton.setVisibility( recipient.isRegistered() && !recipient.isBlocked() && !recipient.isSelf() ? View.VISIBLE : View.GONE);
+
     if (recipient.isSystemContact()) {
       contactText.setText(R.string.ManageRecipientActivity_this_person_is_in_your_contacts);
       contactIcon.setVisibility(View.VISIBLE);
       contactRow.setOnClickListener(v -> {
         startActivityForResult(new Intent(Intent.ACTION_VIEW, recipient.getContactUri()), REQUEST_CODE_VIEW_CONTACT);
       });
-    } else {
+    } else if (!recipient.isBlocked()) {
       contactText.setText(R.string.ManageRecipientActivity_add_to_system_contacts);
       contactIcon.setVisibility(View.GONE);
       contactRow.setOnClickListener(v -> {
         startActivityForResult(RecipientExporter.export(recipient).asAddContactIntent(), REQUEST_CODE_ADD_CONTACT);
       });
+    } else {
+      contactRow.setVisibility(View.GONE);
     }
 
     String aboutText = recipient.getCombinedAboutAndEmoji();
     about.setText(aboutText);
     about.setVisibility(Util.isEmpty(aboutText) ? View.GONE : View.VISIBLE);
 
-    disappearingMessagesCard.setVisibility(recipient.isRegistered() ? View.VISIBLE : View.GONE);
-    addToAGroup.setVisibility(recipient.isRegistered() ? View.VISIBLE : View.GONE);
+    disappearingMessagesCard.setVisibility(recipient.isRegistered() && !recipient.isBlocked() ? View.VISIBLE : View.GONE);
+    addToAGroup             .setVisibility(recipient.isRegistered() && !recipient.isBlocked() ? View.VISIBLE : View.GONE);
 
     AvatarColor recipientColor = recipient.getAvatarColor();
     avatar.setFallbackPhotoProvider(new Recipient.FallbackPhotoProvider() {
@@ -328,9 +335,6 @@ public class ManageRecipientFragment extends LoggingFragment {
                              AvatarPreviewActivity.createTransitionBundle(activity, avatar));
     });
 
-    secureCallButton.setVisibility(recipient.isRegistered() && !recipient.isSelf() ? View.VISIBLE : View.GONE);
-    insecureCallButton.setVisibility(!recipient.isRegistered() && !recipient.isSelf() ? View.VISIBLE : View.GONE);
-    secureVideoCallButton.setVisibility(recipient.isRegistered() && !recipient.isSelf() ? View.VISIBLE : View.GONE);
   }
 
   private void presentMediaCursor(ManageRecipientViewModel.MediaCursor mediaCursor) {

--- a/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/managerecipient/ManageRecipientViewModel.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/managerecipient/ManageRecipientViewModel.java
@@ -111,7 +111,7 @@ public final class ManageRecipientViewModel extends ViewModel {
 
     this.canAddToAGroup = LiveDataUtil.combineLatest(recipient,
                                                      localGroupCount,
-                                                     (r, count) -> count > 0 && r.isRegistered() && !r.isGroup() && !r.isSelf());
+                                                     (r, count) -> count > 0 && r.isRegistered() && !r.isGroup() && !r.isSelf() && !r.isBlocked());
 
     manageRecipientRepository.getActiveGroupCount(localGroupCount::postValue);
   }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Moto X Play, Android 7.1.1
 * Virtual Pixel 2, Android 11.0
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Fixes #10973 and some more for blocked recipients (Fixes #11064).

When a contact is blocked, don't show in the ManageRecipientFragment:

- the buttons for "message", "secure call", "insecure call" and "secure video call"
- "add to a group"
- disappearing message card
- "add to system contacts"
