### PR TITLE
Fixed an issue where spoiler text does not get displayed in story group chat(Empty text). (Fixes signalapp#13052)

### DIFF
--- a/app/src/main/res/layout/stories_group_replies_fragment.xml
+++ b/app/src/main/res/layout/stories_group_replies_fragment.xml
@@ -30,6 +30,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0"
+        app:emoji_renderSpoilers="true"
         tools:itemCount="0" />
 
     <androidx.fragment.app.FragmentContainerView


### PR DESCRIPTION
which when onclick will reveal the spoiler

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
1. Micromax IN 2B, Android 12
2. Virtual Google Pixel 3a, Android 13
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
When text is entered in group stories chat with a spoiler, the content gets displayed as Empty because in EmojiTextView we are not allowing spoilers to be rendered. To solve that we need to add "app:emoji_renderSpoilers="true". Now after displaying the spoiler, on click we need the text to be revealed. This needs to be done using SpoilerAnnotation.SpoilerClickableSpan class. We create a new clickablespan class which will override onclick method which will call spoiler.onclick which reveals the text. 
Find Attached video for reference 

see https://github.com/signalapp/Signal-Android/issues/13052 as an example

https://github.com/signalapp/Signal-Android/assets/108622276/4f0e0c66-6611-48a5-9360-a67ea57d7f26


