### PR TITLE
Fix crash with untitled sticker pack in sticker keyboard

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/keyboard/sticker/StickerKeyboardRepository.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyboard/sticker/StickerKeyboardRepository.kt
@@ -72,7 +72,7 @@ class StickerKeyboardRepository(private val stickerDatabase: StickerDatabase) {
   data class KeyboardStickerPack(
     val packId: String,
     val title: String?,
-    val titleResource: Int? = 0,
+    val titleResource: Int? = null,
     val coverUri: Uri?,
     val coverResource: Int? = null,
     val stickers: List<StickerRecord> = emptyList()


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * OnePlus 8T: Android 11
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
When a sticker pack is installed without a title the sticker keyboard crashes.
The fallback there is implemented correctly to show "Unnamed" in this case, but only if `titleResource` is null.
However `titleResource` is initialized to `0` so Android will try to use string resource 0x0 and crash.
This PR fixes this by initializing the titleResource to `null` instead.

Example sticker pack for reproducing the issue: https://signal.art/addstickers/#pack_id=e16589fa91e82379380c0d710fa847f3&pack_key=3d1990da23871c5ec9608865aebeda05d9bc10dfe627b60ba7e9e187821682b0

Stack trace from crash:
```
07-31 10:42:51.922 31897 31897 E crime.securesm: Invalid ID 0x00000000.
07-31 10:42:51.922 31897 31897 D AndroidRuntime: Shutting down VM
07-31 10:42:51.923 31897 31897 E AndroidRuntime: FATAL EXCEPTION: main
07-31 10:42:51.923 31897 31897 E AndroidRuntime: Process: org.thoughtcrime.securesms, PID: 31897
07-31 10:42:51.923 31897 31897 E AndroidRuntime: android.content.res.Resources$NotFoundException: String resource ID #0x0
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at android.content.res.Resources.getText(Resources.java:444)
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at android.content.res.Resources.getString(Resources.java:537)
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at org.thoughtcrime.securesms.keyboard.sticker.KeyboardStickerListAdapter$StickerHeader.getTitle(KeyboardStickerListAdapter.kt:66)
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at org.thoughtcrime.securesms.keyboard.sticker.KeyboardStickerListAdapter$StickerHeaderViewHolder.bind(KeyboardStickerListAdapter.kt:83)
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at org.thoughtcrime.securesms.keyboard.sticker.KeyboardStickerListAdapter$StickerHeaderViewHolder.bind(KeyboardStickerListAdapter.kt:78)
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at org.thoughtcrime.securesms.util.MappingAdapter.onBindViewHolder(MappingAdapter.java:115)
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at org.thoughtcrime.securesms.util.MappingAdapter.onBindViewHolder(MappingAdapter.java:109)
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at org.thoughtcrime.securesms.util.MappingAdapter.onBindViewHolder(MappingAdapter.java:48)
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at androidx.recyclerview.widget.RecyclerView$Adapter.bindViewHolder(RecyclerView.java:7107)
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at androidx.recyclerview.widget.RecyclerView$Recycler.tryBindViewHolderByDeadline(RecyclerView.java:6012)
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at androidx.recyclerview.widget.RecyclerView$Recycler.tryGetViewHolderForPositionByDeadline(RecyclerView.java:6279)
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at androidx.recyclerview.widget.GapWorker.prefetchPositionWithDeadline(GapWorker.java:288)
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at androidx.recyclerview.widget.GapWorker.flushTaskWithDeadline(GapWorker.java:345)
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at androidx.recyclerview.widget.GapWorker.flushTasksWithDeadline(GapWorker.java:361)
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at androidx.recyclerview.widget.GapWorker.prefetch(GapWorker.java:368)
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at androidx.recyclerview.widget.GapWorker.run(GapWorker.java:399)
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at android.os.Handler.handleCallback(Handler.java:938)
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java:99)
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at android.os.Looper.loop(Looper.java:233)
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at android.app.ActivityThread.main(ActivityThread.java:8010)
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at java.lang.reflect.Method.invoke(Native Method)
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:631)
07-31 10:42:51.923 31897 31897 E AndroidRuntime:        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:978)
```