### PR TITLE
Ensure last version code is stored in SharedPreferences

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -785,6 +785,10 @@ public class TextSecurePreferences {
     return getBooleanPreference(context, ENABLE_MANUAL_MMS_PREF, false);
   }
 
+  public static boolean hasLastVersionCode(Context context) {
+    return containsPreference(context, LAST_VERSION_CODE_PREF);
+  }
+
   public static int getLastVersionCode(Context context) {
     return getIntegerPreference(context, LAST_VERSION_CODE_PREF, Util.getCanonicalVersionCode());
   }
@@ -1121,6 +1125,10 @@ public class TextSecurePreferences {
 
   public static void setArgon2Tested(Context context, boolean tested) {
     setBooleanPreference(context, ARGON2_TESTED, tested);
+  }
+
+  public static boolean containsPreference(Context context, String key) {
+    return PreferenceManager.getDefaultSharedPreferences(context).contains(key);
   }
 
   public static void setBooleanPreference(Context context, String key, boolean value) {

--- a/app/src/main/java/org/thoughtcrime/securesms/util/VersionTracker.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/VersionTracker.java
@@ -33,6 +33,11 @@ public class VersionTracker {
         ApplicationDependencies.getJobManager().add(new RemoteConfigRefreshJob());
         LocalMetrics.getInstance().clear();
       }
+
+      if (!TextSecurePreferences.hasLastVersionCode(context)) {
+        Log.i(TAG, "Last version code is missing. Inserting " + currentVersionCode + " as the initial value.");
+        TextSecurePreferences.setLastVersionCode(context, currentVersionCode);
+      }
     } catch (IOException ioe) {
       throw new AssertionError(ioe);
     }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 3a, Android 11
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

`VersionTracker.updateLastSeenVersion` is the only place in the codebase that sets the last version code in SharedPreferences. However, on the initial run of the app, the preference won't be set. This results in the `TextSecurePreferences.getLastVersionCode` using the current version as the default value.

But this results in the `VersionTracker` code skipping the if-statement block, so it doesn't set the last version code in the SharedPreferences. What results is that we never have a value for the last version code, so `TextSecurePreferences.getLastVersionCode` always defaults to the current version code, and thus we always skip the if-statement in `VersionTracker.updateLastSeenVersion`. 

Side effects of this bug: 
* Feature flags are not refreshed immediately after updating to a newer version
* Local metrics may not be cleared after updating

Fixes #11776