### PR TITLE
UI: Rich Text Can be Pasted into a Signal Message #8058

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiEditText.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiEditText.java
@@ -106,18 +106,19 @@ public class EmojiEditText extends AppCompatEditText {
   @Override
   public boolean onTextContextMenuItem(int id) {
     if (id == android.R.id.paste) {
-      ClipboardManager clipboardManager = ((ClipboardManager) getContext()
-              .getSystemService(Context.CLIPBOARD_SERVICE));
+      ClipboardManager clipboardManager = ((ClipboardManager) getContext().getSystemService(Context.CLIPBOARD_SERVICE));
       ClipData         originalClipData = clipboardManager.getPrimaryClip();
       CharSequence     textToPaste      = getTextFromClipData(originalClipData);
-      if (textToPaste == null) return super.onTextContextMenuItem(id);
+      if (textToPaste == null) {
+        return super.onTextContextMenuItem(id);
+      }
 
-      CharSequence     sanitizedText    = (textToPaste instanceof Spanned) ?
-              clearFormattingFromText(textToPaste) : textToPaste;
+      CharSequence     sanitizedText    = (textToPaste instanceof Spanned) ? clearFormattingFromText(textToPaste)
+                                                                           : textToPaste;
 
       clipboardManager.setPrimaryClip(ClipData.newPlainText("signal_sanitized", sanitizedText));
 
-      boolean           retVal          = super.onTextContextMenuItem(id);
+      boolean retVal = super.onTextContextMenuItem(id);
       clipboardManager.setPrimaryClip(originalClipData);
       return retVal;
     }
@@ -125,7 +126,7 @@ public class EmojiEditText extends AppCompatEditText {
   }
 
   private SpannableStringBuilder clearFormattingFromText(CharSequence text) {
-    List<Mention>                 mentions = MentionAnnotation.getMentionsFromAnnotations(text);
+    List<Mention>          mentions        = MentionAnnotation.getMentionsFromAnnotations(text);
     SpannableStringBuilder spannableString = new SpannableStringBuilder(text.toString());
     MentionAnnotation.setMentionAnnotations(spannableString, mentions);
     return spannableString;
@@ -133,6 +134,6 @@ public class EmojiEditText extends AppCompatEditText {
 
   private CharSequence getTextFromClipData(ClipData data) {
     return data == null || data.getItemCount() == 0 ? null
-            : data.getItemAt(0).coerceToText(getContext());
+                                                    : data.getItemAt(0).coerceToText(getContext());
   }
 }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Techno LD7 Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Removes formatting from pasted text whilst preserving any mentions

To test : 
1. Copy rich text with various formatting eg from [here](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md).
2. Paste it into the message box and note that it won't have the formatting.

### Videos
Issue
https://www.loom.com/share/e3d98b95b6f246768970051d2d0ae431

Fix 
https://www.loom.com/share/38ca580d3ecd47899062f02ce901660d