### PR TITLE
Move arrays out from Strings file for valid Strings entries

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -419,4 +419,14 @@
         <item>@string/PlaybackSpeedToggleTextView__p5x</item>
     </string-array>
 
+    <!-- GV2 access levels -->
+    <array name="GroupManagement_edit_group_membership_choices">
+        <item>@string/GroupManagement_access_level_all_members</item>
+        <item>@string/GroupManagement_access_level_only_admins</item>
+    </array>
+    <array name="GroupManagement_edit_group_info_choices">
+        <item>@string/GroupManagement_access_level_all_members</item>
+        <item>@string/GroupManagement_access_level_only_admins</item>
+    </array>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -576,14 +576,6 @@
     <string name="GroupManagement_access_level_only_admins">Only admins</string>
     <string name="GroupManagement_access_level_no_one">No one</string>
     <string name="GroupManagement_access_level_unknown" translatable="false">Unknown</string>
-    <array name="GroupManagement_edit_group_membership_choices">
-        <item>@string/GroupManagement_access_level_all_members</item>
-        <item>@string/GroupManagement_access_level_only_admins</item>
-    </array>
-    <array name="GroupManagement_edit_group_info_choices">
-        <item>@string/GroupManagement_access_level_all_members</item>
-        <item>@string/GroupManagement_access_level_only_admins</item>
-    </array>
 
     <!-- GV2 invites sent -->
     <plurals name="GroupManagement_invitation_sent">


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)
(Why do I need to provide my address for the CLA for this mini contribution?)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
None.
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
The `array` entry is not a valid entry in a `strings.xml` file according to [the docs](https://developer.android.com/guide/topics/resources/string-resource), therefore I moved it out and into the `arrays.xml` file instead.
