### PR TITLE
Adds content description for viewing user photo

### DIFF
--- a/app/src/main/res/layout/conversation_settings_avatar_preference_item.xml
+++ b/app/src/main/res/layout/conversation_settings_avatar_preference_item.xml
@@ -17,6 +17,7 @@
             android:layout_width="80dp"
             android:layout_height="80dp"
             android:layout_gravity="center_horizontal"
+            android:contentDescription="@string/ImageView__view_contact_photo"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4395,6 +4395,7 @@
 
     <string name="ViewBadgeBottomSheetDialogFragment__become_a_sustainer">Become a sustainer</string>
 
+    <string name="ImageView__view_contact_photo">View Contact Photo</string>
     <string name="ImageView__badge">Badge</string>
 
     <string name="SubscribeFragment__signal_is_powered_by_people_like_you">Signal is powered by people like you.</string>


### PR DESCRIPTION


### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Google Pixel 2, Android 12 (Lineage OS 19)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
fixes https://github.com/signalapp/Signal-Android/issues/12549

If a user has an image set, then the view showing their picture is itself a button that allows you to view the image at a larger size.

If a user does not have an image set, then the view is still a button but the button won't do anything...

After this change, bringing Talkback focus to the user's profile image will read "view contact photo" (even if there is no contact photo to view). I did try to see if I could disambiguate whether there was something to be viewed or not, but that proved a bit beyond my time + skills right now, so hopefully it's more helpful than harmful to have the view labelled this way.

please see the linked issue for screenshots :)