### PR TITLE
Make voice messages long-clickable

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/AudioView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/AudioView.java
@@ -7,6 +7,7 @@ import android.graphics.PorterDuff;
 import android.graphics.Rect;
 import android.net.Uri;
 import android.util.AttributeSet;
+import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.FrameLayout;
@@ -507,46 +508,15 @@ public final class AudioView extends FrameLayout {
   }
 
   private class LongTapAwareTouchListener implements OnTouchListener {
-    private static final int LONG_CLICK_DELAY = 1000;
-    private final int TOLERANCE = ViewUtil.dpToPx(5);
-
-    private long  longClickTime = 0;
-    private float initialX;
-    private float initialY;
+    private final GestureDetector gestureDetector = new GestureDetector(AudioView.this.getContext(), new GestureDetector.SimpleOnGestureListener() {
+      @Override public void onLongPress(MotionEvent e) {
+        performLongClick();
+      }
+    });
 
     @Override
     public boolean onTouch(View v, MotionEvent event) {
-      switch (event.getAction()) {
-        case MotionEvent.ACTION_DOWN:
-          initLongClick(event);
-          break;
-        case MotionEvent.ACTION_CANCEL:
-        case MotionEvent.ACTION_UP:
-          endLongClick();
-          break;
-        case MotionEvent.ACTION_MOVE:
-          if (Math.abs(event.getX() - initialX) > TOLERANCE || Math.abs(event.getY() - initialY) > TOLERANCE) endLongClick();
-          break;
-      }
-      return false;
-    }
-
-    private void initLongClick(MotionEvent event) {
-      longClickTime = event.getEventTime();
-      initialX = event.getX();
-      initialY = event.getY();
-
-      postDelayed(() -> {
-        if (longClickTime != 0) {
-          performLongClick();
-        }
-      }, LONG_CLICK_DELAY);
-    }
-
-    private void endLongClick() {
-      longClickTime = 0;
-      initialX = 0;
-      initialY = 0;
+      return gestureDetector.onTouchEvent(event);
     }
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/components/AudioView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/AudioView.java
@@ -39,7 +39,6 @@ import org.thoughtcrime.securesms.database.AttachmentTable;
 import org.thoughtcrime.securesms.events.PartProgressEvent;
 import org.thoughtcrime.securesms.mms.AudioSlide;
 import org.thoughtcrime.securesms.mms.SlideClickListener;
-import org.thoughtcrime.securesms.util.ViewUtil;
 
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Emulator Nexus 5, Android 10.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Currently, voice messages are not selectable by long-clicking them in the seekbar area. This PR will introduce some advanced touch handling, which will recognize long taps while not disturbing the normal seekbar interaction.

### Screenshot (gif)
![untitled](https://user-images.githubusercontent.com/64581222/206063675-2fc072c1-18c8-42b7-844c-89552a28515e.gif)

