### PR TITLE
Voice Memos Continue to Play When you Open a Video 

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/mediapreview/MediaPreviewV2Activity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediapreview/MediaPreviewV2Activity.kt
@@ -8,8 +8,14 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.commit
 import org.thoughtcrime.securesms.R
+import org.thoughtcrime.securesms.components.voice.VoiceNoteMediaController
+import org.thoughtcrime.securesms.components.voice.VoiceNoteMediaControllerOwner
 
-class MediaPreviewV2Activity : AppCompatActivity(R.layout.activity_mediapreview_v2) {
+class MediaPreviewV2Activity : AppCompatActivity(R.layout.activity_mediapreview_v2),
+  VoiceNoteMediaControllerOwner {
+
+  override lateinit var voiceNoteMediaController: VoiceNoteMediaController
+
 
   override fun attachBaseContext(newBase: Context) {
     delegate.localNightMode = AppCompatDelegate.MODE_NIGHT_YES
@@ -19,6 +25,9 @@ class MediaPreviewV2Activity : AppCompatActivity(R.layout.activity_mediapreview_
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setTheme(R.style.TextSecure_MediaPreview)
+
+    voiceNoteMediaController = VoiceNoteMediaController(this)
+
     if (Build.VERSION.SDK_INT >= 21) {
       val systemBarColor = ContextCompat.getColor(this, R.color.signal_dark_colorSurface)
       window.statusBarColor = systemBarColor


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Pixel 6 Android 13
 * Pixel 4a Android 12
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Pause voice note when a video is opened 

### To test

1. Open a chat with someone 
2. play any voice note
3. while voice note is playing, play a video 
4. Notice that voice note is paused 

### Video 

### Before
https://user-images.githubusercontent.com/93866435/204134962-f8b014ff-4a34-49d3-86b2-6a844def3221.mp4

### After

https://user-images.githubusercontent.com/93866435/204134545-8d9ee287-23d0-4380-9d93-43e4dd7cafcc.mp4


