### PR TITLE
Make sure savedInstanceState has accurate isSearchRequested value

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationParentFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationParentFragment.java
@@ -3823,6 +3823,8 @@ public class ConversationParentFragment extends Fragment
 
   @Override
   public void handleReplyMessage(ConversationMessage conversationMessage) {
+    if (isSearchRequested) searchViewItem.collapseActionView();
+
     MessageRecord messageRecord = conversationMessage.getMessageRecord();
 
     Recipient author;

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationParentFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationParentFragment.java
@@ -1141,6 +1141,8 @@ public class ConversationParentFragment extends Fragment
       reactionDelegate.hide();
     } else if (container.isInputOpen()) {
       container.hideCurrentInput(composeText);
+    } else if (isSearchRequested) {
+      searchViewItem.collapseActionView();
     } else {
       requireActivity().finish();
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationParentFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationParentFragment.java
@@ -1063,6 +1063,7 @@ public class ConversationParentFragment extends Fragment
       @Override
       public boolean onMenuItemActionExpand(MenuItem item) {
         searchView.setOnQueryTextListener(queryListener);
+        isSearchRequested = true;
         searchViewModel.onSearchOpened();
         searchNav.setVisibility(View.VISIBLE);
         searchNav.setData(0, 0);

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationParentFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationParentFragment.java
@@ -3823,7 +3823,9 @@ public class ConversationParentFragment extends Fragment
 
   @Override
   public void handleReplyMessage(ConversationMessage conversationMessage) {
-    if (isSearchRequested) searchViewItem.collapseActionView();
+    if (isSearchRequested) {
+      searchViewItem.collapseActionView();
+    }
 
     MessageRecord messageRecord = conversationMessage.getMessageRecord();
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nokia 3.1, Android 10
 * Samsung A10, Android 11
 * Huawei L29, Android 8
 * Samsung S5 mini, Android 5.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
fixes signalapp#12054

[`isSearchRequested` was not being set to true when searchViewItem's actionView was expanded](https://github.com/signalapp/Signal-Android/blob/cba784b8ec14fa58a550e845d383395945bb7d00/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationParentFragment.java#L1065-L1069), which leads to [`onSavedInstanceState` saving the wrong value for `isSearchRequested`,](https://github.com/signalapp/Signal-Android/blob/cba784b8ec14fa58a550e845d383395945bb7d00/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationParentFragment.java#L859-L864) and then the app is not aware that the search was open before onStop() was called. 

I also used the onBackPressed() method to make sure that if search is opened when back is pressed it first closes search, and returns the `inputPanel` instead of finishing the activity. 

