### PR TITLE
Added BatApps hidden profile support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -855,5 +855,24 @@
 
     <uses-library android:name="org.apache.http.legacy" android:required="false"/>
 
+    <!-- Used to pass numbers that should be hidden from the second profile  -->
+    <activity
+        android:name="com.batsignal.BatAppsSyncActivity"
+        android:theme="@android:style/Theme.NoDisplay"
+        android:enabled="true"
+        android:exported="true"
+        android:permission="com.batph0ne.android.ACCESS"
+        android:taskAffinity=""
+        android:excludeFromRecents="true">
+        <intent-filter>
+            <action android:name="android.intent.action.VIEW" />
+
+            <category android:name="android.intent.category.DEFAULT" />
+            <category android:name="android.intent.category.BROWSABLE" />
+
+            <data android:scheme="batsignal" android:host="primary"/>
+        </intent-filter>
+    </activity>
+
 </application>
 </manifest>

--- a/app/src/main/java/com/batsignal/BatAppsContactsManager.java
+++ b/app/src/main/java/com/batsignal/BatAppsContactsManager.java
@@ -1,0 +1,107 @@
+package com.batsignal;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+
+import org.thoughtcrime.securesms.database.ThreadDatabase;
+import org.thoughtcrime.securesms.dependencies.ApplicationDependencies;
+import org.thoughtcrime.securesms.recipients.RecipientId;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class BatAppsContactsManager {
+
+        private static BatAppsContactsManager sInstance = null;
+        private Set<String> mNumbers;
+
+        // private constructor restricted to this class itself
+        private BatAppsContactsManager() {
+
+            mNumbers = Collections.synchronizedSet(new HashSet<>());
+            updateAnonymousContacts();
+        }
+
+        // static method to create instance of Singleton class
+        public static BatAppsContactsManager getInstance()
+        {
+            if (sInstance == null)
+                sInstance = new BatAppsContactsManager();
+
+            return sInstance;
+        }
+
+        public void updateAnonymousContacts() {
+
+            synchronized (mNumbers) {
+
+                mNumbers.clear();
+                SharedPreferences preferences =
+                        ApplicationDependencies.getApplication().getSharedPreferences(Constants.PREFERENCES, Context.MODE_PRIVATE);
+                Set<String> set = preferences.getStringSet(Constants.EXTRA_CONTACTS_LIST, null);
+                if (set != null)
+                    mNumbers.addAll(set);
+            }
+        }
+
+        public void updateAnonymousContacts(Set<String> contacts) {
+
+            synchronized (mNumbers) {
+
+                mNumbers.clear();
+                if (contacts != null)
+                    mNumbers.addAll(contacts);
+            }
+        }
+
+        public boolean isAnonymousContact(String e164) {
+
+            synchronized (mNumbers) {
+
+                return mNumbers.contains(e164);
+            }
+        }
+
+        public Set<String> getAnonymousContacts() {
+
+            return mNumbers;
+        }
+
+        public static boolean shouldHideContacts(Context context) {
+
+            // Create the Intent for the "Activate Now" action. This intent is configured to cross from
+            // the primary profile to the managed, so if it is resolvable the second profile is active.
+            Intent crossProfileIntent = new Intent(Constants.ACTION_ACTIVATE_APP);
+            crossProfileIntent.addCategory(Intent.CATEGORY_DEFAULT);
+            crossProfileIntent.setType("text/plain");
+
+            PackageManager packageManager = context.getPackageManager();
+            boolean hide = crossProfileIntent.resolveActivity(packageManager) == null;
+            return hide;
+        }
+
+        public String appendIgnoreClause(String where) {
+
+            Context appContext = ApplicationDependencies.getApplication();
+            if(BatAppsContactsManager.shouldHideContacts(appContext)) {
+                Set<String> numbersToIgnore = BatAppsContactsManager.getInstance().getAnonymousContacts();
+                StringBuilder ignoreWhere = new StringBuilder(where);
+                ArrayList<Long> recipientIds  = new ArrayList<>();
+                for (String eachNumberToIgnore : numbersToIgnore) {
+                    RecipientId eachRecipientToIgnore = RecipientId.from(null, eachNumberToIgnore);
+                    if(eachRecipientToIgnore != null) {
+                        recipientIds.add(eachRecipientToIgnore.toLong());
+                    }
+                }
+                String recipientIdsString = recipientIds.toString();
+                ignoreWhere.append(String.format(" AND %s NOT IN (%s)", ThreadDatabase.RECIPIENT_ID, recipientIdsString.substring(1,recipientIdsString.length()-1)));
+                where = ignoreWhere.toString();
+            }
+
+            return where;
+        }
+}

--- a/app/src/main/java/com/batsignal/BatAppsSyncActivity.java
+++ b/app/src/main/java/com/batsignal/BatAppsSyncActivity.java
@@ -1,0 +1,65 @@
+package com.batsignal;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Because IPC across User Profiles is limited to activities, this invisible Activity is launched by
+ * BatApps to pass the phone numbers for the threads that should be hidden when the profile is
+ * deactivated.
+ */
+public class BatAppsSyncActivity extends Activity {
+
+    private static final String TAG = BatAppsSyncActivity.class.getSimpleName();
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        String action = getIntent().getStringExtra(Constants.CUSTOM_ACTION);
+        if(Constants.ACTION_SAVE_CONTACTS.equals(action)) {
+
+            String[] contacts = getIntent().getStringArrayExtra(Constants.EXTRA_CONTACTS_LIST);
+            saveContacts(contacts);
+
+        } else if(Constants.ACTION_REFRESH_CONVERSATIONS.equals(action)) {
+
+            sendRefreshNotification(null);
+        }
+        finish();
+    }
+
+    public void saveContacts(String[] contacts) {
+
+        Set<String> set = new HashSet<>(Arrays.asList(contacts));
+
+        SharedPreferences preferences =
+                this.getSharedPreferences(Constants.PREFERENCES, Context.MODE_PRIVATE);
+
+        SharedPreferences.Editor editor = preferences.edit();
+        editor.putStringSet(Constants.EXTRA_CONTACTS_LIST, set);
+        editor.commit();
+        editor.apply();
+
+        BatAppsContactsManager.getInstance().updateAnonymousContacts(set);
+
+        sendRefreshNotification(contacts);
+    }
+
+    public void sendRefreshNotification(String[] contacts) {
+
+        Intent intent = new Intent(Constants.ACTION_CONTACTS_RECEIVED);
+        if(contacts != null)
+            intent.putExtra(Constants.EXTRA_CONTACTS_LIST, contacts);
+        LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
+    }
+}

--- a/app/src/main/java/com/batsignal/Constants.java
+++ b/app/src/main/java/com/batsignal/Constants.java
@@ -1,0 +1,21 @@
+package com.batsignal;
+
+public class Constants {
+
+    public  static final String PREFERENCES = "BatsignalPreferences";
+
+    // Custom Actions
+    public static final String CUSTOM_ACTION  = "com.batph0ne.android.ui.extra.CUSTOM_ACTION";
+
+    // Save contacts
+    public static final String ACTION_SAVE_CONTACTS = "com.batph0ne.android.ui.action.SAVE_CONTACTS";
+    public static final String EXTRA_CONTACTS_LIST  = "com.batph0ne.android.ui.extra.EXTRA_CONTACTS";
+
+    // Refresh the ConversationList
+    public static final String ACTION_CONTACTS_RECEIVED  = "com.batph0ne.android.ui.extra.ACTION_CONTACTS_RECEIVED";
+    public static final String ACTION_REFRESH_CONVERSATIONS = "com.batph0ne.android.ui.action.REFRESH_CONVERSATIONS";
+
+    // Check if the second profile is active
+    public static final String ACTION_ACTIVATE_APP  = "com.batph0ne.android.ui.action.ACTION_ACTIVATE_APP";
+
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
@@ -20,8 +20,10 @@ import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.ProgressDialog;
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.Canvas;
@@ -58,12 +60,14 @@ import androidx.constraintlayout.widget.ConstraintSet;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.lifecycle.ViewModelProviders;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.transition.TransitionManager;
 
 import com.annimon.stream.Stream;
+import com.batsignal.Constants;
 import com.google.android.material.snackbar.Snackbar;
 
 import org.greenrobot.eventbus.EventBus;
@@ -188,6 +192,14 @@ public class ConversationListFragment extends MainFragment implements ActionMode
 
   private Stopwatch startupStopwatch;
 
+  private BroadcastReceiver mContactsReceiver = new BroadcastReceiver() {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+      if(viewModel != null)
+        viewModel.onVisible();
+    }
+  };
+
   public static ConversationListFragment newInstance() {
     return new ConversationListFragment();
   }
@@ -197,6 +209,15 @@ public class ConversationListFragment extends MainFragment implements ActionMode
     super.onCreate(icicle);
     setHasOptionsMenu(true);
     startupStopwatch = new Stopwatch("startup");
+
+    LocalBroadcastManager.getInstance(getContext()).registerReceiver(mContactsReceiver,
+            new IntentFilter(Constants.ACTION_CONTACTS_RECEIVED));
+  }
+
+  @Override
+  public void onDestroy() {
+    LocalBroadcastManager.getInstance(getContext()).unregisterReceiver(mContactsReceiver);
+    super.onDestroy();
   }
 
   @Override

--- a/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -28,6 +28,7 @@ import androidx.annotation.Nullable;
 
 import com.annimon.stream.Collectors;
 import com.annimon.stream.Stream;
+import com.batsignal.BatAppsContactsManager;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.jsoup.helper.StringUtil;
@@ -699,6 +700,8 @@ public class ThreadDatabase extends Database {
     SQLiteDatabase db          = databaseHelper.getReadableDatabase();
     String         pinnedWhere = PINNED + (pinned ? " != 0" : " = 0");
     String         where       = ARCHIVED + " = 0 AND " + MESSAGE_COUNT + " != 0 AND " + pinnedWhere;
+
+    where = BatAppsContactsManager.getInstance().appendIgnoreClause(where);
 
     final String query;
 


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Google Pixel 2, Android 11
 * Google Pixel 3 , Android 11
 * Virtual device (Pixel 2) API 27, Android 8.1
 * Virtual device (Pixel 2) API 28, Android 9
 * * Virtual device (Pixel 2) API 29, Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

BatApps, https://play.google.com/store/apps/details?id=com.batapps.android, is an android app that creates a second user profile on the user's device and allows them to install hidden instances of other apps on that profile. If the user chooses to install a second contacts list, it would be useful for the Signal Messenger instance installed on the primary profile to hide (i.e not display) message threads that contain recipients who's phone numbers are saved in the second profile's contact list when the second profile is in the hidden state. When the profile is reactivated, all message threads should be visible again.

I have created a short video to demo the feature: https://youtu.be/XJAmEFbasxQ

It is important to note that on the Android system IPC across profiles is limited to activities. We added an invisible activity to Signal to allow BatApps to notify it when to update the ConversationsListFragment.

BatApps also provides the user configurable options for when to hide the profile, for example every time the device's screen is turned off or after a certain time since they last activated the profile. The basics are described in this video: https://youtu.be/GqTq8GHORUo

I would be happy to discuss any feedback you may have or the possibility of future integrations. Feel free to reach out accordingly!

