### PR TITLE
Fix to the issue of showing two keyboards on top of each other

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationParentFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationParentFragment.java
@@ -3270,7 +3270,7 @@ public class ConversationParentFragment extends Fragment
     emojiDrawerStub.get().setFragmentManager(getChildFragmentManager());
 
     if (container.getCurrentInput() == emojiDrawerStub.get()) {
-      container.showSoftkey(composeText);
+      container.showSoftkey(composeText, true);
     } else {
       container.show(composeText, emojiDrawerStub.get());
     }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Galaxy S6 Android 7.0
 * Galaxy S6 Edge Android 6.0.1
 * AVD Pixel 4 API 30
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Disable soft keyboard popping up when the text was selected in the input when the other keyboard was open. Fixes #11780

### Steps to verify the issue
1. Go to a chat
2. Tap on the input field and type in something
3. Long tap what is in the input to select the text
4. While the text is selected, tap on the Emoji button to switch the keyboard type

**Expected**

The keyboard switches to the emoji keyboard.

**Observed**

The emoji keyboard opens on top of the existing soft input keyboard.

### Screen recordings

**Bug**

https://user-images.githubusercontent.com/28482/158038695-17854d91-089e-4c30-a095-323a349fb82b.mp4

**Fixed**

https://user-images.githubusercontent.com/28482/158038705-cc4f07c9-ce3e-4513-83cf-1710ec4c90f1.mp4


