### PR TITLE
Use AlarmManagerCompat.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/AlarmSleepTimer.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/AlarmSleepTimer.java
@@ -6,8 +6,10 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.os.Build;
 import android.os.SystemClock;
+
+import androidx.core.app.AlarmManagerCompat;
+import androidx.core.content.ContextCompat;
 
 import org.signal.core.util.logging.Log;
 import org.whispersystems.signalservice.api.util.SleepTimer;
@@ -66,23 +68,13 @@ public class AlarmSleepTimer implements SleepTimer {
     private void setAlarm(long millis, String action) {
       final Intent        intent        = new Intent(action);
       final PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, intent, 0);
-      final AlarmManager  alarmManager  = (AlarmManager)context.getSystemService(Context.ALARM_SERVICE);
+      final AlarmManager  alarmManager  = ContextCompat.getSystemService(context, AlarmManager.class);
 
       Log.w(TAG, "Setting alarm to wake up in " + millis + "ms.");
 
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        alarmManager.setExactAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP,
-                                               SystemClock.elapsedRealtime() + millis,
-                                               pendingIntent);
-      } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-        alarmManager.setExact(AlarmManager.ELAPSED_REALTIME_WAKEUP,
-                              SystemClock.elapsedRealtime() + millis,
-                              pendingIntent);
-      } else {
-        alarmManager.set(AlarmManager.ELAPSED_REALTIME_WAKEUP,
-                         SystemClock.elapsedRealtime() + millis,
-                         pendingIntent);
-      }
+      AlarmManagerCompat.setExactAndAllowWhileIdle(alarmManager, AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                                                   SystemClock.elapsedRealtime() + millis,
+                                                   pendingIntent);
     }
 
     @Override


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
--> Use `AlarmManagerCompat.setExactAndAllowWhileIdle()` in `AlarmSleepTimer`. The method implementation is the same as the code being replaced.
