### PR TITLE
Use Captcha-URL from BuildConfig

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/CaptchaFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/CaptchaFragment.java
@@ -13,6 +13,7 @@ import androidx.annotation.Nullable;
 import androidx.lifecycle.ViewModelProviders;
 import androidx.navigation.fragment.NavHostFragment;
 
+import org.thoughtcrime.securesms.BuildConfig;
 import org.thoughtcrime.securesms.LoggingFragment;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.registration.viewmodel.BaseRegistrationViewModel;
@@ -55,7 +56,7 @@ public final class CaptchaFragment extends LoggingFragment {
       }
     });
 
-    webView.loadUrl(RegistrationConstants.SIGNAL_CAPTCHA_URL);
+    webView.loadUrl(BuildConfig.RECAPTCHA_PROOF_URL;
 
     CaptchaViewModelProvider provider = null;
     if (getArguments() != null) {


### PR DESCRIPTION
Actually the used URL is read from RegistrationConstants. But in the app's build.gradle we can define the URL for the recaptcha which is than generated in the builds config, but unused here. So it will be nice to really use the defined parameter from that config. Otherwise the definition in build.gradle is useless and can be removed there. I think using the BuildConfig would be the better solution.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement]()

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S9, Android 10
 * Samsung Galaxy S6 Edge, Android 7.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
