### PR TITLE
Stop leaving SQLCipher database cursor open and have it abruptly destroyed

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/contacts/ContactsCursorLoader.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/contacts/ContactsCursorLoader.java
@@ -163,7 +163,7 @@ public class ContactsCursorLoader extends CursorLoader {
 
     if (!isCursorListEmpty(contacts)) {
       cursorList.add(getContactsHeaderCursor());
-      cursorList.addAll(getContactsCursors());
+      cursorList.addAll(contacts);
     }
   }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Pixel 3a API 29
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
As you can see in the first screen record, a SQLCipher cursor is abruptly destroyed when the list of Signal contacts is shown. The error log is attached below. This was because another cursor is opened unnecessarily in the code. After fixing it the error log no longer appears as you can see in another screen record.

<details>
<summary>Error log</summary>

```
2021-02-19 17:28:02.021 396-413/org.thoughtcrime.securesms E/Cursor: Finalizing a Cursor that has not been deactivated or closed. database = /data/user/0/org.thoughtcrime.securesms/databases/signal.db, table = recipient, query = SELECT _id, system_display_name, phone, email, system_phone_label, system_phone_type, registered, ab
    net.sqlcipher.database.DatabaseObjectNotClosedException: Application did not close the cursor or database object that was opened here
        at net.sqlcipher.database.SQLiteCursor.<init>(SQLiteCursor.java:237)
        at net.sqlcipher.database.SQLiteDirectCursorDriver.query(SQLiteDirectCursorDriver.java:71)
        at net.sqlcipher.database.SQLiteDatabase.rawQueryWithFactory(SQLiteDatabase.java:1965)
        at net.sqlcipher.database.SQLiteDatabase.queryWithFactory(SQLiteDatabase.java:1740)
        at net.sqlcipher.database.SQLiteDatabase.query(SQLiteDatabase.java:1692)
        at net.sqlcipher.database.SQLiteDatabase.query(SQLiteDatabase.java:1781)
        at org.thoughtcrime.securesms.database.SQLiteDatabase.lambda$query$2(SQLiteDatabase.java:138)
        at org.thoughtcrime.securesms.database.SQLiteDatabase.lambda$query$2$SQLiteDatabase(Unknown Source:0)
        at org.thoughtcrime.securesms.database.-$$Lambda$SQLiteDatabase$cvMxOy0u0-aa46LyDnbjGx12KKk.run(Unknown Source:16)
        at org.thoughtcrime.securesms.database.SQLiteDatabase.traceSql(SQLiteDatabase.java:92)
        at org.thoughtcrime.securesms.database.SQLiteDatabase.query(SQLiteDatabase.java:138)
        at org.thoughtcrime.securesms.database.RecipientDatabase.getSignalContacts(RecipientDatabase.java:2300)
        at org.thoughtcrime.securesms.contacts.ContactRepository.querySignalContacts(ContactRepository.java:117)
        at org.thoughtcrime.securesms.contacts.ContactsCursorLoader.getContactsCursors(ContactsCursorLoader.java:309)
        at org.thoughtcrime.securesms.contacts.ContactsCursorLoader.addContactsSection(ContactsCursorLoader.java:162)
        at org.thoughtcrime.securesms.contacts.ContactsCursorLoader.getUnfilteredResults(ContactsCursorLoader.java:128)
        at org.thoughtcrime.securesms.contacts.ContactsCursorLoader.loadInBackground(ContactsCursorLoader.java:102)
        at org.thoughtcrime.securesms.contacts.ContactsCursorLoader.loadInBackground(ContactsCursorLoader.java:54)
        at androidx.loader.content.AsyncTaskLoader.onLoadInBackground(AsyncTaskLoader.java:307)
        at androidx.loader.content.AsyncTaskLoader$LoadTask.doInBackground(AsyncTaskLoader.java:60)
        at androidx.loader.content.AsyncTaskLoader$LoadTask.doInBackground(AsyncTaskLoader.java:48)
        at androidx.loader.content.ModernAsyncTask$2.call(ModernAsyncTask.java:141)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:919)
```

</details>

### Screen records

**Bug**

https://user-images.githubusercontent.com/28482/108601315-f854cf00-7369-11eb-9d86-a87a55338e14.mp4

**Fixed**

https://user-images.githubusercontent.com/28482/108601319-fd198300-7369-11eb-885c-aacd7e9328bd.mp4


