### PR TITLE
fix crash when submitting an internal user debuglog during registration

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/logsubmit/LogSectionSenderKey.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/logsubmit/LogSectionSenderKey.java
@@ -7,6 +7,7 @@ import androidx.annotation.NonNull;
 
 import org.signal.core.util.AsciiArt;
 import org.thoughtcrime.securesms.database.SignalDatabase;
+import org.thoughtcrime.securesms.keyvalue.SignalStore;
 
 /**
  * Renders data pertaining to sender key. While all private info is obfuscated, this is still only intended to be printed for internal users.
@@ -23,8 +24,12 @@ public class LogSectionSenderKey implements LogSection {
     StringBuilder builder = new StringBuilder();
 
     builder.append("--- Sender Keys Created By This Device").append("\n\n");
-    try (Cursor cursor = SignalDatabase.senderKeys().getAllCreatedBySelf()) {
-      builder.append(AsciiArt.tableFor(cursor)).append("\n\n");
+    if (SignalStore.account().getAci() != null){
+      try (Cursor cursor = SignalDatabase.senderKeys().getAllCreatedBySelf()) {
+        builder.append(AsciiArt.tableFor(cursor)).append("\n\n");
+      }
+    } else {
+      builder.append("<no ACI assigned yet>").append("\n\n");
     }
 
     builder.append("--- Sender Key Shared State").append("\n\n");


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nokia 3.1, Android 10
 * Huawei AUM-L29, Android 8
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I couldn't find a github issue mentioning this crash. 
----------

### Description

This fixes the crash that happens when you try to submit a debug log from an internal user build, during registration.

The crash happens because [LogSectionSenderKey](https://github.com/signalapp/Signal-Android/blob/master/app/src/main/java/org/thoughtcrime/securesms/logsubmit/LogSectionSenderKey.java) tries to [get all sender keys created by self](https://github.com/signalapp/Signal-Android/blob/67f0ba86246dbd5b0095171a0e4b57d36d5fcf70/app/src/main/java/org/thoughtcrime/securesms/logsubmit/LogSectionSenderKey.java#L26) and in the process [calls Recipient.self()](https://github.com/signalapp/Signal-Android/blob/67f0ba86246dbd5b0095171a0e4b57d36d5fcf70/app/src/main/java/org/thoughtcrime/securesms/database/SenderKeyDatabase.java#L136) before the account has [an ACI or an E164](https://github.com/signalapp/Signal-Android/blob/67f0ba86246dbd5b0095171a0e4b57d36d5fcf70/app/src/main/java/org/thoughtcrime/securesms/recipients/LiveRecipientCache.java#L142-L159)

I've added a null check for SignalStore.account().getAci() before calling SignalDatabase.senderKeys().getAllCreatedBySelf() and if ACI is null, the "--- Sender Keys Created By This Device" section of the log will display "<no ACI assigned yet>" 

I considered adding the check before `builder.append("--- Sender Keys Created By This Device").append("\n\n");`  but I figured you want the debug log template to be static and not miss any parts, while also being informed of the state of the app.

I did not use "not registered" because there are scenario where you can be unregistered and still have sender keys created by yourself, like when you've "disabled Signal for messages and calls" from Settings -> Privacy -> Advanced, or when your client gets unregistered because you've registered the same number on a different device. 

![Screenshot](https://user-images.githubusercontent.com/77681918/154818650-a9f13c9c-4c07-468d-8531-adabd366a4f8.png)



 

