### PR TITLE
Disallow zero width non-joiner

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/StringUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/StringUtil.java
@@ -19,7 +19,9 @@ public final class StringUtil {
                                                                       '\u200F',  // right-to-left mark
                                                                       '\u2007',  // figure space
                                                                       '\u200B',  // zero-width space
-                                                                      '\u2800'); // braille blank
+                                                                      '\u200C',  // zero-width non-joiner
+                                                                      '\u2800');  // braille blank
+                                                                       
 
 
   private static final class Bidi {


### PR DESCRIPTION

Adding zero width non-joiner to the list of disallowed characters for profile names.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This also allows for a visually-empty profile name.

https://en.wikipedia.org/wiki/Zero-width_non-joiner
<!--

-->
