### PR TITLE
Fixes #11819 protobuf issue for building on Apple Silicon-Based Devices

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,8 +47,13 @@ repositories {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.11.4'
+        if (osdetector.os == "osx") {
+            artifact = 'com.google.protobuf:protoc:3.10.0:osx-x86_64'
+        } else {
+            artifact = 'com.google.protobuf:protoc:3.10.0'
+        }
     }
+
     generateProtoTasks {
         all().each { task ->
             task.builtins {

--- a/core-util/build.gradle
+++ b/core-util/build.gradle
@@ -33,8 +33,13 @@ dependencyVerification {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.10.0'
+        if (osdetector.os == "osx") {
+            artifact = 'com.google.protobuf:protoc:3.10.0:osx-x86_64'
+        } else {
+            artifact = 'com.google.protobuf:protoc:3.10.0'
+        }
     }
+
     generateProtoTasks {
         all().each { task ->
             task.builtins {

--- a/libsignal/service/build.gradle
+++ b/libsignal/service/build.gradle
@@ -64,8 +64,13 @@ tasks.whenTaskAdded { task ->
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.10.0'
+        if (osdetector.os == "osx") {
+            artifact = 'com.google.protobuf:protoc:3.10.0:osx-x86_64'
+        } else {
+            artifact = 'com.google.protobuf:protoc:3.10.0'
+        }
     }
+
     generateProtoTasks {
         all().each { task ->
             task.builtins {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Pixel 5, Android 12
 * Device Redmi Note 7 Pro, Android 10

- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix works.
-->

There is an issue of protobuf that it does not get the correct artifact name, which causes the plugin does not build to Android on Apple silicon-based devices
Issue Ref: https://github.com/signalapp/Signal-Android/issues/11819

All these changes are tested multiple times on my Apple Macbook Air (late 2020) on the Apple Silicon version of Android Studio.
