### PR TITLE
Fix Do not animate spoilers if system animations are disabled.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/spoiler/SpoilerPaint.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/spoiler/SpoilerPaint.kt
@@ -11,7 +11,6 @@ import androidx.annotation.MainThread
 import org.signal.core.util.DimensionUnit
 import org.signal.core.util.dp
 import org.thoughtcrime.securesms.dependencies.ApplicationDependencies
-import org.thoughtcrime.securesms.util.AccessibilityUtil
 import org.thoughtcrime.securesms.util.Util
 import kotlin.random.Random
 
@@ -65,14 +64,14 @@ object SpoilerPaint {
       bounds.bottom + strokeWidth.toInt()
     )
 
-    update(!AccessibilityUtil.areAnimationsDisabled(ApplicationDependencies.getApplication()))
+    update()
   }
 
   /**
    * Invoke every time before you need to use the [shader].
    */
   @MainThread
-  fun update(animationsEnabled: Boolean) {
+  fun update() {
     val now = System.currentTimeMillis()
     var dt = now - lastDrawTime
     if (dt < 48) {
@@ -87,7 +86,7 @@ object SpoilerPaint {
     // To avoid that, we draw into a buffer, then swap the buffer into the shader when it's fully drawn.
     val canvas = Canvas(bufferBitmap)
     bufferBitmap.eraseColor(Color.TRANSPARENT)
-    draw(canvas, if (animationsEnabled) dt else 0)
+    draw(canvas, dt)
 
     val swap = shaderBitmap
     shaderBitmap = bufferBitmap

--- a/app/src/main/java/org/thoughtcrime/securesms/components/spoiler/SpoilerRendererDelegate.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/spoiler/SpoilerRendererDelegate.kt
@@ -38,7 +38,7 @@ class SpoilerRendererDelegate @JvmOverloads constructor(
 
   private val animator = TimeAnimator().apply {
     setTimeListener { _, _, _ ->
-      SpoilerPaint.update(systemAnimationsEnabled)
+      SpoilerPaint.update()
       view.invalidate()
     }
   }
@@ -114,7 +114,7 @@ class SpoilerRendererDelegate @JvmOverloads constructor(
       hasSpoilersToRender = true
     }
 
-    if (hasSpoilersToRender) {
+    if (hasSpoilersToRender && systemAnimationsEnabled) {
       if (!animatorRunning) {
         animator.start()
         animatorRunning = true


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:

 * Virtual Pixel XL, Android 12
- [X] My contribution is fully baked and ready to be merged as is

----------

### Description
The commit https://github.com/signalapp/Signal-Android/commit/272860f07132db05e52e0d8f7f017d78e59052cb in 6.24.1 disables the animation of spoilers if system animations are disabled.
When system animations are disabled the draw function
https://github.com/signalapp/Signal-Android/blob/272860f07132db05e52e0d8f7f017d78e59052cb/app/src/main/java/org/thoughtcrime/securesms/components/spoiler/SpoilerPaint.kt#L107
is executed anyway, although the values of the particles do not change, due to dt = 0.

This PR changes this. The update function is called onetime (in the init with update(true)) to compute a spoiler particles image.
Every other call of update() is directly returned, if system animations are disabled.
