### PR TITLE
Update AlertDialog to Material Design 3 (issue #12949)

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/payments/backup/PaymentsRecoveryPasteFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/backup/PaymentsRecoveryPasteFragment.java
@@ -1,6 +1,5 @@
 package org.thoughtcrime.securesms.payments.backup;
 
-import android.app.AlertDialog;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.EditText;
@@ -10,6 +9,8 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.Navigation;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.util.navigation.SafeNavigation;
@@ -53,7 +54,7 @@ public class PaymentsRecoveryPasteFragment extends Fragment {
   }
 
   private void showErrorDialog() {
-    new AlertDialog.Builder(requireContext())
+    new MaterialAlertDialogBuilder(requireContext())
                    .setTitle(R.string.PaymentsRecoveryPasteFragment__invalid_recovery_phrase)
                    .setMessage(getString(R.string.PaymentsRecoveryPasteFragment__make_sure, PaymentsConstants.MNEMONIC_LENGTH))
                    .setPositiveButton(android.R.string.ok, (dialog, which) -> dialog.dismiss())

--- a/app/src/main/java/org/thoughtcrime/securesms/payments/preferences/viewholder/InfoCardViewHolder.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/payments/preferences/viewholder/InfoCardViewHolder.java
@@ -1,6 +1,5 @@
 package org.thoughtcrime.securesms.payments.preferences.viewholder;
 
-import android.app.AlertDialog;
 import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.TextPaint;
@@ -14,6 +13,8 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.appcompat.widget.Toolbar;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.payments.preferences.PaymentsHomeAdapter;
@@ -50,7 +51,7 @@ public class InfoCardViewHolder extends MappingViewHolder<InfoCard> {
     toolbar.inflateMenu(R.menu.payment_info_card_overflow);
     toolbar.setOnMenuItemClickListener(item -> {
       if (item.getItemId() == R.id.action_hide) {
-        new AlertDialog.Builder(getContext())
+        new MaterialAlertDialogBuilder(getContext())
             .setMessage(R.string.payment_info_card_hide_this_card)
             .setPositiveButton(R.string.payment_info_card_hide, (dialog, which) -> {
               model.dismiss();


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device Pixel 4a, Android 13
 * Emulated Pixel 4, Android 11 (API Level 30)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Updates The Alert Dialog Box in 
    - settings > Payments (beta) > (Click on 3 dots on CardView)  ( "Hide this card?" Alert Dialog appears )
    
   To Material Design 3 Dialog Box.

Link to Issue [ [Click Here](https://github.com/signalapp/Signal-Android/issues/12949) ]
   
   Pictures attached for reference.

New Design

![WhatsApp Image 2023-05-22 at 6 54 57 AM](https://github.com/signalapp/Signal-Android/assets/11542687/186295eb-af07-4c19-a8b0-ae47446267e4)

Old Design

![WhatsApp Image 2023-05-22 at 6 54 57 AM (1)](https://github.com/signalapp/Signal-Android/assets/11542687/df2d72ee-0e3b-4067-98b7-361a9b7a22e2)
