### PR TITLE
Fixes #11156 When videos are played pause Voice Memos

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/BindableConversationItem.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/BindableConversationItem.java
@@ -68,6 +68,7 @@ public interface BindableConversationItem extends Unbindable {
     void onJoinGroupCallClicked();
     void onInviteFriendsToGroupClicked(@NonNull GroupId.V2 groupId);
     void onEnableCallNotificationsClicked();
+    void onVideoMessagePlay();
 
     /** @return true if handled, false if you want to let the normal url handling continue */
     boolean onUrlClicked(@NonNull String url);

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
@@ -431,6 +431,7 @@ public class ConversationFragment extends LoggingFragment {
     }
   }
 
+
   private int getStartPosition() {
     return conversationViewModel.getArgs().getStartingPosition();
   }
@@ -1469,6 +1470,12 @@ public class ConversationFragment extends LoggingFragment {
     @Override
     public void onVoiceNotePause(@NonNull Uri uri) {
       voiceNoteMediaController.pausePlayback(uri);
+    }
+
+    @Override
+    public void onVideoMessagePlay() {
+      Uri voiceNoteUri = voiceNoteMediaController.getVoiceNotePlaybackState().getValue().getUri();
+      voiceNoteMediaController.pausePlayback(voiceNoteUri);
     }
 
     @Override

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
@@ -1528,6 +1528,10 @@ public final class ConversationItem extends RelativeLayout implements BindableCo
         intent.putExtra(MediaPreviewActivity.CAPTION_EXTRA, slide.getCaption().orNull());
         intent.putExtra(MediaPreviewActivity.LEFT_IS_RECENT_EXTRA, false);
 
+        if (slide.hasVideo()) {
+          eventListener.onVideoMessagePlay();
+        }
+
         context.startActivity(intent);
       } else if (slide.getUri() != null) {
         Log.i(TAG, "Clicked: " + slide.getUri() + " , " + slide.getContentType());


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual Nexus 5X , Android 29
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
When the user opens a video message while a voice memo/message is playing, the `ConversationFragment` will handle pausing it..