### PR TITLE
Handle incoming unsealed sender plain text content

### DIFF
--- a/libsignal/service/src/main/java/org/whispersystems/signalservice/api/crypto/SignalServiceCipher.java
+++ b/libsignal/service/src/main/java/org/whispersystems/signalservice/api/crypto/SignalServiceCipher.java
@@ -8,6 +8,7 @@ package org.whispersystems.signalservice.api.crypto;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 
+import org.signal.client.internal.Native;
 import org.signal.libsignal.metadata.InvalidMetadataMessageException;
 import org.signal.libsignal.metadata.InvalidMetadataVersionException;
 import org.signal.libsignal.metadata.ProtocolDuplicateMessageException;
@@ -38,6 +39,7 @@ import org.whispersystems.libsignal.UntrustedIdentityException;
 import org.whispersystems.libsignal.groups.GroupCipher;
 import org.whispersystems.libsignal.logging.Log;
 import org.whispersystems.libsignal.protocol.CiphertextMessage;
+import org.whispersystems.libsignal.protocol.PlaintextContent;
 import org.whispersystems.libsignal.protocol.PreKeySignalMessage;
 import org.whispersystems.libsignal.protocol.SignalMessage;
 import org.whispersystems.libsignal.state.SignalProtocolStore;
@@ -212,6 +214,9 @@ public class SignalServiceCipher {
 
         paddedMessage = result.getPaddedMessage();
         metadata      = new SignalServiceMetadata(resultAddress, result.getDeviceId(), envelope.getTimestamp(), envelope.getServerReceivedTimestamp(), envelope.getServerDeliveredTimestamp(), needsReceipt, envelope.getServerGuid(), groupId);
+      } else if (envelope.isPlaintextContent()) {
+        paddedMessage = Native.PlaintextContent_DeserializeAndGetContent(ciphertext);
+        metadata      = new SignalServiceMetadata(envelope.getSourceAddress(), envelope.getSourceDevice(), envelope.getTimestamp(), envelope.getServerReceivedTimestamp(), envelope.getServerDeliveredTimestamp(), false, envelope.getServerGuid(), Optional.absent());
       } else {
         throw new InvalidMetadataMessageException("Unknown type: " + envelope.getType());
       }


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * OnePlus 8T, Android 11
- [ ] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Signal-Android can send plain text content (for DecryptionErrorMessages) via sealed or unsealed envelopes.
But it doesn't handle incoming plain text content in unsealed envelopes, triggering a InvalidMetadataMessageException.

This PR adds the missing handling for this content type.
However it uses internal API from libsignal-client, so a better fix would probably be to add a wrapper somewhere in libsignal-client.

Signal-Android code for sending unsealed plain text content:
https://github.com/signalapp/Signal-Android/blob/cfab195e90355676ad1f51755e25c55af5bfa724/libsignal/service/src/main/java/org/whispersystems/signalservice/api/crypto/EnvelopeContent.java#L158
