### PR TITLE
Fix #11132: the ScreenLockTimeout gui behaves as expected

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/AppProtectionPreferenceFragment.java
@@ -13,6 +13,7 @@ import android.text.style.TextAppearanceSpan;
 import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -254,7 +255,9 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
 
     @Override
     public boolean onPreferenceClick(Preference preference) {
-      new TimeDurationPickerDialog(getContext(), (view, duration) -> {
+      final long minDurationInSeconds = 60;
+
+      TimeDurationPickerDialog timeDurationPickerDialog = new TimeDurationPickerDialog(getContext(), (view, duration) -> {
         if (duration == 0) {
           TextSecurePreferences.setScreenLockTimeout(getContext(), 0);
         } else {
@@ -263,7 +266,21 @@ public class AppProtectionPreferenceFragment extends CorrectedPreferenceFragment
         }
 
         initializeScreenLockTimeoutSummary();
-      }, 0).show();
+      }, 0);
+
+      timeDurationPickerDialog.setOnShowListener(dialog -> {
+        long durationInMilliSeconds = TextSecurePreferences.getScreenLockTimeout(getContext()) * 1000L ;
+        timeDurationPickerDialog.getDurationInput().setDuration(durationInMilliSeconds );
+        Button button = timeDurationPickerDialog.getButton(timeDurationPickerDialog.BUTTON_POSITIVE);
+        button.setEnabled(durationInMilliSeconds >= minDurationInSeconds * 1000L || durationInMilliSeconds == 0);
+      });
+
+      timeDurationPickerDialog.getDurationInput().setOnDurationChangeListener((view, durationInMilliSeconds) -> {
+        Button button = timeDurationPickerDialog.getButton(timeDurationPickerDialog.BUTTON_POSITIVE);
+        button.setEnabled(durationInMilliSeconds >= minDurationInSeconds * 1000L || durationInMilliSeconds == 0);
+      });
+
+      timeDurationPickerDialog.show();
 
       return true;
     }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device Huawei p20, Android 10.0.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This PR does 2 things:
make sure a value below 60s but above 0s cannot be interred in the GUI by disabling the OK button (see fig 1,2, and 3)
update the GUI according to the previously entered preference

fig 1, zero is a valid value (None) and can be validated:
![sol1](https://user-images.githubusercontent.com/10091822/112347030-70424c00-8cbe-11eb-969f-5bcfb6e5e8af.png)

fig 2: 30 is invalid, button OK is disabled
![sol2](https://user-images.githubusercontent.com/10091822/112346817-383b0900-8cbe-11eb-9860-20beb6cf2ae5.png)

fig 3: 60 (00:01:00) is valid, button is enabled
![sol3](https://user-images.githubusercontent.com/10091822/112347075-7a644a80-8cbe-11eb-83d3-c7cb38a3a106.png)


