### PR TITLE
Fix crash if the view has a TransformationMethod set.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiTextView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiTextView.java
@@ -158,6 +158,8 @@ public class EmojiTextView extends AppCompatTextView {
       lastLineWidth = -1;
     } else {
       Layout layout = getLayout();
+      // The text in layout might be different than the original text due to transformation.
+      text = layout.getText();
       int    lines  = layout.getLineCount();
       int    start  = layout.getLineStart(lines - 1);
       int    count  = text.length() - start;


### PR DESCRIPTION
If a TransformationMethod is set on the view, the displayed text might be different in content and length than the original text.
Thus using layout.getText will ensure the start and count are applied to the displayed text.
Otherwise it may cause crash of IllegalArgumentException at line 165.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [ ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
