### PR TITLE
Fix crash for uuid only recipient with isForceSmsSelection (Fixes #11202)

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/recipients/Recipient.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/recipients/Recipient.java
@@ -888,7 +888,7 @@ public class Recipient {
   }
 
   public boolean isForceSmsSelection() {
-    return forceSmsSelection;
+    return forceSmsSelection && hasSmsAddress();
   }
 
   public @NonNull Capability getGroupsV2Capability() {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Signal crashes when opening a conversation with a uuid only user, which previously had a number and was set to send sms by default (`isForceSmsSelection`).
This PR fixes the crash by adapting the `isForceSmsSelection()` method to only return `true` if the recipient has a e164 number.
Fixes #11202

> 06-18 17:35:05.176 21838 21838 E SignalUncaughtException: java.lang.AssertionError: No options of default type!
06-18 17:35:05.176 21838 21838 E SignalUncaughtException: 	at org.thoughtcrime.securesms.TransportOptions.getSelectedTransport(TransportOptions.java:108)
06-18 17:35:05.176 21838 21838 E SignalUncaughtException: 	at org.thoughtcrime.securesms.TransportOptions.notifyTransportChangeListeners(TransportOptions.java:210)
06-18 17:35:05.176 21838 21838 E SignalUncaughtException: 	at org.thoughtcrime.securesms.TransportOptions.setDefaultTransport(TransportOptions.java:67)
06-18 17:35:05.176 21838 21838 E SignalUncaughtException: 	at org.thoughtcrime.securesms.components.SendButton.setDefaultTransport(SendButton.java:87)
06-18 17:35:05.176 21838 21838 E SignalUncaughtException: 	at org.thoughtcrime.securesms.conversation.ConversationActivity.handleSecurityChange(ConversationActivity.java:1519)
06-18 17:35:05.176 21838 21838 E SignalUncaughtException: 	at org.thoughtcrime.securesms.conversation.ConversationActivity.initializeSecurity(ConversationActivity.java:1748)
06-18 17:35:05.176 21838 21838 E SignalUncaughtException: 	at org.thoughtcrime.securesms.conversation.ConversationActivity.onCreate(ConversationActivity.java:461)
06-18 17:35:05.176 21838 21838 E SignalUncaughtException: 	at org.thoughtcrime.securesms.PassphraseRequiredActivity.onCreate(PassphraseRequiredActivity.java:71)