### PR TITLE
Bug fix for temp backups not being deleted on backups disabled

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/backup/BackupDialog.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/BackupDialog.java
@@ -146,11 +146,8 @@ public class BackupDialog {
                    .setMessage(R.string.BackupDialog_disable_and_delete_all_local_backups)
                    .setNegativeButton(android.R.string.cancel, null)
                    .setPositiveButton(R.string.BackupDialog_delete_backups_statement, (dialog, which) -> {
-                     /*onBackupsDisabled.run();
-                     BackupUtil.disableBackups(context);*/
-
-                     BackupUtil.disableBackups(context);
                      onBackupsDisabled.run();
+                     BackupUtil.disableBackups(context);
                    })
                    .create()
                    .show();

--- a/app/src/main/java/org/thoughtcrime/securesms/backup/BackupDialog.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/BackupDialog.java
@@ -146,8 +146,10 @@ public class BackupDialog {
                    .setMessage(R.string.BackupDialog_disable_and_delete_all_local_backups)
                    .setNegativeButton(android.R.string.cancel, null)
                    .setPositiveButton(R.string.BackupDialog_delete_backups_statement, (dialog, which) -> {
-                     BackupUtil.disableBackups(context);
+                     /*onBackupsDisabled.run();
+                     BackupUtil.disableBackups(context);*/
 
+                     BackupUtil.disableBackups(context);
                      onBackupsDisabled.run();
                    })
                    .create()

--- a/app/src/main/java/org/thoughtcrime/securesms/components/ConversationItemFooter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/ConversationItemFooter.java
@@ -246,7 +246,7 @@ public class ConversationItemFooter extends ConstraintLayout {
                                });
 
     if (isOutgoing) {
-      dateView.setMaxWidth(ViewUtil.dpToPx(28));
+      dateView.setMaxWidth(ViewUtil.dpToPx(32));
     } else {
       ConstraintSet constraintSet = new ConstraintSet();
       constraintSet.clone(this);

--- a/app/src/main/java/org/thoughtcrime/securesms/components/ConversationItemFooter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/ConversationItemFooter.java
@@ -246,7 +246,7 @@ public class ConversationItemFooter extends ConstraintLayout {
                                });
 
     if (isOutgoing) {
-      dateView.setMaxWidth(ViewUtil.dpToPx(32));
+      dateView.setMaxWidth(ViewUtil.dpToPx(28));
     } else {
       ConstraintSet constraintSet = new ConstraintSet();
       constraintSet.clone(this);


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S20, Android 11
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Fixes problem of temporary files not being deleted sometimes when a back up is in progress and the user disables the back up.
Tested this by having large conversations, starting a backup for the conversations and disabling the back up while it was in progress. After that I verified if the directory which was set as the back up directory was empty. 
Fixes #11751