### PR TITLE
Fix libsignal Java version in Android Studio

### DIFF
--- a/libsignal/service/build.gradle
+++ b/libsignal/service/build.gradle
@@ -7,6 +7,7 @@ apply plugin: 'idea'
 apply from: 'witness-verifications.gradle'
 
 sourceCompatibility = 1.8
+targetCompatibility = 1.8
 archivesBaseName    = "signal-service-java"
 version             = lib_signal_service_version_number
 group               = lib_signal_service_group_info


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Z3 Compact, Android 6.0.1
 * Samsung A50, Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the ----------

### Description
Android Studio has its internal JDK updated to version 11, which causes problems with some methods on Android. In particular, the ByteBuffer class has a changed interface, which causes startup crashes on some Android versions (tested on 6) when Signal is built in Android Studio with the internal JDK. Changing the JDK that Android Studio uses to OpenJDK 8 or Oracle JDK 1.8.x works but may be cumbersome.

I was alerted by @valldrac that adding the line targetCompatibility = 1.8 in libsignal/service/build,gradle could fix this, and my tests show it does. For ease of development I would recommend to include this fix in Signal.