### PR TITLE
Fix "MediaPreviewActivity_s_to_s"

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -203,23 +203,25 @@ public final class MediaPreviewActivity extends PassphraseRequiredActivity
     else                                  from = "";
 
     if (showThread) {
-      String    to              = null;
+      String    titleText       = null;
       Recipient threadRecipient = mediaItem.threadRecipient;
 
       if (threadRecipient != null) {
-        if (mediaItem.outgoing || threadRecipient.isGroup()) {
+        if (mediaItem.outgoing) {
           if (threadRecipient.isSelf()) {
-            from = getString(R.string.note_to_self);
+            titleText = getString(R.string.note_to_self);
           } else {
-            to = threadRecipient.getDisplayName(this);
+            titleText = getString(R.string.MediaPreviewActivity_you_to_s, threadRecipient.getDisplayName(this));
           }
         } else {
-          to = getString(R.string.MediaPreviewActivity_you);
+          if (threadRecipient.isGroup()) {
+            titleText = getString(R.string.MediaPreviewActivity_s_to_s, from, threadRecipient.getDisplayName(this));
+          } else {
+            titleText = getString(R.string.MediaPreviewActivity_s_to_you, from);
+          }
         }
       }
-
-      return to != null ? getString(R.string.MediaPreviewActivity_s_to_s, from, to)
-                        : from;
+      return titleText != null ? titleText : from;
     } else {
       return from;
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1846,6 +1846,8 @@
     <string name="MediaPreviewActivity_media_delete_confirmation_title">Delete message?</string>
     <string name="MediaPreviewActivity_media_delete_confirmation_message">This will permanently delete this message.</string>
     <string name="MediaPreviewActivity_s_to_s">%1$s to %2$s</string>
+    <string name="MediaPreviewActivity_you_to_s">You to %1$s</string>
+    <string name="MediaPreviewActivity_s_to_you">%1$s to you</string>
     <string name="MediaPreviewActivity_media_no_longer_available">Media no longer available.</string>
     <string name="MediaPreviewActivity_cant_find_an_app_able_to_share_this_media">Can\'t find an app able to share this media.</string>
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual Pixel 2, Android 11
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Fix #12072 

As suggested by @RiseT, an alternative PR to the first PR #12089.
More strings
- You to %1$s
- %1$s to you

were added.

In total there are 4 cases (X to Y) to distinguish.

2 cases with an outgoing media:

1. You to you -> "Note to Self"
2. You to Alice; You to a group

2 cases with an incoming media:

1. Alice to a group
2. Alice to you



