### PR TITLE
Display GroupV1MigrationEvent as ActionMessage in conversation MenuState

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/MenuState.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/MenuState.java
@@ -133,6 +133,7 @@ final class MenuState {
            messageRecord.isIdentityVerified()      ||
            messageRecord.isIdentityDefault()       ||
            messageRecord.isProfileChange()         ||
+           messageRecord.isGroupV1MigrationEvent() ||
            messageRecord.isFailedDecryptionType();
   }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
If in a group conversation you long press the update message that the group was updated to a New Group you have the options to show message details and forward the message. These options should not be shown in the menu.

Btw, the checks in MenuState#isActionMessage are now the same as in MessageRecord#isUpdate.
