### PR TITLE
Fixing notification image preview

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/attachments/Attachment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/attachments/Attachment.java
@@ -108,8 +108,7 @@ public abstract class Attachment {
   @Nullable
   public abstract Uri getUri();
 
-  @Nullable
-  public abstract Uri getPublicUri();
+  public abstract @Nullable Uri getPublicUri();
 
   public int getTransferState() {
     return transferState;

--- a/app/src/main/java/org/thoughtcrime/securesms/attachments/Attachment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/attachments/Attachment.java
@@ -108,6 +108,9 @@ public abstract class Attachment {
   @Nullable
   public abstract Uri getUri();
 
+  @Nullable
+  public abstract Uri getPublicUri();
+
   public int getTransferState() {
     return transferState;
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/attachments/DatabaseAttachment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/attachments/DatabaseAttachment.java
@@ -66,8 +66,7 @@ public class DatabaseAttachment extends Attachment {
   }
 
   @Override
-  @Nullable
-  public Uri getPublicUri() {
+  public @Nullable Uri getPublicUri() {
     if (hasData) {
       return PartAuthority.getAttachmentPublicUri(getUri());
     } else {

--- a/app/src/main/java/org/thoughtcrime/securesms/attachments/DatabaseAttachment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/attachments/DatabaseAttachment.java
@@ -65,6 +65,16 @@ public class DatabaseAttachment extends Attachment {
     }
   }
 
+  @Override
+  @Nullable
+  public Uri getPublicUri() {
+    if (hasData) {
+      return PartAuthority.getAttachmentPublicUri(getUri());
+    } else {
+      return null;
+    }
+  }
+
   public AttachmentId getAttachmentId() {
     return attachmentId;
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/attachments/MmsNotificationAttachment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/attachments/MmsNotificationAttachment.java
@@ -20,9 +20,8 @@ public class MmsNotificationAttachment extends Attachment {
     return null;
   }
 
-  @Nullable
   @Override
-  public Uri getPublicUri() {
+  public @Nullable Uri getPublicUri() {
     return null;
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/attachments/MmsNotificationAttachment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/attachments/MmsNotificationAttachment.java
@@ -20,6 +20,12 @@ public class MmsNotificationAttachment extends Attachment {
     return null;
   }
 
+  @Nullable
+  @Override
+  public Uri getPublicUri() {
+    return null;
+  }
+
   private static int getTransferStateFromStatus(int status) {
     if (status == MmsDatabase.Status.DOWNLOAD_INITIALIZED ||
         status == MmsDatabase.Status.DOWNLOAD_NO_CONNECTIVITY)

--- a/app/src/main/java/org/thoughtcrime/securesms/attachments/PointerAttachment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/attachments/PointerAttachment.java
@@ -46,6 +46,12 @@ public class PointerAttachment extends Attachment {
     return null;
   }
 
+  @Nullable
+  @Override
+  public Uri getPublicUri() {
+    return null;
+  }
+
   public static List<Attachment> forPointers(Optional<List<SignalServiceAttachment>> pointers) {
     List<Attachment> results = new LinkedList<>();
 

--- a/app/src/main/java/org/thoughtcrime/securesms/attachments/PointerAttachment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/attachments/PointerAttachment.java
@@ -46,9 +46,8 @@ public class PointerAttachment extends Attachment {
     return null;
   }
 
-  @Nullable
   @Override
-  public Uri getPublicUri() {
+  public @Nullable Uri getPublicUri() {
     return null;
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/attachments/TombstoneAttachment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/attachments/TombstoneAttachment.java
@@ -23,4 +23,10 @@ public class TombstoneAttachment extends Attachment {
   public @Nullable Uri getUri() {
     return null;
   }
+
+  @Override
+  @Nullable
+  public Uri getPublicUri() {
+    return null;
+  }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/attachments/TombstoneAttachment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/attachments/TombstoneAttachment.java
@@ -25,8 +25,7 @@ public class TombstoneAttachment extends Attachment {
   }
 
   @Override
-  @Nullable
-  public Uri getPublicUri() {
+  public @Nullable Uri getPublicUri() {
     return null;
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/attachments/UriAttachment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/attachments/UriAttachment.java
@@ -59,6 +59,12 @@ public class UriAttachment extends Attachment {
   }
 
   @Override
+  @Nullable
+  public Uri getPublicUri() {
+    return null;
+  }
+
+  @Override
   public boolean equals(Object other) {
     return other != null && other instanceof UriAttachment && ((UriAttachment) other).dataUri.equals(this.dataUri);
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/attachments/UriAttachment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/attachments/UriAttachment.java
@@ -59,8 +59,7 @@ public class UriAttachment extends Attachment {
   }
 
   @Override
-  @Nullable
-  public Uri getPublicUri() {
+  public @Nullable Uri getPublicUri() {
     return null;
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/mms/Slide.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/Slide.java
@@ -55,8 +55,7 @@ public abstract class Slide {
     return attachment.getUri();
   }
 
-  @Nullable
-  public Uri getPublicUri() {
+  public @Nullable Uri getPublicUri() {
     return attachment.getPublicUri();
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/mms/Slide.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/Slide.java
@@ -55,6 +55,11 @@ public abstract class Slide {
     return attachment.getUri();
   }
 
+  @Nullable
+  public Uri getPublicUri() {
+    return attachment.getPublicUri();
+  }
+
   @NonNull
   public Optional<String> getBody() {
     return Optional.absent();

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
@@ -268,7 +268,12 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
     if (slideDeck != null && slideDeck.getThumbnailSlide() != null) {
       Slide thumbnail = slideDeck.getThumbnailSlide();
 
-      dataUri  = thumbnail.getUri();
+      if (Build.VERSION.SDK_INT >= 28) {
+        dataUri = thumbnail.getPublicUri();
+      } else {
+        dataUri  = thumbnail.getUri();
+      }
+
       mimeType = thumbnail.getContentType();
     }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual Pixel 3, Android 11.0
 * Virtual Pixel 3, Android 10.0
 * Virtual Pixel 3, Android 9.0
 * Virtual Pixel 3, Android 8.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/) - <i>I didn't find any matching for this PR.</i>

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Notifications using MessagingStyle in Android 9 (API 28) and higher require that the image URIs passed to MessagingStyle::Message::setData() should be part of an app's File Provider.


Today, Signal is using non 'public' image URIs for the message notifications and the notifications aren't displaying the message pictures on Android 9 and higher.


This fix ensures that the message notifications are using image URIs from the File Provider with the "org.thoughtcrime.securesms.part" authority, so the pictures show up in the notifications as shown in below screenshot.


The fix was tested in AVDs by sending pictures from another device to group and single recipient chats.

![Screenshot_1617059965](https://user-images.githubusercontent.com/3311313/112911575-bd119280-90c3-11eb-8e5a-014658597325.png)
