### PR TITLE
Fix ghost media size in Storage Management Screen #12231

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/MediaDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/MediaDatabase.java
@@ -134,12 +134,18 @@ public class MediaDatabase extends Database {
     SQLiteDatabase   database         = databaseHelper.getSignalReadableDatabase();
 
     try (Cursor cursor = database.rawQuery(UNIQUE_MEDIA_QUERY, new String[0])) {
-      int sizeColumn        = cursor.getColumnIndexOrThrow(AttachmentDatabase.SIZE);
-      int contentTypeColumn = cursor.getColumnIndexOrThrow(AttachmentDatabase.CONTENT_TYPE);
+      int sizeColumn          = cursor.getColumnIndexOrThrow(AttachmentDatabase.SIZE);
+      int contentTypeColumn   = cursor.getColumnIndexOrThrow(AttachmentDatabase.CONTENT_TYPE);
+      int transferStateColumn = cursor.getColumnIndexOrThrow(AttachmentDatabase.TRANSFER_STATE);
 
       while (cursor.moveToNext()) {
-        int    size = cursor.getInt(sizeColumn);
-        String type = cursor.getString(contentTypeColumn);
+        int    size          = cursor.getInt(sizeColumn);
+        String type          = cursor.getString(contentTypeColumn);
+        int    transferState = cursor.getInt(transferStateColumn);
+
+        if (transferState != AttachmentDatabase.TRANSFER_PROGRESS_STARTED
+               && transferState != AttachmentDatabase.TRANSFER_PROGRESS_DONE)
+          continue;
 
         switch (MediaUtil.getSlideTypeFromContentType(type)) {
           case GIF:


### PR DESCRIPTION
In ApplicationPreferencesViewModel, the storage breakdown method were reflecting incorrect allocated media size.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 *Xiaomi Note 10 Pro, Android 12
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
