### PR TITLE
Use ic_save_24_tinted instead of ic_download_24_tinted

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/stories/dialogs/StoryContextMenu.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/stories/dialogs/StoryContextMenu.kt
@@ -227,7 +227,7 @@ object StoryContextMenu {
           }
         )
         add(
-          ActionItem(R.drawable.ic_download_24_tinted, context.getString(R.string.save)) {
+          ActionItem(R.drawable.ic_save_24_tinted, context.getString(R.string.save)) {
             callbacks.onSave()
           }
         )


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual Pixel XL, Android 12
- [X] My contribution is fully baked and ready to be merged as is

----------

### Description
Use the ic_save_24_tinted instead of ic_download_24_tinted in the StoryContextMenu.

![Screenshot_1668527924](https://user-images.githubusercontent.com/49990901/201972360-98206e54-e55f-4f9f-843c-e3647f239458.png) ![Screenshot_1668528694](https://user-images.githubusercontent.com/49990901/201972398-e7cb78e2-ed01-44c2-83d0-a1bde0902406.png)

The save icon is also used in the conversation menu and the My Stories site.

![Screenshot_1668527885](https://user-images.githubusercontent.com/49990901/201972489-21414345-c2a4-4d93-959f-ed4477923a87.png) ![Screenshot_1668527916](https://user-images.githubusercontent.com/49990901/201972519-3e43730d-cc46-4871-b3be-218bb8179077.png)


