### PR TITLE
Call all lifecycle methods on snapshot `mapView`

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/location/SignalMapView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/location/SignalMapView.java
@@ -77,6 +77,7 @@ public class SignalMapView extends LinearLayout {
   public static ListenableFuture<Bitmap> snapshot(final LatLng place, @NonNull final MapView mapView) {
     final SettableFuture<Bitmap> future = new SettableFuture<>();
     mapView.onCreate(null);
+    mapView.onStart();
     mapView.onResume();
 
     mapView.setVisibility(View.VISIBLE);
@@ -91,6 +92,7 @@ public class SignalMapView extends LinearLayout {
         future.set(bitmap);
         mapView.setVisibility(View.GONE);
         mapView.onPause();
+        mapView.onStop();
         mapView.onDestroy();
       }));
     });


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device with Android API 29 and Google Play Services
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

`SignalMapView` consecutively calls the [lifecycle methods between "Activity launched" and "Activity running"](https://developer.android.com/guide/components/images/activity_lifecycle.png) when it wants to spawn the map, but it actually forgets to call `onStart`. Here, the missing line is added.

Similarly, it calls the methods between "Activity running" and "Activity shut down", but actually forgets to call `onStop`.

The current behavior could have strange and unforeseeable consequences in the future.