### PR TITLE
Handle permission results in the fragment when updating the profile picture

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/avatar/picker/AvatarPickerFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/avatar/picker/AvatarPickerFragment.kt
@@ -244,4 +244,8 @@ class AvatarPickerFragment : Fragment(R.layout.avatar_picker_fragment) {
       }
       .execute()
   }
+
+  override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
+    Permissions.onRequestPermissionsResult(this, requestCode, permissions, grantResults)
+  }
 }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Neus 6P API 27
 * AVD Pixel 4 API 30
 * Samsung Galaxy S6 Android 7.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Receive results to the permission request issued from the fragment. Fixes #11808

### Steps to verify the PR
1. Prepare a Signal installation that has Camera permission turned *off*.
2. Open Signal, go to Signal settings.
3. Tap the profile picture of you.
4. Tap Edit Photo.
5. Tap Camera
6. When asked, allow Camera permission.

**Observed before the fix**
It goes back to the previous view so you have to tap Camera again.

**Behavior after the fix**
It opens the camera view.

