### PR TITLE
Use separate URL for Fog Report

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/payments/MobileCoinConfig.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/MobileCoinConfig.java
@@ -27,6 +27,8 @@ public abstract class MobileCoinConfig {
 
   abstract @NonNull Uri getFogUri();
 
+  abstract @NonNull Uri getFogReportUri();
+
   abstract @NonNull byte[] getFogAuthoritySpki();
 
   abstract @NonNull AuthCredentials getAuth() throws IOException;

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/MobileCoinMainNetConfig.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/MobileCoinMainNetConfig.java
@@ -37,6 +37,11 @@ final class MobileCoinMainNetConfig extends MobileCoinConfig {
   }
 
   @Override
+  @NonNull Uri getFogReportUri() {
+    return Uri.parse("fog://fog-rpt-prd.namda.net");
+  }
+
+  @Override
   @NonNull byte[] getFogAuthoritySpki() {
     return Base64.decodeOrThrow("MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAxaNIOgcoQtq0S64dFVha\n"
                                 + "6rn0hDv/ec+W0cKRdFKygiyp5xuWdW3YKVAkK1PPgSDD2dwmMN/1xcGWrPMqezx1\n"

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/MobileCoinTestNetConfig.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/MobileCoinTestNetConfig.java
@@ -43,6 +43,11 @@ final class MobileCoinTestNetConfig extends MobileCoinConfig {
   }
 
   @Override
+  @NonNull Uri getFogReportUri() {
+    return Uri.parse("fog://fog-rpt-stg.namda.net");
+  }
+
+  @Override
   @NonNull byte[] getFogAuthoritySpki() {
     return Base64.decodeOrThrow("MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAoCMq8nnjTq5EEQ4EI7yr\n"
                                 + "ABL9P4y4h1P/h0DepWgXx+w/fywcfRSZINxbaMpvcV3uSJayExrpV1KmaS2wfASe\n"

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/Wallet.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/Wallet.java
@@ -59,7 +59,7 @@ public final class Wallet {
   public Wallet(@NonNull MobileCoinConfig mobileCoinConfig, @NonNull Entropy paymentsEntropy) {
     this.mobileCoinConfig = mobileCoinConfig;
     try {
-      this.account       = AccountKey.fromBip39Entropy(paymentsEntropy.getBytes(), 0, mobileCoinConfig.getFogUri(), "", mobileCoinConfig.getFogAuthoritySpki());
+      this.account       = AccountKey.fromBip39Entropy(paymentsEntropy.getBytes(), 0, mobileCoinConfig.getFogReportUri(), "", mobileCoinConfig.getFogAuthoritySpki());
       this.publicAddress = new MobileCoinPublicAddress(account.getPublicAddress());
 
       this.mobileCoinClient = new MobileCoinClient(account,


### PR DESCRIPTION
### First-time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 5, Android 12
 * Pixel 3a, Android 12
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
The Fog Report URL inflates the size of the `MobileCoinPublicAddress`. 
This PR adds the `getFogReportUri()` method to the `MobileCoinConfig` which provides a shorter Fog Report URL for use in the `Wallet` class which in turn will create a shorter `MobileCoinPublicAddress`. The rest of the services will continue to use the `getFogUri()` method as they were.
