### PR TITLE
[SIG-12] Panning sideways over a zoomed image causes switching to other image

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/ZoomingImageView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/ZoomingImageView.java
@@ -2,7 +2,6 @@ package org.thoughtcrime.securesms.components;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
@@ -10,13 +9,9 @@ import android.view.View;
 import android.widget.FrameLayout;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.exifinterface.media.ExifInterface;
 
-import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
-import com.bumptech.glide.load.engine.GlideException;
-import com.bumptech.glide.request.RequestListener;
 import com.bumptech.glide.request.target.Target;
 import com.davemorrissey.labs.subscaleview.ImageSource;
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView;
@@ -181,6 +176,7 @@ public class ZoomingImageView extends FrameLayout {
   @Override
   public boolean onInterceptTouchEvent(MotionEvent event) {
     getParent().requestDisallowInterceptTouchEvent(event.getPointerCount() > 1);
+    photoView.setAllowParentInterceptOnEdge(photoView.getScale() == ZOOM_LEVEL_MIN);
     return false;
   }
 }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Samsung Galaxy M02, Android 11
 * Pixel 3 Emulator, Android 10
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

#### Issue
- When a zoomed image is swiped left or right on the edge, the image is switched to the next image. (Issue [#10324](https://github.com/signalapp/Signal-Android/issues/10324))

#### Expected Behaviour:
- When a zoomed image is swiped left or right on the edge, the image should not be switched to the next image.
- Swiping to the next image should only be possible if images are not zoomed.

#### Description of the fix:
`PhotoView` class is an extension of `ImageView` class that handles functions related to displaying an image and adding zoom functionality on top of that.
This fix uses `PhotoView.setAllowParentInterceptOnEdge(false)` to disable parent view (in this case the `ViewPager2` class) from intercepting touch event on the edge of the image if the image is zoomed (i.e scale factor is not equal to 1.0f)

#### Recordings
- Issue

https://user-images.githubusercontent.com/13991373/202855449-78fa732c-77c3-4945-997a-d87f381610c7.mov

- Fix

https://user-images.githubusercontent.com/13991373/202855504-2fce7f4b-c042-4f67-81fe-4898d14badcc.mov



