### PR TITLE
Search names with accentuated characters in Greek - fixes #11534

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/RecipientDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/RecipientDatabase.java
@@ -2509,6 +2509,24 @@ public class RecipientDatabase extends Database {
         return "ÝýÿŶ-ŸƔƳƴȲȳɎɏẎẏỲ-ỹỾỿẙ";
       case "z" :
         return "Ź-žƵƶɀẐ-ẕ";
+      case "α":
+        return "\u0386\u0391\u03AC\u03B1\u1F00-\u1F0F\u1F70\u1F71\u1F80-\u1F8F\u1FB0-\u1FB4\u1FB6-\u1FBC";
+      case "ε" :
+        return "\u0388\u0395\u03AD\u03B5\u1F10-\u1F15\u1F18-\u1F1D\u1F72\u1F73\u1FC8\u1FC9";
+      case "η" :
+        return "\u0389\u0397\u03AE\u03B7\u1F20-\u1F2F\u1F74\u1F75\u1F90-\u1F9F\u1F20-\u1F2F\u1F74\u1F75\u1F90-\u1F9F\u1fc2\u1fc3\u1fc4\u1fc6\u1FC7\u1FCA\u1FCB\u1FCC";
+      case "ι" :
+        return "\u038A\u0390\u0399\u03AA\u03AF\u03B9\u03CA\u1F30-\u1F3F\u1F76\u1F77\u1FD0-\u1FD3\u1FD6-\u1FDB";
+      case "ο" :
+        return "\u038C\u039F\u03BF\u03CC\u1F40-\u1F45\u1F48-\u1F4D\u1F78\u1F79\u1FF8\u1FF9";
+      case "σ" :
+        return "\u03A3\u03C2\u03C3";
+      case "ς" :
+        return "\u03A3\u03C2\u03C3";
+      case "υ" :
+        return "\u038E\u03A5\u03AB\u03C5\u03CB\u1F50-\u1F57\u1F59\u1F5B\u1F5D\u1F5F\u1F7A\u1F7B\u1FE0-\u1FE3\u1FE6-\u1FEB";
+      case "ω" :
+        return "\u038F\u03A9\u03C9\u03CE\u1F60-\u1F6F\u1F7C\u1F7D\u1FA0-\u1FAF\u1FF2-\u1FF4\u1FF6\u1FF7\u1FFA-\u1FFC";
       default :
         return "";
     }


### PR DESCRIPTION
Add greek characters to the accent insensitive search of names

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Xiaomi Mi 9 Lite, Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Follow-up on the #10202 PR, this time adding greek characters to it.
Done with the invaluable help from @Dimitri-UNHCR, this PR covers [Greek and Coptic](https://en.wikipedia.org/wiki/Greek_and_Coptic) and [Greek Extended](https://en.wikipedia.org/wiki/Greek_Extended) Unicode blocks.

The characters correspondance was also tested un [Regex101](https://regex101.com/r/Xgiu9t/1)

![IMG_20210903_210231](https://user-images.githubusercontent.com/5560197/132056279-3d3f61ef-6b9e-48ad-9361-c4150c2bd505.jpg)

