### PR TITLE
Fix reaction overlay not showing on first try in RTL mode

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationReactionDelegate.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationReactionDelegate.java
@@ -115,6 +115,7 @@ final class ConversationReactionDelegate {
 
   private @NonNull ConversationReactionOverlay resolveOverlay() {
     ConversationReactionOverlay overlay = overlayStub.get();
+    overlay.requestFitSystemWindows();
 
     overlay.setListVerticalTranslation(translationY);
     overlay.setOnHideListener(onHideListener);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Pixel 3a API 30
 * AVD Nexus 6P API 27
 * AVD Pixel API 23
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
The view needs to request a call to `fitsSystemWindows`; otherwise it cannot determine where to layout itself within the parent that uses `fitsSystemWindows` method to determine the boundary of it.

This fixes the issue reported in [the beta 5.3 forum](https://community.signalusers.org/t/beta-feedback-for-the-upcoming-android-5-3-release/25088/315).

An attempt to fix the same issue was merged at [424979d91f7c86182c98deb6c0d75eb2dd646938] but was reverted at [eba04eb75b1db43bf4005473f534e4f803f4d1f8] due to another issue brought in by the commit. This is the second attempt to fix the issue in a different, hopefully more robust way.

### Screenrecords

**Bug**
Notice the status bar turns darker at the first long tap, but the reaction overlay doesn't appear on the view.

https://user-images.githubusercontent.com/28482/108600929-d35f5c80-7367-11eb-91db-1045074714ee.mp4

**Fixed**

https://user-images.githubusercontent.com/28482/108600953-f427b200-7367-11eb-98e7-fe8c97b142f4.mp4

