### PR TITLE
Fix #8611 : adds orientation listener to camerax

### DIFF
--- a/app/src/main/java/androidx/camera/view/SignalCameraXModule.java
+++ b/app/src/main/java/androidx/camera/view/SignalCameraXModule.java
@@ -22,6 +22,8 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.util.Rational;
 import android.util.Size;
+import android.view.OrientationEventListener;
+import android.view.Surface;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -281,6 +283,31 @@ final class SignalCameraXModule {
     mCurrentLifecycle.getLifecycle().addObserver(mCurrentLifecycleObserver);
     // Enable flash setting in ImageCapture after use cases are created and binded.
     setFlash(getFlash());
+
+    //attach listener for sensor orientation
+    OrientationEventListener orientationEventListener = new OrientationEventListener(getContext()) {
+      @Override
+      public void onOrientationChanged(int orientation) {
+        int rotation;
+
+        // Monitors orientation values to determine the target rotation value
+        if (orientation >= 45 && orientation < 135) {
+          rotation = Surface.ROTATION_270;
+        } else if (orientation >= 135 && orientation < 225) {
+          rotation = Surface.ROTATION_180;
+        } else if (orientation >= 225 && orientation < 315) {
+          rotation = Surface.ROTATION_90;
+        } else {
+          rotation = Surface.ROTATION_0;
+        }
+        if (mImageCapture != null)
+          mImageCapture.setTargetRotation(rotation);
+        if (mVideoCapture != null)
+          mVideoCapture.setTargetRotation(rotation);
+      }
+    };
+
+    orientationEventListener.enable();
   }
 
   public void open() {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device p20, Android 10 (device temporally removed from blacklist for testing)

- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This allow to have the image taken from the camera with the right orientation even though the auto-rotate is turned off, that is the phone is locked to portrait or landscape mode. This is the behavor WhatsApp has. 

To do so, we add a listener like illustrated in the link below which updates the target orientation constantly.
https://developer.android.com/training/camerax/configuration#java

For example, here is a picture taken with auto-rotate off with the user holding the phone in landscape. 
Before the fix
![Screenshot_20210225_224839_org thoughtcrime securesms](https://user-images.githubusercontent.com/10091822/109231091-d621dd80-77bd-11eb-90ab-8a4c7f344d71.jpg)

After the fix
![Screenshot_20210225_225013_org thoughtcrime securesms staging](https://user-images.githubusercontent.com/10091822/109231223-0ff2e400-77be-11eb-8558-b4629f51cf04.jpg)
