### PR TITLE
Fix swapped group title & avatar on rtl layout

### DIFF
--- a/app/src/main/res/layout/conversation_settings_toolbar.xml
+++ b/app/src/main/res/layout/conversation_settings_toolbar.xml
@@ -27,45 +27,52 @@
         app:layout_constraintTop_toTopOf="parent"
         app:navigationIcon="@drawable/ic_arrow_left_24">
 
-        <FrameLayout
-            android:id="@+id/toolbar_avatar_container"
+        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="16dp"
-            android:alpha="0"
-            android:translationY="56dp"
-            tools:alpha="1"
-            tools:translationY="0dp">
+            android:gravity="start">
 
-            <org.thoughtcrime.securesms.components.AvatarImageView
-                android:id="@+id/toolbar_avatar"
-                android:layout_width="36dp"
-                android:layout_height="36dp"
-                app:fallbackImageSize="small" />
+            <FrameLayout
+                android:id="@+id/toolbar_avatar_container"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:alpha="0"
+                android:translationY="56dp"
+                tools:alpha="1"
+                tools:translationY="0dp">
 
-            <org.thoughtcrime.securesms.badges.BadgeImageView
-                android:id="@+id/toolbar_badge"
-                android:layout_width="16dp"
-                android:layout_height="16dp"
-                android:layout_marginStart="20dp"
-                android:layout_marginTop="23dp"
-                app:badge_size="small" />
+                <org.thoughtcrime.securesms.components.AvatarImageView
+                    android:id="@+id/toolbar_avatar"
+                    android:layout_width="36dp"
+                    android:layout_height="36dp"
+                    app:fallbackImageSize="small" />
 
-        </FrameLayout>
+                <org.thoughtcrime.securesms.badges.BadgeImageView
+                    android:id="@+id/toolbar_badge"
+                    android:layout_width="16dp"
+                    android:layout_height="16dp"
+                    android:layout_marginStart="20dp"
+                    android:layout_marginTop="23dp"
+                    app:badge_size="small" />
 
-        <org.thoughtcrime.securesms.components.emoji.EmojiTextView
-            android:id="@+id/toolbar_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:alpha="0"
-            android:ellipsize="end"
-            android:gravity="center_vertical"
-            android:maxLines="1"
-            android:textAppearance="@style/Signal.Text.Title"
-            android:translationY="56dp"
-            tools:alpha="1"
-            tools:text="Miles Morales"
-            tools:translationY="0dp" />
+            </FrameLayout>
+
+                <org.thoughtcrime.securesms.components.emoji.EmojiTextView
+                    android:id="@+id/toolbar_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:layout_marginStart="16dp"
+                    android:alpha="0"
+                    android:ellipsize="end"
+                    android:gravity="center_vertical"
+                    android:maxLines="1"
+                    android:textAppearance="@style/Signal.Text.Title"
+                    android:translationY="56dp"
+                    tools:alpha="1"
+                    tools:text="Miles Morales"
+                    tools:translationY="0dp" />
+
+        </LinearLayout>
 
     </org.thoughtcrime.securesms.util.views.DarkOverflowToolbar>
 


### PR DESCRIPTION
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Header title & avatar appear swapped in group description when the layout is RTL.

### Steps to reproduce
1. Change app language to rtl-based language (for example Arabic)
2. Create a group
3. Go to group description
4. Scroll down until the header appears


### Screenshots
- Before the fix 

![20220523_093459](https://user-images.githubusercontent.com/56456198/169758849-610ca331-8edb-439a-bf74-da99a092f37b.jpg)


- After the fix

![20220523_093436](https://user-images.githubusercontent.com/56456198/169758874-c8b55cb3-91b6-4b88-8ea4-639f62827aeb.jpg)
 