### PR TITLE
Fixes #10911 - You can search blocked users/groups

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationActivity.java
@@ -823,9 +823,15 @@ public class ConversationActivity extends PassphraseRequiredActivity
 
       inflater.inflate(R.menu.conversation_message_requests, menu);
 
-      if (recipient != null && recipient.get().isMuted()) inflater.inflate(R.menu.conversation_muted, menu);
-      else                                                inflater.inflate(R.menu.conversation_unmuted, menu);
-
+      if (recipient != null && recipient.get().isBlocked()) {
+        MenuItem searchViewItem = menu.findItem(R.id.menu_search);
+        searchViewItem.setVisible(true);
+        configureSearchViewItem(menu, searchViewItem);
+      } else {
+        if (recipient != null && recipient.get().isMuted())
+          inflater.inflate(R.menu.conversation_muted, menu);
+        else inflater.inflate(R.menu.conversation_unmuted, menu);
+      }
       super.onCreateOptionsMenu(menu);
       return true;
     }
@@ -928,7 +934,13 @@ public class ConversationActivity extends PassphraseRequiredActivity
     });
 
     searchViewItem = menu.findItem(R.id.menu_search);
+    configureSearchViewItem(menu, searchViewItem);
 
+    super.onCreateOptionsMenu(menu);
+    return true;
+  }
+
+  private void configureSearchViewItem(Menu menu, MenuItem searchViewItem) {
     SearchView                     searchView    = (SearchView) searchViewItem.getActionView();
     SearchView.OnQueryTextListener queryListener = new SearchView.OnQueryTextListener() {
       @Override
@@ -948,7 +960,7 @@ public class ConversationActivity extends PassphraseRequiredActivity
       }
     };
 
-    searchViewItem.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
+        searchViewItem.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
       @Override
       public boolean onMenuItemActionExpand(MenuItem item) {
         searchView.setOnQueryTextListener(queryListener);
@@ -978,8 +990,7 @@ public class ConversationActivity extends PassphraseRequiredActivity
       }
     });
 
-    super.onCreateOptionsMenu(menu);
-    return true;
+
   }
 
   @Override

--- a/app/src/main/res/menu/conversation_message_requests.xml
+++ b/app/src/main/res/menu/conversation_message_requests.xml
@@ -1,8 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu
-    xmlns:android="http://schemas.android.com/apk/res/android">
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item android:title="@string/conversation__menu_view_all_media"
         android:id="@+id/menu_view_media" />
+
+    <item android:title="@string/SearchToolbar_search"
+        android:id="@+id/menu_search"
+        android:visible="false"
+        app:actionViewClass="org.thoughtcrime.securesms.components.SearchView"
+        app:showAsAction="collapseActionView"/>
 
 </menu>


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Nexus 5X  Android 29
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Makes it so that users can search blocked contacts/groups. Hides the menu item to show/hide notifications for that user/group while they are blocked too