### PR TITLE
Revert "Prevent crash in megaphones after backup restore."

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/megaphone/MegaphoneRepository.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/megaphone/MegaphoneRepository.java
@@ -69,7 +69,6 @@ public class MegaphoneRepository {
   public void getNextMegaphone(@NonNull Callback<Megaphone> callback) {
     executor.execute(() -> {
       if (enabled) {
-        init();
         callback.onResult(Megaphones.getNextMegaphone(context, databaseCache));
       } else {
         callback.onResult(null);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device API 29, Android 10.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This reverts commit 7d949ee8fde011234e73834c3ef7c15eb4fa9e86.

Seems to me this fix is not needed anymore, and it's causing significant overhead to the app. This is because every time the conversations list is rendered, it queries the megaphone table twice. And it also makes the megaphone caching useless.

My guess is that when the megaphones' state was stored in the main database, after restoring a backup in a newer version of the app, this fix was needed to sync such state with the megaphones (the "event" list) defined in new release. Now that the megaphones are not part of the backups anymore, the task that calls init() in the megaphone repository constructor should keep the state initialized in all cases.