### PR TITLE
Show large images in correct orientation

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/ZoomingImageView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/ZoomingImageView.java
@@ -8,6 +8,7 @@ import android.view.View;
 import android.widget.FrameLayout;
 
 import androidx.annotation.NonNull;
+import androidx.exifinterface.media.ExifInterface;
 
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.request.target.Target;
@@ -65,9 +66,6 @@ public class ZoomingImageView extends FrameLayout {
 
     this.photoView            = findViewById(R.id.image_view);
     this.subsamplingImageView = findViewById(R.id.subsampling_image_view);
-
-    this.subsamplingImageView.setOrientation(SubsamplingScaleImageView.ORIENTATION_USE_EXIF);
-    this.subsamplingImageView.setOrientation(SubsamplingScaleImageView.ORIENTATION_USE_EXIF);
 
     this.photoView.setZoomTransitionDuration(ZOOM_TRANSITION_DURATION);
     this.photoView.setScaleLevels(ZOOM_LEVEL_MIN, SMALL_IMAGES_ZOOM_LEVEL_MID, SMALL_IMAGES_ZOOM_LEVEL_MAX);
@@ -128,6 +126,26 @@ public class ZoomingImageView extends FrameLayout {
 
     subsamplingImageView.setVisibility(View.VISIBLE);
     photoView.setVisibility(View.GONE);
+
+    // We manually set the orientation ourselves because using
+    // SubsamplingScaleImageView.ORIENTATION_USE_EXIF is unreliable:
+    // https://github.com/signalapp/Signal-Android/issues/11732#issuecomment-963203545
+    try {
+      final InputStream inputStream = PartAuthority.getAttachmentStream(getContext(), uri);
+      final int orientation = BitmapUtil.getExifOrientation(new ExifInterface(inputStream));
+      inputStream.close();
+      if (orientation == ExifInterface.ORIENTATION_ROTATE_90) {
+        subsamplingImageView.setOrientation(SubsamplingScaleImageView.ORIENTATION_90);
+      } else if (orientation == ExifInterface.ORIENTATION_ROTATE_180) {
+        subsamplingImageView.setOrientation(SubsamplingScaleImageView.ORIENTATION_180);
+      } else if (orientation == ExifInterface.ORIENTATION_ROTATE_270) {
+        subsamplingImageView.setOrientation(SubsamplingScaleImageView.ORIENTATION_270);
+      } else {
+        subsamplingImageView.setOrientation(SubsamplingScaleImageView.ORIENTATION_0);
+      }
+    } catch (IOException e) {
+      Log.w(TAG, e);
+    }
 
     subsamplingImageView.setImage(ImageSource.uri(uri));
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/util/BitmapUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/BitmapUtil.java
@@ -244,16 +244,19 @@ public class BitmapUtil {
     return options;
   }
 
+  public static int getExifOrientation(ExifInterface exif) {
+    return exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED);
+  }
+
   @Nullable
-  public static Pair<Integer, Integer> getExifDimensions(InputStream inputStream) throws IOException {
-    ExifInterface exif   = new ExifInterface(inputStream);
-    int           width  = exif.getAttributeInt(ExifInterface.TAG_IMAGE_WIDTH, 0);
-    int           height = exif.getAttributeInt(ExifInterface.TAG_IMAGE_LENGTH, 0);
+  public static Pair<Integer, Integer> getExifDimensions(ExifInterface exif) {
+    int width  = exif.getAttributeInt(ExifInterface.TAG_IMAGE_WIDTH, 0);
+    int height = exif.getAttributeInt(ExifInterface.TAG_IMAGE_LENGTH, 0);
     if (width == 0 || height == 0) {
       return null;
     }
 
-    int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, 0);
+    int orientation = getExifOrientation(exif);
     if (orientation == ExifInterface.ORIENTATION_ROTATE_90  ||
         orientation == ExifInterface.ORIENTATION_ROTATE_270 ||
         orientation == ExifInterface.ORIENTATION_TRANSVERSE ||

--- a/app/src/main/java/org/thoughtcrime/securesms/util/MediaUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/MediaUtil.java
@@ -17,6 +17,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.WorkerThread;
+import androidx.exifinterface.media.ExifInterface;
 
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.resource.gif.GifDrawable;
@@ -189,7 +190,7 @@ public class MediaUtil {
       try {
         if (MediaUtil.isJpegType(contentType)) {
           attachmentStream = PartAuthority.getAttachmentStream(context, uri);
-          dimens = BitmapUtil.getExifDimensions(attachmentStream);
+          dimens = BitmapUtil.getExifDimensions(new ExifInterface(attachmentStream));
           attachmentStream.close();
           attachmentStream = null;
         }


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device, Android 9.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

This PR fixes #11614 by reading the image's Exif data and manually setting its display orientation ourselves as opposed to relying on SubsamplingScaleImageView's seemingly unreliable `SubsamplingScaleImageView.ORIENTATION_USE_EXIF` flag.

| Before | After |
| --- | --- |
| ![Screenshot_1641092764](https://user-images.githubusercontent.com/2595572/147865241-eb1135a7-7144-4d90-8e6e-2f59dbfadae3.png) | ![Screenshot_1641092833](https://user-images.githubusercontent.com/2595572/147865244-e0aacadc-9a5a-432f-aa9b-6ff27edc6d70.png) |

The thumbnail view remains unchanged and correct:

![Screenshot_1641092759](https://user-images.githubusercontent.com/2595572/147865246-084fec76-4b5f-4b01-986c-eb42f3ed686c.png)

<details>
<summary>Test image</summary>

![signal-2022-01-01-220419](https://user-images.githubusercontent.com/2595572/147865313-ba604d20-4dd2-4422-9538-bb5a8ed1e82e.jpeg)


</details>