### PR TITLE
Higher limits for file and video attachments

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/mms/PushMediaConstraints.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/PushMediaConstraints.java
@@ -10,6 +10,7 @@ public class PushMediaConstraints extends MediaConstraints {
   private static final int MAX_IMAGE_DIMEN        = 1600;
   private static final int KB                     = 1024;
   private static final int MB                     = 1024 * KB;
+  private static final int GB                     = 1024 * GB;
 
   private static final int[] FALLBACKS        = { MAX_IMAGE_DIMEN, 1024, 768, 512 };
   private static final int[] FALLBACKS_LOWMEM = { MAX_IMAGE_DIMEN_LOWMEM, 512 };
@@ -42,7 +43,7 @@ public class PushMediaConstraints extends MediaConstraints {
 
   @Override
   public int getVideoMaxSize(Context context) {
-    return 100 * MB;
+    return 1 * GB;
   }
 
   @Override
@@ -64,6 +65,6 @@ public class PushMediaConstraints extends MediaConstraints {
 
   @Override
   public int getDocumentMaxSize(Context context) {
-    return 100 * MB;
+    return 1 * GB;
   }
 }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist

- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * P20 Pro, Android 10.1.0
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

I think Signal should have higher uploading limits because 100MB is quite low for nowadays standards of videos.