### PR TITLE
Fix to the issue that a group's name is unnecessarily ellipsized in the group's chat view

### DIFF
--- a/app/src/main/res/layout/conversation_title_view.xml
+++ b/app/src/main/res/layout/conversation_title_view.xml
@@ -43,7 +43,7 @@
 
     <LinearLayout
         android:id="@+id/content"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
         android:layout_toEndOf="@id/contact_photo_container"
@@ -52,7 +52,7 @@
         <org.thoughtcrime.securesms.components.FromTextView
             android:id="@+id/title"
             style="@style/TextSecure.TitleTextStyle"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical|start"
             android:drawablePadding="3dp"


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S6 Android 7
 * Samsung Galaxy S6 Edge Android 6
 * AVD Pixel 3a API 29
 * AVD Pixel 4 API 30
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Give the longest available width to SimpleEmojiTextView so that it can calculate the width of the text correctly upon onSizeChanged event.

Fixes #11772

[Also fixes a bug reported in the beta forum by "SignalUser"](https://community.signalusers.org/t/beta-feedback-for-the-upcoming-android-5-27-release/38993/208)

### Steps to verify the fix
1. Prepare a group whose name contains one or more emojis but short enough to render the whole name in the action bar.
2. Open Signal and go to the group's chat.
3. See the name is not ellipsized unnecessarily.
4. Change the group name to only have a single emoji.
5. Go to the group chat.
6. See the emoji is not ellipsized.
7. Change the group name to have the maximum length of a group's name
8. Go to the group chat.
9. See the name is properly ellipsized.

### Screen recordings

**Bug**

https://user-images.githubusercontent.com/28482/144715146-84efb9e5-7264-4c25-8feb-fc45693c428d.mp4

**Fixed**

https://user-images.githubusercontent.com/28482/144715168-f2435bba-18e9-44d9-9a85-5a1723e7b7eb.mp4



