### PR TITLE
Fixes #11759

### DIFF
--- a/app/src/androidTest/java/org/thoughtcrime/securesms/util/MediaUtilTest.java
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/util/MediaUtilTest.java
@@ -1,0 +1,37 @@
+package org.thoughtcrime.securesms.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.thoughtcrime.securesms.util.MediaUtil.getSaveTargetPath;
+
+public class MediaUtilTest {
+
+  @Test
+  public void testSaveAttachmentImage() {
+    String actual   = getSaveTargetPath("signal_img.jpg:image/jpeg");
+    String expected = "/storage/emulated/0/Pictures/signal_img.jpg";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testSaveAttachmentVideo() {
+    String actual   = getSaveTargetPath("signal_video.mp4:video/mp4");
+    String expected = "/storage/emulated/0/Movies/signal_video.mp4";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testSaveAttachmentDocument() {
+    String actual   = getSaveTargetPath("signal_document.pdf:application/pdf");
+    String expected = "/storage/emulated/0/Download/signal_document.pdf";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testSaveAttachmentUnknownType() {
+    String actual   = getSaveTargetPath("signal_unknown.bin:application/octet-stream");
+    String expected = "/storage/emulated/0/Download/signal_unknown.bin";
+    assertEquals(expected, actual);
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/util/MediaUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/MediaUtil.java
@@ -47,6 +47,11 @@ import java.io.InputStream;
 import java.net.URLConnection;
 import java.util.concurrent.ExecutionException;
 
+import static android.os.Environment.DIRECTORY_DOWNLOADS;
+import static android.os.Environment.DIRECTORY_MOVIES;
+import static android.os.Environment.DIRECTORY_PICTURES;
+import static android.os.Environment.getExternalStoragePublicDirectory;
+
 public class MediaUtil {
 
   private static final String TAG = Log.tag(MediaUtil.class);
@@ -430,6 +435,24 @@ public class MediaUtil {
     final String[] sections = mimeType.split("/", 2);
     return sections.length > 1 ? sections[0] : null;
   }
+
+  public static String getSaveTargetPath(String fileMetadata) {
+    if (fileMetadata == null || !fileMetadata.contains(":")) {
+      return "Error processing file metadata";
+    }
+    String contentType = fileMetadata.split(":")[1];
+    String fileName    = fileMetadata.split(":")[0];
+    if(isImageType(contentType)) {
+      String imagesDefaultPath = getExternalStoragePublicDirectory(DIRECTORY_PICTURES).getPath();
+      return imagesDefaultPath + "/" + fileName;
+    } else if (isVideo(contentType)) {
+      String videoDefaultPath = getExternalStoragePublicDirectory(DIRECTORY_MOVIES).getPath();
+      return videoDefaultPath + "/" + fileName;
+    }
+    String defaultPathForOtherTypes = getExternalStoragePublicDirectory(DIRECTORY_DOWNLOADS).getPath();
+    return defaultPathForOtherTypes + "/" + fileName;
+  }
+
 
   public static class ThumbnailData implements AutoCloseable {
 

--- a/app/src/main/java/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
@@ -36,6 +36,8 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
+import static org.thoughtcrime.securesms.util.MediaUtil.getSaveTargetPath;
+
 public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTask.Attachment, Void, Pair<Integer, String>> {
   private static final String TAG = Log.tag(SaveAttachmentTask.class);
 
@@ -138,7 +140,7 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
       getContext().getContentResolver().update(mediaUri, updateValues, null, null);
     }
 
-    return outputUri.getLastPathSegment();
+    return fileName + ":" + contentType;
   }
 
   private @NonNull Uri getMediaStoreContentUriForType(@NonNull String contentType) {
@@ -313,8 +315,8 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
                        Toast.LENGTH_LONG).show();
         break;
       case SUCCESS:
-        String message = !TextUtils.isEmpty(result.second())  ? context.getResources().getString(R.string.SaveAttachmentTask_saved_to, result.second())
-                                                              : context.getResources().getString(R.string.SaveAttachmentTask_saved);
+        String message = !TextUtils.isEmpty(result.second()) ? context.getResources().getString(R.string.SaveAttachmentTask_saved_to, getSaveTargetPath(result.second()))
+                                                             : context.getResources().getString(R.string.SaveAttachmentTask_saved);
         Toast.makeText(context, message, Toast.LENGTH_LONG).show();
         break;
       case WRITE_ACCESS_FAILURE:


### PR DESCRIPTION
### First time contributor checklist
- [ x ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [ x ] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [ x ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ x ] I have tested my contribution on these devices:
Android 12
- [ x ] My contribution is fully baked and ready to be merged as is
- [ x ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Related Issue : https://github.com/signalapp/Signal-Android/issues/11759

Method `org.thoughtcrime.securesms.util.SaveAttachmentTask#saveAttachmentìs` responsible for saving attachment but returns a useless string. This string will always be "media".That's why the message shown to the user is "Saved to media".

Instead of returning a value that won't be used later or will be used but without added value, I refactored the method to return a string that can be used to identify the path of a saved attachment(contentType:fileName).

The returned value from `org.thoughtcrime.securesms.util.SaveAttachmentTask#saveAttachment` will be used then by a helper method that will identify the output path based on contentType and fileName using the android.os.Environment constants

The message looks like below :
![signal_scrshot](https://user-images.githubusercontent.com/50799773/145711366-1b4cbf5f-5791-4cc6-bffc-b62de74290d6.png)

