### PR TITLE
fix calls bandwith settings info [UI glitch]

### DIFF
--- a/app/src/main/res/xml/preferences_data_and_storage.xml
+++ b/app/src/main/res/xml/preferences_data_and_storage.xml
@@ -41,9 +41,11 @@
             android:persistent="true"
             android:entries="@array/pref_data_and_storage_call_bandwidth_values"
             android:entryValues="@array/pref_data_and_storage_call_bandwidth_values" />
-    </PreferenceCategory>
 
-    <Preference android:layout="@layout/preference_data_and_storage_call_bandwidth_notice" />
+        <Preference
+            android:layout="@layout/preference_data_and_storage_call_bandwidth_notice"
+            android:enabled="false" />
+    </PreferenceCategory>
 
     <PreferenceCategory android:layout="@layout/preference_divider"/>
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Xiaomi Mi A3, Android 10 (Lineageos)
 * Galaxy S4, Android 10 (Lineage)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/) Not reported on GH

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

The info segment of the calls bandwidth segment was clickable but not resulting in anything. To avoid confusion the preference in question is now set as disabled.