### PR TITLE
Replace only the first emoji in message body

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListItem.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListItem.java
@@ -571,13 +571,13 @@ public final class ConversationListItem extends ConstraintLayout
     final String bodyWithoutMediaPrefix;
 
     if (body.startsWith(EmojiStrings.GIF)) {
-      bodyWithoutMediaPrefix = body.replace(EmojiStrings.GIF, "");
+      bodyWithoutMediaPrefix = body.replaceFirst(EmojiStrings.GIF, "");
     } else if (body.startsWith(EmojiStrings.VIDEO)) {
-      bodyWithoutMediaPrefix = body.replace(EmojiStrings.VIDEO, "");
+      bodyWithoutMediaPrefix = body.replaceFirst(EmojiStrings.VIDEO, "");
     } else if (body.startsWith(EmojiStrings.PHOTO)) {
-      bodyWithoutMediaPrefix = body.replace(EmojiStrings.PHOTO, "");
+      bodyWithoutMediaPrefix = body.replaceFirst(EmojiStrings.PHOTO, "");
     } else if (thread.getExtra() != null && thread.getExtra().getStickerEmoji() != null && body.startsWith(thread.getExtra().getStickerEmoji())) {
-      bodyWithoutMediaPrefix = body.replace(thread.getExtra().getStickerEmoji(), "");
+      bodyWithoutMediaPrefix = body.replaceFirst(thread.getExtra().getStickerEmoji(), "");
     } else {
       return LiveDataUtil.just(body);
     }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual Pixel 2, Android 11
- [X] My contribution is fully baked and ready to be merged as is


----------

### Description

Actually all emojis (of the same type) in the message preview are replaced with "".
For example:
Sending a message
I bought a new camera (:camera:)
looks in the conversation list like
I bought a new camera ()

Only the first replacement is necessary. 

![Screenshot_1637758395](https://user-images.githubusercontent.com/49990901/143243685-71fd305e-f85c-4819-a84a-b96e8f0be310.png)

![Screenshot_1637758383](https://user-images.githubusercontent.com/49990901/143243699-186a9016-6f08-4ad6-a856-3f7d16416363.png)


![Screenshot_1637758613](https://user-images.githubusercontent.com/49990901/143243706-e29b6dda-3676-42d8-9f81-8ceaea6180e1.png)


