### PR TITLE
Shorten "Disappearing message timer info" in "message details"

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/ExpirationUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/ExpirationUtil.java
@@ -26,15 +26,21 @@ public final class ExpirationUtil {
     int secondsRemaining = expirationTime;
 
     int weeks = secondsRemaining / SECONDS_IN_WEEK;
-    displayValue = getDisplayValue(context, displayValue, R.plurals.expiration_weeks, weeks);
+    if (weeks > 0) {
+      return getDisplayValue(context, displayValue, R.plurals.expiration_weeks, weeks);
+    }
     secondsRemaining = secondsRemaining - weeks * SECONDS_IN_WEEK;
 
     int days = secondsRemaining / SECONDS_IN_DAY;
-    displayValue = getDisplayValue(context, displayValue, R.plurals.expiration_days, days);
+    if (days > 0) {
+      return getDisplayValue(context, displayValue, R.plurals.expiration_days, days);
+    }
     secondsRemaining = secondsRemaining - days * SECONDS_IN_DAY;
 
     int hours = secondsRemaining / SECONDS_IN_HOUR;
-    displayValue = getDisplayValue(context, displayValue, R.plurals.expiration_hours, hours);
+    if (hours > 0) {
+      return getDisplayValue(context, displayValue, R.plurals.expiration_hours, hours);
+    }
     secondsRemaining = secondsRemaining - hours * SECONDS_IN_HOUR;
 
     int minutes = secondsRemaining / SECONDS_IN_MINUTE;

--- a/app/src/test/java/org/thoughtcrime/securesms/util/ExpirationUtilTest.java
+++ b/app/src/test/java/org/thoughtcrime/securesms/util/ExpirationUtilTest.java
@@ -73,55 +73,55 @@ public class ExpirationUtilTest {
 
   @Test
   public void shouldFormatAsBreakdown_whenLargerThanWeek() {
-    assertEquals("1 week 1 day",
+    assertEquals("1 week",
                  ExpirationUtil.getExpirationDisplayValue(context, SECONDS_IN_WEEK + SECONDS_IN_DAY));
 
-    assertEquals("1 week 1 hour",
+    assertEquals("1 week",
                  ExpirationUtil.getExpirationDisplayValue(context, SECONDS_IN_WEEK + SECONDS_IN_HOUR));
 
-    assertEquals("1 week 1 minute",
+    assertEquals("1 week",
                  ExpirationUtil.getExpirationDisplayValue(context, SECONDS_IN_WEEK + SECONDS_IN_MINUTE));
 
-    assertEquals("1 week 1 second",
+    assertEquals("1 week",
                  ExpirationUtil.getExpirationDisplayValue(context, SECONDS_IN_WEEK + 1));
 
-    assertEquals("1 week 1 day 1 hour",
+    assertEquals("1 week",
                  ExpirationUtil.getExpirationDisplayValue(context, SECONDS_IN_WEEK + SECONDS_IN_DAY + SECONDS_IN_HOUR));
 
-    assertEquals("1 week 1 day 1 hour 1 minute",
+    assertEquals("1 week",
                  ExpirationUtil.getExpirationDisplayValue(context, SECONDS_IN_WEEK + SECONDS_IN_DAY + SECONDS_IN_HOUR + SECONDS_IN_MINUTE));
 
-    assertEquals("1 week 1 day 1 hour 1 minute 1 second",
+    assertEquals("1 week",
                  ExpirationUtil.getExpirationDisplayValue(context, SECONDS_IN_WEEK + SECONDS_IN_DAY + SECONDS_IN_HOUR + SECONDS_IN_MINUTE + 1));
 
-    assertEquals("1 week 1 hour 1 minute",
+    assertEquals("1 week",
                  ExpirationUtil.getExpirationDisplayValue(context, SECONDS_IN_WEEK + SECONDS_IN_HOUR + SECONDS_IN_MINUTE));
 
-    assertEquals("1 week 1 hour 1 minute 1 second",
+    assertEquals("1 week",
                  ExpirationUtil.getExpirationDisplayValue(context, SECONDS_IN_WEEK + SECONDS_IN_HOUR + SECONDS_IN_MINUTE + 1));
 
-    assertEquals("1 week 1 minute 1 second",
+    assertEquals("1 week",
                  ExpirationUtil.getExpirationDisplayValue(context, SECONDS_IN_WEEK + SECONDS_IN_MINUTE + 1));
   }
 
   @Test
   public void shouldFormatAsBreakdown_whenLargerThanDay() {
-    assertEquals("1 day 1 hour",
+    assertEquals("1 day",
                  ExpirationUtil.getExpirationDisplayValue(context, SECONDS_IN_DAY + SECONDS_IN_HOUR));
 
-    assertEquals("1 day 1 minute",
+    assertEquals("1 day",
                  ExpirationUtil.getExpirationDisplayValue(context, SECONDS_IN_DAY + SECONDS_IN_MINUTE));
 
-    assertEquals("1 day 1 second",
+    assertEquals("1 day",
                  ExpirationUtil.getExpirationDisplayValue(context, SECONDS_IN_DAY + 1));
   }
 
   @Test
   public void shouldFormatAsBreakdown_whenLargerThanHour() {
-    assertEquals("1 hour 1 minute",
+    assertEquals("1 hour",
                  ExpirationUtil.getExpirationDisplayValue(context, SECONDS_IN_HOUR + SECONDS_IN_MINUTE));
 
-    assertEquals("1 hour 1 second",
+    assertEquals("1 hour",
                  ExpirationUtil.getExpirationDisplayValue(context, SECONDS_IN_HOUR + 1));
   }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
* Moto X Play, Android 7.1.1
* Virtual Pixel 2, Android 11.0

- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

Fix #10217

### Description
Only shows the highest value ("days", "hours", "minutes and seconds" or "seconds") of the "disappearing message timer info" in "message details".

![signal-2021-05-05-183038](https://user-images.githubusercontent.com/49990901/117181079-27a9a280-add5-11eb-96bc-6ecfeeb33ad1.png) ![signal-2021-05-05-183038 (1)](https://user-images.githubusercontent.com/49990901/117181082-28423900-add5-11eb-954d-1e585789d6d2.png) ![signal-2021-05-05-183038 (2)](https://user-images.githubusercontent.com/49990901/117181084-28423900-add5-11eb-852f-271d61f09907.png) ![signal-2021-05-05-183038 (3)](https://user-images.githubusercontent.com/49990901/117181081-27a9a280-add5-11eb-8c3b-02c7551a8a53.png)


