### PR TITLE
Fix to a bug which may skew the profile picture on the action bar in the chat view in RTL layout

### DIFF
--- a/app/src/main/res/layout/conversation_title_view.xml
+++ b/app/src/main/res/layout/conversation_title_view.xml
@@ -13,7 +13,8 @@
         android:transitionName="avatar"
         android:id="@+id/contact_photo_container"
         android:layout_width="wrap_content"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:layout_marginEnd="10dp">
 
         <org.thoughtcrime.securesms.components.AvatarImageView
             android:id="@+id/contact_photo_image"
@@ -21,7 +22,6 @@
             android:layout_height="36dp"
             android:layout_alignParentStart="true"
             android:layout_centerVertical="true"
-            android:layout_marginEnd="10dp"
             android:clickable="true"
             android:contentDescription="@string/conversation_list_item_view__contact_photo_image"
             android:cropToPadding="true"


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Pixel API 23
 * AVD Pixel 3a API 29
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fix the profile image on the toolbar may get skewed in RTL layout in some Android versions.

The bug was [reported in the Beta forum by Xashyar](https://community.signalusers.org/t/beta-feedback-for-the-upcoming-android-5-26-release/38629/36).

### Steps to reproduce
1. Prepare an Android 6.0 (API 23) phone
2. Install and launch Signal to it
3. Set its language to one of RTL languages
4. Go to a chat and see the action bar.

**Observed at [dce8fde19513a4fe7cc9a0d52e7dfaf26ca5a577]**

The profile picture gets skewed.

**Expected after the PR**

The profile picture doesn't get skewed.

### Screenshots

|API|Bug|Fixed|
|---|---|---|
|23|![bug](https://user-images.githubusercontent.com/28482/141649086-50842b29-a679-41a7-83ee-8f091438b93e.png)|![fixed](https://user-images.githubusercontent.com/28482/141649103-3c897b02-0a3c-489c-92a5-131c2737c0cd.png)|
|29|(The bug doesn't appear in API 29)|![api29-profile-pic](https://user-images.githubusercontent.com/28482/141649141-5a866425-7f73-4c9c-a75b-a142f933fdc0.png)|