### PR TITLE
Don't show Buttons for Message, Video, Audio/Call in RecipientBottomS…

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/bottomsheet/RecipientBottomSheetDialogFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/bottomsheet/RecipientBottomSheetDialogFragment.java
@@ -211,13 +211,13 @@ public final class RecipientBottomSheetDialogFragment extends BottomSheetDialogF
       }
 
       ButtonStripPreference.State  buttonStripState = new ButtonStripPreference.State(
-          /* isMessageAvailable = */ !recipient.isSelf(),
-          /* isVideoAvailable = */   recipient.isRegistered() && !recipient.isSelf(),
-          /* isAudioAvailable = */   !recipient.isSelf(),
-          /* isMuteAvailable = */    false,
-          /* isSearchAvailable = */  false,
-          /* isAudioSecure = */      recipient.isRegistered(),
-          /* isMuted = */            false
+          /* isMessageAvailable = */ !recipient.isBlocked() && !recipient.isSelf(),
+          /* isVideoAvailable   = */ !recipient.isBlocked() && !recipient.isSelf() && recipient.isRegistered(),
+          /* isAudioAvailable   = */ !recipient.isBlocked() && !recipient.isSelf(),
+          /* isMuteAvailable    = */ false,
+          /* isSearchAvailable  = */ false,
+          /* isAudioSecure      = */ recipient.isRegistered(),
+          /* isMuted            = */ false
       );
 
       ButtonStripPreference.Model buttonStripModel = new ButtonStripPreference.Model(
@@ -246,7 +246,7 @@ public final class RecipientBottomSheetDialogFragment extends BottomSheetDialogF
 
       new ButtonStripPreference.ViewHolder(buttonStrip).bind(buttonStripModel);
 
-      if (recipient.isSystemContact() || recipient.isGroup() || recipient.isSelf()) {
+      if (recipient.isSystemContact() || recipient.isGroup() || recipient.isSelf() || recipient.isBlocked()) {
         addContactButton.setVisibility(View.GONE);
       } else {
         addContactButton.setVisibility(View.VISIBLE);


### PR DESCRIPTION
…heetDialog when recipient is blocked

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:

 * Virtual Pixel 2, Android 11
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Fixes #10971

Prevent displaying the button for "text message", "voice call" and "video call" when recipient is blocked.
Additional also the option to add the recipient to the contacts, when contact is unsaved and blocked.

Before:

![Screenshot_1643472642](https://user-images.githubusercontent.com/49990901/151668304-eb3a037c-9bff-4590-b060-946822559107.png)

After:

![Screenshot_1643472319](https://user-images.githubusercontent.com/49990901/151668103-438f264f-fb72-4c36-890b-be3b054d911e.png)

