### PR TITLE
Fix #9150 huawei phone

### DIFF
--- a/app/src/main/java/androidx/camera/view/SignalCameraXModule.java
+++ b/app/src/main/java/androidx/camera/view/SignalCameraXModule.java
@@ -221,17 +221,14 @@ final class SignalCameraXModule {
     int resolution = CameraXUtil.getIdealResolution(Resources.getSystem().getDisplayMetrics().widthPixels, Resources.getSystem().getDisplayMetrics().heightPixels);
     // End Signal Custom Code Block
 
-    Rational targetAspectRatio;
     if (getCaptureMode() == SignalCameraView.CaptureMode.IMAGE) {
       // Begin Signal Custom Code Block
       mImageCaptureBuilder.setTargetResolution(CameraXUtil.buildResolutionForRatio(resolution, ASPECT_RATIO_4_3, isDisplayPortrait));
       // End Signal Custom Code Block
-      targetAspectRatio = isDisplayPortrait ? ASPECT_RATIO_3_4 : ASPECT_RATIO_4_3;
     } else {
       // Begin Signal Custom Code Block
       mImageCaptureBuilder.setTargetResolution(CameraXUtil.buildResolutionForRatio(resolution, ASPECT_RATIO_16_9, isDisplayPortrait));
       // End Signal Custom Code Block
-      targetAspectRatio = isDisplayPortrait ? ASPECT_RATIO_9_16 : ASPECT_RATIO_16_9;
     }
 
     // Begin Signal Custom Code Block
@@ -253,10 +250,6 @@ final class SignalCameraXModule {
       mVideoCapture = mVideoCaptureBuilder.build();
     }
     // End Signal Custom Code Block
-
-    // Adjusts the preview resolution according to the view size and the target aspect ratio.
-    int height = (int) (getMeasuredWidth() / targetAspectRatio.floatValue());
-    mPreviewBuilder.setTargetResolution(new Size(getMeasuredWidth(), height));
 
     mPreview = mPreviewBuilder.build();
     mPreview.setSurfaceProvider(mCameraView.getPreviewView().getSurfaceProvider());

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/camerax/CameraXModelBlacklist.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/camerax/CameraXModelBlacklist.java
@@ -2,116 +2,119 @@ package org.thoughtcrime.securesms.mediasend.camerax;
 
 import android.os.Build;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.HashMap;
 
 public final class CameraXModelBlacklist {
-  private static final Set<String> BLACKLIST = new HashSet<String>() {{
+  // we list here the name of the phone and the maximum sdk version to be blacklisted
+  // if the device is listed here and has a sdk version <= the value listed, it will be blacklisted
+  private static Integer ALL_SDK_VERSION = Integer.MAX_VALUE;
+  private static final HashMap<String, Integer> BLACKLIST = new HashMap<String, Integer>() {{
     // Pixel 4
-    add("Pixel 4");
-    add("Pixel 4 XL");
+    put("Pixel 4", ALL_SDK_VERSION);
+    put("Pixel 4 XL", ALL_SDK_VERSION);
 
     // Huawei Mate 10
-    add("ALP-L29");
-    add("ALP-L09");
-    add("ALP-AL00");
+    put("ALP-L29",ALL_SDK_VERSION);
+    put("ALP-L09",ALL_SDK_VERSION);
+    put("ALP-AL00",ALL_SDK_VERSION);
 
     // Huawei Mate 10 Pro
-    add("BLA-L29");
-    add("BLA-L09");
-    add("BLA-AL00");
-    add("BLA-A09");
+    put("BLA-L29",ALL_SDK_VERSION);
+    put("BLA-L09",ALL_SDK_VERSION);
+    put("BLA-AL00",ALL_SDK_VERSION);
+    put("BLA-A09",ALL_SDK_VERSION);
 
     // Huawei Mate 20
-    add("HMA-L29");
-    add("HMA-L09");
-    add("HMA-LX9");
-    add("HMA-AL00");
+    put("HMA-L29",ALL_SDK_VERSION);
+    put("HMA-L09",ALL_SDK_VERSION);
+    put("HMA-LX9",ALL_SDK_VERSION);
+    put("HMA-AL00",ALL_SDK_VERSION);
 
     // Huawei Mate 20 Pro
-    add("LYA-L09");
-    add("LYA-L29");
-    add("LYA-AL00");
-    add("LYA-AL10");
-    add("LYA-TL00");
-    add("LYA-L0C");
+    put("LYA-L09",ALL_SDK_VERSION);
+    put("LYA-L29",ALL_SDK_VERSION);
+    put("LYA-AL00",ALL_SDK_VERSION);
+    put("LYA-AL10",ALL_SDK_VERSION);
+    put("LYA-TL00",ALL_SDK_VERSION);
+    put("LYA-L0C",ALL_SDK_VERSION);
 
     // Huawei Mate 20 X
-    add("EVR-L29");
-    add("EVR-AL00");
-    add("EVR-TL00");
+    put("EVR-L29",ALL_SDK_VERSION);
+    put("EVR-AL00",ALL_SDK_VERSION);
+    put("EVR-TL00",ALL_SDK_VERSION);
 
     // Huawei P20
-    add("EML-L29C");
-    add("EML-L09C");
-    add("EML-AL00");
-    add("EML-TL00");
-    add("EML-L29");
-    add("EML-L09");
+    put("EML-L29C",ALL_SDK_VERSION);
+    put("EML-L09C",ALL_SDK_VERSION);
+    put("EML-AL00",ALL_SDK_VERSION);
+    put("EML-TL00",ALL_SDK_VERSION);
+    put("EML-L29",ALL_SDK_VERSION);
+    put("EML-L09",ALL_SDK_VERSION);
 
     // Huawei P20 Pro
-    add("CLT-L29C");
-    add("CLT-L29");
-    add("CLT-L09C");
-    add("CLT-L09");
-    add("CLT-AL00");
-    add("CLT-AL01");
-    add("CLT-TL01");
-    add("CLT-AL00L");
-    add("CLT-L04");
-    add("HW-01K");
+    put("CLT-L29C",ALL_SDK_VERSION);
+    put("CLT-L29",ALL_SDK_VERSION);
+    put("CLT-L09C",ALL_SDK_VERSION);
+    put("CLT-L09",ALL_SDK_VERSION);
+    put("CLT-AL00",ALL_SDK_VERSION);
+    put("CLT-AL01",ALL_SDK_VERSION);
+    put("CLT-TL01",ALL_SDK_VERSION);
+    put("CLT-AL00L",ALL_SDK_VERSION);
+    put("CLT-L04",ALL_SDK_VERSION);
+    put("HW-01K",ALL_SDK_VERSION);
 
     // Huawei P30
-    add("ELE-L29");
-    add("ELE-L09");
-    add("ELE-AL00");
-    add("ELE-TL00");
-    add("ELE-L04");
+    put("ELE-L29",ALL_SDK_VERSION);
+    put("ELE-L09",ALL_SDK_VERSION);
+    put("ELE-AL00",ALL_SDK_VERSION);
+    put("ELE-TL00",ALL_SDK_VERSION);
+    put("ELE-L04",ALL_SDK_VERSION);
 
     // Huawei P30 Pro
-    add("VOG-L29");
-    add("VOG-L09");
-    add("VOG-AL00");
-    add("VOG-TL00");
-    add("VOG-L04");
-    add("VOG-AL10");
+    put("VOG-L29",ALL_SDK_VERSION);
+    put("VOG-L09",ALL_SDK_VERSION);
+    put("VOG-AL00",ALL_SDK_VERSION);
+    put("VOG-TL00",ALL_SDK_VERSION);
+    put("VOG-L04",ALL_SDK_VERSION);
+    put("VOG-AL10",ALL_SDK_VERSION);
 
     // Huawei Honor 10
-    add("COL-AL10");
-    add("COL-L29");
-    add("COL-L19");
+    put("COL-AL10",ALL_SDK_VERSION);
+    put("COL-L29",ALL_SDK_VERSION);
+    put("COL-L19",ALL_SDK_VERSION);
 
     // Huawei Honor 20
-    add("YAL-L21");
-    add("YAL-AL00");
-    add("YAL-TL00");
+    put("YAL-L21",ALL_SDK_VERSION);
+    put("YAL-AL00",ALL_SDK_VERSION);
+    put("YAL-TL00",ALL_SDK_VERSION);
 
     // Samsung Galaxy S6
-    add("SM-G920F");
+    put("SM-G920F",ALL_SDK_VERSION);
 
     // Honor View 10
-    add("BKL-AL20");
-    add("BKL-L04");
-    add("BKL-L09");
-    add("BKL-AL00");
+    put("BKL-AL20",ALL_SDK_VERSION);
+    put("BKL-L04",ALL_SDK_VERSION);
+    put("BKL-L09",ALL_SDK_VERSION);
+    put("BKL-AL00",ALL_SDK_VERSION);
 
     // Honor View 20
-    add("PCT-AL10");
-    add("PCT-TL10");
-    add("PCT-L29");
+    put("PCT-AL10",ALL_SDK_VERSION);
+    put("PCT-TL10",ALL_SDK_VERSION);
+    put("PCT-L29",ALL_SDK_VERSION);
 
     // Honor Play
-    add("COR-L29");
-    add("COR-L09");
-    add("COR-AL00");
-    add("COR-AL10");
-    add("COR-TL10");
+    put("COR-L29",ALL_SDK_VERSION);
+    put("COR-L09",ALL_SDK_VERSION);
+    put("COR-AL00",ALL_SDK_VERSION);
+    put("COR-AL10",ALL_SDK_VERSION);
+    put("COR-TL10",ALL_SDK_VERSION);
   }};
 
   private CameraXModelBlacklist() {
   }
 
   public static boolean isBlacklisted() {
-    return BLACKLIST.contains(Build.MODEL);
+    final Integer max_invalid_sdk = BLACKLIST.get(Build.MODEL);
+    return max_invalid_sdk != null && Build.VERSION.SDK_INT <= max_invalid_sdk;
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/camerax/CameraXModelBlacklist.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/camerax/CameraXModelBlacklist.java
@@ -14,100 +14,100 @@ public final class CameraXModelBlacklist {
     put("Pixel 4 XL", ALL_SDK_VERSION);
 
     // Huawei Mate 10
-    put("ALP-L29",ALL_SDK_VERSION);
-    put("ALP-L09",ALL_SDK_VERSION);
-    put("ALP-AL00",ALL_SDK_VERSION);
+    put("ALP-L29",28);
+    put("ALP-L09",28);
+    put("ALP-AL00",28);
 
     // Huawei Mate 10 Pro
-    put("BLA-L29",ALL_SDK_VERSION);
-    put("BLA-L09",ALL_SDK_VERSION);
-    put("BLA-AL00",ALL_SDK_VERSION);
-    put("BLA-A09",ALL_SDK_VERSION);
+    put("BLA-L29",28);
+    put("BLA-L09",28);
+    put("BLA-AL00",28);
+    put("BLA-A09",28);
 
     // Huawei Mate 20
-    put("HMA-L29",ALL_SDK_VERSION);
-    put("HMA-L09",ALL_SDK_VERSION);
-    put("HMA-LX9",ALL_SDK_VERSION);
-    put("HMA-AL00",ALL_SDK_VERSION);
+    put("HMA-L29",28);
+    put("HMA-L09",28);
+    put("HMA-LX9",28);
+    put("HMA-AL00",28);
 
     // Huawei Mate 20 Pro
-    put("LYA-L09",ALL_SDK_VERSION);
-    put("LYA-L29",ALL_SDK_VERSION);
-    put("LYA-AL00",ALL_SDK_VERSION);
-    put("LYA-AL10",ALL_SDK_VERSION);
-    put("LYA-TL00",ALL_SDK_VERSION);
-    put("LYA-L0C",ALL_SDK_VERSION);
+    put("LYA-L09",28);
+    put("LYA-L29",28);
+    put("LYA-AL00",28);
+    put("LYA-AL10",28);
+    put("LYA-TL00",28);
+    put("LYA-L0C",28);
 
     // Huawei Mate 20 X
-    put("EVR-L29",ALL_SDK_VERSION);
-    put("EVR-AL00",ALL_SDK_VERSION);
-    put("EVR-TL00",ALL_SDK_VERSION);
+    put("EVR-L29",28);
+    put("EVR-AL00",28);
+    put("EVR-TL00",28);
 
     // Huawei P20
-    put("EML-L29C",ALL_SDK_VERSION);
-    put("EML-L09C",ALL_SDK_VERSION);
-    put("EML-AL00",ALL_SDK_VERSION);
-    put("EML-TL00",ALL_SDK_VERSION);
-    put("EML-L29",ALL_SDK_VERSION);
-    put("EML-L09",ALL_SDK_VERSION);
+    put("EML-L29C",28);
+    put("EML-L09C",28);
+    put("EML-AL00",28);
+    put("EML-TL00",28);
+    put("EML-L29",28);
+    put("EML-L09",28);
 
     // Huawei P20 Pro
-    put("CLT-L29C",ALL_SDK_VERSION);
-    put("CLT-L29",ALL_SDK_VERSION);
-    put("CLT-L09C",ALL_SDK_VERSION);
-    put("CLT-L09",ALL_SDK_VERSION);
-    put("CLT-AL00",ALL_SDK_VERSION);
-    put("CLT-AL01",ALL_SDK_VERSION);
-    put("CLT-TL01",ALL_SDK_VERSION);
-    put("CLT-AL00L",ALL_SDK_VERSION);
-    put("CLT-L04",ALL_SDK_VERSION);
-    put("HW-01K",ALL_SDK_VERSION);
+    put("CLT-L29C",28);
+    put("CLT-L29",28);
+    put("CLT-L09C",28);
+    put("CLT-L09",28);
+    put("CLT-AL00",28);
+    put("CLT-AL01",28);
+    put("CLT-TL01",28);
+    put("CLT-AL00L",28);
+    put("CLT-L04",28);
+    put("HW-01K",28);
 
     // Huawei P30
-    put("ELE-L29",ALL_SDK_VERSION);
-    put("ELE-L09",ALL_SDK_VERSION);
-    put("ELE-AL00",ALL_SDK_VERSION);
-    put("ELE-TL00",ALL_SDK_VERSION);
-    put("ELE-L04",ALL_SDK_VERSION);
+    put("ELE-L29",28);
+    put("ELE-L09",28);
+    put("ELE-AL00",28);
+    put("ELE-TL00",28);
+    put("ELE-L04",28);
 
     // Huawei P30 Pro
-    put("VOG-L29",ALL_SDK_VERSION);
-    put("VOG-L09",ALL_SDK_VERSION);
-    put("VOG-AL00",ALL_SDK_VERSION);
-    put("VOG-TL00",ALL_SDK_VERSION);
-    put("VOG-L04",ALL_SDK_VERSION);
-    put("VOG-AL10",ALL_SDK_VERSION);
+    put("VOG-L29",28);
+    put("VOG-L09",28);
+    put("VOG-AL00",28);
+    put("VOG-TL00",28);
+    put("VOG-L04",28);
+    put("VOG-AL10",28);
 
     // Huawei Honor 10
-    put("COL-AL10",ALL_SDK_VERSION);
-    put("COL-L29",ALL_SDK_VERSION);
-    put("COL-L19",ALL_SDK_VERSION);
+    put("COL-AL10",28);
+    put("COL-L29",28);
+    put("COL-L19",28);
 
     // Huawei Honor 20
-    put("YAL-L21",ALL_SDK_VERSION);
-    put("YAL-AL00",ALL_SDK_VERSION);
-    put("YAL-TL00",ALL_SDK_VERSION);
+    put("YAL-L21",28);
+    put("YAL-AL00",28);
+    put("YAL-TL00",28);
 
     // Samsung Galaxy S6
     put("SM-G920F",ALL_SDK_VERSION);
 
     // Honor View 10
-    put("BKL-AL20",ALL_SDK_VERSION);
-    put("BKL-L04",ALL_SDK_VERSION);
-    put("BKL-L09",ALL_SDK_VERSION);
-    put("BKL-AL00",ALL_SDK_VERSION);
+    put("BKL-AL20",28);
+    put("BKL-L04",28);
+    put("BKL-L09",28);
+    put("BKL-AL00",28);
 
     // Honor View 20
-    put("PCT-AL10",ALL_SDK_VERSION);
-    put("PCT-TL10",ALL_SDK_VERSION);
-    put("PCT-L29",ALL_SDK_VERSION);
+    put("PCT-AL10",28);
+    put("PCT-TL10",28);
+    put("PCT-L29",28);
 
     // Honor Play
-    put("COR-L29",ALL_SDK_VERSION);
-    put("COR-L09",ALL_SDK_VERSION);
-    put("COR-AL00",ALL_SDK_VERSION);
-    put("COR-AL10",ALL_SDK_VERSION);
-    put("COR-TL10",ALL_SDK_VERSION);
+    put("COR-L29",28);
+    put("COR-L09",28);
+    put("COR-AL00",28);
+    put("COR-AL10",28);
+    put("COR-TL10",28);
   }};
 
   private CameraXModelBlacklist() {

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/camerax/CameraXUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/camerax/CameraXUtil.java
@@ -131,13 +131,17 @@ public class CameraXUtil {
   }
 
   public static int getIdealResolution(int displayWidth, int displayHeight) {
-    int maxDisplay = Math.max(displayWidth, displayHeight);
-    return Math.max(maxDisplay, 1920);
+    //The maximum available resolution that you can select for an ImageAnalysis is 1080p.
+    // that is 1920×1080 in 16:9 or 1440×1080 in 4:3
+    //so the resolution here is max 1080
+    //see https://developer.android.com/training/camerax/configuration
+    int minDisplay = Math.min(displayWidth, displayHeight);
+    return Math.min(minDisplay, 1080);
   }
 
   @TargetApi(21)
-  public static @NonNull Size buildResolutionForRatio(int longDimension, @NonNull Rational ratio, boolean isPortrait) {
-    int shortDimension = longDimension * ratio.getDenominator() / ratio.getNumerator();
+  public static @NonNull Size buildResolutionForRatio(int shortDimension, @NonNull Rational ratio, boolean isPortrait) {
+    int longDimension = shortDimension * ratio.getNumerator() / ratio.getDenominator();
 
     if (isPortrait) {
       return new Size(shortDimension, longDimension);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device p20, Android 10.0.0
 * Device p30 lite, Android 10.0.0
 * Device p30 pro, Android 10.0.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
The goal is to make some huawei phones work with the CameraX framework. Other Huawei would also probably work (like the mate and honor série) but I could not test them so they remain blacklisted. 

There are 3 commits in this PR.
1. update the blacklist method so we can blacklist by name and sdk version
2. remove all huawei/honor of the list if the sdk >28
3. house cleaning on the IdealResolution function and removed the preview resolution set manually. This preview resolution set manually was likely the problem of the Huawei not working because it forced the preview aspect ration to 16:9 or 4:3 which is not possible when the screen is Full HD. If we do not set the resolution, then CameraX automatically picks the best for us. This was tested on p20, p30 lite and pro, low and high resolution.
