### PR TITLE
Fix reproducible build issues with Git hashes and apkdiff

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -515,7 +515,7 @@ def getLastCommitTimestamp() {
 def getGitHash() {
     def stdout = new ByteArrayOutputStream()
     exec {
-        commandLine 'git', 'rev-parse', '--short', 'HEAD'
+        commandLine 'git', 'rev-parse', 'HEAD'
         standardOutput = stdout
     }
     return stdout.toString().trim()

--- a/reproducible-builds/apkdiff/apkdiff.py
+++ b/reproducible-builds/apkdiff/apkdiff.py
@@ -4,9 +4,7 @@ import sys
 from zipfile import ZipFile
 
 class ApkDiff:
-    # resources.arsc is ignored due to https://issuetracker.google.com/issues/110237303
-    # May be fixed in Android Gradle Plugin 3.4
-    IGNORE_FILES = ["META-INF/MANIFEST.MF", "META-INF/SIGNAL_S.RSA", "META-INF/SIGNAL_S.SF", "resources.arsc"]
+    IGNORE_FILES = ["META-INF/MANIFEST.MF", "META-INF/SIGNAL_S.RSA", "META-INF/SIGNAL_S.SF", "META-INF/CERTIFIC.RSA", "META-INF/CERTIFIC.SF"]
 
     def compare(self, sourceApk, destinationApk):
         sourceZip      = ZipFile(sourceApk, 'r')


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 3a XL
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

I tried to follow the reproducible build instructions for the website APK, but it failed. Using [diffoscope](https://diffoscope.org/), it turns out that the only differences are the Git hash length, and `META-INF/CERTIFIC.SF`, `META-INF/CERTIFIC.RSA`, and `META INF/MANIFEST.MF` :

```diff
$ diffoscope Signal-5.5.5-GooglePlay.apk app/build/outputs/apk/playProd/release/Signal-Android-play-prod-arm64-v8a-release-unsigned-5.5.5.apk 
--- Signal-5.5.5-GooglePlay.apk
+++ app/build/outputs/apk/playProd/release/Signal-Android-play-prod-arm64-v8a-release-unsigned-5.5.5.apk
├── zipinfo /dev/stdin
│ @@ -1,8 +1,8 @@
│ -Zip file size: 37692860 bytes, number of entries: 3564
│ +Zip file size: 37400539 bytes, number of entries: 3561
│  -rw----     0.0 fat      936 b- defN 81-Jan-01 01:01 res/drawable/ic_video_call_24.xml
│  -rw----     0.0 fat      316 b- defN 81-Jan-01 01:01 res/interpolator/btn_checkbox_checked_mtrl_animation_interpolator_0.xml
│  -rw----     0.0 fat      836 b- stor 81-Jan-01 01:01 res/drawable-xhdpi-v4/clear_profile_avatar.webp
│  -rw----     0.0 fat      916 b- defN 81-Jan-01 01:01 res/drawable/error_round.xml
│  -rw----     0.0 fat     1376 b- defN 81-Jan-01 01:01 res/drawable-night-v8/ic_update_group_role_16.xml
│  -rw----     0.0 fat        6 b- defN 81-Jan-01 01:01 META-INF/androidx.navigation_navigation-fragment.version
│  -rw----     0.0 fat      596 b- stor 81-Jan-01 01:01 res/drawable-xhdpi-v4/ic_face_white_24dp.webp
│ @@ -1885,15 +1885,15 @@
│  -rw----     0.0 fat    24868 b- defN 81-Jan-01 01:01 assets/emoji/Flags_1.webp
│  -rw----     0.0 fat   538696 b- defN 81-Jan-01 01:01 res/xml/apns.xml
│  -rw----     0.0 fat      225 b- stor 81-Jan-01 01:01 res/drawable-hdpi-v4/notification_bg_low_pressed.9.png
│  -rw----     0.0 fat     1036 b- defN 81-Jan-01 01:01 res/drawable/ic_any_emoji_32.xml
│  -rw----     0.0 fat      269 b- stor 81-Jan-01 01:01 res/drawable-xhdpi-v4/exo_icon_next.png
│  -rw----     0.0 fat      966 b- stor 81-Jan-01 01:01 res/drawable-xxxhdpi-v4/ic_phone_grey600_32dp.webp
│  -rw----     0.0 fat      576 b- defN 81-Jan-01 01:01 res/layout/design_navigation_item.xml
│ --rw----     0.0 fat  8754944 b- defN 81-Jan-01 01:01 classes.dex
│ +-rw----     0.0 fat  8754948 b- defN 81-Jan-01 01:01 classes.dex
│  -rw----     0.0 fat       68 b- stor 81-Jan-01 01:01 res/drawable-mdpi-v4/notify_panel_notification_icon_bg.webp
│  -rw----     0.0 fat     1264 b- defN 81-Jan-01 01:01 res/layout-v21/mediasend_count_button.xml
│  -rw----     0.0 fat      376 b- defN 81-Jan-01 01:01 res/color/material_on_surface_disabled.xml
│  -rw----     0.0 fat     2696 b- defN 81-Jan-01 01:01 res/layout/backup_enable_dialog.xml
│  -rw----     0.0 fat      230 b- stor 81-Jan-01 01:01 res/drawable-mdpi-v4/exo_controls_shuffle.png
│  -rw----     0.0 fat      212 b- stor 81-Jan-01 01:01 res/drawable-hdpi-v4/abc_list_longpressed_holo.9.png
│  -rw----     0.0 fat     3068 b- defN 81-Jan-01 01:01 res/layout-v21/conversation_title_view.xml
│ @@ -2217,15 +2217,15 @@
│  -rw----     0.0 fat      600 b- defN 81-Jan-01 01:01 res/xml-mcc214-mnc17/mms_config.xml
│  -rw----     0.0 fat      948 b- defN 81-Jan-01 01:01 res/color/mtrl_btn_text_btn_ripple_color.xml
│  -rw----     0.0 fat      268 b- defN 81-Jan-01 01:01 res/xml/standalone_badge.xml
│  -rw----     0.0 fat      105 b- defN 81-Jan-01 01:01 com/google/i18n/phonenumbers/data/PhoneNumberAlternateFormatsProto_855
│  -rw----     0.0 fat      163 b- defN 81-Jan-01 01:01 com/google/i18n/phonenumbers/data/PhoneNumberAlternateFormatsProto_856
│  -rw----     0.0 fat      218 b- stor 81-Jan-01 01:01 res/drawable-xxhdpi-v4/ic_keyboard_arrow_up_white_36dp.webp
│  -rw----     0.0 fat      832 b- defN 81-Jan-01 01:01 res/xml/contactsformat.xml
│ --rw----     0.0 fat  8236428 b- defN 81-Jan-01 01:01 classes2.dex
│ +-rw----     0.0 fat  8236432 b- defN 81-Jan-01 01:01 classes2.dex
│  -rw----     0.0 fat      372 b- defN 81-Jan-01 01:01 res/drawable/qr_code_background.xml
│  -rw----     0.0 fat     1180 b- defN 81-Jan-01 01:01 res/layout/create_passphrase_activity.xml
│  -rw----     0.0 fat    20670 b- stor 81-Jan-01 01:01 res/drawable-xxxhdpi-v4/no_contacts.webp
│  -rw----     0.0 fat      796 b- defN 81-Jan-01 01:01 res/layout/test_design_checkbox.xml
│  -rw----     0.0 fat      588 b- defN 81-Jan-01 01:01 res/menu/manage_recipient_fragment.xml
│  -rw----     0.0 fat     1672 b- defN 81-Jan-01 01:01 res/color/mtrl_bottom_nav_ripple_color.xml
│  -rw----     0.0 fat     1208 b- defN 81-Jan-01 01:01 res/animator/mtrl_card_state_list_anim.xml
│ @@ -3556,11 +3556,8 @@
│  -rw----     0.0 fat      754 b- defN 81-Jan-01 01:01 com/google/i18n/phonenumbers/data/PhoneNumberMetadataProto_CI
│  -rw----     0.0 fat      212 b- stor 81-Jan-01 01:01 res/drawable-hdpi-v4/notification_bg_normal.9.png
│  -rw----     0.0 fat     1676 b- defN 81-Jan-01 01:01 res/drawable/ic_emoji_food_20.xml
│  -rw----     0.0 fat      328 b- defN 81-Jan-01 01:01 com/google/i18n/phonenumbers/data/PhoneNumberMetadataProto_CK
│  -rw----     0.0 fat      421 b- stor 81-Jan-01 01:01 res/drawable-xxxhdpi-v4/ic_clear.png
│  -rw----     0.0 fat      680 b- defN 81-Jan-01 01:01 res/layout-v21/conversation_list_search_toolbar.xml
│  -rw----     0.0 fat     2032 b- defN 81-Jan-01 01:01 com/google/i18n/phonenumbers/data/PhoneNumberMetadataProto_CL
│ (This line is in red) --rw----     2.0 fat   422070 b- defN 81-Jan-01 01:01 META-INF/CERTIFIC.SF
│ (This line is in red) --rw----     2.0 fat     1027 b- defN 81-Jan-01 01:01 META-INF/CERTIFIC.RSA
│ (This line is in red) --rw----     2.0 fat   421943 b- defN 81-Jan-01 01:01 META-INF/MANIFEST.MF
│ -3564 files, 61680348 bytes uncompressed, 37085608 bytes compressed:  39.9%
│ +3561 files, 60835316 bytes uncompressed, 36797990 bytes compressed:  39.5%
├── classes.dex
│ ├── classes.jar
│ │ ├── zipinfo /dev/stdin
│ │ │ @@ -1,8 +1,8 @@
│ │ │ -Zip file size: 15400094 bytes, number of entries: 7795
│ │ │ +Zip file size: 15400096 bytes, number of entries: 7795
│ │ │  ?rwxrwxr-x  2.0 unx      656 b- stor 80-Jan-01 00:00 $$ServiceLoaderMethods.class
│ │ │  ?rwxrwxr-x  2.0 unx      873 b- stor 80-Jan-01 00:00 android/net/LinkAddress$1.class
│ │ │  ?rwxrwxr-x  2.0 unx     1721 b- stor 80-Jan-01 00:00 android/net/LinkAddress.class
│ │ │  ?rwxrwxr-x  2.0 unx     1507 b- stor 80-Jan-01 00:00 android/net/LinkProperties$1.class
│ │ │  ?rwxrwxr-x  2.0 unx     4477 b- stor 80-Jan-01 00:00 android/net/LinkProperties.class
│ │ │  ?rwxrwxr-x  2.0 unx      873 b- stor 80-Jan-01 00:00 android/net/NetworkUtilsHelper.class
│ │ │  ?rwxrwxr-x  2.0 unx      841 b- stor 80-Jan-01 00:00 android/net/ProxyProperties$1.class
│ │ │ @@ -4506,15 +4506,15 @@
│ │ │  ?rwxrwxr-x  2.0 unx      461 b- stor 80-Jan-01 00:00 org/thoughtcrime/securesms/-$$Lambda$KcMWP9HMKdgsJ05uS4CJI-2_kN8.class
│ │ │  ?rwxrwxr-x  2.0 unx      484 b- stor 80-Jan-01 00:00 org/thoughtcrime/securesms/-$$Lambda$QDWaHRQApkwgeYuhsBo9_BIRZqc.class
│ │ │  ?rwxrwxr-x  2.0 unx      467 b- stor 80-Jan-01 00:00 org/thoughtcrime/securesms/-$$Lambda$S7ls-7wXhaY6wtuRrRH7xkpG3vY.class
│ │ │  ?rwxrwxr-x  2.0 unx     3243 b- stor 80-Jan-01 00:00 org/thoughtcrime/securesms/AppInitialization.class
│ │ │  ?rwxrwxr-x  2.0 unx      578 b- stor 80-Jan-01 00:00 org/thoughtcrime/securesms/ApplicationContext$1.class
│ │ │  ?rwxrwxr-x  2.0 unx      377 b- stor 80-Jan-01 00:00 org/thoughtcrime/securesms/ApplicationContext$2.class
│ │ │  ?rwxrwxr-x  2.0 unx      293 b- stor 80-Jan-01 00:00 org/thoughtcrime/securesms/ApplicationContext$ProviderInitializationException.class
│ │ │ -?rwxrwxr-x  2.0 unx     3496 b- stor 80-Jan-01 00:00 org/thoughtcrime/securesms/BuildConfig.class
│ │ │ +?rwxrwxr-x  2.0 unx     3498 b- stor 80-Jan-01 00:00 org/thoughtcrime/securesms/BuildConfig.class
│ │ │  ?rwxrwxr-x  2.0 unx      912 b- stor 80-Jan-01 00:00 org/thoughtcrime/securesms/KbsEnclave.class
│ │ │  ?rwxrwxr-x  2.0 unx      134 b- stor 80-Jan-01 00:00 org/thoughtcrime/securesms/MainNavigator$BackHandler.class
│ │ │  ?rwxrwxr-x  2.0 unx      137 b- stor 80-Jan-01 00:00 org/thoughtcrime/securesms/MasterSecretListener.class
│ │ │  ?rwxrwxr-x  2.0 unx     1912 b- stor 80-Jan-01 00:00 org/thoughtcrime/securesms/attachments/AttachmentId.class
│ │ │  ?rwxrwxr-x  2.0 unx    13848 b- defN 80-Jan-01 00:00 org/thoughtcrime/securesms/components/AudioView.class
│ │ │  ?rwxrwxr-x  2.0 unx      173 b- stor 80-Jan-01 00:00 org/thoughtcrime/securesms/components/ComposeText$CursorPositionChangedListener.class
│ │ │  ?rwxrwxr-x  2.0 unx      203 b- stor 80-Jan-01 00:00 org/thoughtcrime/securesms/components/ConversationSearchBottomBar$EventListener.class
│ │ │ @@ -7790,8 +7790,8 @@
│ │ │  ?rwxrwxr-x  2.0 unx     2328 b- stor 80-Jan-01 00:00 com/fasterxml/jackson/databind/ser/impl/AttributePropertyWriter.class
│ │ │  ?rwxrwxr-x  2.0 unx     2874 b- stor 80-Jan-01 00:00 com/fasterxml/jackson/databind/ser/std/StdArraySerializers$FloatArraySerializer.class
│ │ │  ?rwxrwxr-x  2.0 unx     2838 b- stor 80-Jan-01 00:00 com/fasterxml/jackson/databind/ser/std/StdArraySerializers$LongArraySerializer.class
│ │ │  ?rwxrwxr-x  2.0 unx     2868 b- stor 80-Jan-01 00:00 com/fasterxml/jackson/databind/ser/std/StdArraySerializers$ShortArraySerializer.class
│ │ │  ?rwxrwxr-x  2.0 unx     9928 b- stor 80-Jan-01 00:00 org/thoughtcrime/securesms/PassphraseRequiredActivity.class
│ │ │  ?rwxrwxr-x  2.0 unx    27995 b- defN 80-Jan-01 00:00 org/thoughtcrime/securesms/WebRtcCallActivity.class
│ │ │  ?rwxrwxr-x  2.0 unx   143216 b- defN 80-Jan-01 00:00 org/thoughtcrime/securesms/conversation/ConversationActivity.class
│ │ │ -7795 files, 16948590 bytes uncompressed, 13896526 bytes compressed:  18.0%
│ │ │ +7795 files, 16948592 bytes uncompressed, 13896528 bytes compressed:  18.0%
│ │ ├── org/thoughtcrime/securesms/BuildConfig.class
│ │ │ ├── procyon -ec {}
│ │ │ │ @@ -10,15 +10,15 @@
│ │ │ │      public static final String CDS_MRENCLAVE = "c98e00a4e3ff977a56afefe7362a27e4961e4f19e211febfbb19b897e6b80b15";
│ │ │ │      public static final String CONTENT_PROXY_HOST = "contentproxy.signal.org";
│ │ │ │      public static final int CONTENT_PROXY_PORT = 443;
│ │ │ │      public static final boolean DEBUG = false;
│ │ │ │      public static final String FLAVOR = "playProd";
│ │ │ │      public static final String FLAVOR_distribution = "play";
│ │ │ │      public static final String FLAVOR_environment = "prod";
│ │ │ │ -    public static final String GIT_HASH = "44d014c";
│ │ │ │ +    public static final String GIT_HASH = "44d014c44";
│ │ │ │      public static final KbsEnclave KBS_ENCLAVE;
│ │ │ │      public static final KbsEnclave[] KBS_FALLBACKS;
│ │ │ │      public static final String[] LANGUAGES;
│ │ │ │      public static final String NOPLAY_UPDATE_URL;
│ │ │ │      public static final boolean PLAY_STORE_DISABLED = false;
│ │ │ │      public static final String SIGNAL_AGENT = "OWA";
│ │ │ │      public static final String SIGNAL_CDN2_URL = "https://cdn2.signal.org";
├── smali/org/thoughtcrime/securesms/BuildConfig.smali
│ @@ -22,15 +22,15 @@
│  
│  .field public static final FLAVOR:Ljava/lang/String; = "playProd"
│  
│  .field public static final FLAVOR_distribution:Ljava/lang/String; = "play"
│  
│  .field public static final FLAVOR_environment:Ljava/lang/String; = "prod"
│  
│ -.field public static final GIT_HASH:Ljava/lang/String; = "44d014c"
│ +.field public static final GIT_HASH:Ljava/lang/String; = "44d014c44"
│  
│  .field public static final KBS_ENCLAVE:Lorg/thoughtcrime/securesms/KbsEnclave;
│  
│  .field public static final KBS_FALLBACKS:[Lorg/thoughtcrime/securesms/KbsEnclave;
│  
│  .field public static final LANGUAGES:[Ljava/lang/String;
├── smali_classes2/org/thoughtcrime/securesms/logsubmit/LogSectionSystemInfo.smali
│ @@ -923,15 +923,15 @@
│      invoke-virtual {v1, v0}, Ljava/lang/StringBuilder;->append(I)Ljava/lang/StringBuilder;
│  
│      const-string v0, ") ("
│  
│      .line 77
│      invoke-virtual {v1, v0}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
│  
│ -    const-string v0, "44d014c"
│ +    const-string v0, "44d014c44"
│  
│      .line 78
│      invoke-virtual {v1, v0}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
│  
│      const-string v0, ") \n"
│  
│      invoke-virtual {v1, v0}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;

```

We stop using abbreviated Git hashes and use full hashes instead for the 
debug log output. According to https://github.com/git/git/commit/e6c587c733b4634030b353f4024794b08bc86892,
the default abbreviation is subject to auto sizing depending on the
estimated number of objects in the Git repository. This number can
differ if the Signal developers use private branches for developing but
then only push the squashed commits to the public repository.

To solve this, we just use the full Git hash. The GIT_HASH config field
is only used in the debug log print out anyway, and using the full hash
instead of a hardcoded abbreviated size helps future-proof it as well.

For apkdiff, we ignore the new file names for signing info. We keep the
older versions in case they change again (or if someone wants to verify
a previous version of Signal that had the old names).  Also, the
resources.arsc issue seems to be resolved according to the Google Issue
and local testing.

This can't really be tested properly without a new official build with these
changes. The Git hash change should not change functionality, because the
debug log is the only place it uses the Git hash, and the debug log already
supports long lines.

Fixes #10476