### PR TITLE
Add check for activity in Bubble for Android 12

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationActivity.java
@@ -2082,12 +2082,23 @@ public class ConversationActivity extends PassphraseRequiredActivity
 
   private boolean isInBubble() {
     if (Build.VERSION.SDK_INT >= ConversationUtil.CONVERSATION_SUPPORT_VERSION) {
-      Display display = getDisplay();
-
-      return display != null && display.getDisplayId() != Display.DEFAULT_DISPLAY;
-    } else {
-      return false;
+      return isLaunchedFromBubbleApi30();
+    } else if (Build.VERSION.SDK_INT >= 31) {
+      return isLaunchedFromBubbleApi31();
     }
+      return false;
+  }
+
+  @RequiresApi(30)
+  private boolean isLaunchedFromBubbleApi30() {
+    Display display = getDisplay();
+
+    return display != null && display.getDisplayId() != Display.DEFAULT_DISPLAY;
+  }
+
+  @RequiresApi(31)
+  private boolean isLaunchedFromBubbleApi30() {
+    return this.isLaunchedFromBubble();
   }
 
   private void initializeResources(@NonNull ConversationIntents.Args args) {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationActivity.java
@@ -2098,7 +2098,7 @@ public class ConversationActivity extends PassphraseRequiredActivity
   }
 
   @RequiresApi(31)
-  private boolean isLaunchedFromBubbleApi30() {
+  private boolean isLaunchedFromBubbleApi31() {
     return this.isLaunchedFromBubble();
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationActivity.java
@@ -66,6 +66,7 @@ import android.widget.Toast;
 import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.annotation.WorkerThread;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;


### PR DESCRIPTION
Fixes #11224 

@cody-signal  This is the fix for #11224. Note that I did not actually test this by building Signal, as I am having issues compiling the project, so please apply a similar change as you see fit.

Please find the relevant API change documentation here: https://developer.android.com/reference/android/app/Activity#isLaunchedFromBubble()

Additional sample: https://github.com/android/user-interface-samples/tree/main/People#bubbles-1

Also note that an appcompat lib (ActivityCompat) is in the works and will be available in the future

