### PR TITLE
Fixes #10940 (rotation not updated on phones using Legacy-API)

### DIFF
--- a/app/src/main/java/androidx/camera/view/SignalCameraXModule.java
+++ b/app/src/main/java/androidx/camera/view/SignalCameraXModule.java
@@ -513,6 +513,10 @@ final class SignalCameraXModule {
   }
 
   public void invalidateView() {
+    if (mPreview != null) {
+      mPreview.setTargetRotation(getDisplaySurfaceRotation()); // Fixes issue #10940 (rotation not updated on phones using "Legacy API")
+    }
+
     updateViewInfo();
   }
 

--- a/app/src/main/java/androidx/camera/view/SignalCameraXModule.java
+++ b/app/src/main/java/androidx/camera/view/SignalCameraXModule.java
@@ -512,6 +512,7 @@ final class SignalCameraXModule {
     return rotationDegrees;
   }
 
+  @SuppressLint("UnsafeExperimentalUsageError")
   public void invalidateView() {
     if (mPreview != null) {
       mPreview.setTargetRotation(getDisplaySurfaceRotation()); // Fixes issue #10940 (rotation not updated on phones using "Legacy API")


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * MotoG5, Android 8.1.0
 * A few more devices tested and confirmed by @clauz9
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fixes #10940
See details in the #10940 issue description (by @clauz9) and additionally discussion in the Signal community-forum here:
https://community.signalusers.org/t/starting-built-in-camera-in-portrait-and-then-turning-phone-to-landscape-mode-shows-the-preview-video-90degrees-wrong/28603?u=rainerm77

Signal-community user "clauz" was very helpful and tested this fix on 4 devices, one of which was the one that worked before, and they all rotate correctly.

Remark to @devs:
Please note that this fix uses `Preview.Builder.setTargetRotation()` which in `Preview.java` is marked as 'ExperimentalUseCaseGroup' (I'm not sure if this fact is seen as problematic. If yes, we would need to find an alternative solution)...