### PR TITLE
Use more MaterialAlertDialogBuilder

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/contactshare/ContactUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/contactshare/ContactUtil.java
@@ -14,6 +14,7 @@ import androidx.annotation.WorkerThread;
 import androidx.appcompat.app.AlertDialog;
 
 import com.annimon.stream.Stream;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.i18n.phonenumbers.NumberParseException;
 import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import com.google.i18n.phonenumbers.Phonenumber.PhoneNumber;
@@ -126,7 +127,7 @@ public final class ContactUtil {
         values[i] = getPrettyPhoneNumber(choices.get(i).requireE164(), locale);
       }
 
-      new AlertDialog.Builder(context)
+      new MaterialAlertDialogBuilder(context)
                      .setItems(values, ((dialog, which) -> callback.onSelected(choices.get(which))))
                      .create()
                      .show();

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationActivity.java
@@ -1265,7 +1265,7 @@ public class ConversationActivity extends PassphraseRequiredActivity
   }
 
   private void handleResetSecureSession() {
-    AlertDialog.Builder builder = new AlertDialog.Builder(this);
+    AlertDialog.Builder builder = new MaterialAlertDialogBuilder(this);
     builder.setTitle(R.string.ConversationActivity_reset_secure_session_question);
     builder.setIcon(R.drawable.ic_warning);
     builder.setCancelable(true);
@@ -2599,7 +2599,7 @@ public class ConversationActivity extends PassphraseRequiredActivity
       numberItems[i] = contactData.numbers.get(i).type + ": " + contactData.numbers.get(i).number;
     }
 
-    AlertDialog.Builder builder = new AlertDialog.Builder(this);
+    AlertDialog.Builder builder = new MaterialAlertDialogBuilder(this);
     builder.setIcon(R.drawable.ic_account_box);
     builder.setTitle(R.string.ConversationActivity_select_contact_info);
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
@@ -902,7 +902,7 @@ public class ConversationFragment extends LoggingFragment implements Multiselect
   private AlertDialog.Builder buildRemoteDeleteConfirmationDialog(Set<MessageRecord> messageRecords) {
     Context             context       = requireActivity();
     int                 messagesCount = messageRecords.size();
-    AlertDialog.Builder builder       = new AlertDialog.Builder(getActivity());
+    AlertDialog.Builder builder       = new MaterialAlertDialogBuilder(getActivity());
 
     builder.setTitle(getActivity().getResources().getQuantityString(R.plurals.ConversationFragment_delete_selected_messages, messagesCount, messagesCount));
     builder.setCancelable(true);
@@ -956,7 +956,7 @@ public class ConversationFragment extends LoggingFragment implements Multiselect
     if (SignalStore.uiHints().hasConfirmedDeleteForEveryoneOnce()) {
       deleteForEveryone.run();
     } else {
-      new AlertDialog.Builder(requireActivity())
+      new MaterialAlertDialogBuilder(requireActivity())
                      .setMessage(R.string.ConversationFragment_this_message_will_be_deleted_for_everyone_in_the_conversation)
                      .setPositiveButton(R.string.ConversationFragment_delete_for_everyone, (dialog, which) -> {
                        SignalStore.uiHints().markHasConfirmedDeleteForEveryoneOnce();

--- a/app/src/main/java/org/thoughtcrime/securesms/logsubmit/SubmitDebugLogActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/logsubmit/SubmitDebugLogActivity.java
@@ -21,6 +21,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.dd.CircularProgressButton;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.thoughtcrime.securesms.BaseActivity;
 import org.thoughtcrime.securesms.R;
@@ -225,7 +226,7 @@ public class SubmitDebugLogActivity extends BaseActivity implements SubmitDebugL
   }
 
   private void presentResultDialog(@NonNull String url) {
-    AlertDialog.Builder builder = new AlertDialog.Builder(this)
+    AlertDialog.Builder builder = new MaterialAlertDialogBuilder(this)
                                                  .setTitle(R.string.SubmitDebugLogActivity_success)
                                                  .setCancelable(false)
                                                  .setNeutralButton(android.R.string.ok, (d, w) -> finish())

--- a/app/src/main/java/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
@@ -18,6 +18,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import org.signal.core.util.StreamUtil;
 import org.signal.core.util.logging.Log;
 import org.thoughtcrime.securesms.R;
@@ -348,7 +350,7 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
   }
 
   public static void showWarningDialog(Context context, OnClickListener onAcceptListener, int count) {
-    AlertDialog.Builder builder = new AlertDialog.Builder(context);
+    AlertDialog.Builder builder = new MaterialAlertDialogBuilder(context);
     builder.setTitle(R.string.ConversationFragment_save_to_sd_card);
     builder.setIcon(R.drawable.ic_warning);
     builder.setCancelable(true);


### PR DESCRIPTION
### Contributor checklist
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:

 * Virtual Pixel 2, Android 11.0
- [X] My contribution is fully baked and ready to be merged as is


----------

### Description
Uses the MaterialAlertDialogBuilder for following dialogs:

showWarningDialog in SaveAttachmentTask.java

![Screenshot_1629490713](https://user-images.githubusercontent.com/49990901/130290190-0a4800d0-368d-43db-80f5-758d04e7b304.png)

handleResetSecureSession

![Screenshot_1629490645](https://user-images.githubusercontent.com/49990901/130290222-ecbe3057-cd6d-4cbe-b3e4-1104a06ef5ab.png)

debug log upload


![Screenshot_1629490758](https://user-images.githubusercontent.com/49990901/130290312-35043027-8d5b-4d1e-b3ae-a3002db75509.png)

buildRemoteDeleteConfirmationDialog

![Screenshot_1629490688](https://user-images.githubusercontent.com/49990901/130290357-4b86a1e7-2c34-4719-8245-378d55ca71b4.png)

selectRecipientThroughDialog

![Screenshot_1629489627](https://user-images.githubusercontent.com/49990901/130290379-4a36f9cb-6704-4667-bf43-de11fdad5090.png)

selectContactInfo

[without screenshot]

