### PR TITLE
Fix incorrectly identifying CharSequence as having mixedTextDirection

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/StringUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/StringUtil.java
@@ -179,14 +179,15 @@ public final class StringUtil {
     Boolean isLtr = null;
 
     for (int i = 0, len = Character.codePointCount(text, 0, text.length()); i < len; i++) {
-      int  codePoint = Character.codePointAt(text, i);
-      byte direction = Character.getDirectionality(codePoint);
+      int     codePoint = Character.codePointAt(text, i);
+      byte    direction = Character.getDirectionality(codePoint);
+      boolean isLetter  = Character.isLetter(codePoint);
 
-      if (isLtr != null && isLtr && direction != Character.DIRECTIONALITY_LEFT_TO_RIGHT) {
+      if (isLtr != null && isLtr && direction != Character.DIRECTIONALITY_LEFT_TO_RIGHT && isLetter) {
         return true;
-      } else if (isLtr != null && !isLtr && direction != Character.DIRECTIONALITY_RIGHT_TO_LEFT) {
+      } else if (isLtr != null && !isLtr && direction != Character.DIRECTIONALITY_RIGHT_TO_LEFT && isLetter) {
         return true;
-      } else {
+      } else if (isLetter) {
         isLtr = direction == Character.DIRECTIONALITY_LEFT_TO_RIGHT;
       }
     }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 4a, Android 12
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Characters with direction codes outside of simply LEFT_TO_RIGHT or RIGHT_TO_LEFT (eg. whitespace, punctuation) were causing the method to incorrectly return true. To fix this I changed it so only letters will be checked for direction. My fix passed the test cases provided in the initial commit, as well as returning false for single direction text which included spaces and punctuation.
