### PR TITLE
Fix #11860 Don't show double emoji reaction at end of reaction notifi…

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/v2/NotificationItemV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/v2/NotificationItemV2.kt
@@ -267,9 +267,6 @@ class ReactionNotification(threadRecipient: Recipient, record: MessageRecord, va
         }
       }
 
-      if (text.endsWith(EMOJI_REPLACEMENT_STRING)) {
-        builder.append(reaction.emoji)
-      }
       builder
     }
   }


### PR DESCRIPTION
…cation text


### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual Pixel 2, Android 11
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Fix #11860

The issue is a mix of the form of the japanese translated strings for reaction notification `「%2$s」に %1$s` and the splitting of this strings.

Even the emoji_replacement_string is at the end of the text string, it's split in two parts.
part 0 = "「123456789」に "
part 1 = ""

After part 1 the emoji reaction is added. And then a second time in the if-condition
```
if (text.endsWith(EMOJI_REPLACEMENT_STRING)) {
        builder.append(reaction.emoji)
}
```

japanese
```
NotificationItemV2: getPrimaryTextActual --- text = 「123456789」に __EMOJI__
NotificationItemV2: getPrimaryTextActual --- parts.size = 2
NotificationItemV2: getPrimaryTextActual --- part i = 0 - >「123456789」に <
NotificationItemV2: getPrimaryTextActual --- append reaction.emoji if i != parts.size - 1 👎
NotificationItemV2: getPrimaryTextActual --- part i = 1 - ><
NotificationItemV2: getPrimaryTextActual --- append reaction.emoji if text ends with emoji 👎
```
english

```
NotificationItemV2: getPrimaryTextActual --- text = Reacted __EMOJI__ to: "123456789".
NotificationItemV2: getPrimaryTextActual --- parts.size = 2
NotificationItemV2: getPrimaryTextActual --- part i = 0 - >Reacted <
NotificationItemV2: getPrimaryTextActual --- append reaction.emoji if i != parts.size - 1 👎
NotificationItemV2: getPrimaryTextActual --- part i = 1 - > to: "123456789".<
```
