### PR TITLE
Fix OutdatedBuildReminder duration.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/reminder/OutdatedBuildReminder.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/reminder/OutdatedBuildReminder.java
@@ -22,7 +22,7 @@ public class OutdatedBuildReminder extends Reminder {
   }
 
   private static CharSequence getPluralsText(final Context context) {
-    int days = getDaysUntilExpiry() - 1;
+    int days = getDaysUntilExpiry();
 
     if (days == 0) {
       return context.getString(R.string.OutdatedBuildReminder_your_version_of_signal_will_expire_today);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Motorola Moto G5S, Android 8.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Fixes #11438. That bug was caused by changes in 2784285.

Subtracting _1_ is not needed anymore because _getDaysUntilExpiry()_ already returns _0_ for anything less than one full day.

