### PR TITLE
Replace use of AlertDialog.Builder with MaterialAlertDialogBuilder.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/backup/BackupDialog.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/BackupDialog.java
@@ -23,6 +23,8 @@ import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.Fragment;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import org.signal.core.util.logging.Log;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.keyvalue.SignalStore;
@@ -110,7 +112,7 @@ public class BackupDialog {
 
   @RequiresApi(29)
   public static void showChooseBackupLocationDialog(@NonNull Fragment fragment, int requestCode) {
-    new AlertDialog.Builder(fragment.requireContext())
+    new MaterialAlertDialogBuilder(fragment.requireContext())
                    .setView(R.layout.backup_choose_location_dialog)
                    .setCancelable(true)
                    .setNegativeButton(android.R.string.cancel, (dialog, which) -> {
@@ -141,7 +143,7 @@ public class BackupDialog {
   }
 
   public static void showDisableBackupDialog(@NonNull Context context, @NonNull Runnable onBackupsDisabled) {
-    new AlertDialog.Builder(context)
+    new MaterialAlertDialogBuilder(context)
                    .setTitle(R.string.BackupDialog_delete_backups)
                    .setMessage(R.string.BackupDialog_disable_and_delete_all_local_backups)
                    .setNegativeButton(android.R.string.cancel, null)

--- a/app/src/main/java/org/thoughtcrime/securesms/contactshare/ContactUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/contactshare/ContactUtil.java
@@ -14,6 +14,7 @@ import androidx.annotation.WorkerThread;
 import androidx.appcompat.app.AlertDialog;
 
 import com.annimon.stream.Stream;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.i18n.phonenumbers.NumberParseException;
 import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import com.google.i18n.phonenumbers.Phonenumber.PhoneNumber;
@@ -126,7 +127,7 @@ public final class ContactUtil {
         values[i] = getPrettyPhoneNumber(choices.get(i).requireE164(), locale);
       }
 
-      new AlertDialog.Builder(context)
+      new MaterialAlertDialogBuilder(context)
                      .setItems(values, ((dialog, which) -> callback.onSelected(choices.get(which))))
                      .create()
                      .show();

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
@@ -958,7 +958,7 @@ public class ConversationFragment extends LoggingFragment implements Multiselect
   private AlertDialog.Builder buildRemoteDeleteConfirmationDialog(Set<MessageRecord> messageRecords) {
     Context             context       = requireActivity();
     int                 messagesCount = messageRecords.size();
-    AlertDialog.Builder builder       = new AlertDialog.Builder(getActivity());
+    AlertDialog.Builder builder       = new MaterialAlertDialogBuilder(getActivity());
 
     builder.setTitle(getActivity().getResources().getQuantityString(R.plurals.ConversationFragment_delete_selected_messages, messagesCount, messagesCount));
     builder.setCancelable(true);
@@ -1012,7 +1012,7 @@ public class ConversationFragment extends LoggingFragment implements Multiselect
     if (SignalStore.uiHints().hasConfirmedDeleteForEveryoneOnce()) {
       deleteForEveryone.run();
     } else {
-      new AlertDialog.Builder(requireActivity())
+      new MaterialAlertDialogBuilder(requireActivity())
                      .setMessage(R.string.ConversationFragment_this_message_will_be_deleted_for_everyone_in_the_conversation)
                      .setPositiveButton(R.string.ConversationFragment_delete_for_everyone, (dialog, which) -> {
                        SignalStore.uiHints().markHasConfirmedDeleteForEveryoneOnce();

--- a/app/src/main/java/org/thoughtcrime/securesms/util/CommunicationActions.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/CommunicationActions.java
@@ -20,6 +20,8 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.core.app.TaskStackBuilder;
 import androidx.fragment.app.FragmentActivity;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import org.signal.core.util.concurrent.SignalExecutors;
 import org.signal.core.util.logging.Log;
 import org.thoughtcrime.securesms.R;
@@ -62,7 +64,7 @@ public class CommunicationActions {
           if (resultCode == 1) {
             startCallInternal(activity, recipient, false);
           } else {
-            new AlertDialog.Builder(activity)
+            new MaterialAlertDialogBuilder(activity)
                 .setMessage(R.string.CommunicationActions_start_voice_call)
                 .setPositiveButton(R.string.CommunicationActions_call, (d, w) -> startCallInternal(activity, recipient, false))
                 .setNegativeButton(R.string.CommunicationActions_cancel, (d, w) -> d.dismiss())


### PR DESCRIPTION
### Contributor checklist
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Motorola Moto X Play, Android 7.1.1
 * Virtual Pixel 2, Android 11.0
- [X] My contribution is fully baked and ready to be merged as is


----------

### Description
Next try.
Uses the MaterialAlertDialogBuilder for following dialogs, which are "save" to change from AlertDialog.Builder to MaterialAlertDialogBuilder. (see more for issues with MaterialAlertDialogBuilder https://github.com/signalapp/Signal-Android/pull/11555)

-----------------------------------------------------
buildRemoteDeleteConfirmationDialog

![Screenshot_1630424820](https://user-images.githubusercontent.com/49990901/131574130-cca2d89d-c5e5-4518-8e9a-f7f211cc9e36.png) ![Screenshot_1630424858](https://user-images.githubusercontent.com/49990901/131574134-8ac63658-d2ad-4af3-913c-76296e4cdb71.png)

----------------------------------------------------
handleDeleteForEveryone

![Screenshot_1630424836](https://user-images.githubusercontent.com/49990901/131574159-c63d34be-a062-49c5-93f9-019661c690a3.png) ![Screenshot_1630424863](https://user-images.githubusercontent.com/49990901/131574165-0fbc7b4a-8396-49d1-9df6-fa2983bcf94f.png)

---------------------------------------------------------
startVoiceCall

![Screenshot_1630425748](https://user-images.githubusercontent.com/49990901/131574199-78645b08-a75b-4c74-b68d-70f623b71213.png)

-------------------------------------------------------------
showEnableBackupDialog
showChooseBackupLocationDialog
showDisableBackupDialog
showVerifyBackupPassphraseDialog

![Screenshot_1630427238](https://user-images.githubusercontent.com/49990901/131574220-26e1e3a4-08ed-4f9e-8e21-ede01bdc2bae.png) ![Screenshot_1630425795](https://user-images.githubusercontent.com/49990901/131574226-c4699532-d2f9-415b-9cbc-75687b41e3dc.png) ![Screenshot_1630443214](https://user-images.githubusercontent.com/49990901/131574429-b21217dd-8517-4fc9-b41b-bdae27521406.png) ![Screenshot_1630425867](https://user-images.githubusercontent.com/49990901/131574231-4cfaa958-9e5b-406f-a7e9-48a3fd27c6a7.png)

-------------------------------------------------
selectRecipientThroughDialog

![130290379-4a36f9cb-6704-4667-bf43-de11fdad5090](https://user-images.githubusercontent.com/49990901/131575089-ec76c741-5dd0-434e-974f-2cc21dbaca81.png)









