### PR TITLE
Fix Signal Direct Share Shortcuts not appearing in Android Sharesheet

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -243,6 +243,9 @@
         <meta-data android:name="com.sec.minimode.icon.landscape.normal"
                    android:resource="@mipmap/ic_launcher" />
 
+        <meta-data android:name="android.app.shortcuts"
+                   android:resource="@xml/shortcuts" />
+
     </activity-alias>
 
     <activity android:name=".deeplinks.DeepLinkEntryActivity"

--- a/app/src/main/java/org/thoughtcrime/securesms/sharing/ShareActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/sharing/ShareActivity.java
@@ -283,7 +283,7 @@ public class ShareActivity extends PassphraseRequiredActivity
    * @param extraShortcutId EXTRA_SHORTCUT_ID string as included in direct share intent
    * @return shortcut extras or null
    */
-  @Nullable private Bundle getShortcutExtrasFor(@NonNull String extraShortcutId) {
+  private @Nullable Bundle getShortcutExtrasFor(@NonNull String extraShortcutId) {
     List<ShortcutInfoCompat> shortcuts = ShortcutManagerCompat.getDynamicShortcuts(this);
     for (ShortcutInfoCompat shortcutInfo : shortcuts) {
       if (extraShortcutId.equals(shortcutInfo.getId())) {

--- a/app/src/main/java/org/thoughtcrime/securesms/sharing/ShareActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/sharing/ShareActivity.java
@@ -287,6 +287,7 @@ public class ShareActivity extends PassphraseRequiredActivity
    * @param extraShortcutId EXTRA_SHORTCUT_ID String as included in direct share intent
    * @return shortcutExtras or null
    */
+  @WorkerThread
   private @Nullable Bundle getDirectShareExtras(@NonNull String extraShortcutId) {
     Bundle shortcutExtras = getShortcutExtrasFor(extraShortcutId);
     if (shortcutExtras == null) {
@@ -301,6 +302,7 @@ public class ShareActivity extends PassphraseRequiredActivity
    * @param extraShortcutId EXTRA_SHORTCUT_ID String as included in direct share intent
    * @return shortcutExtras or null
    */
+  @WorkerThread
   private @Nullable Bundle getShortcutExtrasFor(@NonNull String extraShortcutId) {
     List<ShortcutInfoCompat> shortcuts = ShortcutManagerCompat.getDynamicShortcuts(this);
     for (ShortcutInfoCompat shortcutInfo : shortcuts) {
@@ -314,6 +316,7 @@ public class ShareActivity extends PassphraseRequiredActivity
   /**
    * @param extraShortcutId EXTRA_SHORTCUT_ID string as included in direct share intent
    */
+  @WorkerThread
   private @Nullable Bundle createExtrasFromExtraShortcutId(@NonNull String extraShortcutId) {
     Bundle      extras           = new Bundle();
     RecipientId recipientId      = ConversationUtil.getRecipientId(extraShortcutId);

--- a/app/src/main/java/org/thoughtcrime/securesms/sharing/ShareActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/sharing/ShareActivity.java
@@ -428,7 +428,7 @@ public class ShareActivity extends PassphraseRequiredActivity
 
   private void handleDirectShare() {
     Intent      intent           = getIntent();
-    String extra_shortcut_id     = intent.getStringExtra(ShortcutManagerCompat.EXTRA_SHORTCUT_ID);
+    String      extraShortcutId  = intent.getStringExtra(ShortcutManagerCompat.EXTRA_SHORTCUT_ID);
     long        threadId         = -1;
     int         distributionType = -1;
     RecipientId recipientId      = null;
@@ -436,9 +436,9 @@ public class ShareActivity extends PassphraseRequiredActivity
     List<ShortcutInfoCompat> shortcuts = ShortcutManagerCompat.getDynamicShortcuts(this);
 
     for (int a = 0, N = shortcuts.size(); a < N; a++) {
-      ShortcutInfoCompat shortcut_info = shortcuts.get(a);
-      if (extra_shortcut_id.equals(shortcut_info.getId())) {
-        Bundle extras = shortcut_info.getIntent().getExtras();
+      ShortcutInfoCompat shortcutInfo = shortcuts.get(a);
+      if (extraShortcutId.equals(shortcutInfo.getId())) {
+        Bundle extras = shortcutInfo.getIntent().getExtras();
         recipientId = RecipientId.from(extras.getString(EXTRA_RECIPIENT_ID, null));
         threadId = extras.getLong(EXTRA_THREAD_ID, -1);
         distributionType = extras.getInt(EXTRA_DISTRIBUTION_TYPE, -1);

--- a/app/src/main/java/org/thoughtcrime/securesms/sharing/ShareActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/sharing/ShareActivity.java
@@ -55,6 +55,7 @@ import org.thoughtcrime.securesms.mediasend.MediaSendActivity;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.RecipientId;
 import org.thoughtcrime.securesms.sharing.interstitial.ShareInterstitialActivity;
+import org.thoughtcrime.securesms.util.ConversationUtil;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicNoActionBarTheme;
 import org.thoughtcrime.securesms.util.DynamicTheme;
@@ -277,8 +278,7 @@ public class ShareActivity extends PassphraseRequiredActivity
   }
 
   /**
-   * Search for dynamic shortcut originally declared in
-   * {@link org.thoughtcrime.securesms.util.ConversationUtil} and return extras
+   * Search for dynamic shortcut originally declared in {@link ConversationUtil} and return extras
    *
    * @param extraShortcutId EXTRA_SHORTCUT_ID string as included in direct share intent
    * @return shortcut extras or null
@@ -307,12 +307,15 @@ public class ShareActivity extends PassphraseRequiredActivity
    * @param extraShortcutId EXTRA_SHORTCUT_ID string as included in direct share intent
    */
   private void createShortcutIntentFromExtraShortcutId(@NonNull String extraShortcutId) {
-    RecipientId recipientId = RecipientId.from(extraShortcutId);
-    Long        threadId    = DatabaseFactory.getThreadDatabase(this).getThreadIdFor(recipientId);
+    RecipientId recipientId = ConversationUtil.getRecipientId(extraShortcutId);
+    Long        threadId    = null;
 
-    getIntent().putExtra(EXTRA_RECIPIENT_ID, recipientId);
-    getIntent().putExtra(EXTRA_THREAD_ID, threadId != null ? threadId : -1);
-    getIntent().putExtra(EXTRA_DISTRIBUTION_TYPE, ThreadDatabase.DistributionTypes.DEFAULT);
+    if (recipientId != null) {
+      threadId = DatabaseFactory.getThreadDatabase(this).getThreadIdFor(recipientId);
+      getIntent().putExtra(EXTRA_RECIPIENT_ID, recipientId.serialize());
+      getIntent().putExtra(EXTRA_THREAD_ID, threadId != null ? threadId : -1);
+      getIntent().putExtra(EXTRA_DISTRIBUTION_TYPE, ThreadDatabase.DistributionTypes.DEFAULT);
+    }
   }
 
   private void initializeToolbar() {

--- a/app/src/main/java/org/thoughtcrime/securesms/sharing/ShareActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/sharing/ShareActivity.java
@@ -252,17 +252,16 @@ public class ShareActivity extends PassphraseRequiredActivity
       getIntent().putExtra(ContactSelectionListFragment.DISPLAY_MODE, mode);
     }
 
-    boolean isDirectShare = getIntent().hasExtra(ShortcutManagerCompat.EXTRA_SHORTCUT_ID);
+    boolean isDirectShare      = getIntent().hasExtra(ShortcutManagerCompat.EXTRA_SHORTCUT_ID);
     boolean intentHasRecipient = getIntent().hasExtra(EXTRA_RECIPIENT_ID);
 
     if (isDirectShare && !intentHasRecipient) {
       String extraShortcutId = getIntent().getStringExtra(ShortcutManagerCompat.EXTRA_SHORTCUT_ID);
-      Bundle shortcutExtras = getShortcutExtrasFor(extraShortcutId);
+      Bundle shortcutExtras  = getShortcutExtrasFor(extraShortcutId);
 
       if (shortcutExtras != null) {
         moveShortcutExtrasToIntent(shortcutExtras);
       } else {
-        // In case the shortcut no longer exists, fallback to creating intent
         createShortcutIntentFromExtraShortcutId(extraShortcutId);
       }
     }
@@ -279,8 +278,7 @@ public class ShareActivity extends PassphraseRequiredActivity
 
   /**
    * Search for dynamic shortcut originally declared in
-   * {@link org.thoughtcrime.securesms.util.ConversationUtil} and return extras if the shortcut
-   * is found, else return null.
+   * {@link org.thoughtcrime.securesms.util.ConversationUtil} and return extras
    *
    * @param extraShortcutId EXTRA_SHORTCUT_ID string as included in direct share intent
    * @return shortcut extras or null
@@ -296,9 +294,6 @@ public class ShareActivity extends PassphraseRequiredActivity
   }
 
   /**
-   * Move required extras from shortcut intent extras to intent, because
-   * direct share intent does not include our required extras.
-   *
    * @param shortcutExtras shortcut extras as found by
    * {@link ShareActivity#getShortcutExtrasFor(java.lang.String)}
    */
@@ -309,9 +304,6 @@ public class ShareActivity extends PassphraseRequiredActivity
   }
 
   /**
-   * If all we have is EXTRA_SHORTCUT_ID, in other words we're handling a direct share for which
-   * the dynamic shortcut no longer exists, we recreate intent here.
-   *
    * @param extraShortcutId EXTRA_SHORTCUT_ID string as included in direct share intent
    */
   private void createShortcutIntentFromExtraShortcutId(@NonNull String extraShortcutId) {

--- a/app/src/main/java/org/thoughtcrime/securesms/sharing/ShareActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/sharing/ShareActivity.java
@@ -287,8 +287,7 @@ public class ShareActivity extends PassphraseRequiredActivity
    */
   @Nullable private Bundle getShortcutExtrasFor(@NonNull String extraShortcutId) {
     List<ShortcutInfoCompat> shortcuts = ShortcutManagerCompat.getDynamicShortcuts(this);
-    for (int a = 0, N = shortcuts.size(); a < N; a++) {
-      ShortcutInfoCompat shortcutInfo = shortcuts.get(a);
+    for (ShortcutInfoCompat shortcutInfo : shortcuts) {
       if (extraShortcutId.equals(shortcutInfo.getId())) {
         return shortcutInfo.getIntent().getExtras();
       }

--- a/app/src/main/java/org/thoughtcrime/securesms/util/ConversationUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/ConversationUtil.java
@@ -39,6 +39,8 @@ public final class ConversationUtil {
 
   private static final String TAG = Log.tag(ConversationUtil.class);
 
+  private static final String CATEGORY_SHARE_TARGET = "org.thoughtcrime.securesms.sharing.CATEGORY_SHARE_TARGET";
+
   private ConversationUtil() {}
 
 
@@ -204,7 +206,7 @@ public final class ConversationUtil {
                                  .setLongLabel(longName)
                                  .setIcon(AvatarUtil.getIconCompatForShortcut(context, resolved))
                                  .setPersons(persons)
-                                 .setCategories(Collections.singleton("android.shortcut.conversation"))
+                                 .setCategories(Collections.singleton(CATEGORY_SHARE_TARGET))
                                  .setActivity(new ComponentName(context, "org.thoughtcrime.securesms.RoutingActivity"))
                                  .setRank(rank)
                                  .build();

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <share-target android:targetClass="org.thoughtcrime.securesms.sharing.ShareActivity">
+        <data android:mimeType="*/*" />
+        <category android:name="org.thoughtcrime.securesms.sharing.CATEGORY_SHARE_TARGET" />
+    </share-target>
+</shortcuts>


### PR DESCRIPTION
1.  [Declare a share target](https://developer.android.com/training/sharing/receive#declare-share-target)

2.  In `org.thoughtcrime.securesms.sharing.ShareActivity`, before initiating the search/chooser interface, check for the following extra intent field and handle a direct share immediately if it is present: `EXTRA_SHORTCUT_ID`.

    Since a direct share action does not include intent as originally added when building the dynamic shortcut, we need to find the shortcut and get extra fields (threadId, distributionType) from the shortcut.

3.  If direct share fails, show search/chooser UI as before.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * LM-G710EM, Android 10
 * Virtual device Nexus 5X, Android 11
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Signal does not show up on Android Sharesheet, because it:
1. does not declare a [share target](https://developer.android.com/training/sharing/receive#declare-share-target),
2. does not handle androidx.core.content.pm.ShortcutManagerCompat.EXTRA_SHORTCUT_ID at all, and
3. relies on the original shortcut intent when it isn't present on direct share.

This pull request intends to fix these three issues.