### PR TITLE
Adds content descriptions for conversation back buttons

### DIFF
--- a/app/src/main/res/layout/conversation_activity.xml
+++ b/app/src/main/res/layout/conversation_activity.xml
@@ -196,6 +196,7 @@
         android:clipToPadding="false"
         android:minHeight="@dimen/signal_m3_toolbar_height"
         android:theme="?attr/actionBarStyle"
+        app:navigationContentDescription="@string/DSLSettingsToolbar__navigate_up"
         app:contentInsetStart="46dp"
         app:contentInsetStartWithNavigation="0dp"
         app:layout_constraintEnd_toEndOf="@id/parent_end_guideline"

--- a/app/src/main/res/layout/conversation_settings_toolbar.xml
+++ b/app/src/main/res/layout/conversation_settings_toolbar.xml
@@ -22,6 +22,7 @@
         android:layout_height="@dimen/signal_m3_toolbar_height"
         android:minHeight="@dimen/signal_m3_toolbar_height"
         android:theme="?attr/settingsToolbarStyle"
+        app:navigationContentDescription="@string/DSLSettingsToolbar__navigate_up"
         app:contentInsetStartWithNavigation="60dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Google Pixel 2, Android 12 (Lineage OS 19)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fixes https://github.com/signalapp/Signal-Android/issues/12546

The back buttons in the conversation view and conversation settings view were previously unlabelled and would not be correctly announced in Talkback. (please see linked issue for screenshots.)

These buttons should now read "navigate up, button"

Tested by using Talkback on my device. 🎉 :)