### PR TITLE
Fixes #10811 Message Timestamps are Updated when Device Resumes

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
@@ -220,6 +220,18 @@ public class ConversationFragment extends LoggingFragment {
   }
 
   @Override
+  public void onResume() {
+    super.onResume();
+    // update the timestamp strings of visible messages
+    LinearLayoutManager llm = (LinearLayoutManager) list.getLayoutManager();
+    int first = llm.findFirstVisibleItemPosition();
+    if (first != -1) {
+      int itemCount = llm.findLastVisibleItemPosition() - first + 1;
+      list.getAdapter().notifyItemRangeChanged(first, itemCount);
+    }
+  }
+
+  @Override
   public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle bundle) {
     final View view = inflater.inflate(R.layout.conversation_fragment, container, false);
     list                    = view.findViewById(android.R.id.list);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Nexus 5X  API 29
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This overrides `onResume()` in `ConversationFragment` and rebinds the view for each visible item (if any) in the Recycler View. During view binding the "sent 2 minutes ago" String is computed so this will cause visible messages to have an updated timestamp when the user returns to Signal from another app, device sleep/awake, etc 