### PR TITLE
Use getSimpleRelativeTimeSpanString in getCallDateString

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -283,7 +283,7 @@ public abstract class MessageRecord extends DisplayRecord {
   }
 
   private @NonNull String getCallDateString(@NonNull Context context) {
-    return DateUtils.getExtendedRelativeTimeSpanString(context, Locale.getDefault(), getDateSent());
+    return DateUtils.getSimpleRelativeTimeSpanString(context, Locale.getDefault(), getDateSent());
   }
 
   private static @NonNull UpdateDescription fromRecipient(@NonNull Recipient recipient,


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual Pixel 2, Android 11.0
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Use the SimpleRelativeTimeSpanString for CallLogs.

Before:

![Screenshot_1628009452](https://user-images.githubusercontent.com/49990901/128060502-d53744c1-ee7e-49cf-a9ca-a63ffc433618.png) ![Screenshot_1628009341](https://user-images.githubusercontent.com/49990901/128060499-f2ee2d57-3f03-476d-9965-aa7773290a85.png) ![Screenshot_1628009390](https://user-images.githubusercontent.com/49990901/128060504-edc3abc5-60ca-403f-88ad-70693650958a.png)

After:

![Screenshot_1628012154](https://user-images.githubusercontent.com/49990901/128060793-bbc8b1e0-f799-49c1-99c0-112927551c52.png)


