### PR TITLE
add setting for gaining audio focus

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/chats/ChatsSettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/chats/ChatsSettingsFragment.kt
@@ -103,6 +103,15 @@ class ChatsSettingsFragment : DSLSettingsFragment(R.string.preferences_chats__ch
       )
 
       switchPref(
+        title = DSLSettingsText.from(R.string.preferences__gain_audio_focus_while_recording_audio),
+        summary = DSLSettingsText.from(R.string.preferences__gain_audio_focus_while_recording_audio_description),
+        isChecked = state.gainAudioFocusWhileRecordingAudio,
+        onClick = {
+          viewModel.setGainAudioFocusWhileRecordingAudio(!state.gainAudioFocusWhileRecordingAudio)
+        }
+      )
+
+      switchPref(
         title = DSLSettingsText.from(R.string.preferences__pref_use_address_book_photos),
         summary = DSLSettingsText.from(R.string.preferences__display_contact_photos_from_your_address_book_if_available),
         isChecked = state.useAddressBook,

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/chats/ChatsSettingsState.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/chats/ChatsSettingsState.kt
@@ -4,6 +4,7 @@ import org.thoughtcrime.securesms.components.settings.app.chats.sms.SmsExportSta
 
 data class ChatsSettingsState(
   val generateLinkPreviews: Boolean,
+  val gainAudioFocusWhileRecordingAudio: Boolean,
   val useAddressBook: Boolean,
   val keepMutedChatsArchived: Boolean,
   val useSystemEmoji: Boolean,

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/chats/ChatsSettingsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/chats/ChatsSettingsViewModel.kt
@@ -24,6 +24,7 @@ class ChatsSettingsViewModel @JvmOverloads constructor(
   private val store: Store<ChatsSettingsState> = Store(
     ChatsSettingsState(
       generateLinkPreviews = SignalStore.settings().isLinkPreviewsEnabled,
+      gainAudioFocusWhileRecordingAudio = SignalStore.settings().isGainAudioFocusWhileRecordingAudio,
       useAddressBook = SignalStore.settings().isPreferSystemContactPhotos,
       keepMutedChatsArchived = SignalStore.settings().shouldKeepMutedChatsArchived(),
       useSystemEmoji = SignalStore.settings().isPreferSystemEmoji,
@@ -49,6 +50,11 @@ class ChatsSettingsViewModel @JvmOverloads constructor(
     store.update { it.copy(generateLinkPreviews = enabled) }
     SignalStore.settings().isLinkPreviewsEnabled = enabled
     repository.syncLinkPreviewsState()
+  }
+
+  fun setGainAudioFocusWhileRecordingAudio(enabled: Boolean) {
+    store.update { it.copy(gainAudioFocusWhileRecordingAudio = enabled) }
+    SignalStore.settings().isGainAudioFocusWhileRecordingAudio = enabled
   }
 
   fun setUseAddressBook(enabled: Boolean) {

--- a/app/src/main/java/org/thoughtcrime/securesms/keyvalue/SettingsValues.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyvalue/SettingsValues.java
@@ -23,7 +23,6 @@ import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.webrtc.CallBandwidthMode;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 @SuppressWarnings("deprecation")
@@ -32,6 +31,7 @@ public final class SettingsValues extends SignalStoreValues {
   private static final String TAG = Log.tag(SettingsValues.class);
 
   public static final String LINK_PREVIEWS          = "settings.link_previews";
+  public static final String GAIN_AUDIO_FOCUS       = "settings.gain_audio_focus";
   public static final String KEEP_MESSAGES_DURATION = "settings.keep_messages_duration";
 
   public static final String PREFER_SYSTEM_CONTACT_PHOTOS = "settings.prefer.system.contact.photos";
@@ -126,8 +126,16 @@ public final class SettingsValues extends SignalStoreValues {
     return getBoolean(LINK_PREVIEWS, false);
   }
 
+  public boolean isGainAudioFocusWhileRecordingAudio() {
+    return getBoolean(GAIN_AUDIO_FOCUS, true);
+  }
+
   public void setLinkPreviewsEnabled(boolean enabled) {
     putBoolean(LINK_PREVIEWS, enabled);
+  }
+
+  public void setGainAudioFocusWhileRecordingAudio(boolean enabled) {
+    putBoolean(GAIN_AUDIO_FOCUS, enabled);
   }
 
   public @NonNull KeepMessagesDuration getKeepMessagesDuration() {

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -2734,6 +2734,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Заглушените чатове, които биват архивирани, ще останат архивирани, когато пристигне ново съобщение.</string>
     <string name="preferences__generate_link_previews">Генерирайте визуализации на връзки</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Извличайте визуализации на връзки директно от уебсайтове за съобщения, които изпращате.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Фокус на звука по време на аудиозапис</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">Възпроизвеждането на звук от други приложения се спира по време на аудиозапис</string>
     <string name="preferences__change_passphrase">Смени паролата</string>
     <string name="preferences__change_your_passphrase">Сменете паролата си</string>
     <string name="preferences__enable_passphrase">Активиране на парола за защита на екрана</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -2902,6 +2902,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Ztlumené konverzace, které jsou archivovány, zůstanou archivovány i po příchodu nové zprávy.</string>
     <string name="preferences__generate_link_previews">Vygenerovat náhledy odkazů</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Pro zprávy, které odesíláte, získat náhledy odkazů přímo z webů.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Zaměření zvuku během nahrávání zvuku</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">Přehrávání zvuku jiných aplikací je během nahrávání zvuku zastaveno</string>
     <string name="preferences__change_passphrase">Změnit heslo</string>
     <string name="preferences__change_your_passphrase">Změna vašeho hesla</string>
     <string name="preferences__enable_passphrase">Povolit heslo zámku obrazovky</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -2734,6 +2734,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Ignorerede samtaler, der er arkiveret, forbliver arkiveret, når der kommer en ny besked.</string>
     <string name="preferences__generate_link_previews">Generér forhåndsvisninger af links</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Hent forhåndsvisninger direkte fra websteder for links, du sender i beskeder.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Lydfokus under lydoptagelse</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">Afspilning af lyd fra andre apps stoppes under lydoptagelse</string>
     <string name="preferences__change_passphrase">Skift adgangssætning</string>
     <string name="preferences__change_your_passphrase">Skift din adgangssætning</string>
     <string name="preferences__enable_passphrase">Aktiver skærmlås med adgangssætning</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -2734,6 +2734,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Stummgeschaltete Unterhaltungen, die archiviert sind, bleiben beim Eintreffen einer neuen Nachricht archiviert.</string>
     <string name="preferences__generate_link_previews">Link-Vorschauen erzeugen</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Für zu versendende Nachrichten Link-Vorschauen direkt von den verlinkten Webseiten abrufen</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Audiofokus bei Audioaufnahme</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">Audiowiedergabe anderer Apps wird während einer Audioaufnahme gestoppt</string>
     <string name="preferences__change_passphrase">Passphrase ändern</string>
     <string name="preferences__change_your_passphrase">Deine Passphrase ändern</string>
     <string name="preferences__enable_passphrase">Passphrasengeschützte Bildschirmsperre aktivieren</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -2734,6 +2734,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Οι συνομιλίες σε σίγαση που είναι αρχειοθετημένες, θα παραμείνουν σε αρχειοθέτηση όταν λάβεις νέα μηνύματα.</string>
     <string name="preferences__generate_link_previews">Προεπισκόπηση συνδέσμων</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Λάβε προεπισκόπεις συνδέσμων απ\' ευθείας από σελίδες για τα μηνύματα που στέλνεις.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Εστίαση ήχου κατά την εγγραφή ήχου</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">Η αναπαραγωγή ήχου άλλων εφαρμογών διακόπτεται κατά τη διάρκεια της εγγραφής ήχου</string>
     <string name="preferences__change_passphrase">Αλλαγή συνθηματικού</string>
     <string name="preferences__change_your_passphrase">Αλλαγή του συνθηματικού σου</string>
     <string name="preferences__enable_passphrase">Ενεργοποίηση κλειδώματος οθόνης με συνθηματικό</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -2734,6 +2734,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Los chats silenciados archivados permanecerán archivados aunque recibas un nuevo mensaje.</string>
     <string name="preferences__generate_link_previews">Generar vista previa de enlaces</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Esta opción trasmite la vista previa de los enlaces en los mensajes que envíes. La imagen de la vista previa se descarga directamente desde la página web correspondiente generando una visita (adicional) a esa página web desde tu dispositivo.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Enfoque de audio durante la grabación de audio</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">La reproducción de audio de otras aplicaciones se detiene durante la grabación de audio</string>
     <string name="preferences__change_passphrase">Cambiar clave de acceso</string>
     <string name="preferences__change_your_passphrase">Cambia tu clave de acceso</string>
     <string name="preferences__enable_passphrase">Activa bloqueo de pantalla con clave de acceso</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -2734,6 +2734,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Vaigistatud vestlused, mis on arhiveeritud, jäävad uue sõnumi saabudes arhiveerituks.</string>
     <string name="preferences__generate_link_previews">Genereeri lingieelvaateid</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Hangib lingieelvaated otse saitidelt, mida sõnumina saadad.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Audio fookus helisalvestuse ajal</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">Helisalvestuse ajal peatub teiste rakenduste heli taasesitus</string>
     <string name="preferences__change_passphrase">Muuda salasõna</string>
     <string name="preferences__change_your_passphrase">Muuda oma salasõna</string>
     <string name="preferences__enable_passphrase">Luba salaväljendiga ekraanilukk</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -2734,6 +2734,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Arkistoidut mykistetyt keskustelut pysyvät arkistoituina, kun uusi viesti saapuu.</string>
     <string name="preferences__generate_link_previews">Luo esikatselukuvia linkeistä</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Näytä lähettämiesi linkkien esikatselu verkkosivustoilta.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Äänen tarkennus äänitallennuksen aikana</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">Muiden sovellusten äänentoisto pysähtyy äänitallennuksen aikana.</string>
     <string name="preferences__change_passphrase">Salalauseen vaihto</string>
     <string name="preferences__change_your_passphrase">Vaihda salalauseesi</string>
     <string name="preferences__enable_passphrase">Ota käyttöön näytön lukitus salalauseella</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2734,6 +2734,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Les conversations en mode silencieux sont archivées, y compris après réception d’un nouveau message.</string>
     <string name="preferences__generate_link_previews">Générer des aperçus de lien</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Pour les messages que vous envoyez, récupérez des aperçus de lien directement des sites Web.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Mise au point audio pendant l\'enregistrement audio</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">La lecture audio d\'autres applications est arrêtée pendant l\'enregistrement audio.</string>
     <string name="preferences__change_passphrase">Changer la phrase de passe</string>
     <string name="preferences__change_your_passphrase">Changer votre phrase de passe</string>
     <string name="preferences__enable_passphrase">Activer le verrou d’écran avec phrase de passe</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -2734,6 +2734,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">A némítva archivált beszélgetések új üzenet érkezésekor továbbra is archiválva maradnak.</string>
     <string name="preferences__generate_link_previews">Hivatkozások előnézeti képének generálása</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Előnézeti képek lekérése közvetlenül a weboldalról az elküldendő üzenetekhez.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Hangfókusz hangfelvétel közben</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">Más alkalmazások hanglejátszása leáll hangfelvétel közben</string>
     <string name="preferences__change_passphrase">Jelmondat megváltoztatása</string>
     <string name="preferences__change_your_passphrase">Jelmondatod megváltoztatása</string>
     <string name="preferences__enable_passphrase">Jelmondattal védett képernyőzár engedélyezése</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -2650,6 +2650,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Obrolan dibisukan yang diarsipkan akan tetap diarsipkan saat ada pesan baru masuk.</string>
     <string name="preferences__generate_link_previews">Buat pratinjau tautan</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Mengambil pratinjau dari tautan secara langsung dari situs web untuk pesan yang Anda kirimkan.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Fokus audio selama perekaman audio</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">Pemutaran audio dari aplikasi lain dihentikan selama perekaman audio</string>
     <string name="preferences__change_passphrase">Ganti frasa sandi</string>
     <string name="preferences__change_your_passphrase">Ubah frasa sandi Anda</string>
     <string name="preferences__enable_passphrase">Aktifkan frasa sandi untuk kunci layar</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -2734,6 +2734,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Le chat silenziate che archivi rimangono archiviate anche quando arriva un nuovo messaggio.</string>
     <string name="preferences__generate_link_previews">Genera anteprime dei link</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Recupera le anteprime dei link direttamente dai siti web per i messaggi che invii.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Messa a fuoco dell\'audio durante la registrazione audio</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">La riproduzione audio di altre applicazioni viene interrotta durante la registrazione audio</string>
     <string name="preferences__change_passphrase">Cambia password</string>
     <string name="preferences__change_your_passphrase">Cambia la tua password</string>
     <string name="preferences__enable_passphrase">Abilita blocco schermo con password</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -2650,6 +2650,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">アーカイブされており、さらにミュートもしているチャットは、新しいメッセージが届いてもアーカイブされたままになります。</string>
     <string name="preferences__generate_link_previews">リンクプレビューを生成する</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">送信メッセージのリンクプレビューを、ウェブサイトから直接取得します。</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">音声記録時のオーディオフォーカス</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">音声録音中に他のアプリの音声再生が停止する</string>
     <string name="preferences__change_passphrase">パスフレーズを変更</string>
     <string name="preferences__change_your_passphrase">パスフレーズを変更します</string>
     <string name="preferences__enable_passphrase">パスフレーズでの画面ロックを有効にする</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -2650,6 +2650,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">알림을 꺼서 보관한 채팅은 새 메시지가 도착해도 보관 상태로 유지됩니다.</string>
     <string name="preferences__generate_link_previews">링크 미리보기 생성</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">보내는 메시지에 첨부된 웹 사이트의 링크 미리보기를 불러옵니다.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">오디오 녹음 중 오디오 초점</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">오디오 녹음 중에는 다른 앱의 오디오 재생이 중지됩니다.</string>
     <string name="preferences__change_passphrase">암호 변경</string>
     <string name="preferences__change_your_passphrase">암호 변경</string>
     <string name="preferences__enable_passphrase">암호 화면 잠금 활성화</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -2902,6 +2902,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Suarchyvuoti nutildyti pokalbiai gavus naują žinutę liks suarchyvuoti.</string>
     <string name="preferences__generate_link_previews">Generuoti nuorodų peržiūras</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Gauti savo siunčiamoms žinutėms nuorodų peržiūras tiesiogiai iš internetinių svetainių.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Garso fokusavimas įrašant garsą</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">Garso įrašymo metu sustabdomas kitų programų garso atkūrimas</string>
     <string name="preferences__change_passphrase">Pakeisti slaptafrazę</string>
     <string name="preferences__change_your_passphrase">Pakeisti jūsų slaptafrazę</string>
     <string name="preferences__enable_passphrase">Įjungti ekrano užrakinimą slaptafraze</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -2818,6 +2818,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Arhivētas apklusinātās sarunas paliks arhivētas, kad tiks saņemta jauna ziņa.</string>
     <string name="preferences__generate_link_previews">Ģenerēt saišu priekšskatījumus</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Izgūstiet saišu priekšskatījumus nosūtītajām ziņām tieši no tīmekļa vietnēm.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Audio fokuss audio ierakstīšanas laikā</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">Audio ierakstīšanas laikā tiek pārtraukta citu programmu audio atskaņošana</string>
     <string name="preferences__change_passphrase">Nomainīt paroli</string>
     <string name="preferences__change_your_passphrase">Mainīt savu paroli</string>
     <string name="preferences__enable_passphrase">Iespējot ekrāna bloķēšanu ar paroli</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -2734,6 +2734,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Gedempte gesprekken die zijn gearchiveerd, blijven gearchiveerd als er een nieuw bericht binnenkomt.</string>
     <string name="preferences__generate_link_previews">Voorbeeld van website meesturen</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Door dit in te schakelen wordt voor elke link naar een website die je verzendt een voorbeeldafbeelding gegenereerd en met je bericht meegestuurd. Een nadeel is wel dat als je dit inschakelt websites zouden kunnen detecteren dat je hen in je bericht vermeldt en ook welke pagina je vermeldt.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Audio focus tijdens audio opname</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">Audio afspelen van andere apps wordt gestopt tijdens audio opname</string>
     <string name="preferences__change_passphrase">Wachtwoord wijzigen</string>
     <string name="preferences__change_your_passphrase">Wijzig je wachtwoord</string>
     <string name="preferences__enable_passphrase">Appvergrendeling met wachtwoord inschakelen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -2902,6 +2902,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Wyciszone rozmowy pozostaną w archiwum, gdy pojawi się nowa wiadomość.</string>
     <string name="preferences__generate_link_previews">Twórz podglądy linków</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Pobieraj podglądy linków we wiadomościach bezpośrednio ze stron internetowych.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Ostrość dźwięku podczas nagrywania audio</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">Odtwarzanie dźwięku w innych aplikacjach jest zatrzymywane podczas nagrywania dźwięku</string>
     <string name="preferences__change_passphrase">Zmień hasło</string>
     <string name="preferences__change_your_passphrase">Zmień swoje hasło</string>
     <string name="preferences__enable_passphrase">Włącz blokowanie ekranu hasłem</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -2734,6 +2734,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Conversas silenciadas que estão arquivadas permanecerão arquivadas quando uma nova mensagem chegar.</string>
     <string name="preferences__generate_link_previews">Gerar pré-visualização de links</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Carregar pré-visualizações de links diretamente dos sites em mensagens que você envia.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Foco de áudio durante a gravação de áudio</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">A reprodução de áudio de outros aplicativos é interrompida durante a gravação de áudio</string>
     <string name="preferences__change_passphrase">Alterar frase-chave</string>
     <string name="preferences__change_your_passphrase">Alterar sua frase-chave</string>
     <string name="preferences__enable_passphrase">Habilitar o bloqueio da tela com frase-chave</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -2734,6 +2734,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">As conversas silenciadas que se encontram arquivadas irão permanecer arquivadas até que chegue uma nova mensagem.</string>
     <string name="preferences__generate_link_previews">Gerar pré-visualizações de links</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Recupere pré-visualizações de links diretamente a partir de websites para as mensagens que enviar.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Foco áudio durante a gravação áudio</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">A reprodução áudio de outras aplicações é interrompida durante a gravação áudio</string>
     <string name="preferences__change_passphrase">Alterar frase-chave</string>
     <string name="preferences__change_your_passphrase">Alterar a sua frase-chave</string>
     <string name="preferences__enable_passphrase">Ativar o bloqueio de ecrã com frase-chave</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -2818,6 +2818,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Conversațiile pe silențios arhivate vor rămâne arhivate atunci când sosește un mesaj nou.</string>
     <string name="preferences__generate_link_previews">Generează previzualizări ale linkurilor</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Obține previzualizările link-urilor direct de pe site-urile web pentru mesajele pe care le trimiți.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Focalizare audio în timpul înregistrării audio</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">Redarea audio a altor aplicații este oprită în timpul înregistrării audio</string>
     <string name="preferences__change_passphrase">Schimbă parola</string>
     <string name="preferences__change_your_passphrase">Schimbă-ți parola</string>
     <string name="preferences__enable_passphrase">Activează parola pentru ecranul de blocare</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2902,6 +2902,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Архивированные чаты с отключённым звуком будут оставаться архивированными, даже если будет получено новое сообщение.</string>
     <string name="preferences__generate_link_previews">Создавать предпросмотры ссылок</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Получать предпросмотры ссылок напрямую от сайтов для сообщений, которые вы отправляете.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Фокусировка звука во время аудиозаписи</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">Воспроизведение звука в других приложениях останавливается во время записи звука</string>
     <string name="preferences__change_passphrase">Изменить парольную фразу</string>
     <string name="preferences__change_your_passphrase">Изменить свою парольную фразу</string>
     <string name="preferences__enable_passphrase">Включить блокировку экрана парольной фразой</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -2902,6 +2902,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Stlmené čety, ktoré sú archivované, zostanú archivované, keď príde nová správa.</string>
     <string name="preferences__generate_link_previews">Generovať náhľady stránok</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Získať ukážky stránok priamo z webových prepojení pre správy, ktoré odošlete.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Zaostrenie zvuku počas nahrávania zvuku</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">Prehrávanie zvuku iných aplikácií sa počas nahrávania zvuku zastaví</string>
     <string name="preferences__change_passphrase">Zmeniť heslo</string>
     <string name="preferences__change_your_passphrase">Zmeniť heslo</string>
     <string name="preferences__enable_passphrase">Chrániť obrazovku heslom</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -2902,6 +2902,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Utišani klepeti, ki so arhivirani, bodo ostali arhivirani, ko prispe novo sporočilo.</string>
     <string name="preferences__generate_link_previews">Ustvari predoglede</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Za vse spletne strani, ki jih delite, bodo v sporočilu ustvarjene predogledne sličice.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Ostrenje zvoka med snemanjem zvoka</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">Predvajanje zvoka drugih aplikacij se med snemanjem zvoka ustavi</string>
     <string name="preferences__change_passphrase">Zamenjaj geslo</string>
     <string name="preferences__change_your_passphrase">Zamenjava gesla</string>
     <string name="preferences__enable_passphrase">Vklop zaklepanja zaslona z geslom</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -2734,6 +2734,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Tystade chattar som är arkiverade förblir arkiverade när ett nytt meddelande kommer.</string>
     <string name="preferences__generate_link_previews">Skapa länkförhandsgranskningar</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Hämta länkförhandsgranskningar direkt från webbplatser för meddelanden du skickar.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Ljudfokus under ljudinspelning</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">Ljuduppspelning i andra appar stoppas under ljudinspelning</string>
     <string name="preferences__change_passphrase">Ändra lösenord</string>
     <string name="preferences__change_your_passphrase">Ändra ditt lösenord</string>
     <string name="preferences__enable_passphrase">Aktivera låsskärmens lösenord</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -2734,6 +2734,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Arşivlenerek sessize alınan sohbetler, yeni bir mesaj geldiğinde arşivlenmiş olarak kalır.</string>
     <string name="preferences__generate_link_previews">Bağlantı önizlemelerini oluştur</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Gönderdiğiniz iletiler için doğrudan web sitelerinden bağlantı önizlemelerini al.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Ses kaydı sırasında ses odağı</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">Ses kaydı sırasında diğer uygulamaların ses oynatımı durduruluyor</string>
     <string name="preferences__change_passphrase">Parola değiştir</string>
     <string name="preferences__change_your_passphrase">Parolanı değiştir</string>
     <string name="preferences__enable_passphrase">Ekran kilidi parolasını etkinleştirin</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -2902,6 +2902,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Стишені та заархівовані чати залишатимуться заархівованими після отримання нового повідомлення.</string>
     <string name="preferences__generate_link_previews">Генерувати посилання попереднього перегляду</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Для надісланих повідомлень отримувати дані попереднього перегляду посилань напряму з веб-сайтів.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Фокусування звуку під час аудіозапису</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">Відтворення аудіо в інших програмах зупиняється під час запису аудіо</string>
     <string name="preferences__change_passphrase">Змінити фразу-пароль</string>
     <string name="preferences__change_your_passphrase">Змінить вашу фразу-пароль</string>
     <string name="preferences__enable_passphrase">Увімкнути фразу-пароль</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2738,6 +2738,8 @@
     <string name="preferences__muted_chats_that_are_archived_will_remain_archived">Muted chats that are archived will remain archived when a new message arrives.</string>
     <string name="preferences__generate_link_previews">Generate link previews</string>
     <string name="preferences__retrieve_link_previews_from_websites_for_messages">Retrieve link previews directly from websites for messages you send.</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio">Audio focus during audio recording</string>
+    <string name="preferences__gain_audio_focus_while_recording_audio_description">Audio playback of other apps is stopped during audio recording</string>
     <string name="preferences__change_passphrase">Change passphrase</string>
     <string name="preferences__change_your_passphrase">Change your passphrase</string>
     <string name="preferences__enable_passphrase">Enable passphrase screen lock</string>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device: Pixel 6 Pro, Android 13.0 Tested in the following languages: english, german, afrikaans
 * [video](https://www.youtube.com/watch?v=RGNe__AM5sA) of a test
- [x] My contribution is fully baked and ready to be merged as is
- [N/A] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This introduces the possiblity to let the user decide if the audio focus is gained when recording an audio memo or not.
See [feature request](https://community.signalusers.org/t/make-audio-focus-during-voice-memo-recordings-configurable/50903)

The german and english translation was done by myself. The other ones are automatically created.
