### PR TITLE
Fix a bug where the first message of a chat is missing the date marker

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/StickyHeaderDecoration.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/StickyHeaderDecoration.java
@@ -61,7 +61,7 @@ public class StickyHeaderDecoration extends RecyclerView.ItemDecoration {
     outRect.set(0, headerHeight, 0, 0);
   }
 
-  protected boolean hasHeader(RecyclerView parent, StickyHeaderAdapter adapter, int adapterPos) {
+  protected boolean hasHeader(RecyclerView parent, StickyHeaderAdapter<?> adapter, int adapterPos) {
     long headerId = adapter.getHeaderId(adapterPos);
 
     if (headerId == StickyHeaderAdapter.NO_HEADER_ID) {
@@ -69,7 +69,7 @@ public class StickyHeaderDecoration extends RecyclerView.ItemDecoration {
     }
 
     boolean isReverse = isReverseLayout(parent);
-    int     itemCount = ((RecyclerView.Adapter)adapter).getItemCount();
+    int     itemCount = adapter.getItemCount();
 
     if ((isReverse && adapterPos == itemCount - 1 && adapter.getHeaderId(adapterPos) != -1) ||
         (!isReverse && adapterPos == 0))
@@ -80,7 +80,7 @@ public class StickyHeaderDecoration extends RecyclerView.ItemDecoration {
     int  previous         = adapterPos + (isReverse ? 1 : -1);
     long previousHeaderId = adapter.getHeaderId(previous);
 
-    return previousHeaderId != StickyHeaderAdapter.NO_HEADER_ID && headerId != previousHeaderId;
+    return (previousHeaderId == StickyHeaderAdapter.NO_HEADER_ID) || (headerId != previousHeaderId);
   }
 
   protected @NonNull ViewHolder getHeader(RecyclerView parent, StickyHeaderAdapter adapter, int position) {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Pixel 4 API 30
 * AVD Pixel 3a API 29
 * AVD Pixel API 23
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
A conversation item should be decorated with the date when the previous item was a header/footer. Fixes #11536.

### Screenshots

|chat|Before|After|
|---|---|---|
|Group|![bug-11536](https://user-images.githubusercontent.com/28482/137633793-b13b4ded-ab45-4eda-b438-9f96de8d6ce6.png)|![fixed-11536](https://user-images.githubusercontent.com/28482/137633798-504f2fdb-6a29-463c-9ff1-e4b58d0ad8f2.png)|
|1:1|![bug-11536-2](https://user-images.githubusercontent.com/28482/137633820-efae2424-bdcd-441f-889e-9b8947bd31f9.png)|![fixed-11536-2](https://user-images.githubusercontent.com/28482/137633825-c33680ab-9c3a-409f-96cb-f30333d6334f.png)|


