### PR TITLE
Don't call a Signal audio call a Signal video call.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/webrtc/WebRtcCallView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/webrtc/WebRtcCallView.java
@@ -96,8 +96,8 @@ public class WebRtcCallView extends ConstraintLayout {
   private PictureInPictureGestureHelper pictureInPictureGestureHelper;
   private ImageView                     hangup;
   private TextView                      hangupLabel;
-  private View                          answerWithAudio;
-  private View                          answerWithAudioLabel;
+  private View                          answerWithoutVideo;
+  private View                          answerWithoutVideoLabel;
   private View                          topGradient;
   private View                          footerGradient;
   private View                          startCallControls;
@@ -178,8 +178,8 @@ public class WebRtcCallView extends ConstraintLayout {
     ringToggleLabel               = findViewById(R.id.call_screen_audio_ring_toggle_label);
     hangup                        = findViewById(R.id.call_screen_end_call);
     hangupLabel                   = findViewById(R.id.call_screen_end_call_label);
-    answerWithAudio               = findViewById(R.id.call_screen_answer_with_audio);
-    answerWithAudioLabel          = findViewById(R.id.call_screen_answer_with_audio_label);
+    answerWithoutVideo            = findViewById(R.id.call_screen_answer_without_video);
+    answerWithoutVideoLabel       = findViewById(R.id.call_screen_answer_without_video_label);
     topGradient                   = findViewById(R.id.call_screen_header_gradient);
     footerGradient                = findViewById(R.id.call_screen_footer_gradient);
     startCallControls             = findViewById(R.id.call_screen_start_call_controls);
@@ -255,7 +255,7 @@ public class WebRtcCallView extends ConstraintLayout {
     decline.setOnClickListener(v -> runIfNonNull(controlsListener, ControlsListener::onDenyCallPressed));
 
     answer.setOnClickListener(v -> runIfNonNull(controlsListener, ControlsListener::onAcceptCallPressed));
-    answerWithAudio.setOnClickListener(v -> runIfNonNull(controlsListener, ControlsListener::onAcceptCallWithVoiceOnlyPressed));
+    answerWithoutVideo.setOnClickListener(v -> runIfNonNull(controlsListener, ControlsListener::onAcceptCallWithVoiceOnlyPressed));
 
     pictureInPictureGestureHelper   = PictureInPictureGestureHelper.applyTo(smallLocalRenderFrame);
     pictureInPictureExpansionHelper = new PictureInPictureExpansionHelper();
@@ -286,7 +286,7 @@ public class WebRtcCallView extends ConstraintLayout {
 
     rotatableControls.add(hangup);
     rotatableControls.add(answer);
-    rotatableControls.add(answerWithAudio);
+    rotatableControls.add(answerWithoutVideo);
     rotatableControls.add(audioToggle);
     rotatableControls.add(micToggle);
     rotatableControls.add(videoToggle);
@@ -590,19 +590,19 @@ public class WebRtcCallView extends ConstraintLayout {
     if (webRtcControls.displayIncomingCallButtons()) {
       visibleViewSet.addAll(incomingCallViews);
 
-      incomingRingStatus.setText(webRtcControls.displayAnswerWithAudio() ? R.string.WebRtcCallView__signal_call : R.string.WebRtcCallView__signal_video_call);
+      incomingRingStatus.setText(webRtcControls.displayAnswerWithoutVideo() ? R.string.WebRtcCallView__signal_video_call: R.string.WebRtcCallView__signal_call);
 
       answer.setImageDrawable(AppCompatResources.getDrawable(getContext(), R.drawable.webrtc_call_screen_answer));
     }
 
-    if (webRtcControls.displayAnswerWithAudio()) {
-      visibleViewSet.add(answerWithAudio);
-      visibleViewSet.add(answerWithAudioLabel);
+    if (webRtcControls.displayAnswerWithoutVideo()) {
+      visibleViewSet.add(answerWithoutVideo);
+      visibleViewSet.add(answerWithoutVideoLabel);
 
       answer.setImageDrawable(AppCompatResources.getDrawable(getContext(), R.drawable.webrtc_call_screen_answer_with_video));
     }
 
-    if (!webRtcControls.displayIncomingCallButtons() && !webRtcControls.displayAnswerWithAudio()){
+    if (!webRtcControls.displayIncomingCallButtons()){
       incomingRingStatus.setVisibility(GONE);
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/components/webrtc/WebRtcControls.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/webrtc/WebRtcControls.java
@@ -165,7 +165,7 @@ public final class WebRtcControls {
     return isOngoing();
   }
 
-  boolean displayAnswerWithAudio() {
+  boolean displayAnswerWithoutVideo() {
     return isIncoming() && isRemoteVideoEnabled;
   }
 

--- a/app/src/main/res/layout/webrtc_call_view.xml
+++ b/app/src/main/res/layout/webrtc_call_view.xml
@@ -491,19 +491,19 @@
             tools:visibility="gone" />
 
         <ImageView
-            android:id="@+id/call_screen_answer_with_audio"
+            android:id="@+id/call_screen_answer_without_video"
             android:layout_width="56dp"
             android:layout_height="56dp"
             android:layout_marginBottom="5dp"
             android:visibility="gone"
-            app:layout_constraintBottom_toTopOf="@id/call_screen_answer_with_audio_label"
+            app:layout_constraintBottom_toTopOf="@id/call_screen_answer_without_video_label"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:srcCompat="@drawable/webrtc_call_screen_answer_without_video"
             tools:visibility="gone" />
 
         <TextView
-            android:id="@+id/call_screen_answer_with_audio_label"
+            android:id="@+id/call_screen_answer_without_video_label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="9dp"
@@ -612,7 +612,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:barrierDirection="top"
-            app:constraint_referenced_ids="call_screen_answer_call,call_screen_decline_call,call_screen_audio_mic_toggle,call_screen_camera_direction_toggle,call_screen_video_toggle,,call_screen_answer_with_audio,call_screen_speaker_toggle,call_screen_end_call" />
+            app:constraint_referenced_ids="call_screen_answer_call,call_screen_decline_call,call_screen_audio_mic_toggle,call_screen_camera_direction_toggle,call_screen_video_toggle,call_screen_answer_without_video,call_screen_speaker_toggle,call_screen_end_call" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </merge>


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Moto X Play, Android 7.1.1
 * Virtual Pixel 2, Android 11
- [X] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fix that on incoming calling screen "Signal Video Call" is shown when it's only a audio call.
Issue see here: https://community.signalusers.org/t/beta-feedback-for-the-upcoming-android-5-31-release/41424/136
