### PR TITLE
Avoid naming an attachment `null`

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/sharing/ShareRepository.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/sharing/ShareRepository.java
@@ -233,6 +233,10 @@ class ShareRepository {
   }
 
   private static @Nullable String getFileName(@NonNull Context context, @NonNull Uri uri) {
+    if (uri.getScheme().equalsIgnoreCase("file")) {
+      return uri.getLastPathSegment();
+    }
+
     try (Cursor cursor = context.getContentResolver().query(uri, null, null, null, null)) {
       if (cursor != null && cursor.moveToFirst() && cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME) >= 0) {
         return cursor.getString(cursor.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME));


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Pixel API 23
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Use the last part of the URI if the scheme is "file" to avoid returning null as the file's name. Fixes #8561

#### Steps to reproduce
1. Prepare an AVD that runs API 23; install Signal on it
2. Install [Explorer](https://play.google.com/store/apps/details?id=com.speedsoftware.explorer)
3. Prepare a PDF file in a directory accessible from Explorer
4. Open Explorer, long tap the PDF file and choose Send from the three-dot menu
5. Choose Signal app and select a contact

**Actual behavior**
The attachment bubble appears but the name of it is `null`.

**Expected behavior**
The attachment bubble appears and the name of it is the file name.

### Screen records

**Bug**

https://user-images.githubusercontent.com/28482/108636342-9b811380-7452-11eb-9c8a-12a19d707288.mp4

**Fixed**

https://user-images.githubusercontent.com/28482/108636346-a340b800-7452-11eb-9392-082ff642b881.mp4

