### PR TITLE
Do not allow forwarding a link preview when its image is not downloaded yet

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/TransferControlView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/TransferControlView.java
@@ -196,7 +196,7 @@ public final class TransferControlView extends FrameLayout {
 
   private String getDownloadText(@NonNull List<Slide> slides) {
     if (slides.size() == 1) {
-      return slides.get(0).getContentDescription();
+      return slides.get(0).getContentDescription(getContext());
     } else {
       int downloadCount = Stream.of(slides).reduce(0, (count, slide) -> slide.getTransferState() != AttachmentDatabase.TRANSFER_PROGRESS_DONE ? count + 1 : count);
       return getContext().getResources().getQuantityString(R.plurals.TransferControlView_n_items, downloadCount, downloadCount);

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/MenuState.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/MenuState.java
@@ -99,9 +99,10 @@ final class MenuState {
         }
       } else {
         mediaIsSelected = true;
-        if (messageRecord.isMediaPending()) {
-          hasPendingMedia = true;
-        }
+      }
+
+      if (messageRecord.isMediaPending()) {
+        hasPendingMedia = true;
       }
 
       if (messageRecord.isMms() && !((MmsMessageRecord) messageRecord).getSharedContacts().isEmpty()) {

--- a/app/src/main/java/org/thoughtcrime/securesms/database/model/MmsMessageRecord.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/model/MmsMessageRecord.java
@@ -8,6 +8,7 @@ import org.thoughtcrime.securesms.contactshare.Contact;
 import org.thoughtcrime.securesms.database.documents.IdentityKeyMismatch;
 import org.thoughtcrime.securesms.database.documents.NetworkFailure;
 import org.thoughtcrime.securesms.linkpreview.LinkPreview;
+import org.thoughtcrime.securesms.mms.ImageSlide;
 import org.thoughtcrime.securesms.mms.Slide;
 import org.thoughtcrime.securesms.mms.SlideDeck;
 import org.thoughtcrime.securesms.recipients.Recipient;
@@ -68,6 +69,13 @@ public abstract class MmsMessageRecord extends MessageRecord {
   @Override
   public boolean isMediaPending() {
     for (Slide slide : getSlideDeck().getSlides()) {
+      if (slide.isInProgress() || slide.isPendingDownload()) {
+        return true;
+      }
+    }
+
+    for (LinkPreview linkPreview : getLinkPreviews()) {
+      Slide slide = new ImageSlide(null, linkPreview.getThumbnail().get());
       if (slide.isInProgress() || slide.isPendingDownload()) {
         return true;
       }

--- a/app/src/main/java/org/thoughtcrime/securesms/mms/AudioSlide.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/AudioSlide.java
@@ -57,15 +57,15 @@ public class AudioSlide extends Slide {
   }
 
   public AudioSlide(Context context, Uri uri, long dataSize, boolean voiceNote) {
-    super(context, constructAttachmentFromUri(context, uri, MediaUtil.AUDIO_UNSPECIFIED, dataSize, 0, 0, false, null, null, null, null, null, voiceNote, false, false, false));
+    super(constructAttachmentFromUri(context, uri, MediaUtil.AUDIO_UNSPECIFIED, dataSize, 0, 0, false, null, null, null, null, null, voiceNote, false, false, false));
   }
 
   public AudioSlide(Context context, Uri uri, long dataSize, String contentType, boolean voiceNote) {
-    super(context,  new UriAttachment(uri, contentType, AttachmentDatabase.TRANSFER_PROGRESS_STARTED, dataSize, 0, 0, null, null, voiceNote, false, false, false, null, null, null, null, null));
+    super(new UriAttachment(uri, contentType, AttachmentDatabase.TRANSFER_PROGRESS_STARTED, dataSize, 0, 0, null, null, voiceNote, false, false, false, null, null, null, null, null));
   }
 
   public AudioSlide(Context context, Attachment attachment) {
-    super(context, attachment);
+    super(attachment);
   }
 
   @Override
@@ -83,9 +83,8 @@ public class AudioSlide extends Slide {
     return true;
   }
 
-  @NonNull
   @Override
-  public String getContentDescription() {
+  public @NonNull String getContentDescription(@NonNull Context context) {
     return context.getString(R.string.Slide_audio);
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/mms/DocumentSlide.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/DocumentSlide.java
@@ -13,14 +13,14 @@ import org.thoughtcrime.securesms.util.StorageUtil;
 public class DocumentSlide extends Slide {
 
   public DocumentSlide(@NonNull Context context, @NonNull Attachment attachment) {
-    super(context, attachment);
+    super(attachment);
   }
 
   public DocumentSlide(@NonNull Context context, @NonNull Uri uri,
                        @NonNull String contentType,  long size,
                        @Nullable String fileName)
   {
-    super(context, constructAttachmentFromUri(context, uri, contentType, size, 0, 0, true, StorageUtil.getCleanFileName(fileName), null, null, null, null, false, false, false, false));
+    super(constructAttachmentFromUri(context, uri, contentType, size, 0, 0, true, StorageUtil.getCleanFileName(fileName), null, null, null, null, false, false, false, false));
   }
 
   @Override

--- a/app/src/main/java/org/thoughtcrime/securesms/mms/ImageSlide.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/ImageSlide.java
@@ -38,8 +38,8 @@ public class ImageSlide extends Slide {
   @SuppressWarnings("unused")
   private static final String TAG = Log.tag(ImageSlide.class);
 
-  public ImageSlide(@NonNull Context context, @NonNull Attachment attachment) {
-    super(context, attachment);
+  public ImageSlide(@Nullable Context context, @NonNull Attachment attachment) {
+    super(attachment);
     this.borderless = attachment.isBorderless();
   }
 
@@ -52,7 +52,7 @@ public class ImageSlide extends Slide {
   }
 
   public ImageSlide(Context context, Uri uri, String contentType, long size, int width, int height, boolean borderless, @Nullable String caption, @Nullable BlurHash blurHash, @Nullable TransformProperties transformProperties) {
-    super(context, constructAttachmentFromUri(context, uri, contentType, size, width, height, true, null, caption, null, blurHash, null, false, borderless, false, false, transformProperties));
+    super(constructAttachmentFromUri(context, uri, contentType, size, width, height, true, null, caption, null, blurHash, null, false, borderless, false, false, transformProperties));
     this.borderless = borderless;
   }
 
@@ -76,9 +76,8 @@ public class ImageSlide extends Slide {
     return borderless;
   }
 
-  @NonNull
   @Override
-  public String getContentDescription() {
+  public @NonNull String getContentDescription(@NonNull Context context) {
     return context.getString(R.string.Slide_image);
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/mms/MmsSlide.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/MmsSlide.java
@@ -15,7 +15,7 @@ public class MmsSlide extends ImageSlide {
 
   @NonNull
   @Override
-  public String getContentDescription() {
+  public String getContentDescription(@NonNull Context context) {
     return "MMS";
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/mms/Slide.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/Slide.java
@@ -40,10 +40,8 @@ import java.security.SecureRandom;
 public abstract class Slide {
 
   protected final Attachment attachment;
-  protected final Context    context;
 
-  public Slide(@NonNull Context context, @NonNull Attachment attachment) {
-    this.context    = context;
+  public Slide(@NonNull Attachment attachment) {
     this.attachment = attachment;
   }
 
@@ -122,7 +120,7 @@ public abstract class Slide {
     return hasVideo() && attachment.isVideoGif();
   }
 
-  public @NonNull String getContentDescription() { return ""; }
+  public @NonNull String getContentDescription(@NonNull Context context) { return ""; }
 
   public @NonNull Attachment asAttachment() {
     return attachment;

--- a/app/src/main/java/org/thoughtcrime/securesms/mms/StickerSlide.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/StickerSlide.java
@@ -22,12 +22,12 @@ public class StickerSlide extends Slide {
   private final StickerLocator stickerLocator;
 
   public StickerSlide(@NonNull Context context, @NonNull Attachment attachment) {
-    super(context, attachment);
+    super(attachment);
     this.stickerLocator = Objects.requireNonNull(attachment.getSticker());
   }
 
   public StickerSlide(Context context, Uri uri, long size, @NonNull StickerLocator stickerLocator, @NonNull String contentType) {
-    super(context, constructAttachmentFromUri(context, uri, contentType, size, WIDTH, HEIGHT, true, null, null, stickerLocator, null, null, false, false, false, false));
+    super(constructAttachmentFromUri(context, uri, contentType, size, WIDTH, HEIGHT, true, null, null, stickerLocator, null, null, false, false, false, false));
     this.stickerLocator = Objects.requireNonNull(attachment.getSticker());
   }
 
@@ -47,7 +47,7 @@ public class StickerSlide extends Slide {
   }
 
   @Override
-  public @NonNull String getContentDescription() {
+  public @NonNull String getContentDescription(@NonNull Context context) {
     return context.getString(R.string.Slide_sticker);
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/mms/TextSlide.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/TextSlide.java
@@ -13,10 +13,10 @@ import org.thoughtcrime.securesms.util.MediaUtil;
 public class TextSlide extends Slide {
 
   public TextSlide(@NonNull Context context, @NonNull Attachment attachment) {
-    super(context, attachment);
+    super(attachment);
   }
 
   public TextSlide(@NonNull Context context, @NonNull Uri uri, @Nullable String filename, long size) {
-    super(context, constructAttachmentFromUri(context, uri, MediaUtil.LONG_TEXT, size, 0, 0, true, filename, null, null, null, null, false, false, false, false));
+    super(constructAttachmentFromUri(context, uri, MediaUtil.LONG_TEXT, size, 0, 0, true, filename, null, null, null, null, false, false, false, false));
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/mms/VideoSlide.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/VideoSlide.java
@@ -38,15 +38,15 @@ public class VideoSlide extends Slide {
   }
 
   public VideoSlide(Context context, Uri uri, long dataSize, boolean gif, @Nullable String caption, @Nullable AttachmentDatabase.TransformProperties transformProperties) {
-    super(context, constructAttachmentFromUri(context, uri, MediaUtil.VIDEO_UNSPECIFIED, dataSize, 0, 0, MediaUtil.hasVideoThumbnail(context, uri), null, caption, null, null, null, false, false, gif, false, transformProperties));
+    super(constructAttachmentFromUri(context, uri, MediaUtil.VIDEO_UNSPECIFIED, dataSize, 0, 0, MediaUtil.hasVideoThumbnail(context, uri), null, caption, null, null, null, false, false, gif, false, transformProperties));
   }
 
   public VideoSlide(Context context, Uri uri, long dataSize, boolean gif, int width, int height, @Nullable String caption, @Nullable AttachmentDatabase.TransformProperties transformProperties) {
-    super(context, constructAttachmentFromUri(context, uri, MediaUtil.VIDEO_UNSPECIFIED, dataSize, width, height, MediaUtil.hasVideoThumbnail(context, uri), null, caption, null, null, null, false, false, gif, false, transformProperties));
+    super(constructAttachmentFromUri(context, uri, MediaUtil.VIDEO_UNSPECIFIED, dataSize, width, height, MediaUtil.hasVideoThumbnail(context, uri), null, caption, null, null, null, false, false, gif, false, transformProperties));
   }
 
   public VideoSlide(Context context, Attachment attachment) {
-    super(context, attachment);
+    super(attachment);
   }
 
   @Override
@@ -74,8 +74,8 @@ public class VideoSlide extends Slide {
     return true;
   }
 
-  @NonNull @Override
-  public String getContentDescription() {
+  @Override
+  public @NonNull String getContentDescription(@NonNull Context context) {
     return context.getString(R.string.Slide_video);
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/mms/ViewOnceSlide.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/ViewOnceSlide.java
@@ -16,7 +16,7 @@ import org.thoughtcrime.securesms.util.MediaUtil;
 public class ViewOnceSlide extends Slide {
 
   public ViewOnceSlide(@NonNull Context context, @NonNull Attachment attachment) {
-    super(context, attachment);
+    super(attachment);
   }
 
   @Override


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S6, Android 7
 * AVD Pixel 4, API 30
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Link preview can have images and those images can be pending download depending on the media settings. Images and movies cannot be forwarded before they are downloaded but forwarding button is available on the toolbar if you select a link preview whose image is not downloaded yet. But forwarding ultimately fails if the image was not available yet, making the behavior looks confusing to users.

The solution implemented in this PR is to set hasPendingMedia for link previews so that actions that should not be available would not become available.

The bug was [reported in the beta forum by Blue42](https://community.signalusers.org/t/beta-feedback-for-the-upcoming-android-5-27-release/38993/202).

### Screen recordings

**bug**

https://user-images.githubusercontent.com/28482/148703023-90d7b055-ee3c-4ec8-b1cc-71fb54e1d6b5.mp4


**fixed**

https://user-images.githubusercontent.com/28482/148703045-531372d6-b2a3-4845-a400-d51c0181859d.mp4


