### PR TITLE
[#12941] Switch from getActiveNetworkInfo() to getActiveNetwork() and getNetworkCapabilities()

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/jobmanager/impl/NetworkConstraint.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobmanager/impl/NetworkConstraint.java
@@ -4,7 +4,10 @@ import android.app.Application;
 import android.app.job.JobInfo;
 import android.content.Context;
 import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkCapabilities;
 import android.net.NetworkInfo;
+import android.os.Build;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -45,9 +48,15 @@ public class NetworkConstraint implements Constraint {
 
   public static boolean isMet(@NonNull Context context) {
     ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-    NetworkInfo         activeNetworkInfo   = connectivityManager.getActiveNetworkInfo();
-
-    return activeNetworkInfo != null && activeNetworkInfo.isConnected();
+    
+    if (Build.VERSION.SDK_INT >= 23) {
+      Network             activeNetwork       = connectivityManager.getActiveNetwork();
+      NetworkCapabilities networkCapabilities = connectivityManager.getNetworkCapabilities(activeNetwork);
+      return networkCapabilities != null && networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
+    } else {
+      NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
+      return activeNetworkInfo != null && activeNetworkInfo.isConnected();
+    }
   }
 
   public static final class Factory implements Constraint.Factory<NetworkConstraint> {


### PR DESCRIPTION
### First time contributor checklist

- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 6A, Android 13
 * Emulated Pixel 6 Pro, Android 5.1 (API Level 22)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Replaces the deprecated `getActiveNetworkInfo()` call with the new recommended `getNetworkCapabilities()` call that correctly recognizes network connectivity in more situations. (Legacy `getActiveNetworkInfo()` is subject to false negatives with VPNs in particular.)

### Test Plan

Emulated Pixel 6 Pro API Level 22, Airplane Mode On -> Off 

```
IncomingMessageObserver org.thoughtcrime.securesms           D  [Does Not Need Connection] Network: false, Foreground: false, Time Since Last Interaction: 2 ms (within limit), FCM: true, Stay open requests: [], Registered: true, Proxy: false, Force websocket: false, Decrypt Queue Empty: true
...
IncomingMessageObserver org.thoughtcrime.securesms           D  [Needs Connection] Network: true, Foreground: false, Time Since Last Interaction: 9566 ms (within limit), FCM: true, Stay open requests: [], Registered: true, Proxy: false, Force websocket: false, Decrypt Queue Empty: true
```

Hardware Pixel 6A, WiFi, Android 13, Airplane Mode On -> Off

```
IncomingMessageObserver org.thoughtcrime.securesms           D  [Does Not Need Connection] Network: false, Foreground: false, Time Since Last Interaction: 4089 ms (within limit), FCM: true, Stay open requests: [], Registered: true, Proxy: false, Force websocket: false, Decrypt Queue Empty: true
...
IncomingMessageObserver org.thoughtcrime.securesms           D  [Needs Connection] Network: true, Foreground: false, Time Since Last Interaction: 15086 ms (within limit), FCM: true, Stay open requests: [], Registered: true, Proxy: false, Force websocket: false, Decrypt Queue Empty: true
```

Hardware Pixel 6A, WiFi, Android 13, Airplane Mode On, Gnirehtet On -> Off

```
IncomingMessageObserver org.thoughtcrime.securesms           D  [Needs Connection] Network: true, Foreground: true, Time Since Last Interaction: N/A, FCM: true, Stay open requests: [], Registered: true, Proxy: false, Force websocket: false, Decrypt Queue Empty: true
...
IncomingMessageObserver org.thoughtcrime.securesms           D  [Does Not Need Connection] Network: false, Foreground: true, Time Since Last Interaction: N/A, FCM: true, Stay open requests: [], Registered: true, Proxy: false, Force websocket: false, Decrypt Queue Empty: true
```