### PR TITLE
Replace use of AlertDialog.Builder with MaterialAlertDialogBuilder.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/groups/ui/addtogroup/AddToGroupsActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/ui/addtogroup/AddToGroupsActivity.java
@@ -8,10 +8,10 @@ import android.view.View;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
 import androidx.lifecycle.ViewModelProviders;
 
 import com.annimon.stream.Stream;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.thoughtcrime.securesms.ContactSelectionActivity;
 import org.thoughtcrime.securesms.ContactSelectionListFragment;
@@ -84,12 +84,12 @@ public final class AddToGroupsActivity extends ContactSelectionActivity {
         Toast.makeText(this, ((Event.ToastEvent) event).getMessage(), Toast.LENGTH_SHORT).show();
       } else if (event instanceof Event.AddToSingleGroupConfirmationEvent) {
         Event.AddToSingleGroupConfirmationEvent addEvent = (Event.AddToSingleGroupConfirmationEvent) event;
-        new AlertDialog.Builder(this)
-                       .setTitle(addEvent.getTitle())
-                       .setMessage(addEvent.getMessage())
-                       .setPositiveButton(R.string.AddToGroupActivity_add, (dialog, which) -> viewModel.onAddToGroupsConfirmed(addEvent))
-                       .setNegativeButton(android.R.string.cancel, null)
-                       .show();
+        new MaterialAlertDialogBuilder(this)
+           .setTitle(addEvent.getTitle())
+           .setMessage(addEvent.getMessage())
+           .setPositiveButton(R.string.AddToGroupActivity_add, (dialog, which) -> viewModel.onAddToGroupsConfirmed(addEvent))
+           .setNegativeButton(android.R.string.cancel, null)
+           .show();
       } else if (event instanceof Event.LegacyGroupDenialEvent) {
         Toast.makeText(this, R.string.AddToGroupActivity_this_person_cant_be_added_to_legacy_groups, Toast.LENGTH_SHORT).show();
       } else {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual Pixel XL, Android 12
- [X] My contribution is fully baked and ready to be merged as is


----------

### Description
Uses the MaterialAlertDialogBuilder in AddToGroupsActivity.onCreate(...)
