### PR TITLE
Fixes #11064 - No Msg/Call Btns on Blocked Contact Profile

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/managerecipient/ManageRecipientFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/managerecipient/ManageRecipientFragment.java
@@ -305,6 +305,7 @@ public class ManageRecipientFragment extends LoggingFragment {
       contactRow.setOnClickListener(v -> {
         startActivityForResult(RecipientExporter.export(recipient).asAddContactIntent(), REQUEST_CODE_ADD_CONTACT);
       });
+      contactRow.setVisibility(!recipient.isBlocked() ? View.VISIBLE : View.GONE);
     }
 
     String aboutText = recipient.getCombinedAboutAndEmoji();
@@ -338,9 +339,10 @@ public class ManageRecipientFragment extends LoggingFragment {
     colorChip.setImageDrawable(new ColorStateDrawable(colorDrawable, color));
     colorRow.setOnClickListener(v -> handleColorSelection(color));
 
-    secureCallButton.setVisibility(recipient.isRegistered() && !recipient.isSelf() ? View.VISIBLE : View.GONE);
-    insecureCallButton.setVisibility(!recipient.isRegistered() && !recipient.isSelf() ? View.VISIBLE : View.GONE);
-    secureVideoCallButton.setVisibility(recipient.isRegistered() && !recipient.isSelf() ? View.VISIBLE : View.GONE);
+    messageButton.setVisibility(!recipient.isBlocked() ? View.VISIBLE : View.GONE);
+    secureCallButton.setVisibility(recipient.isRegistered() && !recipient.isSelf() && !recipient.isBlocked() ? View.VISIBLE : View.GONE);
+    insecureCallButton.setVisibility(!recipient.isRegistered() && !recipient.isSelf() && !recipient.isBlocked() ? View.VISIBLE : View.GONE);
+    secureVideoCallButton.setVisibility(recipient.isRegistered() && !recipient.isSelf() && !recipient.isBlocked() ? View.VISIBLE : View.GONE);
   }
 
   private void presentMediaCursor(ManageRecipientViewModel.MediaCursor mediaCursor) {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device  Android API 29
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This removes the Message, Secure Call and Secure Video Buttons as well as the "Add to Contact" button from the manage recipient screen of a blocked user. Tested this by blocking a user and ensuring that those UI controls were not visible in the UI flow described in the corresponding ticket. Unblocked that user and ensured that those buttons were once again visible too 