### PR TITLE
Show emoji-only group name in conversation title

### DIFF
--- a/app/src/main/res/layout/conversation_title_view.xml
+++ b/app/src/main/res/layout/conversation_title_view.xml
@@ -49,7 +49,7 @@
         android:layout_toEndOf="@id/contact_photo_container"
         android:orientation="vertical">
 
-        <org.thoughtcrime.securesms.components.FromTextView
+        <org.thoughtcrime.securesms.components.emoji.EmojiTextView
             android:id="@+id/title"
             style="@style/TextSecure.TitleTextStyle"
             android:layout_width="wrap_content"


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Moto X Play, Android 7.1.1
 * Virtual Pixel 2, Android 11
- [X] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fix #11772

The conversation title was "org.thoughtcrime.securesms.components.FromTextView", not showing emojis correctly.
Changed to "org.thoughtcrime.securesms.components.emoji.EmojiTextView"

![Screenshot_1638379158](https://user-images.githubusercontent.com/49990901/144283116-6d73137d-a7ce-4dd6-8a0a-0d253d07f200.png)


