### PR TITLE
Turning off display stops voice message recording

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/InputPanel.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/InputPanel.java
@@ -451,9 +451,6 @@ public class InputPanel extends LinearLayout
     if (listener != null) listener.onRecorderLocked();
   }
 
-  public void onPause() {
-    this.microphoneRecorderView.cancelAction();
-  }
 
   public @NonNull Observer<VoiceNotePlaybackState> getPlaybackStateObserver() {
     return voiceNoteDraftView.getPlaybackStateObserver();

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationParentFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationParentFragment.java
@@ -625,7 +625,6 @@ public class ConversationParentFragment extends Fragment
     }
 
     if (requireActivity().isFinishing()) requireActivity().overridePendingTransition(R.anim.fade_scale_in, R.anim.slide_to_end);
-    inputPanel.onPause();
 
     fragment.setLastSeen(System.currentTimeMillis());
     markLastSeen();


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S10+ android  12

- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

fixes https://github.com/signalapp/Signal-Android/issues/12408

Bug -> https://www.loom.com/share/04b34944a5d04585b72954b42f58ac0d
Fix-> https://www.loom.com/share/d968868cf8064f589162ca2098252c22

When recording a voice message by sliding the icon to the top to lock the recording mode . the recording starts but when the app goes into background and comes Inot foreground , the Input view gets distorted and the recording is paused

After this changes when the app goes into background , the app keeps recording , and when the app comes into foreground , the UI doesn't get distorted.