### PR TITLE
Remove leftover `if` in SearchUtil.java

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/SearchUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/SearchUtil.java
@@ -66,11 +66,6 @@ public class SearchUtil {
       default:
         throw new InvalidParameterException("match mode must be STRICT or MATCH_ALL: " + matchMode);
     }
-    if (matchMode == STRICT) {
-      ranges = getStrictHighlightRanges(locale, text.toString(), highlight);
-    } else {
-      ranges = getHighlightRanges(locale, text.toString(), highlight);
-    }
 
     for (Pair<Integer, Integer> range : ranges) {
       spanned.setSpan(styleFactory.create(), range.first(), range.second(), Spannable.SPAN_INCLUSIVE_EXCLUSIVE);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
* I don't think it needs testing... 
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

I've been looking around the search code, and I've noticed an if that seems to have been leftover probably after some merge operation, from this commit 

https://github.com/signalapp/Signal-Android/commit/e09d162c1ed60352c964e0e9ab8bd22b0ce7f468#diff-30b77e85e0f7cc4ee703f15269e694469ee1e1a480e77dedaa4d052d277157fa

