### PR TITLE
Add an additional button to take another picture (shortcut)

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/mediapreview/MediaRailAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediapreview/MediaRailAdapter.java
@@ -21,6 +21,7 @@ public class MediaRailAdapter extends RecyclerView.Adapter<MediaRailAdapter.Medi
 
   private static final int TYPE_MEDIA  = 1;
   private static final int TYPE_BUTTON = 2;
+  private static final int TYPE_CAMERA = 3;
 
   private final GlideRequests            glideRequests;
   private final List<Media>              media;
@@ -51,6 +52,8 @@ public class MediaRailAdapter extends RecyclerView.Adapter<MediaRailAdapter.Medi
         return new MediaViewHolder(LayoutInflater.from(viewGroup.getContext()).inflate(R.layout.mediarail_media_item, viewGroup, false));
       case TYPE_BUTTON:
         return new ButtonViewHolder(LayoutInflater.from(viewGroup.getContext()).inflate(R.layout.mediarail_button_item, viewGroup, false));
+      case TYPE_CAMERA:
+        return new ButtonViewHolder(LayoutInflater.from(viewGroup.getContext()).inflate(R.layout.mediarail_camera_item, viewGroup, false));
       default:
         throw new UnsupportedOperationException("Unsupported view type: " + type);
     }
@@ -65,6 +68,9 @@ public class MediaRailAdapter extends RecyclerView.Adapter<MediaRailAdapter.Medi
       case TYPE_BUTTON:
         ((ButtonViewHolder) viewHolder).bind(addListener);
         break;
+      case TYPE_CAMERA:
+        ((ButtonViewHolder) viewHolder).bind(addListener, true);
+        break;
       default:
         throw new UnsupportedOperationException("Unsupported view type: " + getItemViewType(i));
     }
@@ -72,7 +78,9 @@ public class MediaRailAdapter extends RecyclerView.Adapter<MediaRailAdapter.Medi
 
   @Override
   public int getItemViewType(int position) {
-    if (editable && position == getItemCount() - 1) {
+    if (editable && position == getItemCount() - 2) {
+      return TYPE_CAMERA;
+    }else if (editable && position == getItemCount() - 1){
       return TYPE_BUTTON;
     } else {
       return TYPE_MEDIA;
@@ -86,7 +94,7 @@ public class MediaRailAdapter extends RecyclerView.Adapter<MediaRailAdapter.Medi
 
   @Override
   public int getItemCount() {
-    return editable ? media.size() + 1 : media.size();
+    return editable ? media.size() + 2 : media.size();
   }
 
   @Override
@@ -94,6 +102,8 @@ public class MediaRailAdapter extends RecyclerView.Adapter<MediaRailAdapter.Medi
     switch (getItemViewType(position)) {
       case TYPE_MEDIA:
         return stableIdGenerator.getId(media.get(position));
+      case TYPE_CAMERA:
+        return Long.MAX_VALUE-1;
       case TYPE_BUTTON:
         return Long.MAX_VALUE;
       default:
@@ -189,8 +199,12 @@ public class MediaRailAdapter extends RecyclerView.Adapter<MediaRailAdapter.Medi
     }
 
     void bind(@Nullable RailItemAddListener addListener) {
+      bind(addListener, false);
+    }
+
+    void bind(@Nullable RailItemAddListener addListener, boolean startCamera) {
       if (addListener != null) {
-        itemView.setOnClickListener(v -> addListener.onRailItemAddClicked());
+        itemView.setOnClickListener(v -> addListener.onRailItemAddClicked(startCamera));
       }
     }
 
@@ -206,6 +220,6 @@ public class MediaRailAdapter extends RecyclerView.Adapter<MediaRailAdapter.Medi
   }
 
   public interface RailItemAddListener {
-    void onRailItemAddClicked();
+    void onRailItemAddClicked(boolean startCamera);
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/MediaSendActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/MediaSendActivity.java
@@ -781,7 +781,12 @@ public class MediaSendActivity extends PassphraseRequiredActivity implements Med
 
     viewModel.getBucketId().observe(this, bucketId -> {
       if (bucketId == null) return;
-      mediaRailAdapter.setAddButtonListener(() -> onAddMediaClicked(bucketId));
+      mediaRailAdapter.setAddButtonListener((startCamera) -> {
+        onAddMediaClicked(bucketId);
+        if (startCamera) {
+          onCameraSelected();
+        }
+      });
     });
 
     viewModel.getError().observe(this, error -> {

--- a/app/src/main/res/layout/mediarail_camera_item.xml
+++ b/app/src/main/res/layout/mediarail_camera_item.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="56dp"
+    android:layout_height="56dp"
+    android:layout_margin="2dp"
+    android:background="@drawable/mediarail_button_background">
+
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        app:srcCompat="@drawable/ic_camera_24"
+        android:elevation="4dp" />
+
+</FrameLayout>


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device Huawei p20, Android 10.0.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
To take multiples pictures one after the other, the current flow involve:
1. Take picture
2. click "+"
3. click up-right camera icon

This flow is tedious because 1) there are three steps although 2 should be enough, and 2) the step 3. is using a camera button which is diagonally opposed to the capture button and thus really hard to reach with one hand
This feature was suggested here:
https://community.signalusers.org/t/ui-improvement-for-adding-multiple-camera-pictures/9200/8

before this PR, 2. and 3. look like that:
![device-2021-03-15-145113](https://user-images.githubusercontent.com/10091822/111174653-83a73600-859f-11eb-81ff-7148ebd3c6b0.png)
![device-2021-03-15-150052](https://user-images.githubusercontent.com/10091822/111174753-9a4d8d00-859f-11eb-881a-6111019caf71.png)

With this PR: 2 looks like that (and 3 is not needed in this flow)
![device-2021-03-15-145440](https://user-images.githubusercontent.com/10091822/111174862-b6512e80-859f-11eb-8008-e9a87874535b.png)


