### PR TITLE
Increase max zoom level for large images (using SentMediaQuality.HIGH)

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/ZoomingImageView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/ZoomingImageView.java
@@ -41,8 +41,8 @@ public class ZoomingImageView extends FrameLayout {
 
   private static final float ZOOM_LEVEL_MIN = 1.0f;
 
-  private static final float LARGE_IMAGES_ZOOM_LEVEL_MID = 1.5f;
-  private static final float LARGE_IMAGES_ZOOM_LEVEL_MAX = 2.0f;
+  private static final float LARGE_IMAGES_ZOOM_LEVEL_MID = 2.0f;
+  private static final float LARGE_IMAGES_ZOOM_LEVEL_MAX = 5.0f;
 
   private static final float SMALL_IMAGES_ZOOM_LEVEL_MID = 3.0f;
   private static final float SMALL_IMAGES_ZOOM_LEVEL_MAX = 8.0f;


### PR DESCRIPTION
Increase the maximum zoom level for large images, making the actual image-details better visible on small screens when using the new "SentMediaQuality.HIGH" (LEVEL_3) method.


<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Moto G5, Android 8.1.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
In v5.11.x the new feature "SentMediaQuality.HIGH" has been introduced. However, as a side-effect of this new feature, the zoom-values of the internal image-viewer have to been updated accordingly, so that actual advantage of the the higher image resolution really can be seen/observed by end users.

Currently, when sending High-Quality images (LEVEL_3), on small screens (e.g. 4.5"-5") you even cannot zoom images to the same maximum size as for low-quality images. Without higher maximum-zoom levels, the actual _image-details (image information)_ of high resolution images are _not much visible_ to users when _directly comparing_ it to the same low-resolution version (at least on small screen and having average eyes). During my beta-tests I exactly got such a feedback by some users (normal users, not beta-experts).

