### PR TITLE
Add option to allow SMS/MMS messages from self

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/chats/sms/SmsSettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/chats/sms/SmsSettingsFragment.kt
@@ -73,6 +73,15 @@ class SmsSettingsFragment : DSLSettingsFragment(R.string.preferences__sms_mms) {
         }
       )
 
+      switchPref(
+        title = DSLSettingsText.from(R.string.preferences__allow_sms_mms_from_self),
+        summary = DSLSettingsText.from(R.string.preferences__allow_sms_mms_from_self_summary),
+        isChecked = state.smsMmsFromSelfEnabled,
+        onClick = {
+          viewModel.setSmsMmsFromOwnNumberEnabled(!state.smsMmsFromSelfEnabled)
+        }
+      )
+
       if (Build.VERSION.SDK_INT < 21) {
         clickPref(
           title = DSLSettingsText.from(R.string.preferences__advanced_mms_access_point_names),

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/chats/sms/SmsSettingsState.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/chats/sms/SmsSettingsState.kt
@@ -3,5 +3,6 @@ package org.thoughtcrime.securesms.components.settings.app.chats.sms
 data class SmsSettingsState(
   val useAsDefaultSmsApp: Boolean,
   val smsDeliveryReportsEnabled: Boolean,
-  val wifiCallingCompatibilityEnabled: Boolean
+  val wifiCallingCompatibilityEnabled: Boolean,
+  val smsMmsFromSelfEnabled: Boolean
 )

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/chats/sms/SmsSettingsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/chats/sms/SmsSettingsViewModel.kt
@@ -13,7 +13,8 @@ class SmsSettingsViewModel : ViewModel() {
     SmsSettingsState(
       useAsDefaultSmsApp = Util.isDefaultSmsProvider(ApplicationDependencies.getApplication()),
       smsDeliveryReportsEnabled = SignalStore.settings().isSmsDeliveryReportsEnabled,
-      wifiCallingCompatibilityEnabled = SignalStore.settings().isWifiCallingCompatibilityModeEnabled
+      wifiCallingCompatibilityEnabled = SignalStore.settings().isWifiCallingCompatibilityModeEnabled,
+      smsMmsFromSelfEnabled = SignalStore.settings().isSmsMmsFromSelfAllowed
     )
   )
 
@@ -27,6 +28,11 @@ class SmsSettingsViewModel : ViewModel() {
   fun setWifiCallingCompatibilityEnabled(enabled: Boolean) {
     store.update { it.copy(wifiCallingCompatibilityEnabled = enabled) }
     SignalStore.settings().isWifiCallingCompatibilityModeEnabled = enabled
+  }
+
+  fun setSmsMmsFromOwnNumberEnabled(enabled: Boolean) {
+    store.update { it.copy(smsMmsFromSelfEnabled = enabled) }
+    SignalStore.settings().isSmsMmsFromSelfAllowed = enabled
   }
 
   fun checkSmsEnabled() {

--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/MmsReceiveJob.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/MmsReceiveJob.java
@@ -14,6 +14,7 @@ import org.thoughtcrime.securesms.database.SignalDatabase;
 import org.thoughtcrime.securesms.dependencies.ApplicationDependencies;
 import org.thoughtcrime.securesms.jobmanager.Data;
 import org.thoughtcrime.securesms.jobmanager.Job;
+import org.thoughtcrime.securesms.keyvalue.SignalStore;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.util.Base64;
 import org.thoughtcrime.securesms.util.Util;
@@ -73,7 +74,7 @@ public class MmsReceiveJob extends BaseJob {
 
     if (isNotification(pdu) && isBlocked(pdu)) {
       Log.w(TAG, "Received an MMS from a blocked user. Ignoring.");
-    } else if (isNotification(pdu) && isSelf(pdu)) {
+    } else if (isNotification(pdu) && isSelf(pdu) && !SignalStore.settings().isSmsMmsFromSelfAllowed()) {
       Log.w(TAG, "Received an MMS from ourselves! Ignoring.");
     } else if (isNotification(pdu)) {
       MessageDatabase  database           = SignalDatabase.mms();

--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/SmsReceiveJob.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/SmsReceiveJob.java
@@ -117,7 +117,7 @@ public class SmsReceiveJob extends BaseJob {
       }
     }
 
-    if (message.isPresent() && SignalStore.account().getE164() != null && message.get().getSender().equals(Recipient.self().getId())) {
+    if (message.isPresent() && isMessageFromSelf(message.get()) && !SignalStore.settings().isSmsMmsFromSelfAllowed()) {
       Log.w(TAG, "Received an SMS from ourselves! Ignoring.");
     } else if (message.isPresent() && !isBlocked(message.get())) {
       Optional<InsertResult> insertResult = storeMessage(message.get());
@@ -141,6 +141,10 @@ public class SmsReceiveJob extends BaseJob {
   public boolean onShouldRetry(@NonNull Exception exception) {
     return exception instanceof MigrationPendingException ||
            exception instanceof RetryLaterException;
+  }
+
+  private boolean isMessageFromSelf(IncomingTextMessage message) {
+    return SignalStore.account().getE164() != null && message.getSender().equals(Recipient.self().getId());
   }
 
   private boolean isBlocked(IncomingTextMessage message) {

--- a/app/src/main/java/org/thoughtcrime/securesms/keyvalue/SettingsValues.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyvalue/SettingsValues.java
@@ -110,7 +110,8 @@ public final class SettingsValues extends SignalStoreValues {
                          CALL_VIBRATE_ENABLED,
                          NOTIFY_WHEN_CONTACT_JOINS_SIGNAL,
                          UNIVERSAL_EXPIRE_TIMER,
-                         SENT_MEDIA_QUALITY);
+                         SENT_MEDIA_QUALITY,
+                         SMS_MMS_FROM_SELF);
   }
 
   public @NonNull LiveData<String> getOnConfigurationSettingChanged() {

--- a/app/src/main/java/org/thoughtcrime/securesms/keyvalue/SettingsValues.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyvalue/SettingsValues.java
@@ -49,6 +49,7 @@ public final class SettingsValues extends SignalStoreValues {
   public static final  String ENTER_KEY_SENDS                         = "settings.enter.key.sends";
   public static final  String BACKUPS_ENABLED                         = "settings.backups.enabled";
   public static final  String SMS_DELIVERY_REPORTS_ENABLED            = "settings.sms.delivery.reports.enabled";
+  public static final  String SMS_MMS_FROM_SELF                       = "settings.sms.mms.from.self";
   public static final  String WIFI_CALLING_COMPATIBILITY_MODE_ENABLED = "settings.wifi.calling.compatibility.mode.enabled";
   public static final  String MESSAGE_NOTIFICATIONS_ENABLED           = "settings.message.notifications.enabled";
   public static final  String MESSAGE_NOTIFICATION_SOUND              = "settings.message.notifications.sound";
@@ -245,6 +246,14 @@ public final class SettingsValues extends SignalStoreValues {
 
   public void setWifiCallingCompatibilityModeEnabled(boolean wifiCallingCompatibilityModeEnabled) {
     putBoolean(WIFI_CALLING_COMPATIBILITY_MODE_ENABLED, wifiCallingCompatibilityModeEnabled);
+  }
+
+  public boolean isSmsMmsFromSelfAllowed() {
+    return getBoolean(SMS_MMS_FROM_SELF, false);
+  }
+
+  public void setSmsMmsFromSelfAllowed(boolean acceptMessagesFromSelf) {
+    putBoolean(SMS_MMS_FROM_SELF, acceptMessagesFromSelf);
   }
 
   public void setMessageNotificationsEnabled(boolean messageNotificationsEnabled) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2527,6 +2527,8 @@
     <string name="preferences__delete_account">Delete account</string>
     <string name="preferences__support_wifi_calling">\'WiFi Calling\' compatibility mode</string>
     <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Enable if your device uses SMS/MMS delivery over WiFi (only enable when \'WiFi Calling\' is enabled on your device)</string>
+    <string name="preferences__allow_sms_mms_from_self">Allow SMS/MMS from self</string>
+    <string name="preferences__allow_sms_mms_from_self_summary">Enable if you need to receive SMS/MMS messages that have your own number as sender</string>
     <string name="preferences__incognito_keyboard">Incognito keyboard</string>
     <string name="preferences__read_receipts">Read receipts</string>
     <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">If read receipts are disabled, you won\'t be able to see read receipts from others.</string>


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nokia 3.1, Android 10
 * Samsung S5 mini, Android 5.1
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Someone opened an issue recently, about not being able to receive SMS's from their own number, https://github.com/signalapp/Signal-Android/issues/12165

While that feature has been disabled to prevent some spamming that was going around, 
the person that opened the issue made a good argument in this comment https://github.com/signalapp/Signal-Android/issues/12165#issuecomment-1099867282 for having the option to allow messages from self, 
so I added such an option in the SMS and MMS menu, that is disabled by default, so the majority of the userbase is protected from the spam.

And the arguably small percentage of the userbase that have legitimate real world use cases for receiving messages from their own number, don't see the app's usefulness reduced.

<details> 

<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/77681918/163712735-c19dd185-4b96-4dad-95ab-87362cd7e81a.png)

</details> 

The strings could probably be improved 🤔
