### PR TITLE
Fix a crash when selecting a contact in creating a new group

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/ContactSelectionListFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ContactSelectionListFragment.java
@@ -746,7 +746,11 @@ public final class ContactSelectionListFragment extends LoggingFragment
       return;
     }
 
-    TransitionManager.beginDelayedTransition(constraintLayout, new AutoTransition().setDuration(CHIP_GROUP_REVEAL_DURATION_MS));
+    AutoTransition transition = new AutoTransition();
+    transition.setDuration(CHIP_GROUP_REVEAL_DURATION_MS);
+    transition.excludeChildren(recyclerView, true);
+    transition.excludeTarget(recyclerView, true);
+    TransitionManager.beginDelayedTransition(constraintLayout, transition);
 
     ConstraintSet constraintSet = new ConstraintSet();
     constraintSet.clone(constraintLayout);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Pixel 4 API 30
 * AVD Pixel 3a API 29
 * AVD Nexus 6 API 27
 * AVD Pixel API 23
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
When animations are disabled through Accessibility settings system wide, a crash was imminent because the recycler view is involved in a transition that interferes its own animations inside.

Fixing the bug by excluding the recycler view from the transition.

Fixes #11722

### Steps to reproduce the crash

1. Open Android's Settings and go to Accessibility.
2. Turn on `Remove animations`
3. Launch Signal
4. Select `New group` from the menu on the home view
5. Enter some characters in the search box to filter out contacts
6. Select a contact

**Observed behavior at [dce8fde19513a4fe7cc9a0d52e7dfaf26ca5a577]**

The app crashes.

**Expected behavior after the PR**

The app doesn't crash. A contact is selected in the view.

### Screen recordings

**Crashing before the PR**

https://user-images.githubusercontent.com/28482/141648206-0f05794f-1219-46b9-88df-b2a8a19c800d.mp4

**Fixed after the PR**

https://user-images.githubusercontent.com/28482/141648213-fb2e7c2d-86e0-4d8b-81cb-3a936471276f.mp4


