### PR TITLE
Enable hyphenation on signal bottom action bar item title

### DIFF
--- a/app/src/main/res/layout/signal_bottom_action_bar_item.xml
+++ b/app/src/main/res/layout/signal_bottom_action_bar_item.xml
@@ -28,6 +28,7 @@
         android:gravity="center_horizontal"
         android:maxLines="2"
         android:ellipsize="end"
+        android:hyphenationFrequency="normal"
         tools:text="Archive"/>
 
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Moto X Play, Android 7.1.1

- [X] My contribution is fully baked and ready to be merged as is


----------

### Description

And again, bad word break:

```
Weiterleite
n
```



Enable hyphenation on signal bottom action bar item title to use the special character SHY on transifex.
Translators can now specify the correct separation with using SHY in the string:

https://github.com/signalapp/Signal-Android/blob/c0008f73838c49e064e3f85b12537e717fc72d0d/app/src/main/res/values/strings.xml#L2785

Without hyphenation and special character SHY:

![signal-2022-01-13-161648](https://user-images.githubusercontent.com/49990901/149364010-fff8efbc-2d03-48e8-a050-001ad38be3f4.jpeg)

With hyphenation and special character SHY:

![signal-2022-01-13-164512](https://user-images.githubusercontent.com/49990901/149364072-e84162eb-2797-45b1-a876-069379ce1a38.jpeg)

----------------------------------------

Also two PR with enabling hyphenation:
https://github.com/signalapp/Signal-Android/pull/11786
https://github.com/signalapp/Signal-Android/pull/11829


