### PR TITLE
set contact avatar for notification previews of media messages pre API28

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,14 +62,14 @@ protobuf {
 }
 
 def canonicalVersionCode = 832
-def canonicalVersionName = "5.9.5"
+def canonicalVersionName = "5.9.6"
 
 def postFixSize = 100
-def abiPostFix = ['universal'   : 0,
-                  'armeabi-v7a' : 1,
-                  'arm64-v8a'   : 2,
-                  'x86'         : 3,
-                  'x86_64'      : 4]
+def abiPostFix = ['universal'   : 5,
+                  'armeabi-v7a' : 6,
+                  'arm64-v8a'   : 7,
+                  'x86'         : 8,
+                  'x86_64'      : 9]
 
 def keystores = [ 'debug'  : loadKeystoreProperties('keystore.debug.properties') ]
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,14 +62,14 @@ protobuf {
 }
 
 def canonicalVersionCode = 832
-def canonicalVersionName = "5.9.6"
+def canonicalVersionName = "5.9.7"
 
 def postFixSize = 100
-def abiPostFix = ['universal'   : 5,
-                  'armeabi-v7a' : 6,
-                  'arm64-v8a'   : 7,
-                  'x86'         : 8,
-                  'x86_64'      : 9]
+def abiPostFix = ['universal'   : 10,
+                  'armeabi-v7a' : 11,
+                  'arm64-v8a'   : 12,
+                  'x86'         : 13,
+                  'x86_64'      : 14]
 
 def keystores = [ 'debug'  : loadKeystoreProperties('keystore.debug.properties') ]
 

--- a/app/src/main/java/org/thoughtcrime/securesms/database/helpers/SQLCipherOpenHelper.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/helpers/SQLCipherOpenHelper.java
@@ -1350,6 +1350,10 @@ public class SQLCipherOpenHelper extends SQLiteOpenHelper implements SignalDatab
             byte[] reactions         = cursor.getBlob(cursor.getColumnIndexOrThrow("reactions"));
             long   notifiedTimestamp = cursor.getLong(cursor.getColumnIndexOrThrow("notified_timestamp"));
 
+            if (reactions == null) {
+              continue;
+            }
+
             try {
               boolean hasReceiveLaterThanNotified = ReactionList.parseFrom(reactions)
                                                                 .getReactionsList()

--- a/app/src/main/java/org/thoughtcrime/securesms/database/helpers/SQLCipherOpenHelper.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/helpers/SQLCipherOpenHelper.java
@@ -1376,6 +1376,10 @@ public class SQLCipherOpenHelper extends SQLiteOpenHelper implements SignalDatab
             byte[] reactions         = cursor.getBlob(cursor.getColumnIndexOrThrow("reactions"));
             long   notifiedTimestamp = cursor.getLong(cursor.getColumnIndexOrThrow("notified_timestamp"));
 
+            if (reactions == null) {
+              continue;
+            }
+
             try {
               boolean hasReceiveLaterThanNotified = ReactionList.parseFrom(reactions)
                                                                 .getReactionsList()


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung J5 Android 6.01
 * Samsung S5 mini Android 6.0.1
 * Philips S326 Android 5.0.1
- [x] My contribution is fully baked and ready to be merged as is

----------

### Description
<!--
This makes large notification previews of media messages show the contact avatar for devices with Android versions lower than 9.0

-->
