### PR TITLE
[SIG-3] An empty line should have no background - Media editing #12557

### DIFF
--- a/image-editor/lib/src/main/java/org/signal/imageeditor/core/renderers/MultiLineTextRenderer.java
+++ b/image-editor/lib/src/main/java/org/signal/imageeditor/core/renderers/MultiLineTextRenderer.java
@@ -320,10 +320,14 @@ public final class MultiLineTextRenderer extends InvalidateableRenderer implemen
       rendererContext.canvasMatrix.concat(projectionMatrix);
 
       if (mode == Mode.HIGHLIGHT) {
-        modeBounds.set(textBounds.left - HIGHLIGHT_HORIZONTAL_PADDING,
-                       selectionBounds.top - HIGHLIGHT_TOP_PADDING,
-                       textBounds.right + HIGHLIGHT_HORIZONTAL_PADDING,
-                       selectionBounds.bottom + HIGHLIGHT_BOTTOM_PADDING);
+        if(text.isEmpty()){
+          modeBounds.setEmpty();
+        }else{
+          modeBounds.set(textBounds.left - HIGHLIGHT_HORIZONTAL_PADDING,
+                  selectionBounds.top - HIGHLIGHT_TOP_PADDING,
+                  textBounds.right + HIGHLIGHT_HORIZONTAL_PADDING,
+                  selectionBounds.bottom + HIGHLIGHT_BOTTOM_PADDING);
+        }
         int alpha = modePaint.getAlpha();
         modePaint.setAlpha(rendererContext.getAlpha(alpha));
         rendererContext.canvas.drawRoundRect(modeBounds, HIGHLIGHT_CORNER_RADIUS, HIGHLIGHT_CORNER_RADIUS, modePaint);


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy M02, Android 11
 * Pixel 3, Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

#### Base for the fix:
The target bound for rendering a text effect (including HIGHLIGHT) is represented by a `RectF` object calculated on top of the text block's intrinsic property. This calculation, and everything related to actual rendering/drawing happens inside `Line` object's `render()` function.

#### The issue:
The `render()` function calculates the render target bound without actually checking if the text block is empty.

The issue is more clear if we look at how the render function calculates the target, but can be generalised as:

> `targetBound = textBlockProperty + additionalProperty`

Even if `textBlockProperty` is null/empty, `targetBound` will always have `additionalProperty` - which is why the issue exists.

#### The fix:
In case the text block is empty (which is currently the case for newlines), then the bound for render target is cleared.

```
  if (mode == Mode.HIGHLIGHT) {
        if(text.isEmpty()){
          modeBounds.setEmpty(); 
        }else{
          modeBounds.set(textBounds.left - HIGHLIGHT_HORIZONTAL_PADDING,
                  selectionBounds.top - HIGHLIGHT_TOP_PADDING,
                  textBounds.right + HIGHLIGHT_HORIZONTAL_PADDING,
                  selectionBounds.bottom + HIGHLIGHT_BOTTOM_PADDING);
        }
```

### Recordings

- Issue



https://user-images.githubusercontent.com/13991373/201327739-d258b1d5-cb31-4eb9-85a7-906550ccb9eb.mov

- Fix

https://user-images.githubusercontent.com/13991373/201327819-d7f54a65-a71c-4f7f-b7b4-74494260bca4.mov



