### PR TITLE
Don't show addToGroupButton in RecipientBottomSheetDialog when recipi…

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/bottomsheet/RecipientDialogViewModel.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/bottomsheet/RecipientDialogViewModel.java
@@ -84,7 +84,7 @@ final class RecipientDialogViewModel extends ViewModel {
     MutableLiveData<Integer> localGroupCount = new MutableLiveData<>(0);
 
     canAddToAGroup = LiveDataUtil.combineLatest(recipient, localGroupCount,
-                                                (r, count) -> count > 0 && r.isRegistered() && !r.isGroup() && !r.isSelf());
+                                                (r, count) -> count > 0 && r.isRegistered() && !r.isGroup() && !r.isSelf() && !r.isBlocked());
 
     recipientDialogRepository.getActiveGroupCount(localGroupCount::postValue);
   }


### PR DESCRIPTION
…ent is blocked


### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:

 * Virtual Pixel 2, Android 11
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Fixes #10970

Adding the condition "!r.isBlocked" to the boolean canAddToAGroup to prevent showing "Add to a group / Add to another group" for blocked recipients.

This commits only disables the button for adding a blocked users to groups. No "deeper" prevention when the activity to group adding is executed.

Before:
![Screenshot_1643464060](https://user-images.githubusercontent.com/49990901/151664401-168d24ba-6fcd-4552-8d2c-79d720731ae0.png)



After:

![Screenshot_1643465117](https://user-images.githubusercontent.com/49990901/151664404-dcea98dc-4230-4359-bc27-562a76de1f6c.png)

