### PR TITLE
Change SpoilerPaint to avoid small visible patterns

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/spoiler/SpoilerPaint.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/spoiler/SpoilerPaint.kt
@@ -27,9 +27,9 @@ object SpoilerPaint {
    */
   var shader: BitmapShader? = null
 
-  private val WIDTH = if (Util.isLowMemory(ApplicationDependencies.getApplication())) 50.dp else 100.dp
-  private val HEIGHT = if (Util.isLowMemory(ApplicationDependencies.getApplication())) 10.dp else 20.dp
-  private val PARTICLES_PER_PIXEL = if (Util.isLowMemory(ApplicationDependencies.getApplication())) 0.002f else 0.004f
+  private val WIDTH = if (Util.isLowMemory(ApplicationDependencies.getApplication())) 100.dp else 120.dp
+  private val HEIGHT = if (Util.isLowMemory(ApplicationDependencies.getApplication())) 100.dp else 120.dp
+  private val PARTICLES_PER_PIXEL = if (Util.isLowMemory(ApplicationDependencies.getApplication())) 0.0002f else 0.0006f
 
   private var shaderBitmap: Bitmap = Bitmap.createBitmap(WIDTH, HEIGHT, Bitmap.Config.ALPHA_8)
   private var bufferBitmap: Bitmap = Bitmap.createBitmap(WIDTH, HEIGHT, Bitmap.Config.ALPHA_8)
@@ -74,10 +74,10 @@ object SpoilerPaint {
   fun update() {
     val now = System.currentTimeMillis()
     var dt = now - lastDrawTime
-    if (dt < 48) {
+    if (dt < 64) {
       return
-    } else if (dt > 64) {
-      dt = 48
+    } else if (dt > 72) {
+      dt = 64
     }
     lastDrawTime = now
 
@@ -104,6 +104,7 @@ object SpoilerPaint {
    * the visual "gaps" between the tiles.
    */
   private fun draw(canvas: Canvas, dt: Long) {
+    val change = dt * velocity
     for (allIndex in allParticles.indices) {
       val particles = allParticles[allIndex]
       for (index in 0 until particleCount) {
@@ -117,7 +118,6 @@ object SpoilerPaint {
           particle.yVel = nextDirection()
           particle.timeRemaining = 350 + 750 * random.nextFloat()
         } else {
-          val change = dt * velocity
           particle.x += particle.xVel * change
           particle.y += particle.yVel * change
         }
@@ -130,6 +130,9 @@ object SpoilerPaint {
     canvas.drawPoints(allPoints[0], 0, particleCount * 2, particlePaints[0])
     canvas.drawPoints(allPoints[1], 0, particleCount * 2, particlePaints[1])
     canvas.drawPoints(allPoints[2], 0, particleCount * 2, particlePaints[2])
+    canvas.drawPoints(allPoints[0], 1, particleCount * 2 - 1, particlePaints[2])
+    canvas.drawPoints(allPoints[1], 1, particleCount * 2 - 1, particlePaints[0])
+    canvas.drawPoints(allPoints[2], 1, particleCount * 2 - 1, particlePaints[1])
   }
 
   private fun nextDirection(): Float {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Moto X Play, Android 7
 * Virtual Pixel XL, Android 12
- [X] My contribution is fully baked and ready to be merged as is

----------

### Description
The actual implementation of SpoilerPaint generates a small visible pattern on spoiler text. The main cause is the small height of 10dp/20dp and tiling the bitmap repeated. Due to the low height only the particles "lives long" with main direction to the x-axis. This also results in the wave-shaped pattern.

On the virtual device the original values gives a bitmap of (175px, 35px) (low perf.) or (350px, 70px) (high perf.)
With low performance the particle_count is 12, given 36 displayed points (12 * 3 alpha channels).
High performance the particle_count is 98 -> 294 displayed points.

![Screenshot_1688294049](https://github.com/signalapp/Signal-Android/assets/49990901/347f4e89-ff01-4abe-9b3e-25dcea4857f2) ![Screenshot_1688294127](https://github.com/signalapp/Signal-Android/assets/49990901/ba144238-a35b-4514-a588-3c6b506caaeb)

This commits change the bitmap size to a better height. On low performance the bitmap is a square of 100dp x 100dp, on the test device this is 350px x 350px. High performance uses a bitmap of 120dp x 120 dp (420px x 420px).
With 24 particles (low perf.) or 105 particles (high perf.) This gives 72 or 315 points. Using additional the canvas.drawPoints with a offset of 1 "doubles" the displayed points to 141 or 627.
The offset of 1 gives points (y_i, x_i+1). So the bitmap must be a square.

![Screenshot_1688294390](https://github.com/signalapp/Signal-Android/assets/49990901/fa13bc35-5b23-49a6-8603-7fd774d826a1) ![Screenshot_1688294632](https://github.com/signalapp/Signal-Android/assets/49990901/677f85ba-a6fa-4b52-9b20-501e24a10578)

For some more performance the frame-rate is reduced to only 64ms. Also the `val change = dt * velocity ` is constant for one call of the draw-method. So no need the recompute the value for each particle.