### PR TITLE
Fixes #12630

### DIFF
--- a/photoview/src/main/java/com/github/chrisbanes/photoview/CustomGestureDetector.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/CustomGestureDetector.java
@@ -120,10 +120,17 @@ class CustomGestureDetector {
     }
 
     private boolean processTouchEvent(MotionEvent ev) {
+        int oldActivePointerIndex = mActivePointerIndex;
+        mActivePointerIndex = ev
+            .findPointerIndex(mActivePointerId != INVALID_POINTER_ID ? mActivePointerId
+                                                                     : 0);
         final int action = ev.getAction();
         switch (action & MotionEvent.ACTION_MASK) {
             case MotionEvent.ACTION_DOWN:
                 mActivePointerId = ev.getPointerId(0);
+                mActivePointerIndex = ev
+                    .findPointerIndex(mActivePointerId != INVALID_POINTER_ID ? mActivePointerId
+                                                                             : 0);
 
                 mVelocityTracker = VelocityTracker.obtain();
                 if (null != mVelocityTracker) {
@@ -146,7 +153,9 @@ class CustomGestureDetector {
                 }
 
                 if (mIsDragging) {
-                    mListener.onDrag(dx, dy);
+                    if (oldActivePointerIndex == mActivePointerIndex) {
+                        mListener.onDrag(dx, dy);
+                    }
                     mLastTouchX = x;
                     mLastTouchY = y;
 
@@ -157,6 +166,7 @@ class CustomGestureDetector {
                 break;
             case MotionEvent.ACTION_CANCEL:
                 mActivePointerId = INVALID_POINTER_ID;
+                mActivePointerIndex = -1;
                 // Recycle Velocity Tracker
                 if (null != mVelocityTracker) {
                     mVelocityTracker.recycle();
@@ -165,6 +175,7 @@ class CustomGestureDetector {
                 break;
             case MotionEvent.ACTION_UP:
                 mActivePointerId = INVALID_POINTER_ID;
+                mActivePointerIndex = -1;
                 if (mIsDragging) {
                     if (null != mVelocityTracker) {
                         mLastTouchX = getActiveX(ev);
@@ -200,15 +211,14 @@ class CustomGestureDetector {
                     // active pointer and adjust accordingly.
                     final int newPointerIndex = pointerIndex == 0 ? 1 : 0;
                     mActivePointerId = ev.getPointerId(newPointerIndex);
+                    mActivePointerIndex = ev
+                        .findPointerIndex(mActivePointerId != INVALID_POINTER_ID ? mActivePointerId
+                        : 0);
                     mLastTouchX = ev.getX(newPointerIndex);
                     mLastTouchY = ev.getY(newPointerIndex);
                 }
                 break;
         }
-
-        mActivePointerIndex = ev
-                .findPointerIndex(mActivePointerId != INVALID_POINTER_ID ? mActivePointerId
-                        : 0);
         return true;
     }
 }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * OnePlus 7 Pro, Android 12
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
If the first finger was released before the second one, onDrag was called with wrong values. This is now fixed by checking whether active pointer index has changed.

| Old behavior | New behavior |
| ---------- | -------- |
<video src="https://github.com/signalapp/Signal-Android/assets/28599313/4b2ce064-fb0b-4167-978b-c2d6dd035ab8" width="200px"> | <video src="https://github.com/signalapp/Signal-Android/assets/28599313/6ff83fe1-d445-47c8-ad2f-15e5f2e44efc" width="200px">


