### PR TITLE
Accept null original intent in registration nav

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/registration/RegistrationNavigationActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/RegistrationNavigationActivity.java
@@ -36,7 +36,7 @@ public final class RegistrationNavigationActivity extends AppCompatActivity {
     Intent intent = new Intent(context, RegistrationNavigationActivity.class);
     intent.putExtra(RE_REGISTRATION_EXTRA, false);
 
-    if (intent != null) {
+    if (originalIntent != null) {
       intent.setData(originalIntent.getData());
     }
 

--- a/app/src/test/java/org/thoughtcrime/securesms/registration/RegistrationNavigationActivityTest.java
+++ b/app/src/test/java/org/thoughtcrime/securesms/registration/RegistrationNavigationActivityTest.java
@@ -1,0 +1,26 @@
+package org.thoughtcrime.securesms.registration;
+
+import android.app.Application;
+import android.content.Context;
+import android.content.Intent;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE, application = Application.class)
+public class RegistrationNavigationActivityTest {
+    private static final Intent NULL_ORIGINAL_INTENT = null;
+
+    @Test
+    public void newIntentForNewRegistration_accepts_null_original_intent() {
+        final Context context = mock(Context.class);
+        Intent intent = RegistrationNavigationActivity.newIntentForNewRegistration(context, NULL_ORIGINAL_INTENT);
+        assertThat(intent).isNotNull();
+    }
+}


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 2 XL Android Emulator, Android 9.0 x86 with Google APIs
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/). *I searched for all open issues with `NPE` and `NullPointerException`, and didn't find any matching this pull request*

----------

### Description
There is a fairly obvious NullPointerException bug in RegistrationNavigationActivity.newIntentForNewRegistration(). There is a null check for `intent` after it has been constructed with the `new` operator ... that is obviously non-null, while the `@Nullable originalIntent` is ignored in the null check.

Testing:

1. I've added a unit test that demonstrates the NullPointerException.

    Without the fix, the unit test gives:

    ```
    java.lang.NullPointerException
	at org.thoughtcrime.securesms.registration.RegistrationNavigationActivity.newIntentForNewRegistration(RegistrationNavigationActivity.java:40)
	at org.thoughtcrime.securesms.registration.RegistrationNavigationActivityTest.newIntentForNewRegistration_accepts_null_original_intent(RegistrationNavigationActivityTest.java:24)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.robolectric.RobolectricTestRunner$HelperTestRunner$1.evaluate(RobolectricTestRunner.java:575)
	at org.robolectric.internal.SandboxTestRunner$2.lambda$evaluate$0(SandboxTestRunner.java:263)
	at org.robolectric.internal.bytecode.Sandbox.lambda$runOnMainThread$0(Sandbox.java:89)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
    ```

    It passes when the fix is applied.

2. I've also ran `./gradlew -Dorg.gradle.java.home=/usr/lib/jvm/java-8-openjdk-amd64 qa` successfully on Ubuntu 18.04 LTS
3. With Pixel 2 XL Android Emulator, Android 9.0 x86 with Google APIs, the registration screen shows as before. (I'm not sure of the correct mechanism to trigger a null `originalIntent` with the Android app)