### PR TITLE
All foldables support on video feature

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/WebRtcCallActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/WebRtcCallActivity.java
@@ -813,7 +813,7 @@ public class WebRtcCallActivity extends BaseActivity implements SafetyNumberChan
       if (feature.isPresent()) {
         FoldingFeature foldingFeature = (FoldingFeature) feature.get();
         Rect           bounds         = foldingFeature.getBounds();
-        if (foldingFeature.getState() == FoldingFeature.State.HALF_OPENED && bounds.top == bounds.bottom) {
+        if (foldingFeature.isSeparating()) {
           Log.d(TAG, "OnWindowLayoutInfo accepted: ensure call view is in table-top display mode");
           viewModel.setFoldableState(WebRtcControls.FoldableState.folded(bounds.top));
         } else {


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Surface Duo, Android 10
 * Surface Duo 2, Android 11
 * 6.7 Horizontal Fold-in, Android 11 and Android 12 (virtual device)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
**Note**: this PR doesn't fix anything that was raised up on an issue.

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Currently the `video call` feature is **intended to be enhanced for foldable devices**, where in `HALF_OPENED` mode, the layout is split into two, providing a better user experience where the video (with the attendees) is located at the top (display), and the video controls are at the bottom (display).

**Problem:** the **current implementation just works on Samsung devices** since there is a check that is just `true` when the app runs on a Samsung foldable device. It would be better to have that enhancement on all foldable devices that support Jetpack Window Manager.

This line: https://github.com/signalapp/Signal-Android/blob/4e2e525509d05499faf245a31b21926c31959b64/app/src/main/java/org/thoughtcrime/securesms/WebRtcCallActivity.java#L816 contains the not-good-enough `if` statement, since it checks for state `HALF_OPEN` and a `FoldingFeature` of `0px`.
There is a better API to use on Jetpack WindowManager and this is [isSeparating](https://developer.android.com/reference/androidx/window/layout/FoldingFeature#isSeparating()) that checks that it's a foldable device on `HALF_OPENED` mode and/or if there is a `hinged` device (such as [Surface Duo](https://www.microsoft.com/en-us/surface/devices/surface-duo?activetab=overview)), where its hinge separates the content.

**Fix:**
I've replaced the current `if` statement that works just on Samsung devices for a more appropriated one that works on all foldable devices using `isSeparating`.
```
if (foldingFeature.isSeparating()) {
```

**Tested:**
Tested that the change work well on physical devices with hinge (Surface Duo v1 and v2), and virtual emulators that mirror other manufacturers devices (such as Samsung foldables).

**Screenshots (Test):**

_Before:_ on Surface Duo, there is no content separation no matter the posture the device uses):
![image](https://user-images.githubusercontent.com/1050785/146243844-d2ccd847-b138-4863-9e45-4427ab3c23a3.png)
**Note:** think that there is a physical hinge in the middle, between the screens, that separates the content (the above screenshot it looks like just one continuous display). For reference [this link](https://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE4AX4U?ver=e041&q=90&m=6&h=920&w=1920&b=%23FFFFFFFF&l=f&o=t&aim=true) shows how is the device and the physical hinge that it has.

_After:_ on Samsung devices and other foldable devices the content separation happens in on `HALF_OPENED` posture as wished, and on hinged devices such as Surface Duo, the content is now separated too (and in fact, just when the FoldingFeature is in horizontal orientation because other code that handles that and that has not been modified).
![image](https://user-images.githubusercontent.com/1050785/146244409-515393bc-15e2-4927-b47b-a71980b2be30.png)

Please, let me know if I need to clarify something else.

Thanks,
Cesar

**Note:** I work for Microsoft in the Surface Duo Developer Experience team. I can provide support about foldables and dual-screen development if needed too. Happy to help!

