### PR TITLE
Suitable transparent color for toolbar in dark theme #12323

### DIFF
--- a/app/src/main/res/values/material3_colors_dark.xml
+++ b/app/src/main/res/values/material3_colors_dark.xml
@@ -38,7 +38,7 @@
     <color name="signal_dark_colorTransparentInverse2">#14000000</color>
     <color name="signal_dark_colorTransparentInverse3">#29000000</color>
     <color name="signal_dark_colorTransparentInverse4">#B8000000</color>
-    <color name="signal_dark_colorTransparentInverse5">#F5000000</color>
+    <color name="signal_dark_colorTransparentInverse5">#F51B1C1F</color>
     <color name="signal_dark_colorNeutralInverse">#E0FFFFFF</color>
     <color name="signal_dark_colorNeutralVariantInverse">#A3FFFFFF</color>
 


### PR DESCRIPTION

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Pixel 5, Android 8.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixes #12323
Transparent dark color should be grey, not black.
I also suggest to make all transparent color variables the same way. It is harder to see during "light" mode, but light transparent colors are also wrong(they represent white color, but light UI background color is not white). 
Here you can see a result of my change.

Inactive toolbar:
![Transparent grey inactive](https://user-images.githubusercontent.com/20519507/187960132-02ca0f24-b460-4ab1-9723-5658bd4b02d5.png)

Scrolling toolbar:
![Transparent grey scroll](https://user-images.githubusercontent.com/20519507/187960145-6dea75b0-483f-46ef-964c-1741d358f88f.png)

As you can see, that color matches the color of UI, despite it is transparent.
