### PR TITLE
Fix bad filtering of search results

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/SearchDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/SearchDatabase.java
@@ -71,8 +71,8 @@ public class SearchDatabase extends Database {
       "INNER JOIN " + ThreadDatabase.TABLE_NAME + " ON " + SMS_FTS_TABLE_NAME + "." + THREAD_ID + " = " + ThreadDatabase.TABLE_NAME + "." + ThreadDatabase.ID + " " +
       "WHERE " + SMS_FTS_TABLE_NAME + " MATCH ? " +
         "AND " + SmsDatabase.TABLE_NAME + "." + SmsDatabase.TYPE + " & " + MmsSmsColumns.Types.GROUP_V2_BIT + " = 0 " +
-        "AND " + SmsDatabase.TABLE_NAME + "." + SmsDatabase.TYPE + " & " + MmsSmsColumns.Types.PROFILE_CHANGE_TYPE + " != " + MmsSmsColumns.Types.PROFILE_CHANGE_TYPE + " " +
-        "AND " + SmsDatabase.TABLE_NAME + "." + SmsDatabase.TYPE + " & " + MmsSmsColumns.Types.GROUP_CALL_TYPE + " != " + MmsSmsColumns.Types.GROUP_CALL_TYPE + " " +
+        "AND ( " + SmsDatabase.TABLE_NAME + "." + SmsDatabase.TYPE + " | " + MmsSmsColumns.Types.PROFILE_CHANGE_TYPE + " ) - ( " + SmsDatabase.TABLE_NAME + "." + SmsDatabase.TYPE + " & " + MmsSmsColumns.Types.PROFILE_CHANGE_TYPE + " ) != 0 " +
+        "AND ( " + SmsDatabase.TABLE_NAME + "." + SmsDatabase.TYPE + " | " + MmsSmsColumns.Types.GROUP_CALL_TYPE + " ) - ( " + SmsDatabase.TABLE_NAME + "." + SmsDatabase.TYPE + " & " + MmsSmsColumns.Types.GROUP_CALL_TYPE + " ) != 0 " +
       "UNION ALL " +
       "SELECT " +
         ThreadDatabase.TABLE_NAME + "." + ThreadDatabase.RECIPIENT_ID + " AS " + CONVERSATION_RECIPIENT + ", " +


### PR DESCRIPTION
I messed up in the filtering of "profile change type" and "group call type" message, 
because I used a bitwise AND, and there are message types like "10485783" aka outgoing Signal 1 on 1 messages, that when ANDed with "profile change type" messages "7" equals "7" and they get filtered out. 

https://github.com/signalapp/Signal-Android/blob/e2c54eef7755ecc8c615c1590203d4c1a23ce655/app/src/main/java/org/thoughtcrime/securesms/database/SearchDatabase.java#L74

so this time I used an XOR instead of AND, but since SQLite doesn't have direct support for XOR (^) operations, I used the equivalent (A | B)  - (A & B) 

https://github.com/clauz9/Signal-Android/blob/32cf43ad3c7ba15dcd8a2aa3360bfd1773e1ec4c/app/src/main/java/org/thoughtcrime/securesms/database/SearchDatabase.java#L74-L75

This issue was discovered and reported by [@newuser on the forum](https://community.signalusers.org/t/beta-feedback-for-the-upcoming-android-5-35-release/43446/59?u=clauz)