### PR TITLE
Android app doesn't include phone number in Verify safety number text #12225

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/verify/VerifyDisplayFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/verify/VerifyDisplayFragment.java
@@ -54,6 +54,7 @@ import org.thoughtcrime.securesms.database.IdentityDatabase;
 import org.thoughtcrime.securesms.dependencies.ApplicationDependencies;
 import org.thoughtcrime.securesms.jobs.MultiDeviceVerifiedUpdateJob;
 import org.thoughtcrime.securesms.keyvalue.SignalStore;
+import org.thoughtcrime.securesms.phonenumbers.PhoneNumberFormatter;
 import org.thoughtcrime.securesms.qr.QrCode;
 import org.thoughtcrime.securesms.recipients.LiveRecipient;
 import org.thoughtcrime.securesms.recipients.Recipient;
@@ -393,9 +394,12 @@ public class VerifyDisplayFragment extends Fragment implements ViewTreeObserver.
   }
 
   private void setRecipientText(Recipient recipient) {
-    String escapedDisplayName = Html.escapeHtml(recipient.getDisplayName(getContext()));
-
-    description.setText(Html.fromHtml(String.format(getActivity().getString(R.string.verify_display_fragment__to_verify_the_security_of_your_end_to_end_encryption_with_s), escapedDisplayName)));
+    String escapedDisplayName   = Html.escapeHtml(recipient.getDisplayName(getContext()));
+    String phoneNumber          = recipient.getE164().isPresent() ? recipient.getE164().get()
+                                                                  : "";
+    String formattedPhoneNumber = PhoneNumberFormatter.get(getContext()).format(phoneNumber);
+    String nameAndNumber        = escapedDisplayName + " " + formattedPhoneNumber;
+    description.setText(Html.fromHtml(String.format(getActivity().getString(R.string.verify_display_fragment__to_verify_the_security_of_your_end_to_end_encryption_with_s), nameAndNumber)));
     description.setMovementMethod(LinkMovementMethod.getInstance());
   }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Techno LD7 Android 10
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Include the phone number in verify safety number screen.

### To test

1. In Signal click open a chat
2. Tap on the name of the contact at the top
3. Tap on `View safety number`
4. Notice that the phone number is now showing.

### Screenshots
### Before
![be4](https://user-images.githubusercontent.com/2725300/203315979-90204e9f-8bc0-4e38-925f-d2999b238c61.png)

###After
![Screenshot_20221122-142940](https://user-images.githubusercontent.com/2725300/203316012-fe08f7c1-dec8-4c74-a8be-3b9e4559e22b.png)
