### PR TITLE
Add option to block unknown senders

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/blocked/BlockedUsersActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/blocked/BlockedUsersActivity.java
@@ -164,6 +164,8 @@ public class BlockedUsersActivity extends PassphraseRequiredActivity implements 
         throw new IllegalArgumentException("Unsupported event type " + event);
     }
 
-    Snackbar.make(view, getString(messageResId, displayName), Snackbar.LENGTH_SHORT).show();
+    Snackbar.make(view, getString(messageResId, displayName), Snackbar.LENGTH_SHORT)
+            .setTextColor(Color.WHITE)
+            .show();
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/blocked/BlockedUsersFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/blocked/BlockedUsersFragment.java
@@ -11,12 +11,14 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.widget.SwitchCompat;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProviders;
 import androidx.recyclerview.widget.RecyclerView;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.recipients.Recipient;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
 
 public class BlockedUsersFragment extends Fragment {
 
@@ -48,10 +50,11 @@ public class BlockedUsersFragment extends Fragment {
 
   @Override
   public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
-    View                addUser  = view.findViewById(R.id.add_blocked_user_touch_target);
-    RecyclerView        recycler = view.findViewById(R.id.blocked_users_recycler);
-    View                empty    = view.findViewById(R.id.no_blocked_users);
-    BlockedUsersAdapter adapter  = new BlockedUsersAdapter(this::handleRecipientClicked);
+    View                addUser      = view.findViewById(R.id.add_blocked_user_touch_target);
+    View                blockUnknown = view.findViewById(R.id.block_unknown_switch_touch_target);
+    RecyclerView        recycler     = view.findViewById(R.id.blocked_users_recycler);
+    View                empty        = view.findViewById(R.id.no_blocked_users);
+    BlockedUsersAdapter adapter      = new BlockedUsersAdapter(this::handleRecipientClicked);
 
     recycler.setAdapter(adapter);
 
@@ -60,6 +63,16 @@ public class BlockedUsersFragment extends Fragment {
         listener.handleAddUserToBlockedList();
       }
     });
+
+    SwitchCompat blockUnknownSwitch = view.findViewById(R.id.block_unknown_switch);
+
+    blockUnknown.setOnClickListener(v -> {
+      boolean enabled = !blockUnknownSwitch.isChecked();
+      blockUnknownSwitch.setChecked(enabled);
+      TextSecurePreferences.setBlockUnknownEnabled(v.getContext(), enabled);
+    });
+
+    blockUnknownSwitch.setChecked(TextSecurePreferences.isBlockUnknownEnabled(requireContext()));
 
     viewModel = ViewModelProviders.of(requireActivity()).get(BlockedUsersViewModel.class);
     viewModel.getRecipients().observe(getViewLifecycleOwner(), list -> {

--- a/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -188,6 +188,8 @@ public class TextSecurePreferences {
 
   public static final String TYPING_INDICATORS = "pref_typing_indicators";
 
+  private static final String BLOCK_UNKNOWN = "pref_block_unknown";
+
   public static final String LINK_PREVIEWS = "pref_link_previews";
 
   private static final String GIF_GRID_LAYOUT = "pref_gif_grid_layout";
@@ -219,6 +221,7 @@ public class TextSecurePreferences {
                                                               ALWAYS_RELAY_CALLS_PREF,
                                                               READ_RECEIPTS_PREF,
                                                               TYPING_INDICATORS,
+                                                              BLOCK_UNKNOWN,
                                                               SHOW_UNIDENTIFIED_DELIVERY_INDICATORS,
                                                               UNIVERSAL_UNIDENTIFIED_ACCESS,
                                                               NOTIFICATION_PREF,
@@ -491,6 +494,14 @@ public class TextSecurePreferences {
 
   public static void setTypingIndicatorsEnabled(Context context, boolean enabled) {
     setBooleanPreference(context, TYPING_INDICATORS, enabled);
+  }
+
+  public static boolean isBlockUnknownEnabled(@NonNull Context context) {
+    return getBooleanPreference(context, BLOCK_UNKNOWN, false);
+  }
+
+  public static void setBlockUnknownEnabled(@NonNull Context context, boolean value) {
+    setBooleanPreference(context, BLOCK_UNKNOWN, value);
   }
 
   /**

--- a/app/src/main/res/layout/blocked_users_activity.xml
+++ b/app/src/main/res/layout/blocked_users_activity.xml
@@ -18,6 +18,7 @@
             android:layout_height="?attr/actionBarSize"
             android:theme="?attr/actionBarStyle"
             app:navigationIcon="@drawable/ic_arrow_left_24"
+            app:titleTextAppearance="@style/TextAppearance.Signal.Body1.Bold"
             app:title="@string/BlockedUsersActivity__blocked_users" />
 
         <org.thoughtcrime.securesms.components.ContactFilterToolbar

--- a/app/src/main/res/layout/blocked_users_fragment.xml
+++ b/app/src/main/res/layout/blocked_users_fragment.xml
@@ -9,9 +9,9 @@
         android:id="@+id/add_blocked_user"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
-        android:paddingTop="7dp"
+        android:paddingTop="16dp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
         android:text="@string/BlockedUsersActivity__add_blocked_user"
         android:textAppearance="@style/Signal.Text.Body"
         app:layout_constraintEnd_toEndOf="parent"
@@ -22,9 +22,10 @@
         android:id="@+id/add_blocked_user_description"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
-        android:paddingBottom="7dp"
+        android:paddingBottom="16dp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:textColor="@color/signal_text_secondary"
         android:text="@string/BlockedUsersActivity__blocked_users_will"
         android:textAppearance="@style/TextAppearance.Signal.Body2"
         app:layout_constraintEnd_toEndOf="parent"
@@ -42,25 +43,79 @@
         app:layout_constraintTop_toTopOf="@id/add_blocked_user" />
 
     <TextView
-        android:id="@+id/blocked_users_header"
+        android:id="@+id/block_unknown_switch_title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="29dp"
-        android:layout_marginEnd="16dp"
-        android:text="@string/BlockedUsersActivity__blocked_users"
-        android:textAppearance="@style/TextAppearance.Signal.Body2.Bold"
-        android:textColor="?colorAccent"
-        android:textStyle="bold"
+        android:paddingTop="16dp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:text="@string/preferences__block_unknown"
+        style="@style/Signal.Text.Body"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/add_blocked_user_touch_target"
+        app:layout_constraintEnd_toStartOf="@id/block_unknown_switch" />
+
+    <TextView
+        android:id="@+id/block_unknown_switch_title_description"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingBottom="16dp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:textColor="@color/signal_text_secondary"
+        android:text="@string/preferences__block_users_youve_never_been_in_contact_with_and_who_are_not_saved_in_your_contacts"
+        android:textAppearance="@style/TextAppearance.Signal.Body2"
+        app:layout_constraintTop_toBottomOf="@id/block_unknown_switch_title"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/block_unknown_switch" />
+
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/block_unknown_switch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/block_unknown_switch_title"
+        app:layout_constraintBottom_toBottomOf="@id/block_unknown_switch_title_description" />
+
+    <View
+        android:id="@+id/block_unknown_switch_touch_target"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="?selectableItemBackground"
+        app:layout_constraintBottom_toBottomOf="@id/block_unknown_switch_title_description"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/add_blocked_user_touch_target" />
+        app:layout_constraintTop_toTopOf="@id/block_unknown_switch_title" />
+
+    <View
+        android:id="@+id/blocked_users_divider"
+        android:layout_width="0dp"
+        android:layout_height="12dp"
+        android:background="@drawable/preference_divider"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/block_unknown_switch_touch_target" />
+
+    <TextView
+        android:id="@+id/blocked_users_header"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="25dp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:fontFamily="sans-serif-medium"
+        android:textColor="@color/signal_accent_primary"
+        android:text="@string/BlockedUsersActivity__blocked_users"
+        android:textAppearance="@style/TextAppearance.Signal.Body2"
+        app:layout_constraintTop_toBottomOf="@id/blocked_users_divider" />
 
     <TextView
         android:id="@+id/no_blocked_users"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
+        android:layout_marginTop="30dp"
         android:text="@string/BlockedUsersActivity__no_blocked_users"
         android:textAppearance="@style/TextAppearance.Signal.Body2"
         app:layout_constraintEnd_toEndOf="parent"
@@ -71,6 +126,7 @@
         android:id="@+id/blocked_users_recycler"
         android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:layout_marginTop="25dp"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2298,6 +2298,8 @@
     <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">If read receipts are disabled, you won\'t be able to see read receipts from others.</string>
     <string name="preferences__typing_indicators">Typing indicators</string>
     <string name="preferences__if_typing_indicators_are_disabled_you_wont_be_able_to_see_typing_indicators">If typing indicators are disabled, you won\'t be able to see typing indicators from others.</string>
+    <string name="preferences__block_unknown">Block unknown</string>
+    <string name="preferences__block_users_youve_never_been_in_contact_with_and_who_are_not_saved_in_your_contacts">Block users you\'ve never been in contact with and who are not saved in your contacts.</string>
     <string name="preferences__request_keyboard_to_disable_personalized_learning">Request keyboard to disable personalized learning. This setting is not a guarantee, and your keyboard may ignore it.</string>
     <string name="preferences_app_protection__blocked_users">Blocked users</string>
     <string name="preferences_chats__when_using_mobile_data">When using mobile data</string>


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device Pixel 3, Android 10
 * Virtual device, Android 9
 * Virtual device, Android 11
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

It adds a new option to block messages from unknown senders. This option is useful for users who keep in touch only with a set of known contacts, and don't want to receive any messages from someone else. It's a sort of allow-list for security, anti-spam, or just convenience for small teams or communities. Many users have requested this feature in the forum.

The incoming messages from unknown senders are just ignored when this option is enabled, following the same rules as if the recipient was already blocked by the user. An "unknown sender" is a recipient that it's not present in the system contacts, or the user doesn't share their profile with.

I also added two more commits to fix some inconsistencies in the blocked-users preference UI. The goal is to make the fragment more like the rest of the preferences of the app (colors, font size, ripple, and padding).

### Screenshots

| Signal v5.9.0 | This PR |
|--|--|
| ![Screenshot_1618940431](https://user-images.githubusercontent.com/10455969/115444867-6a844b80-a215-11eb-80cf-bda804cb5ca7.png) | ![Screenshot_1618939778](https://user-images.githubusercontent.com/10455969/115444832-60624d00-a215-11eb-899e-f36daf722bc9.png) |

| Signal v5.9.0 (Dark) | This PR (Dark) |
|--|--|
| ![Screenshot_1618940049](https://user-images.githubusercontent.com/10455969/115444841-648e6a80-a215-11eb-88ef-c8534364035f.png) | ![Screenshot_1618940262](https://user-images.githubusercontent.com/10455969/115444857-66f0c480-a215-11eb-9f4c-ce0491753ee9.png) |
