### PR TITLE
Fix #11784 Enable Hyphenation on call screen speaker toggle label

### DIFF
--- a/app/src/main/res/layout/webrtc_call_view.xml
+++ b/app/src/main/res/layout/webrtc_call_view.xml
@@ -238,6 +238,7 @@
             android:textAppearance="@style/TextAppearance.Signal.Subtitle"
             android:textColor="@color/core_white"
             android:visibility="gone"
+            android:hyphenationFrequency="normal"
             app:layout_constrainedHeight="true"
             app:layout_constraintBottom_toTopOf="@id/call_screen_start_call_controls"
             app:layout_constraintEnd_toEndOf="@id/call_screen_speaker_toggle"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1497,6 +1497,7 @@
     </plurals>
 
     <string name="WebRtcCallView__flip">Flip</string>
+    <!-- Hyphenation enabled for this string. You can use the special character "Soft Hyphen" (SHY) -->
     <string name="WebRtcCallView__speaker">Speaker</string>
     <string name="WebRtcCallView__camera">Camera</string>
     <string name="WebRtcCallView__mute">Mute</string>


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Moto X Play, Android 7.1.1
 * Virtual Pixel 2, Android 11
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fix #11784
Enabled the hyphenation for the call screen speaker button label.
The special character "Soft Hyphen" SHY can be used by translators on transifex.

Without hyphenation:

![Screenshot_1637753038](https://user-images.githubusercontent.com/49990901/143233953-7bd8e2a1-5af0-49d9-8dc3-08d1cf80a0b2.png)

With hyphenation:


![Screenshot_1637753432](https://user-images.githubusercontent.com/49990901/143233974-3389d1eb-d3b0-421d-a9ba-8adfb1da6910.png)

