### PR TITLE
Fixed an issue where the charset in the link preview of some pages was not identified correctly (Fixes signalapp#13050)

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/OkHttpUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/OkHttpUtil.java
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms.util;
 
 import androidx.annotation.NonNull;
+import androidx.core.text.HtmlCompat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -8,11 +9,15 @@ import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import okhttp3.MediaType;
 import okhttp3.ResponseBody;
 
 public final class OkHttpUtil {
+
+  private static final Pattern CHARSET_PATTERN = Pattern.compile("charset=[\"']?([a-zA-Z0-9\\\\-]+)[\"']?");
 
   private OkHttpUtil() {}
 
@@ -41,8 +46,24 @@ public final class OkHttpUtil {
 
     byte[]    data        = readAsBytes(body.byteStream(), sizeLimit);
     MediaType contentType = body.contentType();
-    Charset   charset     = contentType != null ? contentType.charset(StandardCharsets.UTF_8) : StandardCharsets.UTF_8;
+    Charset   charset     = contentType != null ? contentType.charset(null) : null;
+
+    charset = charset == null ? getHtmlCharset(new String(data)) : charset;
 
     return new String(data, Objects.requireNonNull(charset));
+  }
+
+  private static @NonNull Charset getHtmlCharset(String html) {
+    Matcher charsetMatcher = CHARSET_PATTERN.matcher(html);
+    if (charsetMatcher.find() && charsetMatcher.groupCount() > 0) {
+      try {
+        return Objects.requireNonNull(Charset.forName(fromDoubleEncoded(charsetMatcher.group(1))));
+      } catch (Exception ignored) {}
+    }
+    return StandardCharsets.UTF_8;
+  }
+
+  private static @NonNull String fromDoubleEncoded(@NonNull String html) {
+    return HtmlCompat.fromHtml(HtmlCompat.fromHtml(html, 0).toString(), 0).toString();
   }
 }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S22 Ultra, Android 13
 * Virtual Pixel 5, Android 11
 * Virtual Pixel 5, Android 12
 * Virtual Pixel 5, Android 13
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------
Fixes: #13050 

----------


### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

When entering a URL of certain pages into the message edit field, the link preview text would use an incorrect charset and become unreadable.

This occurs when the page has the charset (which is not UTF-8) declared only in the HTML head, while the charset in the HTTP response is not explicitly declared.

See signalapp#13050 for an example.

This fix, instead of immediately defaulting to UTF-8 if an explicit charset was not declared in the HTTP response, looks for a charset declaration in the HTML.


| Old behavior| New behavior |
|--------|--------|
| ![Screenshot_20230708_163432](https://github.com/signalapp/Signal-Android/assets/7279173/98333e50-52df-4654-9153-d79da317ae8a)| ![Screenshot_20230708_162921](https://github.com/signalapp/Signal-Android/assets/7279173/37850045-9729-40db-8fd8-e6e18aac534e) |
