### PR TITLE
Fix SMS delivery reports.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/SmsSendJob.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/SmsSendJob.java
@@ -19,6 +19,7 @@ import org.thoughtcrime.securesms.dependencies.ApplicationDependencies;
 import org.thoughtcrime.securesms.jobmanager.Data;
 import org.thoughtcrime.securesms.jobmanager.Job;
 import org.thoughtcrime.securesms.jobmanager.impl.NetworkOrCellServiceConstraint;
+import org.thoughtcrime.securesms.keyvalue.SignalStore;
 import org.thoughtcrime.securesms.phonenumbers.NumberUtil;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.service.SmsDeliveryListener;
@@ -186,7 +187,7 @@ public class SmsSendJob extends SendJob {
   }
 
   private ArrayList<PendingIntent> constructDeliveredIntents(long messageId, long type, ArrayList<String> messages) {
-    if (!TextSecurePreferences.isSmsDeliveryReportsEnabled(context)) {
+    if (!SignalStore.settings().isSmsDeliveryReportsEnabled()) {
       return null;
     }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Moto X Play, Android 7.1.1

- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fix #11444
Fix #11807 


TextSecurePreferences.isSmsDeliveryReportsEnabled was marked as deprected on May 2021.

https://github.com/signalapp/Signal-Android/blob/f2d5ea03919933e7c02f6d15a379e1372c9bfae6/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java#L945-L948

The new file SMSSettingsFragment was introduced.

https://github.com/signalapp/Signal-Android/blob/f2d5ea03919933e7c02f6d15a379e1372c9bfae6/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/chats/sms/SmsSettingsFragment.kt#L50-L57

and the SMS_DELIVERY_REPORTS_ENABLED

https://github.com/signalapp/Signal-Android/blob/f2d5ea03919933e7c02f6d15a379e1372c9bfae6/app/src/main/java/org/thoughtcrime/securesms/keyvalue/SettingsValues.java#L43

<br><br><br>


![signal-2022-04-23-223621_001](https://user-images.githubusercontent.com/49990901/164945489-269007e1-cd3a-4b0c-8d35-725894ba0b19.jpeg)


![signal-2022-04-23-223621_002](https://user-images.githubusercontent.com/49990901/164945490-507706b4-1599-4109-ab00-bf1e3e81e20a.jpeg)
![signal-2022-04-23-223621_003](https://user-images.githubusercontent.com/49990901/164945491-4e55329c-2891-4c9b-bf56-59e097bfca30.jpeg)


