### PR TITLE
disable scrolling while context menu is shown (fixes #12530)

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/ContactSelectionListFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ContactSelectionListFragment.java
@@ -732,7 +732,7 @@ public final class ContactSelectionListFragment extends LoggingFragment
     @Override
     public boolean onItemLongClick(ContactSelectionListItem item) {
       if (onItemLongClickListener != null) {
-        return onItemLongClickListener.onLongClick(item);
+        return onItemLongClickListener.onLongClick(item, recyclerView);
       } else {
         return false;
       }
@@ -868,7 +868,7 @@ public final class ContactSelectionListFragment extends LoggingFragment
   }
 
   public interface OnItemLongClickListener {
-    boolean onLongClick(ContactSelectionListItem contactSelectionListItem);
+    boolean onLongClick(ContactSelectionListItem contactSelectionListItem, RecyclerView recyclerView);
   }
 
   public interface AbstractContactsCursorLoaderFactoryProvider {

--- a/app/src/main/java/org/thoughtcrime/securesms/NewConversationActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/NewConversationActivity.java
@@ -29,6 +29,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AlertDialog;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.snackbar.Snackbar;
@@ -232,7 +233,7 @@ public class NewConversationActivity extends ContactSelectionActivity
   }
 
   @Override
-  public boolean onLongClick(ContactSelectionListItem contactSelectionListItem) {
+  public boolean onLongClick(ContactSelectionListItem contactSelectionListItem, RecyclerView recyclerView) {
     RecipientId recipientId = contactSelectionListItem.getRecipientId().orElse(null);
     if (recipientId == null) {
       return false;
@@ -248,7 +249,10 @@ public class NewConversationActivity extends ContactSelectionActivity
         .preferredHorizontalPosition(SignalContextMenu.HorizontalPosition.START)
         .offsetX((int) DimensionUnit.DP.toPixels(12))
         .offsetY((int) DimensionUnit.DP.toPixels(12))
+        .onDismiss(() -> recyclerView.suppressLayout(false))
         .show(actions);
+
+    recyclerView.suppressLayout(true);
 
     return true;
   }


### PR DESCRIPTION


<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung S5 mini, Android 6.0
 * Emulator Nexus 5, Android 10.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This disables scrolling in the contact selection list of NewConversationActivity while a context menu is shown to match to the main screen behavior. The implementation is done in the same way as it was done for the conversations list in 8cb4cc5ac39b60ffcd7c43841ae8d9ea32e7b2a1


Fixes #12530