### PR TITLE
Use MaterialAlertDialogBuilder in RegistrationLockV2Dialog.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/pin/RegistrationLockV2Dialog.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/pin/RegistrationLockV2Dialog.java
@@ -8,6 +8,8 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import org.signal.core.util.concurrent.SignalExecutors;
 import org.signal.core.util.logging.Log;
 import org.thoughtcrime.securesms.R;
@@ -23,13 +25,13 @@ public final class RegistrationLockV2Dialog {
   private RegistrationLockV2Dialog() {}
 
   public static void showEnableDialog(@NonNull Context context, @NonNull Runnable onSuccess) {
-      AlertDialog dialog = new AlertDialog.Builder(context)
-                                          .setTitle(R.string.RegistrationLockV2Dialog_turn_on_registration_lock)
-                                          .setView(R.layout.registration_lock_v2_dialog)
-                                          .setMessage(R.string.RegistrationLockV2Dialog_if_you_forget_your_signal_pin_when_registering_again)
-                                          .setNegativeButton(android.R.string.cancel, null)
-                                          .setPositiveButton(R.string.RegistrationLockV2Dialog_turn_on, null)
-                                          .create();
+      AlertDialog dialog = new MaterialAlertDialogBuilder(context)
+                              .setTitle(R.string.RegistrationLockV2Dialog_turn_on_registration_lock)
+                              .setView(R.layout.registration_lock_v2_dialog)
+                              .setMessage(R.string.RegistrationLockV2Dialog_if_you_forget_your_signal_pin_when_registering_again)
+                              .setNegativeButton(android.R.string.cancel, null)
+                              .setPositiveButton(R.string.RegistrationLockV2Dialog_turn_on, null)
+                              .create();
       dialog.setOnShowListener(d -> {
         ProgressBar progress       = Objects.requireNonNull(dialog.findViewById(R.id.reglockv2_dialog_progress));
         View        positiveButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE);
@@ -65,12 +67,12 @@ public final class RegistrationLockV2Dialog {
   }
 
   public static void showDisableDialog(@NonNull Context context, @NonNull Runnable onSuccess) {
-    AlertDialog dialog = new AlertDialog.Builder(context)
-                                        .setTitle(R.string.RegistrationLockV2Dialog_turn_off_registration_lock)
-                                        .setView(R.layout.registration_lock_v2_dialog)
-                                        .setNegativeButton(android.R.string.cancel, null)
-                                        .setPositiveButton(R.string.RegistrationLockV2Dialog_turn_off, null)
-                                        .create();
+    AlertDialog dialog = new MaterialAlertDialogBuilder(context)
+                            .setTitle(R.string.RegistrationLockV2Dialog_turn_off_registration_lock)
+                            .setView(R.layout.registration_lock_v2_dialog)
+                            .setNegativeButton(android.R.string.cancel, null)
+                            .setPositiveButton(R.string.RegistrationLockV2Dialog_turn_off, null)
+                            .create();
     dialog.setOnShowListener(d -> {
       ProgressBar progress       = Objects.requireNonNull(dialog.findViewById(R.id.reglockv2_dialog_progress));
       View        positiveButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual Pixel XL, Android 12
- [X] My contribution is fully baked and ready to be merged as is


----------

### Description
Use MaterialAlertDialogBuilder in RegistrationLockV2Dialog.

Before:
![Screenshot_1656709568](https://user-images.githubusercontent.com/49990901/176968889-771df6d9-2a01-4739-b2ec-816e6a5b19f2.png)
![Screenshot_1656709195](https://user-images.githubusercontent.com/49990901/176968890-6024ccf5-daec-4a4f-b3f9-1fb3ae5a51cf.png)

After:
![Screenshot_1656709797](https://user-images.githubusercontent.com/49990901/176968891-d59757c2-8f96-4871-b42e-adf98521cbb3.png)
![Screenshot_1656709542](https://user-images.githubusercontent.com/49990901/176968893-5cbe8ecf-d920-4a96-86a2-b485fe066318.png)


