### PR TITLE
Replace use of AlertDialog.Builder with MaterialAlertDialogBuilder.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/groups/ui/addmembers/AddMembersActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/ui/addmembers/AddMembersActivity.java
@@ -7,8 +7,9 @@ import android.view.View;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
 import androidx.lifecycle.ViewModelProviders;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.thoughtcrime.securesms.ContactSelectionActivity;
 import org.thoughtcrime.securesms.ContactSelectionListFragment;
@@ -140,7 +141,7 @@ public class AddMembersActivity extends PushContactSelectionActivity {
     String message = getResources().getQuantityString(R.plurals.AddMembersActivity__add_d_members_to_s, state.getSelectionCount(),
                                                       recipient.getDisplayName(this), state.getGroupTitle(), state.getSelectionCount());
 
-    new AlertDialog.Builder(this)
+    new MaterialAlertDialogBuilder(this)
                    .setMessage(message)
                    .setNegativeButton(android.R.string.cancel, (dialog, which) -> dialog.cancel())
                    .setPositiveButton(R.string.AddMembersActivity__add, (dialog, which) -> {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Moto X Play, Android 7.1.1

- [X] My contribution is fully baked and ready to be merged as is

----------

### Description
Uses the MaterialAlertDialogBuilder in AddMembersActivity.displayAlertMessage(...)

Old: AlertDialog.Builder

![signal-2022-04-27-212948_001](https://user-images.githubusercontent.com/49990901/165609364-c6ab22be-5bf9-441b-8740-746831e30509.jpeg)

New: MaterialAlertDialogBuilder

![signal-2022-04-27-212948_002](https://user-images.githubusercontent.com/49990901/165609418-07b32513-9cda-4c53-8921-7219635fa741.jpeg)

With max font and display size in Android settings

![signal-2022-04-27-214454](https://user-images.githubusercontent.com/49990901/165616465-cd083e69-6bdf-4c67-9832-8d2b7c6adf8e.jpeg)




