### PR TITLE
Enable smooth transition to Picture-in-Picture in gesture navigation

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/WebRtcCallActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/WebRtcCallActivity.java
@@ -126,6 +126,7 @@ public class WebRtcCallActivity extends BaseActivity implements SafetyNumberChan
   private WindowLayoutInfoConsumer         windowLayoutInfoConsumer;
   private WindowInfoTrackerCallbackAdapter windowInfoTrackerCallbackAdapter;
   private ThrottledDebouncer               requestNewSizesThrottle;
+  private PictureInPictureParams.Builder   pipBuilderParams;
 
   private Disposable ephemeralStateDisposable = Disposable.empty();
 
@@ -157,6 +158,7 @@ public class WebRtcCallActivity extends BaseActivity implements SafetyNumberChan
 
     initializeResources();
     initializeViewModel(isLandscapeEnabled);
+    initializePictureInPictureParams();
 
     processIntent(getIntent());
 
@@ -276,14 +278,16 @@ public class WebRtcCallActivity extends BaseActivity implements SafetyNumberChan
   }
 
   private boolean enterPipModeIfPossible() {
-    if (viewModel.canEnterPipMode() && isSystemPipEnabledAndAvailable()) {
-      PictureInPictureParams params = new PictureInPictureParams.Builder()
-          .setAspectRatio(new Rational(9, 16))
-          .build();
-      enterPictureInPictureMode(params);
-      CallParticipantsListDialog.dismiss(getSupportFragmentManager());
+    if (isSystemPipEnabledAndAvailable()) {
+      if (viewModel.canEnterPipMode()) {
+        enterPictureInPictureMode(pipBuilderParams.build());
+        CallParticipantsListDialog.dismiss(getSupportFragmentManager());
 
-      return true;
+        return true;
+      }
+      if (Build.VERSION.SDK_INT >= 31) {
+        pipBuilderParams.setAutoEnterEnabled(false);
+      }
     }
     return false;
   }
@@ -361,6 +365,19 @@ public class WebRtcCallActivity extends BaseActivity implements SafetyNumberChan
       participantUpdateWindow.setEnabled(!info.isInPictureInPictureMode());
       callStateUpdatePopupWindow.setEnabled(!info.isInPictureInPictureMode());
     });
+  }
+
+  private void initializePictureInPictureParams() {
+    if (isSystemPipEnabledAndAvailable()) {
+      pipBuilderParams = new PictureInPictureParams.Builder();
+      pipBuilderParams.setAspectRatio(new Rational(9, 16));
+      if (Build.VERSION.SDK_INT >= 31) {
+        pipBuilderParams.setAutoEnterEnabled(true);
+      }
+      if (Build.VERSION.SDK_INT >= 26) {
+        setPictureInPictureParams(pipBuilderParams.build());
+      }
+    }
   }
 
   private void handleViewModelEvent(@NonNull WebRtcCallViewModel.Event event) {


### PR DESCRIPTION

### Contributor checklist
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Pixel 7, Android 13
- [ ] My contribution is fully baked and ready to be merged as is
       Unsure, as I am not aware of what tests needs fixing if any.

### Description

Enables smoother transition into picture-in-picture from a video call when in gestural navigation mode. 
by setting [setAutoEnterEnabled(true)](https://developer.android.com/reference/android/app/PictureInPictureParams.Builder#setAutoEnterEnabled(boolean))

Example of a before and after 

Before 
![image1](https://user-images.githubusercontent.com/494160/230176762-cd0e665e-e158-4d70-9511-69ede246bfa5.gif)

After
![image2](https://user-images.githubusercontent.com/494160/230176996-ac663d0e-8111-4475-87ed-d0b5255bdc12.gif)
