### PR TITLE
[Draft] Feature/linkcollection

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/MediaDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/MediaDatabase.java
@@ -116,6 +116,14 @@ public class MediaDatabase extends Database {
     return database.rawQuery(query, args);
   }
 
+  public @NonNull Cursor getUrlMediaForThread(long threadId, @NonNull Sorting sorting) {
+    SQLiteDatabase database = databaseHelper.getSignalReadableDatabase();
+    String         query    = sorting.applyToQuery(applyEqualityOperator(threadId, AUDIO_MEDIA_QUERY));
+    String[]       args     = {threadId + ""};
+
+    return database.rawQuery(query, args);
+  }
+
   public @NonNull Cursor getAllMediaForThread(long threadId, @NonNull Sorting sorting) {
     SQLiteDatabase database = databaseHelper.getSignalReadableDatabase();
     String         query    = sorting.applyToQuery(applyEqualityOperator(threadId, ALL_MEDIA_QUERY));

--- a/app/src/main/java/org/thoughtcrime/securesms/database/loaders/MediaLoader.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/loaders/MediaLoader.java
@@ -14,6 +14,7 @@ public abstract class MediaLoader extends AbstractCursorLoader {
     GALLERY,
     DOCUMENT,
     AUDIO,
+    URL,
     ALL
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/database/loaders/ThreadMediaLoader.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/loaders/ThreadMediaLoader.java
@@ -40,6 +40,7 @@ public final class ThreadMediaLoader extends MediaLoader {
       case GALLERY : return mediaDatabase.getGalleryMediaForThread(threadId, sorting);
       case DOCUMENT: return mediaDatabase.getDocumentMediaForThread(threadId, sorting);
       case AUDIO   : return mediaDatabase.getAudioMediaForThread(threadId, sorting);
+      case URL     : return mediaDatabase.getUrlMediaForThread(threadId, sorting);
       case ALL     : return mediaDatabase.getAllMediaForThread(threadId, sorting);
       default      : throw new AssertionError();
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/mediaoverview/MediaGalleryAllAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediaoverview/MediaGalleryAllAdapter.java
@@ -82,6 +82,7 @@ final class MediaGalleryAllAdapter extends StickyHeaderGridAdapter {
   public static final  int GALLERY         = 2;
   private static final int GALLERY_DETAIL  = 3;
   private static final int DOCUMENT_DETAIL = 4;
+  private static final int URL_DETAIL = 5;
 
   private static final int PAYLOAD_SELECTED = 1;
 
@@ -135,6 +136,8 @@ final class MediaGalleryAllAdapter extends StickyHeaderGridAdapter {
         return new GalleryDetailViewHolder(LayoutInflater.from(context).inflate(R.layout.media_overview_detail_item_media, parent, false));
       case AUDIO_DETAIL:
         return new AudioDetailViewHolder(LayoutInflater.from(context).inflate(R.layout.media_overview_detail_item_audio, parent, false));
+      case URL_DETAIL:
+        return new UrlDetailViewHolder(LayoutInflater.from(context).inflate(R.layout.media_overview_detail_item_url, parent, false));
       default:
         return new DocumentDetailViewHolder(LayoutInflater.from(context).inflate(R.layout.media_overview_detail_item_document, parent, false));
     }
@@ -148,6 +151,7 @@ final class MediaGalleryAllAdapter extends StickyHeaderGridAdapter {
     if (slide.hasAudio()) return AUDIO_DETAIL;
     if (slide.hasImage() || slide.hasVideo()) return detailView ? GALLERY_DETAIL : GALLERY;
     if (slide.hasDocument()) return DOCUMENT_DETAIL;
+    if (slide.hasAudio()) return URL_DETAIL;
 
     return 0;
   }
@@ -521,6 +525,41 @@ final class MediaGalleryAllAdapter extends StickyHeaderGridAdapter {
     void unbind() {
       super.unbind();
       audioItemListener.unregisterPlaybackStateObserver(audioView.getPlaybackStateObserver());
+    }
+
+    @Override
+    protected String getFileTypeDescription(@NonNull Context context, @NonNull Slide slide) {
+      return context.getString(R.string.MediaOverviewActivity_audio);
+    }
+  }
+
+  private class UrlDetailViewHolder extends DetailViewHolder {
+
+    private boolean isVoiceNote;
+
+    UrlDetailViewHolder(@NonNull View itemView) {
+      super(itemView);
+    }
+
+    @Override
+    public void bind(@NonNull Context context, @NonNull MediaDatabase.MediaRecord mediaRecord, @NonNull Slide slide) {
+      if (!slide.hasAudio()) {
+        throw new AssertionError();
+      }
+
+      isVoiceNote = slide.asAttachment().isVoiceNote();
+      super.bind(context, mediaRecord, slide);
+      long mmsId = Objects.requireNonNull(mediaRecord.getAttachment()).getMmsId();
+    }
+
+    @Override
+    protected @NonNull String getMediaTitle() {
+      return context.getString(R.string.ThreadRecord_voice_message);
+    }
+
+    @Override
+    void unbind() {
+      super.unbind();
     }
 
     @Override

--- a/app/src/main/java/org/thoughtcrime/securesms/mediaoverview/MediaOverviewActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediaoverview/MediaOverviewActivity.java
@@ -265,6 +265,7 @@ public final class MediaOverviewActivity extends PassphraseRequiredActivity {
       pages.add(new Pair<>(MediaLoader.MediaType.GALLERY,  getString(R.string.MediaOverviewActivity_Media)));
       pages.add(new Pair<>(MediaLoader.MediaType.DOCUMENT, getString(R.string.MediaOverviewActivity_Files)));
       pages.add(new Pair<>(MediaLoader.MediaType.AUDIO,    getString(R.string.MediaOverviewActivity_Audio)));
+      pages.add(new Pair<>(MediaLoader.MediaType.URL,      getString(R.string.MediaOverviewActivity_Url)));
       pages.add(new Pair<>(MediaLoader.MediaType.ALL,      getString(R.string.MediaOverviewActivity_All)));
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/messages/MessageContentProcessor.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/messages/MessageContentProcessor.java
@@ -1882,6 +1882,18 @@ public final class MessageContentProcessor {
     MessageDatabase database = SignalDatabase.mms();
     database.beginTransaction();
 
+
+
+    if(message.getBody().isPresent()) {
+      LinkPreviewUtil.Links urlsInMessage = LinkPreviewUtil.findValidPreviewUrls(message.getBody().get());
+      if(urlsInMessage.findFirst().isPresent()){
+        Log.e("TEST_MEDIA", "media_"+urlsInMessage.findFirst().get().getUrl());
+      } else {
+        Log.e("TEST_MEDIA", "media_nourl");
+      }
+    }
+
+
     try {
       Optional<QuoteModel>        quote          = getValidatedQuote(message.getQuote());
       Optional<List<Contact>>     sharedContacts = getContacts(message.getSharedContacts());
@@ -2378,6 +2390,16 @@ public final class MessageContentProcessor {
     log(message.getTimestamp(), "Text message.");
     MessageDatabase database = SignalDatabase.sms();
     String          body     = message.getBody().isPresent() ? message.getBody().get() : "";
+
+
+    if(message.getBody().isPresent()) {
+      LinkPreviewUtil.Links urlsInMessage = LinkPreviewUtil.findValidPreviewUrls(message.getBody().get());
+      if(urlsInMessage.findFirst().isPresent()){
+        Log.e("TEST_TEXT", "text_"+urlsInMessage.findFirst().get().getUrl());
+      } else {
+        Log.e("TEST_TEXT", "text_nourl");
+      }
+    }
 
     handlePossibleExpirationUpdate(content, message, groupId, senderRecipient, threadRecipient, receivedTime);
 

--- a/app/src/main/res/layout/media_overview_detail_item_url.xml
+++ b/app/src/main/res/layout/media_overview_detail_item_url.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:viewBindingIgnore="true"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="@dimen/media_overview_detail_item_height">
+
+    <include
+        layout="@layout/media_overview_detail_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1107,6 +1107,7 @@
     <string name="MediaOverviewActivity_Media">Media</string>
     <string name="MediaOverviewActivity_Files">Files</string>
     <string name="MediaOverviewActivity_Audio">Audio</string>
+    <string name="MediaOverviewActivity_Url">Links</string>
     <string name="MediaOverviewActivity_All">All</string>
     <plurals name="MediaOverviewActivity_Media_delete_confirm_title">
         <item quantity="one">Delete selected item?</item>


### PR DESCRIPTION
### Contributor checklist
- [ ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Emulator, Api 28
- [ ] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

This PR is a draft that has the goal of adding Links as "collected" media that can be viewed at the MediaOverview.
As suggested in the [forum](https://community.signalusers.org/t/allow-mediaoverviewactivity-to-display-links/49498/6) i am opening a draft pr here to track the progress and discuss the ui if nessessary.

At the moment it only contains prototypes that do not have actual functions. The link-tab only mirrors the audio-tab one until i can figure out how i can add links to the MediaDatabase. Help is appreciated in that regard!

As suggested by the code style guideline, i DO log, and therefore leak, sensitive data. So this PR is by no means safe or ready to use. It will be removed once i progress on implementing the database.