### PR TITLE
Fixes #11770 HTML Escape Display Names on Safety Num Screen

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/VerifyIdentityActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/VerifyIdentityActivity.java
@@ -516,7 +516,8 @@ public class VerifyIdentityActivity extends PassphraseRequiredActivity implement
     }
 
     private void setRecipientText(Recipient recipient) {
-      description.setText(Html.fromHtml(String.format(getActivity().getString(R.string.verify_display_fragment__to_verify_the_security_of_your_end_to_end_encryption_with_s), recipient.getDisplayName(getContext()))));
+      String escapedDisplayName = Html.escapeHtml(recipient.getDisplayName(getContext()));
+      description.setText(Html.fromHtml(String.format(getActivity().getString(R.string.verify_display_fragment__to_verify_the_security_of_your_end_to_end_encryption_with_s), escapedDisplayName)));
       description.setMovementMethod(LinkMovementMethod.getInstance());
     }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Pixel 2, Android API 29
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
HTML Escapes recipient display name on the Verify Safety Number screen. This makes sure that for a contact "Tim<3333" the screen looks like this:


![fixed](https://user-images.githubusercontent.com/22125581/142276149-93a7f3bf-c876-48e6-b8a7-0ee84d91c4c9.PNG)

and not like this:
![bad](https://user-images.githubusercontent.com/22125581/142276164-ae631c29-c309-4407-9e5b-18a640ca0451.PNG)

