### PR TITLE
Use EmojiTextView to display group names in AvatarPreviewActivity

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/AvatarPreviewActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/AvatarPreviewActivity.java
@@ -27,6 +27,7 @@ import com.bumptech.glide.request.target.Target;
 import com.bumptech.glide.request.transition.Transition;
 
 import org.signal.core.util.logging.Log;
+import org.thoughtcrime.securesms.components.emoji.EmojiTextView;
 import org.thoughtcrime.securesms.contacts.avatars.ContactPhoto;
 import org.thoughtcrime.securesms.contacts.avatars.FallbackContactPhoto;
 import org.thoughtcrime.securesms.contacts.avatars.ProfileContactPhoto;
@@ -71,12 +72,14 @@ public final class AvatarPreviewActivity extends PassphraseRequiredActivity {
       getWindow().setSharedElementReturnTransition(inflater.inflateTransition(R.transition.full_screen_avatar_image_return_transition_set));
     }
 
-    Toolbar   toolbar = findViewById(R.id.toolbar);
-    ImageView avatar  = findViewById(R.id.avatar);
+    Toolbar       toolbar = findViewById(R.id.toolbar);
+    EmojiTextView title   = findViewById(R.id.title);
+    ImageView     avatar  = findViewById(R.id.avatar);
 
     setSupportActionBar(toolbar);
 
     requireSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    requireSupportActionBar().setDisplayShowTitleEnabled(false);
 
     Context     context     = getApplicationContext();
     RecipientId recipientId = RecipientId.from(getIntent().getStringExtra(RECIPIENT_ID_EXTRA));
@@ -122,7 +125,7 @@ public final class AvatarPreviewActivity extends PassphraseRequiredActivity {
                 }
               });
 
-      toolbar.setTitle(recipient.getDisplayName(context));
+      title.setText(recipient.getDisplayName(context));
     });
 
     FullscreenHelper fullscreenHelper = new FullscreenHelper(this);

--- a/app/src/main/res/layout/contact_photo_preview_activity.xml
+++ b/app/src/main/res/layout/contact_photo_preview_activity.xml
@@ -33,7 +33,20 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
-            android:background="@android:color/transparent" />
+            android:background="@android:color/transparent">
+
+            <org.thoughtcrime.securesms.components.emoji.EmojiTextView
+                android:id="@+id/title"
+                style="@style/TextSecure.TitleTextStyle.Dark"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical|start"
+                android:ellipsize="end"
+                android:gravity="center_vertical"
+                android:maxLines="1"
+                tools:text="Avatar name" />
+
+        </androidx.appcompat.widget.Toolbar>
 
     </com.google.android.material.appbar.AppBarLayout>
 


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * OnePlus 8T, Android 11
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
The `AvatarPreviewActivity`, which shows a full screen contact or group avatar, shows system emojis in the toolbar. Especially group names often contain emojis so the toolbar should show the Signal emojis.

To reproduce:
- Create a group with emojis in the name
- Open group details
- Click on group avatar
-> the ActionBar/Toolbar shows system emojis

This PR replaces the default toolbar title with an `EmojiTextView`.