### PR TITLE
Fixes #11598 HTML unescaped encoded entities in link preview issue.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/linkpreview/LinkPreview.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/linkpreview/LinkPreview.java
@@ -1,5 +1,8 @@
 package org.thoughtcrime.securesms.linkpreview;
 
+import android.os.Build;
+import android.text.Html;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -13,6 +16,8 @@ import org.thoughtcrime.securesms.util.JsonUtils;
 import org.whispersystems.libsignal.util.guava.Optional;
 
 import java.io.IOException;
+
+import static android.text.Html.FROM_HTML_MODE_LEGACY;
 
 public class LinkPreview {
 
@@ -71,14 +76,23 @@ public class LinkPreview {
   }
 
   public @NonNull String getTitle() {
-    return title;
+    // HTML entities in og:title will be converted to regular character on API level 24 and
+    // onwards.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      return Html.fromHtml(title, FROM_HTML_MODE_LEGACY).toString();
+    } else {
+      return title;
+    }
   }
 
   public @NonNull String getDescription() {
     if (description.equals(title)) {
       return "";
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      return Html.fromHtml(description, FROM_HTML_MODE_LEGACY).toString();
+    } else {
+      return description;
     }
-    return description;
   }
 
   public long getDate() {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Redmi Note 9 Pro, Android 10
 * Virtual device Nexus S, Android 8.1
 * Virtual device Pixel 2, Android 11
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234 ` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a 
whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixes #11598 
I have fixed the issue of escaped title and descriptions in Link Preview.

This is how the URL preview screenshot in provided in the issue looks like now.
![image](https://user-images.githubusercontent.com/75429250/152222340-f3d5746b-d5c7-4a6b-80f8-6cafbc25edb4.jpg)

Now escape characters in og:title and og:description will be shown in correct format on API level 24 and above. It's a closed issue (due to no activity for long time but I thought to fix it as I could do that.
