### PR TITLE
Add "existing group" picker dialog to new group flow

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/groups/ui/creategroup/CreateGroupActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/ui/creategroup/CreateGroupActivity.java
@@ -19,7 +19,9 @@ import org.thoughtcrime.securesms.ContactSelectionListFragment;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.contacts.ContactsCursorLoader;
 import org.thoughtcrime.securesms.contacts.sync.ContactDiscovery;
+import org.thoughtcrime.securesms.database.GroupDatabase;
 import org.thoughtcrime.securesms.database.RecipientDatabase;
+import org.thoughtcrime.securesms.database.SignalDatabase;
 import org.thoughtcrime.securesms.groups.ui.creategroup.details.AddGroupDetailsActivity;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.RecipientId;
@@ -166,9 +168,17 @@ public class CreateGroupActivity extends ContactSelectionActivity {
 
       return ids;
     }, recipientIds -> {
+      List<GroupDatabase.GroupRecord> existingGroups = SignalDatabase.groups().getGroupsWithMembers(recipientIds);
+      stopwatch.split("group-search");
+
       dismissibleDialog.dismiss();
       stopwatch.stop(TAG);
-      startActivityForResult(AddGroupDetailsActivity.newIntent(this, recipientIds), REQUEST_CODE_ADD_DETAILS);
+      if (existingGroups.isEmpty()) {
+        startActivityForResult(AddGroupDetailsActivity.newIntent(this, recipientIds), REQUEST_CODE_ADD_DETAILS);
+      } else {
+        ExistingGroupChooserDialog existingGroupChooserDialog = new ExistingGroupChooserDialog(existingGroups, recipientIds);
+        existingGroupChooserDialog.show(getSupportFragmentManager(), "ExistingGroupChooserFragment");
+      }
     });
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/ui/creategroup/ExistingGroupChooserDialog.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/ui/creategroup/ExistingGroupChooserDialog.java
@@ -1,0 +1,79 @@
+package org.thoughtcrime.securesms.groups.ui.creategroup;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+import androidx.recyclerview.widget.RecyclerView;
+
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.conversation.ConversationIntents;
+import org.thoughtcrime.securesms.database.GroupDatabase;
+import org.thoughtcrime.securesms.database.SignalDatabase;
+import org.thoughtcrime.securesms.database.ThreadDatabase;
+import org.thoughtcrime.securesms.groups.ui.creategroup.details.AddGroupDetailsActivity;
+import org.thoughtcrime.securesms.recipients.Recipient;
+import org.thoughtcrime.securesms.recipients.RecipientId;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ExistingGroupChooserDialog extends DialogFragment {
+
+  private final int REQUEST_CODE = 2840;
+
+  private final List<GroupDatabase.GroupRecord> groups;
+  private final List<RecipientId>               recipientIds;
+
+  ExistingGroupChooserDialog(List<GroupDatabase.GroupRecord> groups, List<RecipientId> recipientIds) {
+    this.groups       = groups;
+    this.recipientIds = recipientIds;
+  }
+
+  @NonNull @Override public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+    AlertDialog.Builder alertBuilder = new AlertDialog.Builder(getActivity());
+
+    LayoutInflater inflater     = requireActivity().getLayoutInflater();
+    View           view         = inflater.inflate(R.layout.choose_existing_group_dialog, null);
+    RecyclerView   recyclerView = view.findViewById(R.id.selected_list);
+    ExistingGroupMappingAdapter adapter =
+        new ExistingGroupMappingAdapter(groups.stream()
+                                              .map(this::createModel)
+                                              .collect(Collectors.toList()),
+                                        this::onClick);
+    recyclerView.setAdapter(adapter);
+
+    view.findViewById(R.id.cancel_button).setOnClickListener(view1 -> {
+      ExistingGroupChooserDialog.this.getDialog().cancel();
+      startActivityForResult(AddGroupDetailsActivity.newIntent(requireActivity(), recipientIds),
+                             REQUEST_CODE);
+    });
+
+
+    return alertBuilder.setView(view).create();
+  }
+
+  private void onClick(ExistingGroupMappingAdapter.GroupModel group) {
+    long threadId = SignalDatabase.threads().getOrCreateThreadIdFor(group.getRecipient(),
+                                                                    ThreadDatabase.DistributionTypes.CONVERSATION);
+    Intent intent = ConversationIntents.createBuilder(requireActivity(),
+                                                      group.getRecipient().getId(),
+                                                      threadId)
+                                       .build();
+    startActivity(intent);
+    dismiss();
+    requireActivity().finish();
+  }
+
+  private ExistingGroupMappingAdapter.GroupModel createModel(GroupDatabase.GroupRecord record) {
+    RecipientId recipientId    = SignalDatabase.recipients().getOrInsertFromGroupId(record.getId());
+    Recipient   groupRecipient = Recipient.resolved(recipientId);
+    return new ExistingGroupMappingAdapter.GroupModel(groupRecipient);
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/ui/creategroup/ExistingGroupMappingAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/ui/creategroup/ExistingGroupMappingAdapter.java
@@ -1,0 +1,80 @@
+package org.thoughtcrime.securesms.groups.ui.creategroup;
+
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.components.AvatarImageView;
+import org.thoughtcrime.securesms.components.FromTextView;
+import org.thoughtcrime.securesms.recipients.Recipient;
+import org.thoughtcrime.securesms.util.adapter.mapping.LayoutFactory;
+import org.thoughtcrime.securesms.util.adapter.mapping.MappingAdapter;
+import org.thoughtcrime.securesms.util.adapter.mapping.MappingModel;
+import org.thoughtcrime.securesms.util.adapter.mapping.MappingViewHolder;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+class ExistingGroupMappingAdapter extends MappingAdapter {
+
+  private final List<GroupModel> groups;
+  private final Consumer<GroupModel> onClickListener;
+
+  ExistingGroupMappingAdapter(List<GroupModel> groups, Consumer<GroupModel> onClickListener) {
+    this.groups = groups;
+    this.onClickListener = onClickListener;
+    registerFactory(GroupModel.class,
+                    new LayoutFactory<>(GroupViewHolder::new, R.layout.group_selection_item));
+
+    submitList(Collections.unmodifiableList(groups));
+  }
+
+
+
+  static class GroupModel implements MappingModel<GroupModel> {
+
+    private final Recipient recipient;
+
+    GroupModel(Recipient recipient) {
+      this.recipient = recipient;
+    }
+
+    public Recipient getRecipient() {
+      return recipient;
+    }
+
+    @Override public boolean areItemsTheSame(@NonNull GroupModel newItem) {
+      return recipient.equals(newItem.recipient);
+    }
+
+    @Override public boolean areContentsTheSame(@NonNull GroupModel newItem) {
+      return recipient.hasSameContent(newItem.recipient);
+    }
+  }
+
+  private class GroupViewHolder extends MappingViewHolder<GroupModel> {
+
+    public GroupViewHolder(@NonNull View itemView) {
+      super(itemView);
+      itemView.setOnClickListener(view -> {
+        int pos = getAbsoluteAdapterPosition();
+        if (pos != RecyclerView.NO_POSITION) {
+          GroupModel model = groups.get(pos);
+          onClickListener.accept(model);
+        }
+      });
+    }
+
+    @Override public void bind(@NonNull GroupModel groupModel) {
+      FromTextView textView = findViewById(R.id.conversation_list_item_name);
+      AvatarImageView imageView = findViewById(R.id.conversation_list_item_avatar);
+
+      textView.setText(groupModel.getRecipient());
+      imageView.setAvatar(groupModel.getRecipient());
+    }
+
+  }
+}

--- a/app/src/main/res/layout/choose_existing_group_dialog.xml
+++ b/app/src/main/res/layout/choose_existing_group_dialog.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingVertical="12dp"
+        android:gravity="center"
+        android:text="@string/ChooseExistingGroup__choose"
+        android:textAppearance="@style/Signal.Text.Body"
+        android:textStyle="bold"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/selected_list"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingHorizontal="@dimen/dsl_settings_gutter"
+        app:layout_constrainedHeight="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHeight_max="300dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/title"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        tools:listitem="@layout/group_selection_item" />
+
+    <Button
+        android:id="@+id/cancel_button"
+        android:text="@string/contact_selection_activity__new_group"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginVertical="12dp"
+        android:layout_marginHorizontal="8dp"
+        app:layout_constraintTop_toBottomOf="@+id/selected_list"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/group_selection_item.xml
+++ b/app/src/main/res/layout/group_selection_item.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="@dimen/contact_selection_item_height"
+    android:paddingStart="@dimen/dsl_settings_gutter"
+    android:paddingEnd="@dimen/dsl_settings_gutter"
+    android:layout_marginBottom="3dp"
+    android:background="@drawable/rounded_rectangle">
+
+    <org.thoughtcrime.securesms.components.AvatarImageView
+        android:id="@+id/conversation_list_item_avatar"
+        android:layout_width="@dimen/conversation_list_avatar_size"
+        android:layout_height="@dimen/conversation_list_avatar_size"
+        android:layout_marginTop="4dp"
+        android:contentDescription="@string/conversation_list_item_view__contact_photo_image"
+        android:foreground="@drawable/contact_photo_background"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:src="@drawable/ic_contact_picture" />
+
+
+    <org.thoughtcrime.securesms.components.FromTextView
+        android:id="@+id/conversation_list_item_name"
+        style="@style/Signal.Text.BodyLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:drawablePadding="5dp"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textColor="@color/signal_colorOnSurface"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/conversation_list_item_avatar"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constrainedWidth="true"
+        tools:text="Long Chat name for overflow testing purposes" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5338,6 +5338,8 @@
     <!-- Button label to start export -->
     <string name="SetSignalAsDefaultSmsAppFragment__next">Next</string>
 
+    <string name="ChooseExistingGroup__choose">Reuse an existing group?</string>
+
     <!-- EOF -->
 
 </resources>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 5 Android 12
 * Virtual device Android 9
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This change adds a new dialog as part of the new group flow between the user selection and the group naming. The dialog only shows if there exists groups locally that match the added members. The dialog also allows the user to continue to create a new group.

The inspiration behind this is I often forget the name I set for old groups and occasionally create new groups when I would have preferred to find the old group.
![Member selection screen](https://user-images.githubusercontent.com/22810320/175802643-58165581-e19c-4039-9876-a8644fb6bb1e.png)

![New Dialog after the user presses next](https://user-images.githubusercontent.com/22810320/175802648-765c2fbd-d46b-4e3a-8837-10e8f883b1bd.png)


