### PR TITLE
Allow clear proxy address

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/EditProxyFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/EditProxyFragment.java
@@ -73,7 +73,7 @@ public class EditProxyFragment extends Fragment {
 
     saveButton.setOnClickListener(v -> onSaveClicked());
     shareButton.setOnClickListener(v -> onShareClicked());
-    proxySwitch.setOnCheckedChangeListener((buttonView, isChecked) -> viewModel.onToggleProxy(isChecked));
+    proxySwitch.setOnCheckedChangeListener((buttonView, isChecked) -> viewModel.onToggleProxy(isChecked, proxyText.getText().toString()));
 
     LearnMoreTextView description = view.findViewById(R.id.edit_proxy_switch_title_description);
     description.setLearnMoreVisible(true);
@@ -103,6 +103,8 @@ public class EditProxyFragment extends Fragment {
       case ALL_ENABLED:
         proxyText.setEnabled(true);
         proxyText.setAlpha(1);
+        saveButton.setEnabled(true);
+        saveButton.setAlpha(1);
         proxyTitle.setAlpha(1);
         onProxyTextChanged(proxyText.getText().toString());
         break;
@@ -182,7 +184,12 @@ public class EditProxyFragment extends Fragment {
   }
 
   private void onSaveClicked() {
-    viewModel.onSaveClicked(proxyText.getText().toString());
+    String text = proxyText.getText().toString();
+    if (Util.isEmpty(text)) {
+      proxySwitch.setChecked(false);
+    } else {
+      viewModel.onSaveClicked(text);
+    }
   }
 
   private void onShareClicked() {
@@ -195,14 +202,10 @@ public class EditProxyFragment extends Fragment {
 
   private void onProxyTextChanged(@NonNull String text) {
     if (Util.isEmpty(text)) {
-      saveButton.setEnabled(false);
-      saveButton.setAlpha(0.5f);
       shareButton.setEnabled(false);
       shareButton.setAlpha(0.5f);
       proxyStatus.setVisibility(View.INVISIBLE);
     } else {
-      saveButton.setEnabled(true);
-      saveButton.setAlpha(1);
       shareButton.setEnabled(true);
       shareButton.setAlpha(1);
 

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/EditProxyViewModel.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/EditProxyViewModel.java
@@ -43,7 +43,7 @@ public class EditProxyViewModel extends ViewModel {
     }
   }
 
-  void onToggleProxy(boolean enabled) {
+  void onToggleProxy(boolean enabled, String text) {
     if (enabled) {
       SignalProxy currentProxy = SignalStore.proxy().getProxy();
 
@@ -51,9 +51,12 @@ public class EditProxyViewModel extends ViewModel {
         SignalProxyUtil.enableProxy(currentProxy);
       }
       uiState.postValue(UiState.ALL_ENABLED);
+    } else if (Util.isEmpty(text)) {
+        SignalProxyUtil.disableAndClearProxy();
+        uiState.postValue(UiState.ALL_DISABLED);
     } else {
-      SignalProxyUtil.disableProxy();
-      uiState.postValue(UiState.ALL_DISABLED);
+        SignalProxyUtil.disableProxy();
+        uiState.postValue(UiState.ALL_DISABLED);
     }
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/util/SignalProxyUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/SignalProxyUtil.java
@@ -67,6 +67,11 @@ public final class SignalProxyUtil {
     startListeningToWebsocket();
   }
 
+  public static void disableAndClearProxy(){
+    disableProxy();
+    SignalStore.proxy().setProxy(null);
+  }
+
   /**
    * A blocking call that will wait until the websocket either successfully connects, or fails.
    * It is assumed that the app state is already configured how you would like it, e.g. you've


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual Pixel XL, Android 12
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fixes #12485 

Allows to clear the proxy (address). When proxy address field is empty there are two ways to clear the proxy.
- Press "Save" button
- Disabled "Proxy"

Pressing the "Save" button internally disables the proxy.
When the proxy switch is toggled to "disabled" and the proxy address field is empty,
the proxy is disabled and the proxy data is set to null.
