### PR TITLE
Fix sending normal group messages when falling back to socket

### DIFF
--- a/libsignal/service/src/main/java/org/whispersystems/signalservice/api/SignalServiceMessageSender.java
+++ b/libsignal/service/src/main/java/org/whispersystems/signalservice/api/SignalServiceMessageSender.java
@@ -1968,7 +1968,7 @@ public class SignalServiceMessageSender {
           Log.w(TAG, "[sendGroupMessage][" + timestamp + "] Pipe failed, falling back... (" + e.getClass().getSimpleName() + ": " + e.getMessage() + ")");
         }
 
-        SendGroupMessageResponse response = socket.sendGroupMessage(ciphertext, joinedUnidentifiedAccess, timestamp, online, urgent, true);
+        SendGroupMessageResponse response = socket.sendGroupMessage(ciphertext, joinedUnidentifiedAccess, timestamp, online, urgent, story);
         return transformGroupResponseToMessageResults(targetInfo.devices, response, content);
       } catch (GroupMismatchedDevicesException e) {
         Log.w(TAG, "[sendGroupMessage][" + timestamp + "] Handling mismatched devices. (" + e.getMessage() + ")");


### PR DESCRIPTION
In the sendGroupMessage message the socket fallback for sending normal group messages always set the story parameter to true. This causes the message to be discarded by the receivers, because it has a story envelope, but no story content
> Envelope was flagged as a story, but it did not have any story-related content! Dropping.

Issue was introduced in https://github.com/signalapp/Signal-Android/commit/3895578d5188c7d2ef3378d61d7a9aa6efa03928#diff-6820409682d75df5f8d2fe5804e63c2712ccab77e99d0f987a40e50646fcddacR1957

@greyson-signal I think this is a rather severe issue, that could cause group messages to go missing, if the websocket is not connected.