### PR TITLE
Renaming TextSecureExpiredException to SignalExpiredException

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/SignalExpiredException.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/SignalExpiredException.java
@@ -1,0 +1,7 @@
+package org.thoughtcrime.securesms;
+
+public class SignalExpiredException extends Exception {
+  public SignalExpiredException(String message) {
+    super(message);
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/TextSecureExpiredException.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/TextSecureExpiredException.java
@@ -1,7 +1,0 @@
-package org.thoughtcrime.securesms;
-
-public class TextSecureExpiredException extends Exception {
-  public TextSecureExpiredException(String message) {
-    super(message);
-  }
-}

--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/PushSendJob.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/PushSendJob.java
@@ -16,7 +16,7 @@ import org.greenrobot.eventbus.ThreadMode;
 import org.signal.core.util.logging.Log;
 import org.signal.libsignal.metadata.certificate.InvalidCertificateException;
 import org.signal.libsignal.metadata.certificate.SenderCertificate;
-import org.thoughtcrime.securesms.TextSecureExpiredException;
+import org.thoughtcrime.securesms.SignalExpiredException;
 import org.thoughtcrime.securesms.attachments.Attachment;
 import org.thoughtcrime.securesms.attachments.DatabaseAttachment;
 import org.thoughtcrime.securesms.blurhash.BlurHash;
@@ -52,14 +52,11 @@ import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.util.Util;
 import org.whispersystems.libsignal.util.guava.Optional;
-import org.whispersystems.signalservice.api.crypto.UnidentifiedAccessPair;
 import org.whispersystems.signalservice.api.messages.SignalServiceAttachment;
 import org.whispersystems.signalservice.api.messages.SignalServiceAttachmentPointer;
 import org.whispersystems.signalservice.api.messages.SignalServiceAttachmentRemoteId;
 import org.whispersystems.signalservice.api.messages.SignalServiceDataMessage;
 import org.whispersystems.signalservice.api.messages.SignalServiceDataMessage.Preview;
-import org.whispersystems.signalservice.api.messages.multidevice.SentTranscriptMessage;
-import org.whispersystems.signalservice.api.messages.multidevice.SignalServiceSyncMessage;
 import org.whispersystems.signalservice.api.messages.shared.SharedContact;
 import org.whispersystems.signalservice.api.push.SignalServiceAddress;
 import org.whispersystems.signalservice.api.push.exceptions.NonSuccessfulResponseCodeException;
@@ -70,7 +67,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -102,7 +98,7 @@ public abstract class PushSendJob extends SendJob {
   protected final void onSend() throws Exception {
     if (TextSecurePreferences.getSignedPreKeyFailureCount(context) > 5) {
       ApplicationDependencies.getJobManager().add(new RotateSignedPreKeyJob());
-      throw new TextSecureExpiredException("Too many signed prekey rotation failures");
+      throw new SignalExpiredException("Too many signed prekey rotation failures");
     }
 
     if (!Recipient.self().isRegistered()) {

--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/SendJob.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/SendJob.java
@@ -6,7 +6,7 @@ import com.annimon.stream.Stream;
 
 import org.signal.core.util.logging.Log;
 import org.thoughtcrime.securesms.BuildConfig;
-import org.thoughtcrime.securesms.TextSecureExpiredException;
+import org.thoughtcrime.securesms.SignalExpiredException;
 import org.thoughtcrime.securesms.attachments.Attachment;
 import org.thoughtcrime.securesms.attachments.DatabaseAttachment;
 import org.thoughtcrime.securesms.contactshare.Contact;
@@ -33,7 +33,7 @@ public abstract class SendJob extends BaseJob {
   @Override
   public final void onRun() throws Exception {
     if (SignalStore.misc().isClientDeprecated()) {
-      throw new TextSecureExpiredException(String.format("TextSecure expired (build %d, now %d)",
+      throw new SignalExpiredException(String.format("Signal expired (build %d, now %d)",
                                                          BuildConfig.BUILD_TIMESTAMP,
                                                          System.currentTimeMillis()));
     }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual Pixel 2, Android 11
- [X] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Renaming the class TextSecureExpiredException to SignalExpiredException