### PR TITLE
Fix #10307 Typing Indicators triggers a switch from SMS to Signal mes…

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationActivity.java
@@ -3246,7 +3246,7 @@ public class ConversationActivity extends PassphraseRequiredActivity
 
     @Override
     public void onTextChanged(String text) {
-      if (enabled && threadId > 0 && isSecureText && !isSmsForced() && !recipient.get().isBlocked() && !recipient.get().isSelf()) {
+      if (enabled && (threadId > 0) && isSecureText && !sendButton.getSelectedTransport().isSms() && !recipient.get().isBlocked() && !recipient.get().isSelf()) {
         TypingStatusSender typingStatusSender = ApplicationDependencies.getTypingStatusSender();
 
         if (text.length() == 0) {


### PR DESCRIPTION
…sages to the receiver

### Contributor checklist
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Moto X Play, Android 7.1.1
 * Virtual Pixel 2, Android 11.0
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Fix #10307 

```
    public void onTextChanged(String text) {
      if (enabled && threadId > 0 && isSecureText && !isSmsForced() && !recipient.get().isBlocked()) {
        TypingStatusSender typingStatusSender = ApplicationDependencies.getTypingStatusSender();
        ...
```

```
  private boolean isSmsForced() {
    return sendButton.isManualSelection() && sendButton.getSelectedTransport().isSms();
  }
```

isSmsForced() does not work as expected. Evaluates always to "false".
This is caused by `sendButton.isManualSelection()`

```
  //sendbutton.java
  public boolean isManualSelection() {
    return transportOptions.isManualSelection();
  }

  //transportOptions.java
  public boolean isManualSelection() {
    return this.selectedOption.isPresent();
  }

 private Optional<TransportOption> selectedOption        = Optional.absent();

```

Replaced !isSmsForced() with !sendButton.getSelectedTransport().isSms() on the function onTextChanged(String text)

isSmsForced() is used also in:
- private void sendSharedContact(List<Contact> contacts) {
- private void sendKeyboardImage(@NonNull Uri uri, @NonNull String contentType, @Nullable KeyboardImageDetails details) {
- public void onActivityResult(final int reqCode, int resultCode, Intent data) {

I have not checked the three functions to see whether there could be problems with an incorrect evaluation of isSmsForced().
The condition `sendButton.isManualSelection()` is also used in other places.

---------------------------

While checking, I came across the question of whether you could do the typing indicator handling without the "onTypingStopped".
At the receiving end, the display (of the typing indicator) also stops without the typing-stop message.



