### PR TITLE
Added null check Fixes #12952

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/AttachmentTable.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/AttachmentTable.java
@@ -1265,7 +1265,7 @@ public class AttachmentTable extends DatabaseTable {
                                               MediaUtil.isImageType(contentType) || MediaUtil.isVideoType(contentType),
                                               contentType,
                                               object.getInt(TRANSFER_STATE),
-                                              object.getLong(SIZE),
+                                              object.isNull(SIZE) ? 0L : object.getLong(SIZE),
                                               object.getString(FILE_NAME),
                                               object.getInt(CDN_NUMBER),
                                               object.getString(CONTENT_LOCATION),


### PR DESCRIPTION

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * PIXEL 6 Pro
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
**Fixes Issue #12952**

The changes include adding a null check for the SIZE field in the getAttachments() method to avoid the JSONException when parsing the JSON data.