### PR TITLE
CI: Add --warning-mode=all to Gradle build

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -25,7 +25,7 @@ jobs:
       uses: gradle/wrapper-validation-action@v1
 
     - name: Build with Gradle
-      run: ./gradlew qa
+      run: ./gradlew qa --warning-mode=all
 
     - name: Archive reports for failed build
       if: ${{ failure() }}


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] My contribution is fully baked and ready to be merged as is

----------

### Description
Run the `gradlew qa` step in the CI with `--warning-mode=all` to display individual warnings about depreciations and such. This helps to quicker catch future errors in the build process.

See: https://docs.gradle.org/current/userguide/command_line_interface.html#sec:command_line_warnings
