### PR TITLE
Make it clear that payment notes have limited length

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/payments/create/EditNoteFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/create/EditNoteFragment.java
@@ -4,6 +4,8 @@ import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
+import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -15,11 +17,16 @@ import org.thoughtcrime.securesms.LoggingFragment;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.emoji.EmojiEditText;
 import org.thoughtcrime.securesms.util.ViewUtil;
+import org.thoughtcrime.securesms.util.text.AfterTextChanged;
+
+import java.util.Locale;
 
 public class EditNoteFragment extends LoggingFragment {
 
   private CreatePaymentViewModel viewModel;
   private EmojiEditText          noteEditText;
+
+  private static final int NOTE_MAX_LENGTH = 40;
 
   public EditNoteFragment() {
     super(R.layout.edit_note_fragment);
@@ -47,6 +54,16 @@ public class EditNoteFragment extends LoggingFragment {
       }
       return false;
     });
+
+    TextView lengthIndicator = view.findViewById(R.id.character_count);
+    noteEditText.addTextChangedListener(new AfterTextChanged(editable -> {
+      lengthIndicator.setText(String.format(Locale.getDefault(), "%d/%d", noteEditText.length(), NOTE_MAX_LENGTH));
+
+      if (editable.length() == NOTE_MAX_LENGTH) {
+        Toast.makeText(requireContext(), R.string.EditNoteFragment__maximum_note_length_reached, Toast.LENGTH_SHORT)
+             .show();
+      }
+    }));
 
     View fab = view.findViewById(R.id.edit_note_fragment_fab);
     fab.setOnClickListener(v -> saveNote());

--- a/app/src/main/res/layout/edit_note_fragment.xml
+++ b/app/src/main/res/layout/edit_note_fragment.xml
@@ -29,6 +29,16 @@
         android:maxLength="40"
         android:singleLine="true" />
 
+    <TextView
+        android:id="@+id/character_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:paddingHorizontal="16dp"
+        android:textColor="@color/signal_text_secondary"
+        tools:text="40/40"
+        tools:visibility="visible" />
+
     <Space
         android:layout_width="match_parent"
         android:layout_height="0dp"
@@ -41,6 +51,7 @@
         android:layout_gravity="end"
         android:layout_margin="16dp"
         android:tint="@color/core_white"
-        app:srcCompat="@drawable/ic_check_24" />
+        app:srcCompat="@drawable/ic_check_24"
+        android:contentDescription="@string/EditNoteFragment__content_description_save_note" />
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3051,6 +3051,10 @@
 
     <!-- EditNoteFragment -->
     <string name="EditNoteFragment_note">Note</string>
+    <!-- Note displayed in a toast to inform the user that the maximum note length has been reached -->
+    <string name="EditNoteFragment__maximum_note_length_reached">Maximum note length reached</string>
+    <!-- Content descriptor explaining the use of the save note FAB for Android accessibility settings-->
+    <string name="EditNoteFragment__content_description_save_note">Save note</string>
 
     <!-- ConfirmPaymentFragment -->
     <string name="ConfirmPayment__confirm_payment">Confirm payment</string>


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device A, Android 13
- [x] My contribution is fully baked and ready to be merged as is

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Payment notes are limited in length to 40 characters, but previously there was absolutely no indication of this, which is very confusing.

This commit adds a simple character counter, and a toast when the EditText is full, to make it clear how much you can write. A missing accessibility description has also been added to the save note button.

<img src="https://user-images.githubusercontent.com/88595467/202564737-645f7188-19fa-4aeb-88c2-c0268ce705f0.jpeg" width="200" />