### PR TITLE
Add divider in ChatSettingsFragment

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/chats/ChatsSettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/chats/ChatsSettingsFragment.kt
@@ -39,6 +39,8 @@ class ChatsSettingsFragment : DSLSettingsFragment(R.string.preferences_chats__ch
         }
       )
 
+      dividerPref()
+
       switchPref(
         title = DSLSettingsText.from(R.string.preferences__generate_link_previews),
         summary = DSLSettingsText.from(R.string.preferences__retrieve_link_previews_from_websites_for_messages),


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual Pixel XL, Android 12
- [X] My contribution is fully baked and ready to be merged as is


----------

### Description

Adds a divider between "SMS and MMS" and "Generate link previews".

![Screenshot_1651998550](https://user-images.githubusercontent.com/49990901/167288745-7e7798a5-7e45-4906-8762-82fa89a016e1.png) ![Screenshot_1651999221](https://user-images.githubusercontent.com/49990901/167288749-3a0b75d8-51b7-4011-a56d-79650acc132a.png)

