### PR TITLE
Fix distance between icon and title in dsl_payments_preference.xml

### DIFF
--- a/app/src/main/res/layout/dsl_payments_preference.xml
+++ b/app/src/main/res/layout/dsl_payments_preference.xml
@@ -22,7 +22,7 @@
         android:id="@id/title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="32dp"
+        android:layout_marginStart="24dp"
         android:layout_marginEnd="4dp"
         android:text="@string/preferences__payments"
         android:textAppearance="@style/Signal.Text.Body"


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual Pixel 2, Android 11
- [X] My contribution is fully baked and ready to be merged as is
----------

### Description
Fix the marginStart of title "Payments" to 24dp.

Actually the marginStart is 32dp, what is not the same as the other distances.

![Screenshot_1630526380](https://user-images.githubusercontent.com/49990901/131737236-b2de7abd-c839-43ba-ae93-a91177116815.png)

-------------------------------------------------------------------
Fix marginStart 24dp.

![Screenshot_1630526429](https://user-images.githubusercontent.com/49990901/131737268-9527e4b9-29fe-4851-b28a-9efcc671ae94.png)


