### PR TITLE
Attempt to create the directory to save media files if it does not exist

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.ref.WeakReference;
 import java.text.SimpleDateFormat;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -152,17 +153,53 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
     }
   }
 
-  public String getExternalPathToFileForType(String contentType) {
-    File storage;
+  private @Nullable File ensureExternalPath(@Nullable File path) {
+    if (path != null && path.exists()) {
+      return path;
+    }
+
+    if (path == null) {
+      File documents = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS);
+      if (documents.exists() || documents.mkdirs()) {
+        return documents;
+      } else {
+        return null;
+      }
+    }
+
+    if (path.mkdirs()) {
+      return path;
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Returns a path to a shared media (or documents) directory for the type of the file.
+   *
+   * Note that this method attempts to create a directory if the path returned from
+   * Environment object does not exist yet. The attempt may fail in which case it attempts
+   * to return the default "Document" path. It finally returns null if it also fails.
+   * Otherwise it returns the absolute path to the directory.
+   *
+   * @param contentType a MIME type of a file
+   * @return an absolute path to a directory or null
+   */
+  private @Nullable String getExternalPathForType(String contentType) {
+    File storage = null;
     if (contentType.startsWith("video/")) {
       storage = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES);
     } else if (contentType.startsWith("audio/")) {
       storage = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MUSIC);
     } else if (contentType.startsWith("image/")) {
       storage = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
-    } else {
-      storage = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS);
     }
+
+    storage = ensureExternalPath(storage);
+    if (storage == null) {
+      return null;
+    }
+
     return storage.getAbsolutePath();
   }
 
@@ -217,13 +254,18 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
 
       return Uri.fromFile(outputFile);
     } else {
+      String dir = getExternalPathForType(contentType);
+      if (dir == null) {
+        throw new IOException(String.format(Locale.US, "Path for type: %s was not available", contentType));
+      }
+
       String outputFileName = fileName;
-      String dataPath       = String.format("%s/%s", getExternalPathToFileForType(contentType), outputFileName);
+      String dataPath       = String.format("%s/%s", dir, outputFileName);
       int    i              = 0;
       while (pathTaken(outputUri, dataPath)) {
         Log.d(TAG, "The content exists. Rename and check again.");
         outputFileName = base + "-" + (++i) + "." + extension;
-        dataPath       = String.format("%s/%s", getExternalPathToFileForType(contentType), outputFileName);
+        dataPath       = String.format("%s/%s", dir, outputFileName);
       }
       contentValues.put(MediaStore.MediaColumns.DATA, dataPath);
     }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Pixel API 23
 * AVD Nexus 6P API 27 
 * AVD Pixel3a API 29
 * AVD Pixel3a API 30
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
The current code may create an empty media in the media store if the path that [Environment.getExternalStoragePublicDirectory](https://developer.android.com/reference/android/os/Environment#getExternalStoragePublicDirectory(java.lang.String)) may returns does not exist.

The code in this PR tries a little harder to find a place to store the file before accepting a directory path that may not exist.

Fixes #11505

### Steps to verify the fix
 1. Prepare a Signal chat that has a movie file received or sent.
 2. Using `adb shell` or by any other ways, delete or rename the device's file system directory that is used for "Environment.DIRECTORY_MOVIES". In many cases this should be "/sdcard/Movies".
 3. Open Signal chat prepared at the step 1.
 4. Try to save the video file.
 5. In the chat tap on the [+] button to open the attachment keyboard.
 6. See the list of recent media files.

**Expected behavior after this PR**
The file should be saved. The directory (/sdcard/Movies) is created.

The list of recent media files has the video file that was just saved.

**Actual behavior in the current master at [429fdf0d76465e3f826c67d1334c1761cea41914]**
The file is not saved. Toast appears to tell the user something has gone wrong.

The list of recent media files has a blank (black or white) empty item in it.
