### PR TITLE
Fix text lines overlap with each other on the image editor

### DIFF
--- a/image-editor/lib/src/main/java/org/signal/imageeditor/core/renderers/MultiLineTextRenderer.java
+++ b/image-editor/lib/src/main/java/org/signal/imageeditor/core/renderers/MultiLineTextRenderer.java
@@ -176,8 +176,8 @@ public final class MultiLineTextRenderer extends InvalidateableRenderer implemen
   }
 
   private class Line {
-    private final Matrix accentMatrix            = new Matrix();
-    private final Matrix decentMatrix            = new Matrix();
+    private final Matrix ascentMatrix            = new Matrix();
+    private final Matrix descentMatrix           = new Matrix();
     private final Matrix projectionMatrix        = new Matrix();
     private final Matrix inverseProjectionMatrix = new Matrix();
     private final RectF  selectionBounds         = new RectF();
@@ -255,8 +255,8 @@ public final class MultiLineTextRenderer extends InvalidateableRenderer implemen
       projectionMatrix.preTranslate(-textBounds.centerX(), 0);
       projectionMatrix.invert(inverseProjectionMatrix);
 
-      accentMatrix.setTranslate(0, -ascentInBounds);
-      decentMatrix.setTranslate(0, descentInBounds);
+      ascentMatrix.setTranslate(0, -ascentInBounds);
+      descentMatrix.setTranslate(0, descentInBounds + HIGHLIGHT_TOP_PADDING + HIGHLIGHT_BOTTOM_PADDING);
 
       invalidate();
     }
@@ -313,7 +313,7 @@ public final class MultiLineTextRenderer extends InvalidateableRenderer implemen
 
     public void render(@NonNull RendererContext rendererContext) {
       // add our ascent for ourselves and the next lines
-      rendererContext.canvasMatrix.concat(accentMatrix);
+      rendererContext.canvasMatrix.concat(ascentMatrix);
 
       rendererContext.save();
 
@@ -324,7 +324,6 @@ public final class MultiLineTextRenderer extends InvalidateableRenderer implemen
                        selectionBounds.top - HIGHLIGHT_TOP_PADDING,
                        textBounds.right + HIGHLIGHT_HORIZONTAL_PADDING,
                        selectionBounds.bottom + HIGHLIGHT_BOTTOM_PADDING);
-
         int alpha = modePaint.getAlpha();
         modePaint.setAlpha(rendererContext.getAlpha(alpha));
         rendererContext.canvas.drawRoundRect(modeBounds, HIGHLIGHT_CORNER_RADIUS, HIGHLIGHT_CORNER_RADIUS, modePaint);
@@ -370,7 +369,7 @@ public final class MultiLineTextRenderer extends InvalidateableRenderer implemen
       rendererContext.restore();
 
       // add our descent for the next lines
-      rendererContext.canvasMatrix.concat(decentMatrix);
+      rendererContext.canvasMatrix.concat(descentMatrix);
     }
 
     void setSelection(int selStart, int selEnd) {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S6, Android 7
 * Samsung Galaxy S6 Edge, Android 6
 * AVD Pixel 4, API 30
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Adds additional padding to the bottom of the line so the following line wouldn't overlap the previous line.

Fixes a bug [reported by Salt505 in the beta forum](https://community.signalusers.org/t/beta-feedback-for-the-upcoming-android-5-26-release/38629/163).

### Screenshots

| Before | After |
|-|-|
|![bug-pad-overlap](https://user-images.githubusercontent.com/28482/144714374-adea2671-baff-4d31-bcd5-cd6ef83c9ede.png)|![fixed-pad-overlap](https://user-images.githubusercontent.com/28482/144714389-62509b35-b3f3-4743-9399-437ee975fbb1.png)|
