### PR TITLE
Reconnect WiFi SMS compatibility behavior to stored setting

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/jobmanager/impl/NetworkOrCellServiceConstraint.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobmanager/impl/NetworkOrCellServiceConstraint.java
@@ -6,7 +6,7 @@ import android.app.job.JobInfo;
 import androidx.annotation.NonNull;
 
 import org.thoughtcrime.securesms.jobmanager.Constraint;
-import org.thoughtcrime.securesms.util.TextSecurePreferences;
+import org.thoughtcrime.securesms.keyvalue.SignalStore;
 
 public class NetworkOrCellServiceConstraint implements Constraint {
 
@@ -28,7 +28,7 @@ public class NetworkOrCellServiceConstraint implements Constraint {
 
   @Override
   public boolean isMet() {
-    if (TextSecurePreferences.isWifiSmsEnabled(application)) {
+    if (SignalStore.settings().isWifiCallingCompatibilityModeEnabled()) {
       return networkConstraint.isMet() || hasCellService(application);
     } else {
       return hasCellService(application);

--- a/app/src/main/java/org/thoughtcrime/securesms/logsubmit/LogSectionKeyPreferences.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/logsubmit/LogSectionKeyPreferences.java
@@ -22,7 +22,7 @@ final class LogSectionKeyPreferences implements LogSection {
     return new StringBuilder().append("Screen Lock          : ").append(TextSecurePreferences.isScreenLockEnabled(context)).append("\n")
                               .append("Screen Lock Timeout  : ").append(TextSecurePreferences.getScreenLockTimeout(context)).append("\n")
                               .append("Password Disabled    : ").append(TextSecurePreferences.isPasswordDisabled(context)).append("\n")
-                              .append("WiFi SMS             : ").append(TextSecurePreferences.isWifiSmsEnabled(context)).append("\n")
+                              .append("WiFi SMS             : ").append(SignalStore.settings().isWifiCallingCompatibilityModeEnabled()).append("\n")
                               .append("Default SMS          : ").append(Util.isDefaultSmsProvider(context)).append("\n")
                               .append("Prefer Contact Photos: ").append(SignalStore.settings().isPreferSystemContactPhotos()).append("\n")
                               .append("Call Bandwidth Mode  : ").append(SignalStore.settings().getCallBandwidthMode()).append("\n")


### PR DESCRIPTION
Reconnect WiFi SMS compatibility behavior to stored setting
Fixes #11898

### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Pixel 3, Lineage 18.1
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
There was a settings framework refactor that neglected to link up the wifi compatibility setting switch.

Tested by running on a real device and verifying that SMS sends properly when out of cell service with wifi compat enabled and that the debug logs reflect the actual setting instead of always saying false.
-->
