### PR TITLE
made transparent background behind the send button

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/InputPanel.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/InputPanel.java
@@ -316,7 +316,7 @@ public class InputPanel extends LinearLayout
       setBackground(new ColorDrawable(getContext().getResources().getColor(R.color.wallpaper_compose_background)));
       composeContainer.setBackground(Objects.requireNonNull(ContextCompat.getDrawable(getContext(), R.drawable.compose_background_wallpaper)));
     } else {
-      setBackground(new ColorDrawable(getContext().getResources().getColor(R.color.signal_background_primary)));
+      setBackground(new ColorDrawable(getContext().getResources().getColor(R.color.transparent)));
       composeContainer.setBackground(Objects.requireNonNull(ContextCompat.getDrawable(getContext(), R.drawable.compose_background)));
     }
   }


### PR DESCRIPTION
Made the background behind the signal message box and the attach/send button in signal.

https://community.signalusers.org/t/any-chance-of-removing-the-background-colour-behind-the-button-and-text-input-box/34567/5

credit to @signal.de on the forums for this fix. I will work out how to add a border later.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Samsung 10 on android 9
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
A very small fix for the background behind the signal message box and the send/attach button as [per discussion in the forums](https://community.signalusers.org/t/any-chance-of-removing-the-background-colour-behind-the-button-and-text-input-box/34567/4).