### PR TITLE
Keep action mode visible until message deletion is confirmed

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
@@ -828,7 +828,6 @@ public class ConversationFragment extends LoggingFragment implements Multiselect
     if (menuState.shouldShowDeleteAction()) {
       items.add(new ActionItem(R.drawable.ic_delete_tinted_24, getResources().getString(R.string.conversation_selection__menu_delete), () -> {
         handleDeleteMessages(selectedParts);
-        actionMode.finish();
       }));
     }
 
@@ -1004,6 +1003,7 @@ public class ConversationFragment extends LoggingFragment implements Multiselect
     builder.setCancelable(true);
 
     builder.setPositiveButton(R.string.ConversationFragment_delete_for_me, (dialog, which) -> {
+      closeActionModeIfOpen();
       new ProgressDialogAsyncTask<Void, Void, Void>(getActivity(),
                                                     R.string.ConversationFragment_deleting,
                                                     R.string.ConversationFragment_deleting_messages)
@@ -1033,7 +1033,10 @@ public class ConversationFragment extends LoggingFragment implements Multiselect
     });
 
     if (RemoteDeleteUtil.isValidSend(messageRecords, System.currentTimeMillis())) {
-      builder.setNeutralButton(R.string.ConversationFragment_delete_for_everyone, (dialog, which) -> handleDeleteForEveryone(messageRecords));
+      builder.setNeutralButton(R.string.ConversationFragment_delete_for_everyone, (dialog, which) -> {
+        closeActionModeIfOpen();
+        handleDeleteForEveryone(messageRecords);
+      });
     }
 
     builder.setNegativeButton(android.R.string.cancel, null);

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
@@ -507,9 +507,7 @@ public class ConversationFragment extends LoggingFragment implements Multiselect
   public void onNewIntent() {
     Log.d(TAG, "[onNewIntent]");
 
-    if (actionMode != null) {
-      actionMode.finish();
-    }
+    closeActionModeIfOpen();
 
     long oldThreadId = threadId;
 
@@ -1131,6 +1129,12 @@ public class ConversationFragment extends LoggingFragment implements Multiselect
                    Toast.LENGTH_LONG).show();
   }
 
+  private void closeActionModeIfOpen() {
+    if (actionMode != null) {
+      actionMode.finish();
+    }
+  }
+
   public long stageOutgoingMessage(OutgoingMediaMessage message) {
     MessageRecord messageRecord = MmsDatabase.readerFor(message, threadId).getCurrent();
 
@@ -1368,9 +1372,7 @@ public class ConversationFragment extends LoggingFragment implements Multiselect
 
   @Override
   public void onFinishForwardAction() {
-    if (actionMode != null) {
-      actionMode.finish();
-    }
+    closeActionModeIfOpen();
   }
 
   @Override

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java
@@ -997,14 +997,14 @@ public class ConversationFragment extends LoggingFragment implements Multiselect
   private AlertDialog.Builder buildRemoteDeleteConfirmationDialog(Set<MessageRecord> messageRecords) {
     Context             context       = requireActivity();
     int                 messagesCount = messageRecords.size();
-    AlertDialog.Builder builder       = new MaterialAlertDialogBuilder(getActivity());
+    AlertDialog.Builder builder       = new MaterialAlertDialogBuilder(context);
 
-    builder.setTitle(getActivity().getResources().getQuantityString(R.plurals.ConversationFragment_delete_selected_messages, messagesCount, messagesCount));
+    builder.setTitle(context.getResources().getQuantityString(R.plurals.ConversationFragment_delete_selected_messages, messagesCount, messagesCount));
     builder.setCancelable(true);
 
     builder.setPositiveButton(R.string.ConversationFragment_delete_for_me, (dialog, which) -> {
       closeActionModeIfOpen();
-      new ProgressDialogAsyncTask<Void, Void, Void>(getActivity(),
+      new ProgressDialogAsyncTask<Void, Void, Void>(context,
                                                     R.string.ConversationFragment_deleting,
                                                     R.string.ConversationFragment_deleting_messages)
       {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nokia 3.1, Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Currently the action mode is closed as soon as you tap the "delete" button,  which means that if you change your mind, and tap "cancel" at the confirmation dialog, your message selection is gone, and you need to start all over again. 

I made it so it will close the action mode only if the confirmation dialog starts one of the "delete for me" or "delete for everyone" actions. 

<details> 
<summary> Before </summary>

![image](https://user-images.githubusercontent.com/77681918/166565987-a967651f-ee06-4ddc-847d-854dd8773bce.png)


</details>

<details>
<summary> After </summary>

![image](https://user-images.githubusercontent.com/77681918/166566039-dcfc5880-8bfb-45fd-9978-361b393a3421.png)


</details>


As an added benefit, this will also maintain the selection count on the top bar, during the confirmation dialog, which will provide a visual aid for an interesting translation edge case. 

According to the [pluralization rules](https://unicode-org.github.io/cldr-staging/charts/latest/supplemental/language_plural_rules.html?utm_source=hs_email&utm_medium=email) languages like Lithuanian, Russian, Ukrainian use the same pluralization variant for 1 and 21, the `one` variant 

![image](https://user-images.githubusercontent.com/77681918/166574290-43a8c828-ff0c-4144-95f7-3980bfad935d.png)


and since this string, is pluralized.

https://github.com/signalapp/Signal-Android/blob/38836198a1813c8d7c02d7c68feea8fbcb00bb19/app/src/main/res/values/strings.xml#L320-L323

and depends on the selected message count

https://github.com/signalapp/Signal-Android/blob/38836198a1813c8d7c02d7c68feea8fbcb00bb19/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java#L1005

The user will be presented with the same translation for 1 selection and for 21 selections, so having the count still visible might be helpful, for the 21 scenario.

thanks to @u32i64 for the translation observations.

A few suggestions: 
 - Perhaps going forward, a general rule of thumb should be to never pluralize strings that don't contain a placeholder for the item count they are referring to, and instead use more generalized language. 
- The grey for the selection highlight should be reconsidered for dark mode, considering the alert dialog is also grey.
<details>
<summary> Dark mode Screenshot</summary>

![image](https://user-images.githubusercontent.com/77681918/166582743-f39c6baa-192b-4c72-a25c-a41bb11f4a1a.png)

</details>

<details>
<summary> Light mode Screenshot</summary>

![image](https://user-images.githubusercontent.com/77681918/166582469-814644d8-6495-48c8-abf0-38662b004ffd.png)

</details>


Regarding the last commit https://github.com/signalapp/Signal-Android/commit/3f0dce1a6de0eee3d88faf29c5ec2e7f9717482a, feel free to leave it out,
but I've noticed there was an unused Context variable, and I assumed it was added to replace subsequent `getActivity()` calls and prevent a possible NPE in this method

https://github.com/signalapp/Signal-Android/blob/38836198a1813c8d7c02d7c68feea8fbcb00bb19/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationFragment.java#L999-L1012





