### PR TITLE
Fix one more place where Note to Self should be used.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/wallpaper/ChatWallpaperPreviewActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/wallpaper/ChatWallpaperPreviewActivity.java
@@ -97,7 +97,9 @@ public class ChatWallpaperPreviewActivity extends PassphraseRequiredActivity {
     final ChatColors chatColors;
     if (recipientId != null && Recipient.live(recipientId).get().hasOwnChatColors()) {
       Recipient recipient = Recipient.live(recipientId).get();
-      bubble2Text.setText(getString(R.string.ChatWallpaperPreviewActivity__set_wallpaper_for_s, recipient.getDisplayName(this)));
+      bubble2Text.setText(getString(R.string.ChatWallpaperPreviewActivity__set_wallpaper_for_s,
+                                    recipient.isSelf() ? getString(R.string.note_to_self)
+                                                       : recipient.getDisplayName(this)));
       chatColors = recipient.getChatColors();
       bubble2.addOnLayoutChangeListener((v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) -> {
         updateChatColors(chatColors);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual Pixel XL, Android 12
- [X] My contribution is fully baked and ready to be merged as is


----------

### Description

Show "Note to Self" when in ChatWallpaperPreview for "Note to Self"-Conversation settings.
