### PR TITLE
fixes signalapp#12033 escape html from shared groups before showing

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
@@ -30,6 +30,7 @@ import android.graphics.Rect;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.text.Html;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -545,7 +546,7 @@ public class ConversationFragment extends LoggingFragment implements Multiselect
     boolean      isSelf             = Recipient.self().equals(recipient);
     int          memberCount        = recipientInfo.getGroupMemberCount();
     int          pendingMemberCount = recipientInfo.getGroupPendingMemberCount();
-    List<String> groups             = recipientInfo.getSharedGroups();
+    List<String> escapedGroups      = Stream.of(recipientInfo.getSharedGroups()).map(Html::escapeHtml).toList();
 
     conversationBanner.setBadge(recipient);
 
@@ -580,7 +581,7 @@ public class ConversationFragment extends LoggingFragment implements Multiselect
       }
     }
 
-    if (groups.isEmpty() || isSelf) {
+    if (escapedGroups.isEmpty() || isSelf) {
       if (TextUtils.isEmpty(recipientInfo.getGroupDescription())) {
         conversationBanner.setLinkifyDescription(false);
         conversationBanner.hideDescription();
@@ -600,21 +601,21 @@ public class ConversationFragment extends LoggingFragment implements Multiselect
     } else {
       final String description;
 
-      switch (groups.size()) {
+      switch (escapedGroups.size()) {
         case 1:
-          description = context.getString(R.string.MessageRequestProfileView_member_of_one_group, HtmlUtil.bold(groups.get(0)));
+          description = context.getString(R.string.MessageRequestProfileView_member_of_one_group, HtmlUtil.bold(escapedGroups.get(0)));
           break;
         case 2:
-          description = context.getString(R.string.MessageRequestProfileView_member_of_two_groups, HtmlUtil.bold(groups.get(0)), HtmlUtil.bold(groups.get(1)));
+          description = context.getString(R.string.MessageRequestProfileView_member_of_two_groups, HtmlUtil.bold(escapedGroups.get(0)), HtmlUtil.bold(escapedGroups.get(1)));
           break;
         case 3:
-          description = context.getString(R.string.MessageRequestProfileView_member_of_many_groups, HtmlUtil.bold(groups.get(0)), HtmlUtil.bold(groups.get(1)), HtmlUtil.bold(groups.get(2)));
+          description = context.getString(R.string.MessageRequestProfileView_member_of_many_groups, HtmlUtil.bold(escapedGroups.get(0)), HtmlUtil.bold(escapedGroups.get(1)), HtmlUtil.bold(escapedGroups.get(2)));
           break;
         default:
-          int others = groups.size() - 2;
+          int others = escapedGroups.size() - 2;
           description = context.getString(R.string.MessageRequestProfileView_member_of_many_groups,
-                                          HtmlUtil.bold(groups.get(0)),
-                                          HtmlUtil.bold(groups.get(1)),
+                                          HtmlUtil.bold(escapedGroups.get(0)),
+                                          HtmlUtil.bold(escapedGroups.get(1)),
                                           context.getResources().getQuantityString(R.plurals.MessageRequestProfileView_member_of_d_additional_groups, others, others));
       }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nokia 3.1, Android 10
 * Huawei L29, Android 8

- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)


----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
This Fixes #12033, by escaping html characters from the [names of shared groups,](https://github.com/signalapp/Signal-Android/blob/a84c971cbe262c02b49c13b7c9552816b49bcee7/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java#L548) before [adding a bold HTML tag](https://github.com/signalapp/Signal-Android/blob/a84c971cbe262c02b49c13b7c9552816b49bcee7/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java#L603-L619) and then [parsing the resulting HTML](https://github.com/signalapp/Signal-Android/blob/a84c971cbe262c02b49c13b7c9552816b49bcee7/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java#L621) to be displayed in 1 on 1 conversations.


