### PR TITLE
Use StandardCharsets in OkHttpUtil

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/OkHttpUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/OkHttpUtil.java
@@ -6,12 +6,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 import okhttp3.MediaType;
 import okhttp3.ResponseBody;
-
-import static okhttp3.internal.Util.UTF_8;
 
 public final class OkHttpUtil {
 
@@ -42,7 +41,7 @@ public final class OkHttpUtil {
 
     byte[]    data        = readAsBytes(body.byteStream(), sizeLimit);
     MediaType contentType = body.contentType();
-    Charset   charset     = contentType != null ? contentType.charset(UTF_8) : UTF_8;
+    Charset   charset     = contentType != null ? contentType.charset(StandardCharsets.UTF_8) : StandardCharsets.UTF_8;
 
     return new String(data, Objects.requireNonNull(charset));
   }


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 6 Pro, Android 13
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/) N/A

----------

### Description

`okhttp3.internal.Util.UTF_8` was never meant to be used outside of okhttp3 library; and it has been deleted in later versions.
Signal should use `java.nio.charset.StandardCharsets` instead.
No functional change.
