### PR TITLE
Fix #12017 pulse to position not happening 

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
@@ -1192,10 +1192,9 @@ public class ConversationFragment extends LoggingFragment implements Multiselect
                                  if (child != null && layoutManager.isViewPartiallyVisible(child, true, false)) {
                                    getListAdapter().pulseAtPosition(position);
                                  } else {
-                                   pulsePosition = position;
+                                   layoutManager.scrollToPositionWithOffset(p, list.getHeight() / 4);
+                                   getListAdapter().pulseAtPosition(position);
                                  }
-
-                                 layoutManager.scrollToPositionWithOffset(p, list.getHeight() / 4);
                                } else {
                                  layoutManager.scrollToPositionWithOffset(p, list.getHeight() / 4);
                                  getListAdapter().pulseAtPosition(position);

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
@@ -1189,16 +1189,13 @@ public class ConversationFragment extends LoggingFragment implements Multiselect
                                if (Math.abs(layoutManager.findFirstVisibleItemPosition() - p) < SCROLL_ANIMATION_THRESHOLD) {
                                  View child = layoutManager.findViewByPosition(position);
 
-                                 if (child != null && layoutManager.isViewPartiallyVisible(child, true, false)) {
-                                   getListAdapter().pulseAtPosition(position);
-                                 } else {
+                                 if (child == null || !layoutManager.isViewPartiallyVisible(child, true, false)) {
                                    layoutManager.scrollToPositionWithOffset(p, list.getHeight() / 4);
-                                   getListAdapter().pulseAtPosition(position);
                                  }
                                } else {
                                  layoutManager.scrollToPositionWithOffset(p, list.getHeight() / 4);
-                                 getListAdapter().pulseAtPosition(position);
                                }
+                               getListAdapter().pulseAtPosition(position);
                              })
                          ))
                          .withOnInvalidPosition(() -> {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nokia 3.1, Android 10
 * Huawei L29, Android 8
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

This pull request Fixes #12017 the issue was happening because according to the documentation [scrollToPositionWithOffset() doesn't reflect the scroll position change until the next layout call](https://developer.android.com/reference/androidx/recyclerview/widget/LinearLayoutManager#scrollToPositionWithOffset(int,%20int)) and also, the debugger never stopped at the [break point I placed here](https://github.com/signalapp/Signal-Android/blob/1314b0499436dd721c7525dbf26c12a09e33c7ee/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java#L1382) when I clicked on a quoted message or a search result for the first time, 

which means the code was in this state, [setting the pulsePosition variable to the current position, and scrolling to position with offset,](https://github.com/signalapp/Signal-Android/blob/1314b0499436dd721c7525dbf26c12a09e33c7ee/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java#L1195-L1198) then waiting for [onScrollStateChange to run, and pulse at the newly set pulsePosition](https://github.com/signalapp/Signal-Android/blob/1314b0499436dd721c7525dbf26c12a09e33c7ee/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java#L1378-L1384)

which doesn't happen, so I changed it to make sure pulseAtPosition runs after scrollToPositionWithOffset no matter what path the code takes
