### PR TITLE
Bug fix for pasting media in conversations

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/ComposeText.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/ComposeText.java
@@ -1,8 +1,12 @@
 package org.thoughtcrime.securesms.components;
 
+import android.content.ClipData;
+import android.content.ClipDescription;
+import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.Canvas;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.Annotation;
@@ -371,6 +375,27 @@ public class ComposeText extends EmojiEditText {
       return delimiterSearchIndex + 1;
     }
     return -1;
+  }
+
+  @Override
+  public boolean onTextContextMenuItem(int id) {
+    if (id == android.R.id.paste) {
+      ClipboardManager clipboardManager = (ClipboardManager) getContext().getSystemService(Context.CLIPBOARD_SERVICE);
+      ClipData clipData = clipboardManager.getPrimaryClip();
+      if (clipData != null) {
+        ClipData.Item clipItem = clipData.getItemAt(0);
+        Uri pasteUri = clipItem.getUri();
+        if (pasteUri != null) {
+          ClipDescription clipDescription = clipData.getDescription();
+          String mimeType = clipDescription.getMimeType(0);
+          if (mediaListener != null) {
+            mediaListener.onMediaSelected(pasteUri, mimeType);
+            return true;
+          }
+        }
+      }
+    }
+    return super.onTextContextMenuItem(id);
   }
 
   private static class CommitContentListener implements InputConnectionCompat.OnCommitContentListener {

--- a/app/src/main/java/org/thoughtcrime/securesms/components/ConversationItemFooter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/ConversationItemFooter.java
@@ -246,7 +246,7 @@ public class ConversationItemFooter extends ConstraintLayout {
                                });
 
     if (isOutgoing) {
-      dateView.setMaxWidth(ViewUtil.dpToPx(28));
+      dateView.setMaxWidth(ViewUtil.dpToPx(32));
     } else {
       ConstraintSet constraintSet = new ConstraintSet();
       constraintSet.clone(this);

--- a/app/src/main/java/org/thoughtcrime/securesms/components/ConversationItemFooter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/ConversationItemFooter.java
@@ -246,7 +246,7 @@ public class ConversationItemFooter extends ConstraintLayout {
                                });
 
     if (isOutgoing) {
-      dateView.setMaxWidth(ViewUtil.dpToPx(32));
+      dateView.setMaxWidth(ViewUtil.dpToPx(28));
     } else {
       ConstraintSet constraintSet = new ConstraintSet();
       constraintSet.clone(this);


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S20, Android 11
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Fixed problem of pasting media (images, gifs, etc) into the input for a message not working properly. Tested this by copying an image/gif from a web browser, long tapping on the input field in a conversion until the paste option was shown, clicked paste and checked if the media was properly pasted

https://user-images.githubusercontent.com/32488931/141474441-604c4318-b2e2-4b75-a0cd-8e3680c7ac16.mp4


Fixes #11740
