### PR TITLE
Fix a bug that forces the media pager go back to the first page when a chat receives a new media message

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -611,6 +611,8 @@ public final class MediaPreviewActivity extends PassphraseRequiredActivity
 
         viewModel.setActiveAlbumRailItem(MediaPreviewActivity.this, position);
         initializeActionBar();
+
+        restartItem = position;
       }
     }
 
@@ -626,6 +628,8 @@ public final class MediaPreviewActivity extends PassphraseRequiredActivity
         }
 
         adapter.pause(position);
+
+        restartItem = -1;
       }
     }
   }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S6 Android 7.0
 * Samsung Galaxy S6 Edge Android 6
 * AVD Pixel 4 API 30
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
When you are browsing a set of images in a chat and you receive a new media message in the chat, the image pager forcefully returns the first page.

The solution is to remember the page number we are at when the user selects the page, as the app is already doing in onPause/onResume cycle.

Fixes #11816

### Steps to verify the fix
1. Prepare a Signal chat between two devices (A and B)
2. A sends multiple images to B
3. B opens the image and go to page 2, 3, and more
4. While B is on the page other than the first page, A sends one of **media** messages such as an image, a movie or a sticker.

**Expected**
B sees a notification but the media pager stays on the page.

**Observed before the fix**
B sees a notification and the media pager suddenly goes back to the first page.