### PR TITLE
Remove GMS utility function from emoji/EmojiJsonParser.kt

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/emoji/EmojiJsonParser.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/emoji/EmojiJsonParser.kt
@@ -3,11 +3,11 @@ package org.thoughtcrime.securesms.emoji
 import android.net.Uri
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.google.android.gms.common.util.Hex
 import org.thoughtcrime.securesms.components.emoji.CompositeEmojiPageModel
 import org.thoughtcrime.securesms.components.emoji.Emoji
 import org.thoughtcrime.securesms.components.emoji.EmojiPageModel
 import org.thoughtcrime.securesms.components.emoji.StaticEmojiPageModel
+import org.thoughtcrime.securesms.util.Hex
 import java.io.InputStream
 import java.nio.charset.Charset
 
@@ -101,7 +101,7 @@ private fun JsonNode.toDensityList(): List<String> {
   return map { it.textValue() }
 }
 
-private fun String.encodeAsUtf16() = String(Hex.stringToBytes(this), Charset.forName("UTF-16"))
+private fun String.encodeAsUtf16() = String(Hex.fromStringCondensed(this), Charset.forName("UTF-16"))
 private fun String.asCategoryKey() = replace("(_\\d+)*$".toRegex(), "")
 private fun String.getPageIndex() = "^.*_(\\d+)+$".toRegex().find(this)?.let { it.groupValues[1] }?.toInt() ?: throw IllegalStateException("No index.")
 


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S9+, Android 10
- [x] My contribution is fully baked and ready to be merged as is

----------

### Description

Signal 5.10.x series introduced a new import of `com.google.android.gms.common.util.Hex` in `emoji/EmojiJasonParser.kt`, to use Google's proprietary hex-to-string conversion utility function.

This two-liner commit replaces it with Signal's internal `util.Hex` function. Thanks if you can merge into 5.11!