### PR TITLE
Add mobile call data usage option

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -70,6 +70,7 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActivity
   public static final String LAUNCH_TO_HELP_FRAGMENT          = "launch.to.help.fragment";
   public static final String LAUNCH_TO_PROXY_FRAGMENT         = "launch.to.proxy.fragment";
   public static final String LAUNCH_TO_NOTIFICATIONS_FRAGMENT = "launch.to.notifications.fragment";
+  public static final String LAUNCH_TO_DATA_AND_STORAGE_FRAGMENT = "launch.to.data_and_storage.fragment";
 
   @SuppressWarnings("unused")
   private static final String TAG = ApplicationPreferencesActivity.class.getSimpleName();
@@ -115,6 +116,8 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActivity
       initFragment(android.R.id.content, EditProxyFragment.newInstance());
     } else if (getIntent() != null && getIntent().getBooleanExtra(LAUNCH_TO_NOTIFICATIONS_FRAGMENT, false)) {
       initFragment(android.R.id.content, new NotificationsPreferenceFragment());
+    } else if (getIntent() != null && getIntent().getBooleanExtra(LAUNCH_TO_DATA_AND_STORAGE_FRAGMENT, false)) {
+      initFragment(android.R.id.content, new DataAndStoragePreferenceFragment());
     } else if (icicle == null) {
       initFragment(android.R.id.content, new ApplicationPreferenceFragment());
     } else {

--- a/app/src/main/java/org/thoughtcrime/securesms/components/webrtc/MobileCallNotAllowedDialog.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/webrtc/MobileCallNotAllowedDialog.java
@@ -1,0 +1,38 @@
+package org.thoughtcrime.securesms.components.webrtc;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+
+import androidx.appcompat.app.AlertDialog;
+
+import org.thoughtcrime.securesms.ApplicationPreferencesActivity;
+import org.thoughtcrime.securesms.R;
+
+public final class MobileCallNotAllowedDialog {
+    public static Intent getCallPreferencesIntent(Context context) {
+        Intent intent = new Intent(context, ApplicationPreferencesActivity.class);
+        intent.putExtra(ApplicationPreferencesActivity.LAUNCH_TO_DATA_AND_STORAGE_FRAGMENT, true);
+        return intent;
+    }
+
+    public static void show(Activity activity) {
+        AlertDialog dialog = new AlertDialog.Builder(activity)
+                .setTitle(R.string.MobileCallNotAllowedDialog_title)
+                .setMessage(R.string.MobileCallNotAllowedDialog_message)
+                .setPositiveButton(R.string.MobileCallNotAllowedDialog_positive_button, (dialog1, which) -> {
+                    Intent intent = getCallPreferencesIntent(activity);
+                    activity.startActivity(intent);
+                    activity.finish();
+                })
+                .setNegativeButton(android.R.string.cancel, (dialog12, which) -> {
+                    dialog12.dismiss();
+                    activity.finish();
+                })
+                .setOnDismissListener(dialog13 -> activity.finish())
+                .create();
+
+        dialog.setIcon(activity.getResources().getDrawable(R.drawable.icon_dialog));
+        dialog.show();
+    }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/GroupNetworkUnavailableActionProcessor.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/GroupNetworkUnavailableActionProcessor.java
@@ -46,7 +46,8 @@ class GroupNetworkUnavailableActionProcessor extends WebRtcActionProcessor {
     GroupCall groupCall = webRtcInteractor.getCallManager().createGroupCall(groupId,
                                                                             BuildConfig.SIGNAL_SFU_URL,
                                                                             currentState.getVideoState().requireEglBase(),
-                                                                            webRtcInteractor.getGroupCallObserver());
+                                                                            webRtcInteractor.getGroupCallObserver(),
+                                                                            currentState.getCallSetupState().isMobileDataAllowed());
 
     return currentState.builder()
                        .changeCallInfoState()

--- a/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/GroupPreJoinActionProcessor.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/GroupPreJoinActionProcessor.java
@@ -48,7 +48,8 @@ public class GroupPreJoinActionProcessor extends GroupActionProcessor {
     GroupCall groupCall = webRtcInteractor.getCallManager().createGroupCall(groupId,
                                                                             BuildConfig.SIGNAL_SFU_URL,
                                                                             currentState.getVideoState().requireEglBase(),
-                                                                            webRtcInteractor.getGroupCallObserver());
+                                                                            webRtcInteractor.getGroupCallObserver(),
+                                                                            currentState.getCallSetupState().isMobileDataAllowed());
 
     try {
       groupCall.setOutgoingAudioMuted(true);

--- a/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/IdleActionProcessor.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/IdleActionProcessor.java
@@ -8,6 +8,7 @@ import org.thoughtcrime.securesms.events.WebRtcViewModel;
 import org.thoughtcrime.securesms.ringrtc.Camera;
 import org.thoughtcrime.securesms.ringrtc.RemotePeer;
 import org.thoughtcrime.securesms.service.webrtc.state.WebRtcServiceState;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.webrtc.CapturerObserver;
 import org.webrtc.VideoFrame;
 import org.whispersystems.signalservice.api.messages.calls.OfferMessage;
@@ -32,6 +33,7 @@ public class IdleActionProcessor extends WebRtcActionProcessor {
     Log.i(TAG, "handleStartIncomingCall():");
 
     currentState = WebRtcVideoUtil.initializeVideo(context, webRtcInteractor.getCameraEventListener(), currentState);
+    currentState = initializeMobileDataAllowed(currentState);
     return beginCallDelegate.handleStartIncomingCall(currentState, remotePeer);
   }
 
@@ -43,6 +45,7 @@ public class IdleActionProcessor extends WebRtcActionProcessor {
     Log.i(TAG, "handleOutgoingCall():");
 
     currentState = WebRtcVideoUtil.initializeVideo(context, webRtcInteractor.getCameraEventListener(), currentState);
+    currentState = initializeMobileDataAllowed(currentState);
     return beginCallDelegate.handleOutgoingCall(currentState, remotePeer, offerType);
   }
 
@@ -65,5 +68,14 @@ public class IdleActionProcessor extends WebRtcActionProcessor {
 
     return isGroupCall ? currentState.getActionProcessor().handlePreJoinCall(currentState, remotePeer)
                        : currentState;
+  }
+
+  private @NonNull WebRtcServiceState initializeMobileDataAllowed(@NonNull WebRtcServiceState currentState) {
+    boolean isMobileDataAllowed = TextSecurePreferences.isCallMobileDataAllowed(context);
+    return currentState.builder()
+                       .changeCallSetupState()
+                       .mobileDataAllowed(isMobileDataAllowed)
+                       .commit()
+                       .build();
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/IncomingCallActionProcessor.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/IncomingCallActionProcessor.java
@@ -94,7 +94,8 @@ public class IncomingCallActionProcessor extends DeviceAwareActionProcessor {
                                                 iceServers,
                                                 hideIp,
                                                 NetworkUtil.getCallingBandwidthMode(context),
-                                                false);
+                                                false,
+                                                currentState.getCallSetupState().isMobileDataAllowed());
     } catch (CallException e) {
       return callFailure(currentState, "Unable to proceed with call: ", e);
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/OutgoingCallActionProcessor.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/OutgoingCallActionProcessor.java
@@ -18,6 +18,7 @@ import org.thoughtcrime.securesms.ringrtc.IceCandidateParcel;
 import org.thoughtcrime.securesms.ringrtc.RemotePeer;
 import org.thoughtcrime.securesms.service.webrtc.WebRtcData.CallMetadata;
 import org.thoughtcrime.securesms.service.webrtc.WebRtcData.OfferMetadata;
+import org.thoughtcrime.securesms.service.webrtc.state.CallSetupState;
 import org.thoughtcrime.securesms.service.webrtc.state.VideoState;
 import org.thoughtcrime.securesms.service.webrtc.state.WebRtcServiceState;
 import org.thoughtcrime.securesms.service.webrtc.state.WebRtcServiceStateBuilder;
@@ -110,6 +111,7 @@ public class OutgoingCallActionProcessor extends DeviceAwareActionProcessor {
       VideoState      videoState      = currentState.getVideoState();
       RemotePeer      activePeer      = currentState.getCallInfoState().requireActivePeer();
       CallParticipant callParticipant = Objects.requireNonNull(currentState.getCallInfoState().getRemoteCallParticipant(activePeer.getRecipient()));
+      CallSetupState  callSetupState  = currentState.getCallSetupState();
 
       webRtcInteractor.getCallManager().proceed(activePeer.getCallId(),
                                                 context,
@@ -120,7 +122,8 @@ public class OutgoingCallActionProcessor extends DeviceAwareActionProcessor {
                                                 iceServers,
                                                 isAlwaysTurn,
                                                 NetworkUtil.getCallingBandwidthMode(context),
-                                                currentState.getCallSetupState().isEnableVideoOnCreate());
+                                                callSetupState.isEnableVideoOnCreate(),
+                                                callSetupState.isMobileDataAllowed());
     } catch (CallException e) {
       return callFailure(currentState, "Unable to proceed with call: ", e);
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/state/CallSetupState.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/state/CallSetupState.java
@@ -10,20 +10,22 @@ public final class CallSetupState {
   boolean isRemoteVideoOffer;
   boolean acceptWithVideo;
   boolean sentJoinedMessage;
+  boolean mobileDataAllowed;
 
   public CallSetupState() {
-    this(false, false, false, false);
+    this(false, false, false, false, false);
   }
 
   public CallSetupState(@NonNull CallSetupState toCopy) {
-    this(toCopy.enableVideoOnCreate, toCopy.isRemoteVideoOffer, toCopy.acceptWithVideo, toCopy.sentJoinedMessage);
+    this(toCopy.enableVideoOnCreate, toCopy.isRemoteVideoOffer, toCopy.acceptWithVideo, toCopy.sentJoinedMessage, toCopy.mobileDataAllowed);
   }
 
-  public CallSetupState(boolean enableVideoOnCreate, boolean isRemoteVideoOffer, boolean acceptWithVideo, boolean sentJoinedMessage) {
+  public CallSetupState(boolean enableVideoOnCreate, boolean isRemoteVideoOffer, boolean acceptWithVideo, boolean sentJoinedMessage, boolean mobileDataAllowed) {
     this.enableVideoOnCreate = enableVideoOnCreate;
     this.isRemoteVideoOffer  = isRemoteVideoOffer;
     this.acceptWithVideo     = acceptWithVideo;
     this.sentJoinedMessage   = sentJoinedMessage;
+    this.mobileDataAllowed   = mobileDataAllowed;
   }
 
   public boolean isEnableVideoOnCreate() {
@@ -40,5 +42,9 @@ public final class CallSetupState {
 
   public boolean hasSentJoinedMessage() {
     return sentJoinedMessage;
+  }
+
+  public boolean isMobileDataAllowed() {
+    return mobileDataAllowed;
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/state/WebRtcServiceStateBuilder.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/state/WebRtcServiceStateBuilder.java
@@ -143,6 +143,11 @@ public class WebRtcServiceStateBuilder {
       toBuild.sentJoinedMessage = sentJoinedMessage;
       return this;
     }
+
+    public @NonNull CallSetupStateBuilder mobileDataAllowed(boolean mobileDataAllowed) {
+      toBuild.mobileDataAllowed = mobileDataAllowed;
+      return this;
+    }
   }
 
   public class VideoStateBuilder {

--- a/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -113,6 +113,7 @@ public class TextSecurePreferences {
   public  static final String MEDIA_DOWNLOAD_ROAMING_PREF      = "pref_media_download_roaming";
 
   public  static final String CALL_BANDWIDTH_PREF              = "pref_data_call_bandwidth";
+  public  static final String CALL_MOBILE_DATA_ALLOWED_PREF    = "pref_data_call_mobile_data_allowed";
 
   public  static final String SYSTEM_EMOJI_PREF                = "pref_system_emoji";
   private static final String MULTI_DEVICE_PROVISIONED_PREF    = "pref_multi_device";
@@ -899,6 +900,10 @@ public class TextSecurePreferences {
 
   public static boolean isInterceptAllSmsEnabled(Context context) {
     return getBooleanPreference(context, ALL_SMS_PREF, true);
+  }
+
+  public static boolean isCallMobileDataAllowed(Context context) {
+    return getBooleanPreference(context, CALL_MOBILE_DATA_ALLOWED_PREF, true);
   }
 
   public static boolean isNotificationsEnabled(Context context) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -968,8 +968,10 @@
     <string name="NotificationBarManager_signal_call_in_progress">Signal call in progress</string>
     <string name="NotificationBarManager__establishing_signal_call">Establishing Signal call</string>
     <string name="NotificationBarManager__incoming_signal_call">Incoming Signal call</string>
+    <string name="NotificationBarManager__incoming_signal_call_mobile_signal_calls_disabled">Mobile Signal calls disabled</string>
     <string name="NotificationBarManager__deny_call">Deny call</string>
     <string name="NotificationBarManager__answer_call">Answer call</string>
+    <string name="NotificationBarManager__preferences">Preferences</string>
     <string name="NotificationBarManager__end_call">End call</string>
     <string name="NotificationBarManager__cancel_call">Cancel call</string>
 
@@ -1414,6 +1416,10 @@
     <string name="ProxyBottomSheetFragment_use_proxy">Use proxy</string>
     <string name="ProxyBottomSheetFragment_successfully_connected_to_proxy">Successfully connected to proxy.</string>
 
+    <!-- MobileCallNotAllowedDialog -->
+    <string name="MobileCallNotAllowedDialog_title">Cannot start call</string>
+    <string name="MobileCallNotAllowedDialog_message">Cannot start call on a mobile data connection. Allow calls to use mobile data in the preferences or connect to WiFi.</string>
+    <string name="MobileCallNotAllowedDialog_positive_button">Preferences</string>
 
     <!-- RegistrationActivity -->
     <string name="RegistrationActivity_select_your_country">Select your country</string>
@@ -2304,6 +2310,8 @@
     <string name="preferences_data_and_storage__never">Never</string>
     <string name="preferences_data_and_storage__wifi_and_cellular">WiFi and Cellular</string>
     <string name="preferences_data_and_storage__cellular_only">Cellular only</string>
+    <string name="preferences_data_and_storage__mobile_data">Mobile data</string>
+    <string name="preferences_data_and_storage__allow_calls_to_use_mobile_data">Allow calls to use mobile data</string>
     <string name="preference_data_and_storage__using_less_data_may_improve_calls_on_bad_networks">Using less data may improve calls on bad networks</string>
     <string name="preferences_notifications__messages">Messages</string>
     <string name="preferences_notifications__events">Events</string>

--- a/app/src/main/res/xml/preferences_data_and_storage.xml
+++ b/app/src/main/res/xml/preferences_data_and_storage.xml
@@ -34,6 +34,11 @@
     <PreferenceCategory android:layout="@layout/preference_divider"/>
 
     <PreferenceCategory android:title="@string/preferences_data_and_storage__calls">
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="pref_data_call_mobile_data_allowed"
+            android:title="@string/preferences_data_and_storage__mobile_data"
+            android:summary="@string/preferences_data_and_storage__allow_calls_to_use_mobile_data"/>
         <ListPreference
             android:title="@string/preferences_data_and_storage__use_less_data_for_calls"
             android:key="pref_data_call_bandwidth"


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Motorola G7, Android 10
 * Virtual device Pixel_3a_API_30_x86, Android 11
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This change adds an option to restrict calls from using mobile data. My wife
experienced a video call using 750 MB of data even though she was on WiFI. It
needs to be controllable in case you are on a metered plan since it might
otherwise make the call very expensive. My wife almost uninstalled Signal
because of this, but I got her to stay by promising I would fix it.

This change depends on my changes made to RingRTC (see https://github.com/signalapp/ringrtc/pull/26). You need to make sure you have the right version of RingRTC. This fixes #8529 
