### PR TITLE
Remove redundant call of ConversationTitleView.updateVerifiedSubtitle…

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationTitleView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationTitleView.java
@@ -177,7 +177,6 @@ public class ConversationTitleView extends RelativeLayout {
     this.title.setText(displayName);
     this.subtitle.setText(null);
     updateSubtitleVisibility();
-    updateVerifiedSubtitleVisibility();
   }
 
   private void updateVerifiedSubtitleVisibility() {


### PR DESCRIPTION
…Visibility

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Moto X Play, 7.1.1

- [X] My contribution is fully baked and ready to be merged as is

----------

### Description

In `conversationTitleView.setIndividualRecipientTitle` `updateSubtitleVisibility` is called.
The `updateSubtitleVisibility` calls `updateVerifiedSubtitleVisibility`.
After returning to `setIndividualRecipientTitle` the `updateVerifiedSubtitleVisibility` is called again.

https://github.com/signalapp/Signal-Android/blob/38836198a1813c8d7c02d7c68feea8fbcb00bb19/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationTitleView.java#L175-L190