### PR TITLE
Renaming TransportOption.Type.TEXTSECURE to SIGNAL

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/TransportOption.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/TransportOption.java
@@ -15,7 +15,7 @@ public class TransportOption implements Parcelable {
 
   public enum Type {
     SMS,
-    TEXTSECURE
+    SIGNAL
   }
 
   private final int                             drawable;

--- a/app/src/main/java/org/thoughtcrime/securesms/TransportOptions.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/TransportOptions.java
@@ -109,7 +109,7 @@ public class TransportOptions {
   }
 
   public static @NonNull TransportOption getPushTransportOption(@NonNull Context context) {
-    return new TransportOption(Type.TEXTSECURE,
+    return new TransportOption(Type.SIGNAL,
                                R.drawable.ic_send_lock_24,
                                context.getResources().getColor(R.color.core_ultramarine),
                                context.getString(R.string.ConversationActivity_transport_signal),

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationParentFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationParentFragment.java
@@ -1549,7 +1549,7 @@ public class ConversationParentFragment extends Fragment
     sendButton.resetAvailableTransports(isMediaMessage);
 
     if (!isSecureText && !isPushGroupConversation() && !recipient.get().isAciOnly() && !recipient.get().isReleaseNotes()) {
-      sendButton.disableTransport(Type.TEXTSECURE);
+      sendButton.disableTransport(Type.SIGNAL);
     }
 
     if (recipient.get().isPushGroup() || (!recipient.get().isMmsGroup() && !recipient.get().hasSmsAddress())) {
@@ -1560,7 +1560,7 @@ public class ConversationParentFragment extends Fragment
       sendButton.setDefaultTransport(Type.SMS);
     } else {
       if (isSecureText || isPushGroupConversation() || recipient.get().isAciOnly() || recipient.get().isReleaseNotes()) {
-        sendButton.setDefaultTransport(Type.TEXTSECURE);
+        sendButton.setDefaultTransport(Type.SIGNAL);
       } else {
         sendButton.setDefaultTransport(Type.SMS);
       }
@@ -2844,7 +2844,7 @@ public class ConversationParentFragment extends Fragment
   }
 
   private MediaConstraints getCurrentMediaConstraints() {
-    return sendButton.getSelectedTransport().getType() == Type.TEXTSECURE
+    return sendButton.getSelectedTransport().getType() == Type.SIGNAL
            ? MediaConstraints.getPushMediaConstraints()
            : MediaConstraints.getMmsMediaConstraints(sendButton.getSelectedTransport().getSimSubscriptionId().or(-1));
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/sharing/MultiShareSender.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/sharing/MultiShareSender.java
@@ -155,7 +155,7 @@ public final class MultiShareSender {
                                        @NonNull List<Mention> validatedMentions)
   {
     String body = multiShareArgs.getDraftText();
-    if (transportOption.isType(TransportOption.Type.TEXTSECURE) && !forceSms && body != null) {
+    if (transportOption.isType(TransportOption.Type.SIGNAL) && !forceSms && body != null) {
       MessageUtil.SplitResult splitMessage = MessageUtil.getSplitMessage(context, body, transportOption.calculateCharacters(body).maxPrimaryMessageSize);
       body = splitMessage.getBody();
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual Pixel 2, Android 11
- [X] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Renaming the TransportOption.Type.TEXTSECURE to SIGNAL