### PR TITLE
Remove seconds from screen lock timeout summary

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/PrivacySettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/PrivacySettingsFragment.kt
@@ -359,13 +359,12 @@ class PrivacySettingsFragment : DSLSettingsFragment(R.string.preferences__privac
 
   private fun getScreenLockInactivityTimeoutSummary(timeoutSeconds: Long): String {
     val hours = TimeUnit.SECONDS.toHours(timeoutSeconds)
-    val minutes =
-      TimeUnit.SECONDS.toMinutes(timeoutSeconds) - TimeUnit.SECONDS.toHours(timeoutSeconds) * 60
+    val minutes = TimeUnit.SECONDS.toMinutes(timeoutSeconds) - hours * 60
 
     return if (timeoutSeconds <= 0) {
       getString(R.string.AppProtectionPreferenceFragment_none)
     } else {
-      String.format(Locale.getDefault(), "%02d:%02d:00", hours, minutes)
+      String.format(Locale.getDefault(), "%02d:%02d", hours, minutes)
     }
   }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual Pixel 2, Android 11
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------
EDIT 2021-07-06:
Fixes #11427 

### Description
- removes the seconds from the screen lock timeout summary
- replacement from "TimeUnit.SECONDS.toHours(timeoutSeconds)" by "hours" in calculating "minutes", because "hours" was calculated one step before.
- removes an unnecessary semicolon

From the 5.9 beta one issue is that the display of the 00 seconds not using the locale.
https://community.signalusers.org/t/beta-feedback-for-the-upcoming-android-5-9-release/31524/82

--------------------------

![Screenshot_1619544058](https://user-images.githubusercontent.com/49990901/116288504-e0e2f980-a791-11eb-9cf8-e07389b5fac4.png) ![Screenshot_1619544085](https://user-images.githubusercontent.com/49990901/116288509-e2142680-a791-11eb-8790-87e4478de56c.png)


-------------------------

Alternatively:

```
    findPreference(TextSecurePreferences.SCREEN_LOCK_TIMEOUT)
        .setSummary(timeoutSeconds <= 0 ? getString(R.string.AppProtectionPreferenceFragment_none) :
                                          String.format(Locale.getDefault(), "%02d:%02d:%02d", hours, minutes, 00));
```

![Screenshot_1619546403](https://user-images.githubusercontent.com/49990901/116290002-4b486980-a793-11eb-92e4-af2a8ea8fb42.png)

