### PR TITLE
Do not collapse list to hide only one entry.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/conversation/ConversationSettingsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/conversation/ConversationSettingsViewModel.kt
@@ -164,12 +164,13 @@ sealed class ConversationSettingsViewModel(
         repository.getGroupsInCommon(recipientId) { groupsInCommon ->
           store.update { state ->
             val recipientSettings = state.requireRecipientSettingsState()
-            val expanded = recipientSettings.groupsInCommonExpanded
+            val canShowMore = !recipientSettings.groupsInCommonExpanded && groupsInCommon.size > 6
+
             state.copy(
               specificSettingsState = recipientSettings.copy(
                 allGroupsInCommon = groupsInCommon,
-                groupsInCommon = if (expanded) groupsInCommon else groupsInCommon.take(5),
-                canShowMoreGroupsInCommon = !expanded && groupsInCommon.size > 5
+                groupsInCommon = if (!canShowMore) groupsInCommon else groupsInCommon.take(5),
+                canShowMoreGroupsInCommon = canShowMore
               )
             )
           }
@@ -304,12 +305,13 @@ sealed class ConversationSettingsViewModel(
 
       store.update(liveGroup.fullMembers) { fullMembers, state ->
         val groupState = state.requireGroupSettingsState()
+        val canShowMore = !groupState.groupMembersExpanded && fullMembers.size > 6
 
         state.copy(
           specificSettingsState = groupState.copy(
             allMembers = fullMembers,
-            members = if (groupState.groupMembersExpanded) fullMembers else fullMembers.take(5),
-            canShowMoreGroupMembers = !groupState.groupMembersExpanded && fullMembers.size > 5
+            members = if (!canShowMore) fullMembers else fullMembers.take(5),
+            canShowMoreGroupMembers = canShowMore
           )
         )
       }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Motorola Moto G5S, Android 8.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
**This is a reimplementation of my change 4271700046d4ac2efc4a348fce5f8ff28b611d3d that @greyson-signal had committed but that was lost in the refactoring in da2ee33dff378b7910b388dd169153fa403f6e79.**

Currently if you have a group of exactly 6 members the group member list in the conversation settings screen will show 5 group members and one additional entry to expand the list. So the collapsed list has 6 entries, but the full list has 6 entries as well. It makes more sense to collapse the list only if two or more entries are hidden.

With this PR:

- up to 6 group members: all members are shown immediately
- 7 or more members: show 5 members and allow to expand

I chose the parameters so that the list has a maximum number of 6 entries, as it is now. Alternatively you could of course use parameters 5/4 to limit the number of initially shown members to a maximum of 5 (as it is now as well).