### PR TITLE
Remove padded bytes when downloading attachment files

### DIFF
--- a/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/util/ContentLengthInputStream.java
+++ b/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/util/ContentLengthInputStream.java
@@ -32,10 +32,15 @@ public class ContentLengthInputStream extends FilterInputStream {
   public int read(byte[] buffer, int offset, int length) throws IOException {
     if (bytesRemaining == 0) return -1;
 
-    int result = super.read(buffer, offset, Math.min(length, Util.toIntExact(bytesRemaining)));
+    int lengthToRead = Math.min(length, Util.toIntExact(bytesRemaining));
+    int result       = super.read(buffer, offset, lengthToRead);
 
-    bytesRemaining -= result;
-    return result;
+    if (result <= lengthToRead) {
+      bytesRemaining -= result;
+      return result;
+    } else {
+      bytesRemaining = 0;
+      return lengthToRead;
+    }
   }
-
 }

--- a/libsignal/service/src/test/java/org/whispersystems/signalservice/api/crypto/AttachmentCipherTest.java
+++ b/libsignal/service/src/test/java/org/whispersystems/signalservice/api/crypto/AttachmentCipherTest.java
@@ -4,8 +4,11 @@ import org.conscrypt.Conscrypt;
 import org.junit.Test;
 import org.whispersystems.libsignal.InvalidMessageException;
 import org.whispersystems.libsignal.kdf.HKDFv3;
+import org.whispersystems.signalservice.internal.crypto.PaddingInputStream;
+import org.whispersystems.signalservice.internal.push.http.AttachmentCipherOutputStreamFactory;
 import org.whispersystems.signalservice.internal.util.Util;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -101,6 +104,44 @@ public final class AttachmentCipherTest {
     }
 
     assertTrue(hitCorrectException);
+  }
+
+  @Test
+  public void attachment_encryptDecryptPaddedContent() throws IOException, InvalidMessageException {
+    // The test used to fail when the length was between 520 and 540.
+    // The bug was reported in GitHub for a file whose length was 531.
+    int    length         = 531;
+    byte[] plaintextInput = new byte[length];
+
+    for (int i = 0; i < length; i++) {
+      plaintextInput[i] = (byte) 0x97;
+    }
+
+    // Mimic what we do when we send a file as an attachment, specifically, we use PaddingInputStream to
+    // add padding to obfuscate the length of the file sent over the wire.
+    byte[]                key             = Util.getSecretBytes(64);
+    ByteArrayInputStream  inputStream     = new ByteArrayInputStream(plaintextInput);
+    InputStream           dataStream      = new PaddingInputStream(inputStream, length);
+    ByteArrayOutputStream encryptedStream = new ByteArrayOutputStream();
+    DigestingOutputStream digestStream    = new AttachmentCipherOutputStreamFactory(key, null).createFor(encryptedStream);
+
+    Util.copy(dataStream, digestStream);
+    digestStream.flush();
+
+    byte[] digest        = digestStream.getTransmittedDigest();
+    byte[] encryptedData = encryptedStream.toByteArray();
+
+    encryptedStream.close();
+    inputStream.close();
+
+    File cipherFile = writeToFile(encryptedData);
+
+    InputStream decryptedStream = AttachmentCipherInputStream.createForAttachment(cipherFile, length, key, digest);
+    byte[]      plaintextOutput = readInputStreamFully(decryptedStream);
+
+    assertArrayEquals(plaintextInput, plaintextOutput);
+
+    cipherFile.delete();
   }
 
   @Test


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Pixel 3a API 39
 * AVD Pixel 3a API 29
 * AVD Pixel API 23
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Some bytes are added when [Signal sends a file attachment in order to obfuscate the length of the file](https://github.com/signalapp/SignalCoreKit/blob/bacb5ab174e8638458ab2032a7a472422efdf165/SignalCoreKit/src/Cryptography.swift#L204-L207) according to a comment in Signal-iOS source code. [Signal iOS removes the padded bytes here](https://github.com/signalapp/SignalCoreKit/blob/bacb5ab174e8638458ab2032a7a472422efdf165/SignalCoreKit/src/Cryptography.swift#L479-L486) and [Signal Desktop does it here](https://github.com/signalapp/Signal-Desktop/blob/1913752fa0a98f4f57d60af9850be0d01dc46044/ts/textsecure/MessageReceiver.ts#L1190-L1201).

Signal-Andorid doesn't do the similar processing, resulting some files of certain length would add some padded trailing bytes when the app downloads the file, as was reported in #11573 . The added test found that it failed at least for files whose size was between 520 and 540. See the screen recordings for how it happens in the app too, as was reported in the aforementioned GH issue.

This PR is to add the similar processing to what iOS and Desktop does to Android, so it ignores the padded bytes in the file if there would be any.

#### Screen Recordings

**Before the fix at [556ca5a5730e57046419fe8805249204c5be237f]**

Note that the size of the file was initially reported as 531B but it becomes 541B after downloading it.

https://user-images.githubusercontent.com/28482/134777454-09a704bb-799e-44ec-abe3-a15a1f79ca26.mp4

**After the fix by the PR**

https://user-images.githubusercontent.com/28482/134777475-c1d1619e-8358-44f9-a71e-e8bc72c257b9.mp4



