### PR TITLE
Create 1.5x speed for voice messages

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -412,7 +412,7 @@
     </integer-array>
     <string-array name="PlaybackSpeedToggleTextView__speed_labels">
         <item>@string/PlaybackSpeedToggleTextView__1x</item>
-        <item>@string/PlaybackSpeedToggleTextView__1p5x<item>
+        <item>@string/PlaybackSpeedToggleTextView__1p5x</item>
         <item>@string/PlaybackSpeedToggleTextView__2x</item>
         <item>@string/PlaybackSpeedToggleTextView__p5x</item>
     </string-array>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -406,11 +406,13 @@
 
     <integer-array name="PlaybackSpeedToggleTextView__speeds">
         <item>100</item>
+        <item>150</item>
         <item>200</item>
         <item>50</item>
     </integer-array>
     <string-array name="PlaybackSpeedToggleTextView__speed_labels">
         <item>@string/PlaybackSpeedToggleTextView__1x</item>
+        <item>@string/PlaybackSpeedToggleTextView__1p5x<item>
         <item>@string/PlaybackSpeedToggleTextView__2x</item>
         <item>@string/PlaybackSpeedToggleTextView__p5x</item>
     </string-array>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3681,6 +3681,7 @@
     <!-- PlaybackSpeedToggleTextView -->
     <string name="PlaybackSpeedToggleTextView__p5x">.5x</string>
     <string name="PlaybackSpeedToggleTextView__1x">1x</string>
+    <string name="PlaybackSpeedToggleTextView__1p5x">1.5x</string>
     <string name="PlaybackSpeedToggleTextView__2x">2x</string>
 
     <!-- PaymentRecipientSelectionFragment -->


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [ ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This is a follow-up for #11593 with the tag closed correctly and the strings.xml updated. This adds a 1.5x speed option for voice messages.

