### PR TITLE
Add support for upcoming Themed App Icons in Android 13

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/core_ultramarine_icon"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Google Pixel 6, Android 13 Beta 4
 * Virtual device Pixel 5, Android 12 (uses normal icon)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This added line in ic_launcher.xml adds support for the upcoming "Themed app icons" standard as described [here](https://developer.android.com/about/versions/13/features#themed-app-icons) which unifies the colouring of app icons.

<p float="left">
  Enabled<img src="https://i.imgur.com/AchcnS3.png" width="24%" />
  Enabled<img src="https://i.imgur.com/IYH97Xg.png" width="24%" />
  Disabled<img src="https://i.imgur.com/0cy9KkU.png" width="24%" />
</p>
