### PR TITLE
Fixes a bug where a chat bubble doesn't have its background color

### DIFF
--- a/app/src/main/res/layout/chat_wallpaper_crop_activity.xml
+++ b/app/src/main/res/layout/chat_wallpaper_crop_activity.xml
@@ -5,11 +5,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <org.thoughtcrime.securesms.conversation.colors.ColorizerView
-        android:id="@+id/colorizer"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
-
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/status_bar_guideline"
         android:layout_width="wrap_content"
@@ -32,6 +27,11 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <org.thoughtcrime.securesms.conversation.colors.ColorizerView
+        android:id="@+id/colorizer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Pixel 4 API 30
 * AVD Pixel 3a API 29
 * AVD Pixel 3a API 23
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
A chat bubble in the "set wallpaper" view looks having a transparent background. In order for the colorized background to appear as the bubble's background, it should be right behind the chat bubbles. Fixes #11391

### Screen recordings

**Behavior at [343aadcd9af23ebe5be25e3ce722d017d77868cd]**

https://user-images.githubusercontent.com/28482/137633205-774605bc-a46c-4b50-b69d-912a60e73a07.mp4

**Fixed by this PR**

https://user-images.githubusercontent.com/28482/137633243-77903672-8116-46a7-9633-c77dd34870b5.mp4



