### PR TITLE
Fixes #12149: Multi context menu in Conversation List

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
@@ -1104,6 +1104,10 @@ public class ConversationListFragment extends MainFragment implements ActionMode
       return true;
     }
 
+    if (viewModel.isContextMenuVisible()) {
+      return true;
+    }
+
     view.setSelected(true);
 
     Collection<Long> id = Collections.singleton(conversation.getThreadRecord().getThreadId());
@@ -1149,10 +1153,12 @@ public class ConversationListFragment extends MainFragment implements ActionMode
         .onDismiss(() -> {
           view.setSelected(false);
           list.suppressLayout(false);
+          viewModel.setContextMenuVisible(false);
         })
         .show(items);
 
     list.suppressLayout(true);
+    viewModel.setContextMenuVisible(true);
 
     return true;
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListViewModel.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListViewModel.java
@@ -80,6 +80,8 @@ class ConversationListViewModel extends ViewModel {
   private SearchResult activeSearchResult;
   private int          pinnedCount;
 
+  private boolean contextMenuVisible = false;
+
   private ConversationListViewModel(@NonNull Application application, @NonNull SearchRepository searchRepository, boolean isArchived) {
     this.megaphone                      = new MutableLiveData<>();
     this.searchResult                   = new MutableLiveData<>();
@@ -170,6 +172,14 @@ class ConversationListViewModel extends ViewModel {
     }
 
     coldStart = false;
+  }
+
+  boolean isContextMenuVisible() {
+    return contextMenuVisible;
+  }
+
+  void setContextMenuVisible(boolean visible) {
+    contextMenuVisible = visible;
   }
 
   @NonNull Set<Conversation> currentSelectedConversations() {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nokia 3.1, Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

I've added a boolean in the viewmodel that gets flipped when the context menu is shown, and dismissed
that is checked before a new context menu is created. 

fixes #12149 