### PR TITLE
Enable hyphenation on notification profiles empty title

### DIFF
--- a/app/src/main/res/layout/notification_profiles_empty.xml
+++ b/app/src/main/res/layout/notification_profiles_empty.xml
@@ -29,6 +29,7 @@
         android:gravity="center"
         android:text="@string/NotificationProfilesFragment__notification_profiles"
         android:textAppearance="@style/TextAppearance.Signal.Title1"
+        android:hyphenationFrequency="normal"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/notification_profiles_empty_icon" />


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Device Moto X Play, Android 7.1.1
 * Virtual Pixel 2, Android 11
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

https://community.signalusers.org/t/beta-feedback-for-the-upcoming-android-5-28-release/39659/76

The translated title "Benachrichtigungsprofile" is separated incorrectly. Enabling hyphenation for the TextView 
`notification_profiles_empty_title`. Translators can now specify the correct separation with using the special character SHY in the string:

https://github.com/signalapp/Signal-Android/blob/a0235cbc6c95eab53cfd60f72858b98ce4c502d8/app/src/main/res/values/strings.xml#L3661

![signal-2021-12-10-174731_001](https://user-images.githubusercontent.com/49990901/145616052-3ce5c460-b451-4f4b-aa9f-a5e8d29cd6f2.png)

![signal-2021-12-10-174731_002](https://user-images.githubusercontent.com/49990901/145616100-73c95ed2-496d-439d-a8bf-43fd9c36e0f8.png)



