### PR TITLE
Handle Network Access Loss in Background Due to Data Saver

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/messages/IncomingMessageObserver.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/messages/IncomingMessageObserver.kt
@@ -87,9 +87,9 @@ class IncomingMessageObserver(private val context: Application) {
 
   private val lock: ReentrantLock = ReentrantLock()
   private val connectionNecessarySemaphore = Semaphore(0)
-  private val networkConnectionListener = NetworkConnectionListener(context) { isNetworkAvailable ->
+  private val networkConnectionListener = NetworkConnectionListener(context) { isNetworkLost ->
     lock.withLock {
-      if (isNetworkAvailable()) {
+      if (isNetworkLost()) {
         Log.w(TAG, "Lost network connection. Shutting down our websocket connections and resetting the drained state.")
         decryptionDrained = false
         disconnect()

--- a/app/src/main/java/org/thoughtcrime/securesms/messages/NetworkConnectionListener.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/messages/NetworkConnectionListener.kt
@@ -49,6 +49,12 @@ class NetworkConnectionListener(private val context: Context, private val onNetw
       Log.d(TAG, "ConnectivityManager.NetworkCallback onLost()")
       onNetworkLost { true }
     }
+
+    override fun onBlockedStatusChanged(network: Network, blocked: Boolean) {
+      super.onBlockedStatusChanged(network, blocked);
+      Log.d(TAG, "ConnectivityManager.NetworkCallback onBlockedStatusChanged($blocked)")
+      onNetworkLost { blocked }
+    }
   }
 
   private val connectionReceiver = object : BroadcastReceiver() {


### PR DESCRIPTION
### Contributor checklist
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Pixel 6A, Android 13, Data Saver On, Wifi set to "Metered"
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Notification delivery is a bit wonky if data saver is on, as this causes the network to be blocked in the background any time the app is not running a foreground service. 

The overall problem here is that the foreground service stops too early, before the delivery receipt makes it out. Then, if more messages come in, FCM will buffer and delay the alerts for them because it just woke the app up right before, and it looks like the app is still running. 

The behavior right now is that if I send two consecutive messages to a device in Data Saver mode, only the first one will make it through. The second one will be delayed for some arbitrary amount of time. Also, if I send a message to a device in Data Saver right after the app is backgrounded, the message will be delayed. 

This is a small incremental change that saves the app from continuing to wait on a WebSocket that is already dead. This resolves some of the delays around messages that arrive right after the app is foregrounded.