### PR TITLE
Show in progress spinner after phone number is confirmed in EnterPhoneNumberFragment

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/EnterPhoneNumberFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/EnterPhoneNumberFragment.java
@@ -458,7 +458,6 @@ public final class EnterPhoneNumberFragment extends LoggingFragment implements R
                                    @NonNull String e164number,
                                    @NonNull Runnable onConfirmed)
   {
-    enterInProgressUiState();
 
     disposables.add(
         viewModel.canEnterSkipSmsFlow()


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Samsung A14, Android 13
 * Nokia 3.1, Android 10
- [X] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Current behavior of the continue/progress button, in `EnterPhoneNumberFragment` makes for a confusing user experience.

<details>

<summary> GIF Recording Before changes </summary>

![before](https://github.com/signalapp/Signal-Android/assets/77681918/a1b3569f-aa0b-4ce8-a993-0f1f14cefd4b)
</details>

after you confirm the phone number, the spinner is canceled, and the user is left with an active "Continue" button, and no indication that something is happening in the background. 

the spinner is cancelled by this call to `exitInProgressUiState()` on line `473`

https://github.com/signalapp/Signal-Android/blob/98424f6cbb79954736c4a6abe80db1700aee4357/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/EnterPhoneNumberFragment.java#L466-L480

And also, it will be canceled by the use of the `onDismissListener()` in `showConfirmNumberDialogIfTranslated()` 

https://github.com/signalapp/Signal-Android/blob/98424f6cbb79954736c4a6abe80db1700aee4357/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/RegistrationViewDelegate.kt#L61 

which according to the [docs]( https://developer.android.com/reference/android/app/AlertDialog.Builder.html#setOnDismissListener(android.content.DialogInterface.OnDismissListener) ) is called for any reason, if the dialog is dismissed. 

So I changed it with `setOnCancelListener()` which gets called, when you cancel the dialog, this includes tapping outside the dialog


This is the behavior after the change.. 

<details>

<summary>GIF Recording after changed</summary>
 
![after](https://github.com/signalapp/Signal-Android/assets/77681918/bd3731bb-b7b1-4df2-ae32-9c105ff73242)

</details>


 
