### PR TITLE
Fix to a bug which may skew the profile picture on the action bar in the chat view in RTL layout

### DIFF
--- a/app/src/main/res/layout/conversation_title_view.xml
+++ b/app/src/main/res/layout/conversation_title_view.xml
@@ -23,7 +23,6 @@
             android:layout_alignParentStart="true"
             android:layout_centerVertical="true"
             android:clickable="true"
-            android:layout_marginEnd="10dp"
             android:contentDescription="@string/conversation_list_item_view__contact_photo_image"
             android:cropToPadding="true"
             android:foreground="@drawable/contact_photo_background"


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Pixel API 23
 * AVD Pixel 4 API 30
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Removes unnecessary marginEnd attribute.

The issue was [reported first by Xashyar in the beta forum](https://community.signalusers.org/t/beta-feedback-for-the-upcoming-android-5-33-release/42513/59).

### Steps to reproduce
1. Prepare an Android 6.0 (API 23) phone
2. Install and launch Signal to it
3. Set its language to one of RTL languages
4. Go to a chat and see the action bar.

**Observed at v5.34.8**

The profile picture gets skewed.

**Expected after the PR**

The profile picture doesn't get skewed.

### Screenshots

|API / Lang|Bug|Fixed|
|---|---|---|
|23 RTL|![api23-rtl-before](https://user-images.githubusercontent.com/28482/161403117-df87292f-9ee7-4f2e-b359-cb412577fea0.png)|![api23-rtl-after](https://user-images.githubusercontent.com/28482/161403127-f49d64d4-11eb-48ed-b4d2-2806ab5ae9a0.png)|
|30 RTL (to show there's no regression after the fix)|![api30-rtl-before](https://user-images.githubusercontent.com/28482/161403145-b7998f2b-a033-45b0-903a-a4a73a63f34f.png)|![api30-rtl-after](https://user-images.githubusercontent.com/28482/161403146-0795f6ed-8d3a-4e98-8d03-1eea39688e01.png)|
|