### PR TITLE
Fix #12895 ellipsize bio preference about

### DIFF
--- a/app/src/main/res/layout/bio_preference_item.xml
+++ b/app/src/main/res/layout/bio_preference_item.xml
@@ -55,8 +55,8 @@
             style="@style/Signal.Text.BodyMedium"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:ellipsize="end"
-            android:maxLines="1"
+            android:ellipsize="marquee"
+            android:singleLine="true"
             android:textAlignment="viewStart"
             android:textColor="@color/signal_colorOnSurfaceVariant"
             tools:text="Crusin' the web" />


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual Pixel XL, Android 12
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fixes #12895

android:ellipsize="end" is already set in the xml-file

https://github.com/signalapp/Signal-Android/blob/e33a68b203dc8bdfb576ca35d02119a4fd45ce1c/app/src/main/res/layout/bio_preference_item.xml#L58-L59

Changed this to
```
 android:ellipsize="marquee"
 android:singleLine="true"
```

and it works.

![Screenshot_1681634571](https://user-images.githubusercontent.com/49990901/232287622-d9e18d49-0361-460f-bf72-2633d18abe00.png)

