### PR TITLE
introduce chunked backups

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/backup/MultiFileInputStream.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/MultiFileInputStream.java
@@ -1,0 +1,71 @@
+package org.thoughtcrime.securesms.backup;
+
+import android.content.ContentResolver;
+import android.net.Uri;
+
+import java.io.InputStream;
+import java.io.IOException;
+
+public class MultiFileInputStream extends InputStream {
+  private int currentChunk = -1;
+  private InputStream currentInputStream = null;
+  ContentResolver contentResolver;
+  Uri[] uris;
+  boolean noFilesLeft;
+
+  public MultiFileInputStream(ContentResolver contentResolver,
+                              Uri[] uris) {
+    this.contentResolver = contentResolver;
+    this.uris = uris;
+    this.noFilesLeft = (uris.length == 0);
+  }
+
+  public void close() throws IOException {
+    if (currentInputStream != null) {
+      currentInputStream.close();
+    }
+  }
+
+  public void swapFiles() throws IOException, SecurityException {
+    if (currentInputStream != null) {
+      currentInputStream.close();
+    }
+    currentChunk++;
+    Uri uri = uris[currentChunk];
+    currentInputStream = contentResolver.openInputStream(uri);
+  }
+
+  public int read() throws IOException {
+    byte[] b = new byte[1];
+    if (read(b) == -1) {
+      return -1;
+    }
+    return b[0];
+  }
+
+  public int read(byte[] b) throws IOException {
+    return read(b, 0, b.length);
+  }
+
+  public int read(byte[] b, int off, int len) throws IOException {
+    if (currentInputStream == null) {
+      if (noFilesLeft) {
+        return -1;
+      }
+      swapFiles();
+    }
+    while (true) {
+      int bytesRead = currentInputStream.read(b, off, len);
+      boolean eofRead = (bytesRead == -1);
+      if (eofRead) {
+        if (noFilesLeft) {
+          return -1;
+        } else {
+          swapFiles();
+        }
+      } else {
+        return bytesRead;
+      }
+    }
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/backup/MultiFileOutputStream.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/MultiFileOutputStream.java
@@ -1,0 +1,83 @@
+package org.thoughtcrime.securesms.backup;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public class MultiFileOutputStream extends OutputStream {
+    private int currentChunk = -1;
+    private int bytesRemaining = 0;
+    private OutputStream currentOutputStream = null;
+    private final File dir;
+    private final String prefix;
+    private final String suffix;
+    private final List<File> files;
+
+    public MultiFileOutputStream(File dir,
+                                 String prefix,
+                                 String suffix) {
+        this.dir = dir;
+        this.prefix = prefix;
+        this.suffix = suffix;
+        this.files = new ArrayList<>();
+    }
+
+    public void close() throws IOException {
+        if (currentOutputStream != null) {
+            currentOutputStream.close();
+        }
+    }
+
+    public void flush() throws IOException {
+        if (currentOutputStream != null) {
+            currentOutputStream.flush();
+        }
+    }
+
+    public void write(int b) throws IOException {
+        byte[] c = new byte[1];
+        c[0] = (byte) b;
+        write(c);
+    }
+
+    public void write(byte[] b) throws IOException {
+        write(b, 0, b.length);
+    }
+
+    private void swapFiles() throws IOException {
+        if (currentOutputStream != null) {
+            currentOutputStream.close();
+        }
+        currentChunk++;
+        String filename = String.format(Locale.ENGLISH, "%s.%03d%s", prefix, currentChunk, suffix);
+        File f = new File(dir, filename);
+        files.add(f);
+        currentOutputStream = new FileOutputStream(f);
+        bytesRemaining = Util.MAX_BYTES_PER_FILE;
+    }
+
+    public void write(byte[] b, int offset, int len) throws IOException {
+        if (bytesRemaining == 0) {
+            swapFiles();
+        }
+        int lLen = len;
+        int lOffset = offset;
+        while (bytesRemaining < lLen) {
+            int bytesToWrite = bytesRemaining;
+            currentOutputStream.write(b, lOffset, bytesToWrite);
+            swapFiles();
+            lOffset += bytesToWrite;
+            lLen -= bytesToWrite;
+        }
+        currentOutputStream.write(b, lOffset, lLen);
+        bytesRemaining -= lLen;
+    }
+
+    public List<File> getFiles() {
+        return files;
+    }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/backup/MultiFileOutputStream29.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/MultiFileOutputStream29.java
@@ -1,0 +1,89 @@
+package org.thoughtcrime.securesms.backup;
+
+import android.content.Context;
+
+import androidx.documentfile.provider.DocumentFile;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+public class MultiFileOutputStream29 extends OutputStream {
+  private int currentChunk = -1;
+  private int bytesRemaining = 0;
+  private OutputStream currentOutputStream = null;
+  private final DocumentFile dir;
+  private final String prefix;
+  private final String suffix;
+  private final List<DocumentFile> files;
+  private final Context context;
+
+  public MultiFileOutputStream29(Context context,
+                                 DocumentFile dir,
+                                 String prefix,
+                                 String suffix) {
+    this.context = context;
+    this.dir = dir;
+    this.prefix = prefix;
+    this.files = new ArrayList<>();
+    this.suffix  = suffix;
+  }
+
+  public void close() throws IOException {
+    if (currentOutputStream != null) {
+      currentOutputStream.close();
+    }
+  }
+
+  public void flush() throws IOException {
+    if (currentOutputStream != null) {
+      currentOutputStream.flush();
+    }
+  }
+
+  public void write(int b) throws IOException {
+    byte[] c = new byte[1];
+    c[0] = (byte) b;
+    write(c);
+  }
+
+  public void write(byte[] b) throws IOException {
+    write(b, 0, b.length);
+  }
+
+  private void swapFiles() throws IOException {
+    if (currentOutputStream != null) {
+      currentOutputStream.close();
+    }
+    currentChunk++;
+    String filename = String.format(Locale.ENGLISH, "%s.%03d%s", prefix, currentChunk, suffix);
+    DocumentFile f = dir.createFile("application/octet-stream", filename);
+    files.add(f);
+    currentOutputStream = Objects.requireNonNull(context.getContentResolver().openOutputStream(f.getUri()));
+    bytesRemaining = Util.MAX_BYTES_PER_FILE;
+  }
+
+  public void write(byte[] b, int offset, int len) throws IOException {
+    if (bytesRemaining == 0) {
+      swapFiles();
+    }
+    int lLen = len;
+    int lOffset = offset;
+    while (bytesRemaining < lLen) {
+      int bytesToWrite = bytesRemaining;
+      currentOutputStream.write(b, lOffset, bytesToWrite);
+      swapFiles();
+      lOffset += bytesToWrite;
+      lLen -= bytesToWrite;
+    }
+    currentOutputStream.write(b, lOffset, lLen);
+    bytesRemaining -= lLen;
+  }
+
+  public List<DocumentFile> getFiles() {
+    return files;
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/backup/Util.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/Util.java
@@ -1,0 +1,34 @@
+package org.thoughtcrime.securesms.backup;
+
+import java.io.File;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+
+class Util {
+    public final static int MAX_BYTES_PER_FILE = 1024 * 1024 * 1024;
+
+    public static void renameMulti(List<File> fromFiles, List<File> toFiles) {
+        if (fromFiles.size() != toFiles.size()) {
+            throw (new RuntimeException("fromFiles.size() doesn't match toFiles.size()"));
+        }
+        for (int i = 0; i < fromFiles.size(); ++i) {
+            File from = fromFiles.get(i);
+            File to = toFiles.get(i);
+            from.renameTo(to);
+        }
+    }
+
+    public static List<File> generateBackupFilenames(File backupDirectory, int n) {
+        String timestamp = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss", Locale.US).format(new Date());
+        List<File> files = new ArrayList<>(n);
+        for (int i = 0; i < n; ++i) {
+            String fileName  = String.format("signal-%s.backup.part%03d", timestamp, n);
+            File file = new File(backupDirectory, fileName);
+            files.add(file);
+        }
+        return files;
+    }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/devicetransfer/newdevice/NewDeviceServerTask.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/devicetransfer/newdevice/NewDeviceServerTask.java
@@ -47,6 +47,7 @@ final class NewDeviceServerTask implements ServerTask {
                                     AttachmentSecretProvider.getInstance(context).getOrCreateAttachmentSecret(),
                                     database,
                                     inputStream,
+                                    false,
                                     passphrase);
 
       SignalDatabase.upgradeRestored(database);

--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/JobManagerFactories.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/JobManagerFactories.java
@@ -105,7 +105,9 @@ public final class JobManagerFactories {
       put(LeaveGroupV2Job.KEY,                       new LeaveGroupV2Job.Factory());
       put(LeaveGroupV2WorkerJob.KEY,                 new LeaveGroupV2WorkerJob.Factory());
       put(LocalBackupJob.KEY,                        new LocalBackupJob.Factory());
+      put(LocalChunkedBackupJob.KEY,                 new LocalChunkedBackupJob.Factory());
       put(LocalBackupJobApi29.KEY,                   new LocalBackupJobApi29.Factory());
+      put(LocalChunkedBackupJobApi29.KEY,            new LocalChunkedBackupJobApi29.Factory());
       put(MarkerJob.KEY,                             new MarkerJob.Factory());
       put(MmsDownloadJob.KEY,                        new MmsDownloadJob.Factory());
       put(MmsReceiveJob.KEY,                         new MmsReceiveJob.Factory());

--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/LocalChunkedBackupJob.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/LocalChunkedBackupJob.java
@@ -1,0 +1,176 @@
+package org.thoughtcrime.securesms.jobs;
+
+
+import android.Manifest;
+
+import androidx.annotation.NonNull;
+
+import org.signal.core.util.logging.Log;
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.backup.BackupFileIOError;
+import org.thoughtcrime.securesms.backup.BackupPassphrase;
+import org.thoughtcrime.securesms.backup.FullBackupExporter;
+import org.thoughtcrime.securesms.crypto.AttachmentSecretProvider;
+import org.thoughtcrime.securesms.database.NoExternalStorageException;
+import org.thoughtcrime.securesms.database.SignalDatabase;
+import org.thoughtcrime.securesms.dependencies.ApplicationDependencies;
+import org.thoughtcrime.securesms.jobmanager.Data;
+import org.thoughtcrime.securesms.jobmanager.Job;
+import org.thoughtcrime.securesms.jobmanager.JobManager;
+import org.thoughtcrime.securesms.jobmanager.impl.ChargingConstraint;
+import org.thoughtcrime.securesms.notifications.NotificationChannels;
+import org.thoughtcrime.securesms.permissions.Permissions;
+import org.thoughtcrime.securesms.service.GenericForegroundService;
+import org.thoughtcrime.securesms.service.NotificationController;
+import org.thoughtcrime.securesms.util.BackupUtil;
+import org.thoughtcrime.securesms.util.StorageUtil;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+public final class LocalChunkedBackupJob extends BaseJob {
+
+  public static final String KEY = "LocalChunkedBackupJob";
+
+  private static final String TAG = Log.tag(LocalChunkedBackupJob.class);
+
+  public static final String QUEUE = "__LOCAL_CHUNKED_BACKUP__";
+
+  public static final String TEMP_BACKUP_FILE_PREFIX = ".backup";
+  public static final String TEMP_BACKUP_FILE_SUFFIX = ".tmp";
+
+  public static void enqueue(boolean force) {
+    JobManager         jobManager = ApplicationDependencies.getJobManager();
+    Parameters.Builder parameters = new Parameters.Builder()
+        .setQueue(QUEUE)
+        .setMaxInstancesForFactory(1)
+        .setMaxAttempts(3);
+    if (force) {
+      jobManager.cancelAllInQueue(QUEUE);
+    } else {
+      parameters.addConstraint(ChargingConstraint.KEY);
+    }
+
+    if (BackupUtil.isUserSelectionRequired(ApplicationDependencies.getApplication())) {
+      jobManager.add(new LocalChunkedBackupJobApi29(parameters.build()));
+    } else {
+      jobManager.add(new LocalChunkedBackupJob(parameters.build()));
+    }
+  }
+
+  private LocalChunkedBackupJob(@NonNull Job.Parameters parameters) {
+    super(parameters);
+  }
+
+  @Override
+  public @NonNull Data serialize() {
+    return Data.EMPTY;
+  }
+
+  @Override
+  public @NonNull String getFactoryKey() {
+    return KEY;
+  }
+
+  @Override
+  public void onRun() throws NoExternalStorageException, IOException {
+    Log.i(TAG, "Executing backup job...");
+
+    BackupFileIOError.clearNotification(context);
+
+    if (!Permissions.hasAll(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+      throw new IOException("No external storage permission!");
+    }
+
+    try (NotificationController notification = GenericForegroundService.startForegroundTask(context,
+                                                                                            context.getString(R.string.LocalBackupJob_creating_signal_backup),
+                                                                                            NotificationChannels.BACKUPS,
+                                                                                            R.drawable.ic_signal_backup))
+    {
+      notification.setIndeterminateProgress();
+
+      String backupPassword  = BackupPassphrase.get(context);
+      File   backupDirectory = StorageUtil.getOrCreateBackupDirectory();
+
+      deleteOldTemporaryBackups(backupDirectory);
+
+      if (backupPassword == null) {
+        throw new IOException("Backup password is null");
+      }
+
+      List<File> tmpFiles = null;
+
+      try {
+        tmpFiles = FullBackupExporter.exportChunked(context,
+                                                    AttachmentSecretProvider.getInstance(context).getOrCreateAttachmentSecret(),
+                                                    SignalDatabase.getBackupDatabase(),
+                                                    backupDirectory,
+                                                    TEMP_BACKUP_FILE_PREFIX,
+                                                    TEMP_BACKUP_FILE_SUFFIX,
+                                                    backupPassword,
+                                                    this::isCanceled);
+        List<File> outFiles = BackupUtil.generateBackupFilenames2(backupDirectory, tmpFiles.size());
+        if (!BackupUtil.renameMulti(tmpFiles, outFiles)) {
+          Log.w(TAG, "Failed to rename temp files");
+          throw new IOException("Renaming temporary backup files failed!");
+        }
+      } catch (FullBackupExporter.BackupCanceledException e) {
+        Log.w(TAG, "Backup cancelled");
+        throw e;
+      } catch (IOException e) {
+        BackupFileIOError.postNotificationForException(context, e, getRunAttempt());
+        throw e;
+      } finally {
+        if (tmpFiles != null) {
+          for (File tempFile: tmpFiles) {
+            if (tempFile.exists()) {
+              if (tempFile.delete()) {
+                Log.w(TAG, "Backup failed. Deleted temp file");
+              } else {
+                Log.w(TAG, "Backup failed. Failed to delete temp file " + tempFile);
+              }
+            }
+          }
+        }
+      }
+
+      BackupUtil.deleteOldChunkedBackups();
+    }
+  }
+
+  private static void deleteOldTemporaryBackups(@NonNull File backupDirectory) {
+    for (File file : Objects.requireNonNull(backupDirectory.listFiles())) {
+      if (file.isFile()) {
+        String name = file.getName();
+        if (name.startsWith(TEMP_BACKUP_FILE_PREFIX) && name.endsWith(TEMP_BACKUP_FILE_SUFFIX)) {
+          if (file.delete()) {
+            Log.w(TAG, "Deleted old temporary backup file");
+          } else {
+            Log.w(TAG, "Could not delete old temporary backup file");
+          }
+        }
+      }
+    }
+  }
+
+  @Override
+  public boolean onShouldRetry(@NonNull Exception e) {
+    return false;
+  }
+
+  @Override
+  public void onFailure() {
+  }
+
+  public static class Factory implements Job.Factory<LocalChunkedBackupJob> {
+    @Override
+    public @NonNull LocalChunkedBackupJob create(@NonNull Parameters parameters, @NonNull Data data) {
+      return new LocalChunkedBackupJob(parameters);
+    }
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/LocalChunkedBackupJobApi29.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/LocalChunkedBackupJobApi29.java
@@ -1,0 +1,175 @@
+package org.thoughtcrime.securesms.jobs;
+
+
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+import androidx.documentfile.provider.DocumentFile;
+
+import org.signal.core.util.logging.Log;
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.backup.BackupFileIOError;
+import org.thoughtcrime.securesms.backup.BackupPassphrase;
+import org.thoughtcrime.securesms.backup.FullBackupExporter;
+import org.thoughtcrime.securesms.crypto.AttachmentSecretProvider;
+import org.thoughtcrime.securesms.database.SignalDatabase;
+import org.thoughtcrime.securesms.jobmanager.Data;
+import org.thoughtcrime.securesms.jobmanager.Job;
+import org.thoughtcrime.securesms.keyvalue.SignalStore;
+import org.thoughtcrime.securesms.notifications.NotificationChannels;
+import org.thoughtcrime.securesms.service.GenericForegroundService;
+import org.thoughtcrime.securesms.service.NotificationController;
+import org.thoughtcrime.securesms.util.BackupUtil;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
+/**
+ * Backup Job for installs requiring Scoped Storage.
+ *
+ * @see LocalBackupJob#enqueue(boolean)
+ */
+public final class LocalChunkedBackupJobApi29 extends BaseJob {
+
+  public static final String KEY = "LocalChunkedBackupJobApi29";
+
+  private static final String TAG = Log.tag(LocalChunkedBackupJobApi29.class);
+
+  public static final String TEMP_BACKUP_FILE_PREFIX = ".backup";
+  public static final String TEMP_BACKUP_FILE_SUFFIX = ".tmp";
+
+  LocalChunkedBackupJobApi29(@NonNull Parameters parameters) {
+    super(parameters);
+  }
+
+  @Override
+  public @NonNull Data serialize() {
+    return Data.EMPTY;
+  }
+
+  @Override
+  public @NonNull String getFactoryKey() {
+    return KEY;
+  }
+
+  @Override
+  public void onRun() throws IOException {
+    Log.i(TAG, "Executing backup job...");
+
+    BackupFileIOError.clearNotification(context);
+
+    if (!BackupUtil.isUserSelectionRequired(context)) {
+      throw new IOException("Wrong backup job!");
+    }
+
+    Uri backupDirectoryUri = SignalStore.settings().getSignalBackupDirectory();
+    if (backupDirectoryUri == null || backupDirectoryUri.getPath() == null) {
+      throw new IOException("Backup Directory has not been selected!");
+    }
+
+    try (NotificationController notification = GenericForegroundService.startForegroundTask(context,
+                                                                                            context.getString(R.string.LocalBackupJob_creating_signal_backup),
+                                                                                            NotificationChannels.BACKUPS,
+                                                                                            R.drawable.ic_signal_backup))
+    {
+      notification.setIndeterminateProgress();
+
+      String       backupPassword  = BackupPassphrase.get(context);
+      DocumentFile backupDirectory = DocumentFile.fromTreeUri(context, backupDirectoryUri);
+      String       timestamp       = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss", Locale.US).format(new Date());
+      String       fileName        = String.format("signal-%s.backup", timestamp);
+
+      if (backupDirectory == null || !backupDirectory.canWrite()) {
+        BackupFileIOError.ACCESS_ERROR.postNotification(context);
+        throw new IOException("Cannot write to backup directory location.");
+      }
+
+      deleteOldTemporaryBackups(backupDirectory);
+
+      if (backupDirectory.findFile(fileName) != null) {
+        throw new IOException("Backup file already exists!");
+      }
+
+      String       temporaryPrefix = String.format(Locale.US, "%s%s", TEMP_BACKUP_FILE_PREFIX, UUID.randomUUID());
+
+      if (backupPassword == null) {
+        throw new IOException("Backup password is null");
+      }
+
+      List<DocumentFile> tmpFiles = null;
+
+      try {
+        tmpFiles = FullBackupExporter.exportChunked(context,
+                                                    AttachmentSecretProvider.getInstance(context).getOrCreateAttachmentSecret(),
+                                                    SignalDatabase.getBackupDatabase(),
+                                                    backupDirectory,
+                                                    temporaryPrefix,
+                                                    TEMP_BACKUP_FILE_SUFFIX,
+                                                    backupPassword,
+                                                    this::isCanceled);
+        List<String> outFiles = BackupUtil.generateBackupFilenames(tmpFiles.size());
+        if (!BackupUtil.renameMulti2(tmpFiles, outFiles)) {
+          Log.w(TAG, "Failed to rename temp files");
+          throw new IOException("Renaming temporary backup files failed!");
+        }
+      } catch (FullBackupExporter.BackupCanceledException e) {
+        Log.w(TAG, "Backup cancelled");
+        throw e;
+      } catch (IOException e) {
+        Log.w(TAG, "Error during backup!", e);
+        BackupFileIOError.postNotificationForException(context, e, getRunAttempt());
+        throw e;
+      } finally {
+        if (tmpFiles != null) {
+          for (DocumentFile fileToCleanUp : tmpFiles) {
+            if (fileToCleanUp != null) {
+              if (fileToCleanUp.delete()) {
+                Log.w(TAG, "Backup failed. Deleted temp file");
+              } else {
+                Log.w(TAG, "Backup failed. Failed to delete temp file " + fileToCleanUp.getName());
+              }
+            }
+          }
+        }
+      }
+
+      BackupUtil.deleteOldChunkedBackups();
+    }
+  }
+
+  private static void deleteOldTemporaryBackups(@NonNull DocumentFile backupDirectory) {
+    for (DocumentFile file : backupDirectory.listFiles()) {
+      if (file.isFile()) {
+        String name = file.getName();
+        if (name != null && name.startsWith(TEMP_BACKUP_FILE_PREFIX) && name.endsWith(TEMP_BACKUP_FILE_SUFFIX)) {
+          if (file.delete()) {
+            Log.w(TAG, "Deleted old temporary backup file");
+          } else {
+            Log.w(TAG, "Could not delete old temporary backup file");
+          }
+        }
+      }
+    }
+  }
+
+  @Override
+  public boolean onShouldRetry(@NonNull Exception e) {
+    return false;
+  }
+
+  @Override
+  public void onFailure() {
+  }
+
+  public static class Factory implements Job.Factory<LocalChunkedBackupJobApi29> {
+    @Override
+    public @NonNull
+    LocalChunkedBackupJobApi29 create(@NonNull Parameters parameters, @NonNull Data data) {
+      return new LocalChunkedBackupJobApi29(parameters);
+    }
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/ChooseBackupFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/ChooseBackupFragment.java
@@ -2,7 +2,9 @@ package org.thoughtcrime.securesms.registration.fragments;
 
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
+import android.content.ClipData;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.DocumentsContract;
@@ -24,6 +26,8 @@ import org.thoughtcrime.securesms.LoggingFragment;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.keyvalue.SignalStore;
 import org.thoughtcrime.securesms.util.navigation.SafeNavigation;
+
+import java.util.Arrays;
 
 public class ChooseBackupFragment extends LoggingFragment {
 
@@ -54,7 +58,16 @@ public class ChooseBackupFragment extends LoggingFragment {
     if (requestCode == OPEN_FILE_REQUEST_CODE && resultCode == Activity.RESULT_OK && data != null) {
       ChooseBackupFragmentDirections.ActionRestore restore = ChooseBackupFragmentDirections.actionRestore();
 
+      ClipData clipData = data.getClipData();
+      int multiUrisCount = clipData == null ? 0 : clipData.getItemCount();
+      Uri[] multiUris = new Uri[multiUrisCount];
+      for (int i = 0; i < multiUrisCount; ++i) {
+        Uri uri = clipData.getItemAt(i).getUri();
+        multiUris[i] = uri;
+      }
+
       restore.setUri(data.getData());
+      restore.setMultiUris(multiUris);
 
       SafeNavigation.safeNavigate(Navigation.findNavController(requireView()), restore);
     }
@@ -67,6 +80,7 @@ public class ChooseBackupFragment extends LoggingFragment {
     intent.setType("application/octet-stream");
     intent.addCategory(Intent.CATEGORY_OPENABLE);
     intent.putExtra(Intent.EXTRA_LOCAL_ONLY, true);
+    intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
 
     if (Build.VERSION.SDK_INT >= 26) {
       intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, SignalStore.settings().getLatestSignalBackupDirectory());

--- a/app/src/main/java/org/thoughtcrime/securesms/util/BackupUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/BackupUtil.java
@@ -24,9 +24,13 @@ import org.thoughtcrime.securesms.permissions.Permissions;
 
 import java.io.File;
 import java.security.SecureRandom;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -40,6 +44,18 @@ public class BackupUtil {
   public static @NonNull String getLastBackupTime(@NonNull Context context, @NonNull Locale locale) {
     try {
       BackupInfo backup = getLatestBackup();
+
+      if (backup == null) return context.getString(R.string.BackupUtil_never);
+      else                return DateUtils.getExtendedRelativeTimeSpanString(context, locale, backup.getTimestamp());
+    } catch (NoExternalStorageException e) {
+      Log.w(TAG, e);
+      return context.getString(R.string.BackupUtil_unknown);
+    }
+  }
+
+  public static @NonNull String getLastChunkedBackupTime(@NonNull Context context, @NonNull Locale locale) {
+    try {
+      BackupInfo backup = getLatestChunkedBackup();
 
       if (backup == null) return context.getString(R.string.BackupUtil_never);
       else                return DateUtils.getExtendedRelativeTimeSpanString(context, locale, backup.getTimestamp());
@@ -73,6 +89,12 @@ public class BackupUtil {
     return backups.isEmpty() ? null : backups.get(0);
   }
 
+  public static @Nullable BackupInfo getLatestChunkedBackup() throws NoExternalStorageException {
+    List<BackupInfo> backups = getAllChunkedBackupsNewestFirst();
+
+    return backups.isEmpty() ? null : backups.get(0);
+  }
+
   public static void deleteAllBackups() {
     Log.i(TAG, "Deleting all backups");
 
@@ -92,6 +114,20 @@ public class BackupUtil {
 
     try {
       List<BackupInfo> backups = getAllBackupsNewestFirst();
+
+      for (int i = 2; i < backups.size(); i++) {
+        backups.get(i).delete();
+      }
+    } catch (NoExternalStorageException e) {
+      Log.w(TAG, e);
+    }
+  }
+
+  public static void deleteOldChunkedBackups() {
+    Log.i(TAG, "Deleting older backups");
+
+    try {
+      List<BackupInfo> backups = getAllChunkedBackupsNewestFirst();
 
       for (int i = 2; i < backups.size(); i++) {
         backups.get(i).delete();
@@ -134,6 +170,14 @@ public class BackupUtil {
     }
   }
 
+  private static List<BackupInfo> getAllChunkedBackupsNewestFirst() throws NoExternalStorageException {
+    if (isUserSelectionRequired(ApplicationDependencies.getApplication())) {
+      return getAllChunkedBackupsNewestFirstApi29();
+    } else {
+      return getAllChunkedBackupsNewestFirstLegacy();
+    }
+  }
+
   @RequiresApi(29)
   private static List<BackupInfo> getAllBackupsNewestFirstApi29() {
     Uri backupDirectoryUri = SignalStore.settings().getSignalBackupDirectory();
@@ -166,6 +210,65 @@ public class BackupUtil {
     return backups;
   }
 
+  @RequiresApi(29)
+  private static List<BackupInfo> getAllChunkedBackupsNewestFirstApi29() {
+    Uri backupDirectoryUri = SignalStore.settings().getSignalBackupDirectory();
+    if (backupDirectoryUri == null) {
+      Log.i(TAG, "Backup directory is not set. Returning an empty list.");
+      return Collections.emptyList();
+    }
+
+    DocumentFile backupDirectory = DocumentFile.fromTreeUri(ApplicationDependencies.getApplication(), backupDirectoryUri);
+    if (backupDirectory == null || !backupDirectory.exists() || !backupDirectory.canRead()) {
+      Log.w(TAG, "Backup directory is inaccessible. Returning an empty list.");
+      return Collections.emptyList();
+    }
+
+    DocumentFile[]   files   = backupDirectory.listFiles();
+    List<BackupInfo> backups = new ArrayList<>(files.length);
+
+    HashMap<Long, List<DocumentFile>> m = new HashMap<>();
+
+    for (DocumentFile file : files) {
+      if (!file.isFile()) {
+        continue;
+      }
+      String name = file.getName();
+      long backupTimestamp = getBackupTimestampFromMultiFileBackup(name);
+      if (backupTimestamp == -1) {
+        continue;
+      }
+      if (!m.containsKey(backupTimestamp)) {
+        m.put(backupTimestamp, new ArrayList<>());
+      }
+      m.get(backupTimestamp).add(file);
+    }
+
+    for (List<DocumentFile> l: m.values()) {
+      Collections.sort(l, Comparator.comparing(DocumentFile::getName));
+    }
+
+    for (long backupTimestamp: m.keySet()) {
+      long size = 0;
+      List<DocumentFile> documentFiles = m.get(backupTimestamp);
+
+      for (DocumentFile d: documentFiles) {
+        size += d.length();
+      }
+
+      Uri[] uris = new Uri[documentFiles.size()];
+      for (int i = 0; i < uris.length; ++i) {
+        uris[i] = documentFiles.get(i).getUri();
+      }
+      BackupInfo backupInfo = new BackupInfo(backupTimestamp, size, uris);
+      backups.add(backupInfo);
+    }
+
+    Collections.sort(backups, (a, b) -> Long.compare(b.timestamp, a.timestamp));
+
+    return backups;
+  }
+
   public static @Nullable BackupInfo getBackupInfoFromSingleUri(@NonNull Context context, @NonNull Uri singleUri) throws BackupFileException {
     DocumentFile documentFile = Objects.requireNonNull(DocumentFile.fromSingleUri(context, singleUri));
 
@@ -186,6 +289,20 @@ public class BackupUtil {
     }
   }
 
+  public static @Nullable BackupInfo getBackupInfoFromMultiUris(@NonNull Context context, @NonNull Uri[] multiUris) throws BackupFileException {
+    DocumentFile[] documentFiles = toDocumentFiles(context, multiUris);
+    BackupFileState backupFileState = getBackupFileState(documentFiles);
+
+    if (backupFileState.isSuccess()) {
+      long backupTimestamp = getBackupTimestampFromMultiFileBackup(Objects.requireNonNull(documentFiles[0].getName()));
+      return new BackupInfo(backupTimestamp, getLength(documentFiles), multiUris);
+    }
+
+    Log.w(TAG, "Could not load backup info.");
+    backupFileState.throwIfError();
+    return null;
+  }
+
   private static List<BackupInfo> getAllBackupsNewestFirstLegacy() throws NoExternalStorageException {
     File             backupDirectory = StorageUtil.getOrCreateBackupDirectory();
     File[]           files           = backupDirectory.listFiles();
@@ -199,6 +316,54 @@ public class BackupUtil {
           backups.add(new BackupInfo(backupTimestamp, file.length(), Uri.fromFile(file)));
         }
       }
+    }
+
+    Collections.sort(backups, (a, b) -> Long.compare(b.timestamp, a.timestamp));
+
+    return backups;
+  }
+
+  private static List<BackupInfo> getAllChunkedBackupsNewestFirstLegacy() throws NoExternalStorageException {
+    File backupDirectory = StorageUtil.getOrCreateBackupDirectory();
+    File[] files = backupDirectory.listFiles();
+    List<BackupInfo> backups = new ArrayList<>(files.length);
+
+    HashMap<Long, List<File>> m = new HashMap<>();
+
+    for (File file: files) {
+      if (!file.isFile()) {
+        continue;
+      }
+      String name = file.getName();
+      long backupTimestamp = getBackupTimestampFromMultiFileBackup(name);
+      if (backupTimestamp == -1) {
+        continue;
+      }
+      if (!m.containsKey(backupTimestamp)) {
+        m.put(backupTimestamp, new ArrayList<>());
+      }
+      m.get(backupTimestamp).add(file);
+    }
+
+    for (List<File> l: m.values()) {
+      Collections.sort(l, Comparator.comparing(File::getName));
+    }
+
+    for (long backupTimestamp: m.keySet()) {
+      long size = 0;
+      List<File> filesList = m.get(backupTimestamp);
+
+      for (File f: filesList) {
+        size += f.length();
+      }
+
+      Uri[] uris = new Uri[filesList.size()];
+      for (int i = 0; i < uris.length; ++i) {
+        File f = filesList.get(i);
+        uris[i] = Uri.fromFile(f);
+      }
+      BackupInfo backupInfo = new BackupInfo(backupTimestamp, size, uris);
+      backups.add(backupInfo);
     }
 
     Collections.sort(backups, (a, b) -> Long.compare(b.timestamp, a.timestamp));
@@ -239,6 +404,53 @@ public class BackupUtil {
     }
   }
 
+  public static boolean renameMulti(List<File> fromFiles, List<File> toFiles) {
+    if (fromFiles.size() != toFiles.size()) {
+      throw (new RuntimeException("fromFiles.size() doesn't match toFiles.size()"));
+    }
+    boolean success = true;
+    for (int i = 0; i < fromFiles.size(); ++i) {
+      File from = fromFiles.get(i);
+      File to = toFiles.get(i);
+      success = success && from.renameTo(to);
+    }
+    return success;
+  }
+
+  public static boolean renameMulti2(List<DocumentFile> fromFiles, List<String> toFiles) {
+    if (fromFiles.size() != toFiles.size()) {
+      throw (new RuntimeException("fromFiles.size() doesn't match toFiles.size()"));
+    }
+    boolean success = true;
+    for (int i = 0; i < fromFiles.size(); ++i) {
+      DocumentFile from = fromFiles.get(i);
+      String to = toFiles.get(i);
+      success = success && from.renameTo(to);
+      fromFiles.set(i, null);
+    }
+    return success;
+  }
+
+  public static List<String> generateBackupFilenames(int n) {
+    String timestamp = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss", Locale.US).format(new Date());
+    List<String> filenames = new ArrayList<>(n);
+    for (int i = 0; i < n; ++i) {
+      String filename  = String.format(Locale.ENGLISH, "signal-%s.backup.part%03d", timestamp, i);
+      filenames.add(filename);
+    }
+    return filenames;
+  }
+
+  public static List<File> generateBackupFilenames2(File backupDirectory, int n) {
+    List<String> filenames = generateBackupFilenames(n);
+    List<File> result = new ArrayList<>(filenames.size());
+    for (int i = 0; i < n; ++i) {
+      File f = new File(backupDirectory, filenames.get(i));
+      result.add(i, f);
+    }
+    return result;
+  }
+
   private static long getBackupTimestamp(@NonNull String backupName) {
     String[] prefixSuffix = backupName.split("[.]");
 
@@ -274,8 +486,51 @@ public class BackupUtil {
     } else if (Util.isEmpty(documentFile.getName()) || !documentFile.getName().endsWith(".backup")) {
       return BackupFileState.UNSUPPORTED_FILE_EXTENSION;
     } else {
-      return BackupFileState.READABLE;
+        return BackupFileState.READABLE;
     }
+  }
+
+  static final String multiFileRegex = "^signal-\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}.backup.part\\d{3}$";
+
+  private static BackupFileState getBackupFileState(@NonNull DocumentFile[] documentFiles) {
+    if (documentFiles.length == 0) {
+      return BackupFileState.NOT_FOUND;
+    }
+    for (DocumentFile documentFile: documentFiles) {
+      if (!documentFile.exists()) {
+        return BackupFileState.NOT_FOUND;
+      } else if (!documentFile.canRead()) {
+        return BackupFileState.NOT_READABLE;
+      } else if (Util.isEmpty(documentFile.getName()) || !documentFile.getName().matches(multiFileRegex)) {
+        return BackupFileState.UNSUPPORTED_FILE_EXTENSION;
+      }
+    }
+    return BackupFileState.READABLE;
+  }
+
+  private static DocumentFile[] toDocumentFiles(Context context, @NonNull Uri[] uris) {
+    DocumentFile[] documentFiles = new DocumentFile[uris.length];
+    for (int i = 0; i < uris.length; i++) {
+      documentFiles[i] = DocumentFile.fromSingleUri(context, uris[i]);
+    }
+    return documentFiles;
+  }
+
+  private static long getLength(@NonNull DocumentFile[] documentFiles) {
+    long length = 0;
+    for(DocumentFile documentFile: documentFiles) {
+      length += documentFile.length();
+    }
+    return length;
+  }
+
+  private static long getBackupTimestampFromMultiFileBackup(@NonNull String filename) {
+    if (!filename.matches(multiFileRegex)) {
+      // this is no (correctly named) multifile backup
+      return -1;
+    }
+    String s = filename.substring(0, filename.length() - ".partXXX".length());
+    return getBackupTimestamp(s);
   }
 
   /**
@@ -326,11 +581,28 @@ public class BackupUtil {
     private final long timestamp;
     private final long size;
     private final Uri  uri;
+    private final Uri[] uris;
 
     BackupInfo(long timestamp, long size, Uri uri) {
       this.timestamp = timestamp;
       this.size      = size;
       this.uri       = uri;
+      this.uris      = null;
+    }
+
+    BackupInfo(long timestamp, long size, Uri[] uris) {
+      this.timestamp = timestamp;
+      this.size      = size;
+      this.uri       = null;
+      this.uris      = uris;
+    }
+
+    public boolean isSingleFileBackup() {
+      return uri != null;
+    }
+
+    public boolean isMultiFileBackup() {
+      return uris != null;
     }
 
     public long getTimestamp() {
@@ -345,7 +617,11 @@ public class BackupUtil {
       return uri;
     }
 
-    private void delete() {
+    public Uri[] getUris() {
+      return uris;
+    }
+
+    private static void delete(Uri uri) {
       File file = new File(Objects.requireNonNull(uri.getPath()));
 
       if (file.exists()) {
@@ -362,6 +638,17 @@ public class BackupUtil {
           if (!document.delete()) {
             Log.w(TAG, "Delete failed: " + uri);
           }
+        }
+      }
+    }
+
+    private void delete() {
+      if (uri != null) {
+        delete(uri);
+      }
+      if (uris != null) {
+        for (Uri uri: uris) {
+          delete(uri);
         }
       }
     }

--- a/app/src/main/res/layout/fragment_backups.xml
+++ b/app/src/main/res/layout/fragment_backups.xml
@@ -87,6 +87,73 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/fragment_backup_create_chunked"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            android:minHeight="?attr/listPreferredItemHeightLarge"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <TextView
+                android:id="@+id/fragment_backup_create_chunked_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:text="@string/BackupsPreferenceFragment__create_chunked_backup"
+                android:textAppearance="@style/Signal.Text.Body"
+                android:textColor="@color/signal_text_primary"
+                app:layout_constraintBottom_toTopOf="@id/fragment_backup_create_chunked_summary"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintVertical_chainStyle="packed" />
+
+            <TextView
+                android:id="@+id/fragment_backup_create_chunked_summary"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:text="@string/BackupsPreferenceFragment__last_backup"
+                android:textAppearance="@style/Signal.Text.Preview"
+                android:textColor="@color/signal_text_secondary"
+                app:layout_constraintBottom_toTopOf="@id/fragment_backup_chunked_progress"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/fragment_backup_create_chunked_title" />
+
+            <ProgressBar
+                android:id="@+id/fragment_backup_chunked_progress"
+                style="?android:progressBarStyleHorizontal"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:indeterminate="true"
+                android:visibility="gone"
+                app:layout_constraintBottom_toTopOf="@id/fragment_backup_chunked_progress_summary"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/fragment_backup_create_chunked_summary"
+                tools:visibility="visible" />
+
+            <TextView
+                android:id="@+id/fragment_backup_chunked_progress_summary"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:textColor="@color/signal_text_secondary"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/fragment_backup_chunked_progress"
+                tools:text="10000 so far..."
+                tools:visibility="visible" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
         <LinearLayout
             android:id="@+id/fragment_backup_folder"
             android:layout_width="match_parent"

--- a/app/src/main/res/navigation/registration.xml
+++ b/app/src/main/res/navigation/registration.xml
@@ -253,6 +253,12 @@
             app:argType="android.net.Uri"
             app:nullable="true" />
 
+        <argument
+            android:name="multiUris"
+            android:defaultValue="@null"
+            app:argType="android.net.Uri[]"
+            app:nullable="true" />
+
     </fragment>
 
     <fragment

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -499,6 +499,7 @@
     <string name="BackupsPreferenceFragment__chat_backups">Chat backups</string>
     <string name="BackupsPreferenceFragment__backups_are_encrypted_with_a_passphrase">Backups are encrypted with a passphrase and stored on your device.</string>
     <string name="BackupsPreferenceFragment__create_backup">Create backup</string>
+    <string name="BackupsPreferenceFragment__create_chunked_backup">Create chunked backup</string>
     <string name="BackupsPreferenceFragment__last_backup">Last backup: %1$s</string>
     <string name="BackupsPreferenceFragment__backup_folder">Backup folder</string>
     <string name="BackupsPreferenceFragment__verify_backup_passphrase">Verify backup passphrase</string>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Oneplus 3, Android 9
 * Virtual device, Android 9
 * Virtual device, Android 11
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

I work for bevuta IT GmbH, a company based in Germany.  Our boss is a Signal user on Android. He has the problem that he can't backup his Signal app data to the SD card and despite 128 GB of internal memory,  he no longer has free internal storage, mainly because of the signal backups.  The most reasonable explanation was that his Android version doesn't support file systems other than FAT32 on SD cards.  FAT32 has some limitations, such as a maximum file size of ~4 GB.  His Signal installation uses more than 4 GB.  To us, the use of a sd card for backups also seems advantageous, as it is easier to get at the data if the device breaks down.

We discussed several solutions.  The best solution we came up with, is to just chunk the Signal backup into parts smaller than 4 GB, if desired.  I was tasked to implement it.  To use this code in a real Signal installation, it has to be in the official release.  Now, here is my MR! :-)