### PR TITLE
Fixed issue 11545 where emojis found via serach didn't appear in the …

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiPageViewGridAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiPageViewGridAdapter.java
@@ -10,9 +10,11 @@ import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 
 import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.dependencies.ApplicationDependencies;
 import org.thoughtcrime.securesms.util.MappingAdapter;
 import org.thoughtcrime.securesms.util.MappingModel;
 import org.thoughtcrime.securesms.util.MappingViewHolder;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
 
 public class EmojiPageViewGridAdapter extends MappingAdapter implements PopupWindow.OnDismissListener {
 
@@ -147,6 +149,8 @@ public class EmojiPageViewGridAdapter extends MappingAdapter implements PopupWin
 
       itemView.setOnClickListener(v -> {
         emojiEventListener.onEmojiSelected(model.emoji.getValue());
+
+        new RecentEmojiPageModel(ApplicationDependencies.getApplication(), TextSecurePreferences.RECENT_STORAGE_KEY).onCodePointSelected(model.emoji.getValue());
       });
 
       if (allowVariations && model.emoji.hasMultipleVariations()) {


### PR DESCRIPTION



### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x ] I have tested my contribution on these devices:
 * Device Xiaomi Redmi Note 9T, Android 10
- [x ] My contribution is fully baked and ready to be merged as is
- [x ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the Fixes #11545 

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
--> Currently all the emojis picked from the emojis keyboard were added in the recently used list and shown after reentering the chat. That's not the case for emojis picked from an emoji search. Now it has been fixed to have the same behavoir in both cases.
