### PR TITLE
Fix #10973 You can add blocked users to groups

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/conversation/ConversationSettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/conversation/ConversationSettingsFragment.kt
@@ -402,7 +402,7 @@ class ConversationSettingsFragment : DSLSettingsFragment(
         enabled = it.canEditGroupAttributes && !state.recipient.isBlocked
       }
 
-      if (!state.recipient.isReleaseNotes) {
+      if (!state.recipient.isReleaseNotes && !state.recipient.isBlocked) {
         clickPref(
           title = DSLSettingsText.from(R.string.ConversationSettingsFragment__disappearing_messages),
           summary = summary,
@@ -539,15 +539,17 @@ class ConversationSettingsFragment : DSLSettingsFragment(
             )
           )
 
-          customPref(
-            LargeIconClickPreference.Model(
-              title = DSLSettingsText.from(R.string.ConversationSettingsFragment__add_to_a_group),
-              icon = DSLSettingsIcon.from(R.drawable.add_to_a_group, NO_TINT),
-              onClick = {
-                viewModel.onAddToGroup()
-              }
+          if (!state.recipient.isBlocked) {
+            customPref(
+              LargeIconClickPreference.Model(
+                title = DSLSettingsText.from(R.string.ConversationSettingsFragment__add_to_a_group),
+                icon = DSLSettingsIcon.from(R.drawable.add_to_a_group, NO_TINT),
+                onClick = {
+                  viewModel.onAddToGroup()
+                }
+              )
             )
-          )
+          }
 
           for (group in recipientSettingsState.groupsInCommon) {
             customPref(

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/conversation/ConversationSettingsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/conversation/ConversationSettingsViewModel.kt
@@ -152,7 +152,7 @@ sealed class ConversationSettingsViewModel(
           canModifyBlockedState = !recipient.isSelf && RecipientUtil.isBlockable(recipient),
           specificSettingsState = state.requireRecipientSettingsState().copy(
             contactLinkState = when {
-              recipient.isSelf || recipient.isReleaseNotes -> ContactLinkState.NONE
+              recipient.isSelf || recipient.isReleaseNotes || recipient.isBlocked -> ContactLinkState.NONE
               recipient.isSystemContact -> ContactLinkState.OPEN
               else -> ContactLinkState.ADD
             }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationParentFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationParentFragment.java
@@ -984,6 +984,10 @@ public class ConversationParentFragment extends Fragment
 
     inflater.inflate(R.menu.conversation, menu);
 
+    if (isInMessageRequest() && !recipient.get().isBlocked()) {
+      hideMenuItem(menu, R.id.menu_conversation_settings);
+    }
+
     if (isSingleConversation() && !isSecureText && !recipient.get().isReleaseNotes()) {
       inflater.inflate(R.menu.conversation_insecure, menu);
     }
@@ -1252,7 +1256,7 @@ public class ConversationParentFragment extends Fragment
       return;
     }
 
-    if (isInMessageRequest()) return;
+    if (isInMessageRequest() && !recipient.get().isBlocked()) return;
 
     Intent intent = ConversationSettingsActivity.forRecipient(requireContext(), recipient.getId());
     Bundle bundle = ConversationSettingsActivity.createTransitionBundle(requireActivity(), titleView.findViewById(R.id.contact_photo_image), toolbar);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual Pixel 2, Android 11
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Fixes https://github.com/signalapp/Signal-Android/issues/10973 and some more for blocked recipients.

When a contact is blocked, don't show in the ConversationSettingsFragment:

    "disappearing message"
    "add to system contacts"
    "add to a group"

The menu item "Conversation settings" was also made functional again, when a recipient is blocked.
The menu item was shown, but not functional, when conversation "isInMessageRequest".

https://github.com/signalapp/Signal-Android/blob/45e406013a5c85b0003462183a8f11c247b0eef8/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationParentFragment.java#L1232

Now menu item "Conversation settings" is hidden when conversation is in message request, but not blocked.

-------------------------------

![signal-2022-02-09-193624_001](https://user-images.githubusercontent.com/49990901/153268208-31eddef1-0b1d-47af-babc-395f84e02370.png)


![signal-2022-02-09-193624_002](https://user-images.githubusercontent.com/49990901/153268227-b109c43f-d9d4-4eeb-a461-5d0598ecde9f.png)


