### PR TITLE
Make text in permission dialog scrollable and use hyphenation 

### DIFF
--- a/app/src/main/res/layout/permissions_rationale_dialog.xml
+++ b/app/src/main/res/layout/permissions_rationale_dialog.xml
@@ -16,15 +16,22 @@
 
     </LinearLayout>
 
-    <TextView android:id="@+id/message"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:paddingTop="40dp"
-              android:paddingBottom="40dp"
-              android:paddingStart="20dp"
-              android:paddingEnd="20dp"
-              android:textSize="15sp"
-              android:lineSpacingMultiplier="1.3"
-              tools:text="Signal needs access to your contacts and media in order to connect with friends, exchange messages, and make secure calls."/>
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView android:id="@+id/message"
+                  android:layout_width="match_parent"
+                  android:layout_height="wrap_content"
+                  android:hyphenationFrequency="normal"
+                  android:paddingTop="40dp"
+                  android:paddingBottom="40dp"
+                  android:paddingStart="20dp"
+                  android:paddingEnd="20dp"
+                  android:textSize="15sp"
+                  android:lineSpacingMultiplier="1.3"
+                  tools:text="Signal needs access to your contacts and media in order to connect with friends, exchange messages, and make secure calls."/>
+
+    </ScrollView>
 
 </LinearLayout>


### PR DESCRIPTION


### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Nexus 5 Emulator, Android 10.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Make text in permission dialog scrollable and enable hyphenation.

fix #12527

|Before (Text is cut off)|Now|Now (scrolled to the end)|
-|-|-
![grafik](https://user-images.githubusercontent.com/64581222/195991902-4706b40b-3834-41eb-9809-ff36a7f6131d.png)|![grafik](https://user-images.githubusercontent.com/64581222/196289258-c72c4c95-3710-431d-b1af-517f24ce07e3.png)|![grafik](https://user-images.githubusercontent.com/64581222/196289588-a322fdb6-048b-4d08-b684-2d21f234b352.png)


