### PR TITLE
Add Feature: Show path of saved attachment

### DIFF
--- a/app/src/androidTest/java/org/thoughtcrime/securesms/util/MediaUtilTest.java
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/util/MediaUtilTest.java
@@ -1,0 +1,37 @@
+package org.thoughtcrime.securesms.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.thoughtcrime.securesms.util.MediaUtil.getSaveTargetPath;
+
+public class MediaUtilTest {
+
+  @Test
+  public void testSaveAttachmentImage() {
+    String actual   = getSaveTargetPath("signal_img.jpg:image/jpeg");
+    String expected = "/storage/emulated/0/Pictures/signal_img.jpg";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testSaveAttachmentVideo() {
+    String actual   = getSaveTargetPath("signal_video.mp4:video/mp4");
+    String expected = "/storage/emulated/0/Movies/signal_video.mp4";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testSaveAttachmentDocument() {
+    String actual   = getSaveTargetPath("signal_document.pdf:application/pdf");
+    String expected = "/storage/emulated/0/Download/signal_document.pdf";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testSaveAttachmentUnknownType() {
+    String actual   = getSaveTargetPath("signal_unknown.bin:application/octet-stream");
+    String expected = "/storage/emulated/0/Download/signal_unknown.bin";
+    assertEquals(expected, actual);
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
@@ -36,14 +36,16 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
+import static org.thoughtcrime.securesms.util.MediaUtil.getSaveTargetPath;
+
 public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTask.Attachment, Void, Pair<Integer, String>> {
   private static final String TAG = Log.tag(SaveAttachmentTask.class);
 
-          static final int SUCCESS              = 0;
+  static final         int SUCCESS              = 0;
   private static final int FAILURE              = 1;
   private static final int WRITE_ACCESS_FAILURE = 2;
 
-  private final WeakReference<Context>      contextReference;
+  private final WeakReference<Context> contextReference;
 
   private final int attachmentCount;
 
@@ -55,8 +57,8 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
     super(context,
           context.getResources().getQuantityString(R.plurals.ConversationFragment_saving_n_attachments, count, count),
           context.getResources().getQuantityString(R.plurals.ConversationFragment_saving_n_attachments_to_sd_card, count, count));
-    this.contextReference      = new WeakReference<>(context);
-    this.attachmentCount       = count;
+    this.contextReference = new WeakReference<>(context);
+    this.attachmentCount  = count;
   }
 
   @Override
@@ -66,9 +68,8 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
     }
 
     try {
-      Context      context      = contextReference.get();
-      String       directory    = null;
-
+      Context context = contextReference.get();
+      String fileMetadata = null;
       if (!StorageUtil.canWriteToMediaStore()) {
         return new Pair<>(WRITE_ACCESS_FAILURE, null);
       }
@@ -79,13 +80,13 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
 
       for (Attachment attachment : attachments) {
         if (attachment != null) {
-          directory = saveAttachment(context, attachment);
-          if (directory == null) return new Pair<>(FAILURE, null);
+          fileMetadata = saveAttachment(context, attachment);
+          if (fileMetadata == null) return new Pair<>(FAILURE, null);
         }
       }
 
       if (attachments.length > 1) return new Pair<>(SUCCESS, null);
-      else                        return new Pair<>(SUCCESS, directory);
+      else return new Pair<>(SUCCESS, fileMetadata);
     } catch (IOException ioe) {
       Log.w(TAG, ioe);
       return new Pair<>(FAILURE, null);
@@ -94,8 +95,8 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
 
   private @Nullable String saveAttachment(Context context, Attachment attachment) throws IOException
   {
-    String      contentType = Objects.requireNonNull(MediaUtil.getCorrectedMimeType(attachment.contentType));
-    String         fileName = attachment.fileName;
+    String contentType = Objects.requireNonNull(MediaUtil.getCorrectedMimeType(attachment.contentType));
+    String fileName    = attachment.fileName;
 
     if (fileName == null) fileName = generateOutputFileName(contentType, attachment.date);
     fileName = sanitizeOutputFileName(fileName);
@@ -118,7 +119,7 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
       if (Objects.equals(outputUri.getScheme(), ContentResolver.SCHEME_FILE)) {
         try (OutputStream outputStream = new FileOutputStream(mediaUri.getPath())) {
           StreamUtil.copy(inputStream, outputStream);
-          MediaScannerConnection.scanFile(context, new String[]{mediaUri.getPath()}, new String[]{contentType}, null);
+          MediaScannerConnection.scanFile(context, new String[] { mediaUri.getPath() }, new String[] { contentType }, null);
         }
       } else {
         try (OutputStream outputStream = context.getContentResolver().openOutputStream(mediaUri, "w")) {
@@ -137,8 +138,7 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
     if (updateValues.size() > 0) {
       getContext().getContentResolver().update(mediaUri, updateValues, null, null);
     }
-
-    return outputUri.getLastPathSegment();
+    return fileName + ":" + contentType;
   }
 
   private @NonNull Uri getMediaStoreContentUriForType(@NonNull String contentType) {
@@ -176,7 +176,7 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
 
   /**
    * Returns a path to a shared media (or documents) directory for the type of the file.
-   *
+   * <p>
    * Note that this method attempts to create a directory if the path returned from
    * Environment object does not exist yet. The attempt may fail in which case it attempts
    * to return the default "Document" path. It finally returns null if it also fails.
@@ -294,7 +294,7 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
     result[0] = tokens[0];
 
     if (tokens.length > 1) result[1] = tokens[1];
-    else                   result[1] = "";
+    else result[1] = "";
 
     return result;
   }
@@ -313,16 +313,18 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
                        Toast.LENGTH_LONG).show();
         break;
       case SUCCESS:
-        String message = !TextUtils.isEmpty(result.second())  ? context.getResources().getString(R.string.SaveAttachmentTask_saved_to, result.second())
-                                                              : context.getResources().getString(R.string.SaveAttachmentTask_saved);
+
+        String message = !TextUtils.isEmpty(result.second()) ? context.getResources().getString(R.string.SaveAttachmentTask_saved_to, getSaveTargetPath(result.second()))
+                                                             : context.getResources().getString(R.string.SaveAttachmentTask_saved);
         Toast.makeText(context, message, Toast.LENGTH_LONG).show();
         break;
       case WRITE_ACCESS_FAILURE:
         Toast.makeText(context, R.string.ConversationFragment_unable_to_write_to_sd_card_exclamation,
-            Toast.LENGTH_LONG).show();
+                       Toast.LENGTH_LONG).show();
         break;
     }
   }
+
 
   public static class Attachment {
     public Uri    uri;


### PR DESCRIPTION
- [ x ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [ x ] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [ x ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ x ] I have tested my contribution on these devices:
 * Device A, Android 12
- [ x ] My contribution is fully baked and ready to be merged as is
- [ x ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Related Issue: https://github.com/signalapp/Signal-Android/issues/11759
Method `org.thoughtcrime.securesms.util.SaveAttachmentTask#saveAttachment`ìs responsible for saving attachment but returns a useless string. This string will always be "media".That's why the message shown to the user is "Saved to media". 

Instead of returning a value that won't be used later or will be used but without added value, I refactored the method to return a string that can be used to identify the  path of a saved attachment(`contentType:fileName`).

The returned value from ``org.thoughtcrime.securesms.util.SaveAttachmentTask#saveAttachment`` will be used then by a helper method that will identify the output path based on `contentType` and `fileName` using the `android.os.Environment` constants

The message looks like below :

![signal_msg](https://user-images.githubusercontent.com/50799773/144761058-631e74ec-0d2e-41b6-972d-2c1ae111f315.png)

The extension should be also shown. In the example shown above, I tested with an unknown file type.
