### PR TITLE
Change text when blocking/unblocking unregistered recipient

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/BlockUnblockDialog.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/BlockUnblockDialog.java
@@ -83,7 +83,8 @@ public final class BlockUnblockDialog {
       builder.setNegativeButton(android.R.string.cancel, null);
     } else {
       builder.setTitle(resources.getString(R.string.BlockUnblockDialog_block_s, recipient.getDisplayName(context)));
-      builder.setMessage(R.string.BlockUnblockDialog_blocked_people_wont_be_able_to_call_you_or_send_you_messages);
+      builder.setMessage(recipient.isRegistered() ? R.string.BlockUnblockDialog_blocked_people_wont_be_able_to_call_you_or_send_you_messages
+                                                  : R.string.BlockUnblockDialog_blocked_people_wont_be_able_to_send_you_messages);
 
       if (onBlockAndReportSpam != null) {
         builder.setNeutralButton(android.R.string.cancel, null);
@@ -128,7 +129,8 @@ public final class BlockUnblockDialog {
       builder.setNegativeButton(android.R.string.cancel, null);
     } else {
       builder.setTitle(resources.getString(R.string.BlockUnblockDialog_unblock_s, recipient.getDisplayName(context)));
-      builder.setMessage(R.string.BlockUnblockDialog_you_will_be_able_to_call_and_message_each_other);
+      builder.setMessage(recipient.isRegistered() ? R.string.BlockUnblockDialog_you_will_be_able_to_call_and_message_each_other
+                                                  : R.string.BlockUnblockDialog_you_will_be_able_to_message_each_other);
       builder.setPositiveButton(R.string.RecipientPreferenceActivity_unblock, ((dialog, which) -> onUnblock.run()));
       builder.setNegativeButton(android.R.string.cancel, null);
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/messagerequests/MessageRequestsBottomView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/messagerequests/MessageRequestsBottomView.java
@@ -76,7 +76,8 @@ public class MessageRequestsBottomView extends ConstraintLayout {
     switch (messageData.getMessageState()) {
       case BLOCKED_INDIVIDUAL:
         int message = recipient.isReleaseNotes() ? R.string.MessageRequestBottomView_get_updates_and_news_from_s_you_wont_receive_any_updates_until_you_unblock_them
-                                                 : R.string.MessageRequestBottomView_do_you_want_to_let_s_message_you_wont_receive_any_messages_until_you_unblock_them;
+                                                 : recipient.isRegistered() ? R.string.MessageRequestBottomView_do_you_want_to_let_s_message_you_wont_receive_any_messages_until_you_unblock_them
+                                                                            : R.string.MessageRequestBottomView_do_you_want_to_let_s_message_you_wont_receive_any_messages_until_you_unblock_them_SMS;
 
         question.setText(HtmlCompat.fromHtml(getContext().getString(message,
                                                                     HtmlUtil.bold(recipient.getShortDisplayName(getContext()))), 0));

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,7 +115,9 @@
     <string name="BlockUnblockDialog_group_members_wont_be_able_to_add_you">Group members won\'t be able to add you to this group again.</string>
     <string name="BlockUnblockDialog_group_members_will_be_able_to_add_you">Group members will be able to add you to this group again.</string>
     <string name="BlockUnblockDialog_you_will_be_able_to_call_and_message_each_other">You will be able to message and call each other and your name and photo will be shared with them.</string>
+    <string name="BlockUnblockDialog_you_will_be_able_to_message_each_other">You will be able to message each other.</string>
     <string name="BlockUnblockDialog_blocked_people_wont_be_able_to_call_you_or_send_you_messages">Blocked people won\'t be able to call you or send you messages.</string>
+    <string name="BlockUnblockDialog_blocked_people_wont_be_able_to_send_you_messages">Blocked people won\'t be able to send you messages.</string>
     <!-- Message shown on block dialog when blocking the Signal release notes recipient -->
     <string name="BlockUnblockDialog_block_getting_signal_updates_and_news">Block getting Signal updates and news.</string>
     <!-- Message shown on unblock dialog when unblocking the Signal release notes recipient -->
@@ -1317,6 +1319,7 @@
     <string name="MessageRequestBottomView_unblock">Unblock</string>
     <string name="MessageRequestBottomView_do_you_want_to_let_s_message_you_they_wont_know_youve_seen_their_messages_until_you_accept">Let %1$s message you and share your name and photo with them? They won\'t know you\'ve seen their message until you accept.</string>
     <string name="MessageRequestBottomView_do_you_want_to_let_s_message_you_wont_receive_any_messages_until_you_unblock_them">Let %1$s message you and share your name and photo with them? You won\'t receive any messages until you unblock them.</string>
+    <string name="MessageRequestBottomView_do_you_want_to_let_s_message_you_wont_receive_any_messages_until_you_unblock_them_SMS">Let %1$s message you? You won\'t receive any messages until you unblock them.</string>
     <string name="MessageRequestBottomView_get_updates_and_news_from_s_you_wont_receive_any_updates_until_you_unblock_them">Get updates and news from %1$s? You won\'t receive any updates until you unblock them.</string>
     <string name="MessageRequestBottomView_continue_your_conversation_with_this_group_and_share_your_name_and_photo">Continue your conversation with this group and share your name and photo with its members?</string>
     <string name="MessageRequestBottomView_upgrade_this_group_to_activate_new_features">Upgrade this group to activate new features like @mentions and admins. Members who have not shared their name or photo in this group will be invited to join.</string>


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:

 * Moto X Play, Android 7.1.1
 
- [X] My contribution is fully baked and ready to be merged as is

----------

### Description

Adds text for blocking/unblocking unregistered recipients (SMS contacts).

When blocking a SMS contact, Signal shows:
`Blocked people won't be able to call you or send you messages.`
A blocked SMS contact can still call you. So adding the new string:
`Blocked people won\'t be able to send you messages.`

The MessageRequestBottom shows:
`Let %1$s message you and share your name and photo with them? You won't receive any messages until you unblock them.`
It's a SMS contact so no sharing of name or photo when unblocked. Adding the new string:
`Let %1$s message you? You won\'t receive any messages until you unblock them.`

The unblocking text shows:
`You will be able to message and call each other and your name and photo will be shared with them.`
The new string:
`You will be able to message each other.`
