### PR TITLE
Allow ScreenLockTimeout with seconds

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/PrivacySettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/PrivacySettingsFragment.kt
@@ -262,7 +262,7 @@ class PrivacySettingsFragment : DSLSettingsFragment(R.string.preferences__privac
                 val timeoutSeconds = TimeUnit.MILLISECONDS.toSeconds(duration)
                 viewModel.setScreenLockTimeout(timeoutSeconds)
               },
-              0, TimeDurationPicker.HH_MM
+              0, TimeDurationPicker.HH_MM_SS
             ).show()
           }
         )
@@ -359,13 +359,13 @@ class PrivacySettingsFragment : DSLSettingsFragment(R.string.preferences__privac
 
   private fun getScreenLockInactivityTimeoutSummary(timeoutSeconds: Long): String {
     val hours = TimeUnit.SECONDS.toHours(timeoutSeconds)
-    val minutes =
-      TimeUnit.SECONDS.toMinutes(timeoutSeconds) - TimeUnit.SECONDS.toHours(timeoutSeconds) * 60
+    val minutes = TimeUnit.SECONDS.toMinutes(timeoutSeconds) - hours * 60
+    val seconds = timeoutSeconds - minutes * 60 - hours * 3600
 
-    return if (timeoutSeconds <= 0) {
+    return if (timeoutSeconds < 5) {
       getString(R.string.AppProtectionPreferenceFragment_none)
     } else {
-      String.format(Locale.getDefault(), "%02d:%02d:00", hours, minutes)
+      String.format(Locale.getDefault(), "%02d:%02d:%02d", hours, minutes, seconds)
     }
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/service/KeyCachingService.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/KeyCachingService.java
@@ -235,7 +235,7 @@ public class KeyCachingService extends Service {
     boolean passLockActive   = timeoutEnabled && !TextSecurePreferences.isPasswordDisabled(context);
 
     long    screenTimeout    = TextSecurePreferences.getScreenLockTimeout(context);
-    boolean screenLockActive = screenTimeout >= 60 && TextSecurePreferences.isScreenLockEnabled(context);
+    boolean screenLockActive = screenTimeout >= 5 && TextSecurePreferences.isScreenLockEnabled(context);
 
     if (!appVisible && secretSet && (passLockActive || screenLockActive)) {
       long passphraseTimeoutMinutes = TextSecurePreferences.getPassphraseTimeoutInterval(context);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual Pixel XL, Android 12
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
fixes #10208 

Currently no seconds can be entered in TimeDurationPicker. Enabling seconds for the TimeDurationPicker.
