### PR TITLE
Fixes #13031: Use username in note to self details screen

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/FromTextView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/FromTextView.java
@@ -40,17 +40,21 @@ public class FromTextView extends SimpleEmojiTextView {
   }
 
   public void setText(Recipient recipient, boolean read) {
-    setText(recipient, read, null);
+    setText(recipient, read, null, true);
   }
 
-  public void setText(Recipient recipient, boolean read, @Nullable String suffix) {
-    setText(recipient, recipient.getDisplayNameOrUsername(getContext()), read, suffix);
+  public void setText(Recipient recipient, boolean read, boolean shouldSetSelfAsNoteToSelfText) {
+    setText(recipient, read, null, shouldSetSelfAsNoteToSelfText);
   }
 
-  public void setText(Recipient recipient, @Nullable CharSequence fromString, boolean read, @Nullable String suffix) {
+  public void setText(Recipient recipient, boolean read, @Nullable String suffix, boolean shouldSetSelfAsNoteToSelfText) {
+    setText(recipient, recipient.getDisplayNameOrUsername(getContext()), read, suffix, shouldSetSelfAsNoteToSelfText);
+  }
+
+  public void setText(Recipient recipient, @Nullable CharSequence fromString, boolean read, @Nullable String suffix, boolean shouldSetSelfAsNoteToSelfText) {
     SpannableStringBuilder builder  = new SpannableStringBuilder();
 
-    if (recipient.isSelf()) {
+    if (shouldSetSelfAsNoteToSelfText && recipient.isSelf()) {
       builder.append(getContext().getString(R.string.note_to_self));
     } else {
       builder.append(fromString);

--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListItem.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListItem.java
@@ -236,9 +236,9 @@ public final class ConversationListItem extends ConstraintLayout implements Bind
     if (highlightSubstring != null) {
       String name = recipient.get().isSelf() ? getContext().getString(R.string.note_to_self) : recipient.get().getDisplayName(getContext());
 
-      this.fromView.setText(recipient.get(), SearchUtil.getHighlightedSpan(locale, searchStyleFactory, name, highlightSubstring, SearchUtil.MATCH_ALL), true, null);
+      this.fromView.setText(recipient.get(), SearchUtil.getHighlightedSpan(locale, searchStyleFactory, name, highlightSubstring, SearchUtil.MATCH_ALL), true, null, true);
     } else {
-      this.fromView.setText(recipient.get(), false);
+      this.fromView.setText(recipient.get(), false, true);
     }
 
     this.typingThreads = typingThreads;
@@ -293,7 +293,7 @@ public final class ConversationListItem extends ConstraintLayout implements Bind
     joinMembersDisposable.dispose();
     setSubjectViewText(null);
 
-    fromView.setText(contact, SearchUtil.getHighlightedSpan(locale, searchStyleFactory, new SpannableString(contact.getDisplayName(getContext())), highlightSubstring, SearchUtil.MATCH_ALL), true, null);
+    fromView.setText(contact, SearchUtil.getHighlightedSpan(locale, searchStyleFactory, new SpannableString(contact.getDisplayName(getContext())), highlightSubstring, SearchUtil.MATCH_ALL), true, null, true);
     setSubjectViewText(SearchUtil.getHighlightedSpan(locale, searchStyleFactory, contact.getE164().orElse(""), highlightSubstring, SearchUtil.MATCH_ALL));
     dateView.setText("");
     archivedView.setVisibility(GONE);
@@ -553,7 +553,7 @@ public final class ConversationListItem extends ConstraintLayout implements Bind
 
     if (highlightSubstring != null) {
       String name = recipient.isSelf() ? getContext().getString(R.string.note_to_self) : recipient.getDisplayName(getContext());
-      fromView.setText(recipient, SearchUtil.getHighlightedSpan(locale, searchStyleFactory, new SpannableString(name), highlightSubstring, SearchUtil.MATCH_ALL), true, null);
+      fromView.setText(recipient, SearchUtil.getHighlightedSpan(locale, searchStyleFactory, new SpannableString(name), highlightSubstring, SearchUtil.MATCH_ALL), true, null, true);
     } else {
       fromView.setText(recipient, false);
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/CameraContactSelectionAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/CameraContactSelectionAdapter.java
@@ -60,7 +60,7 @@ class CameraContactSelectionAdapter extends RecyclerView.Adapter<CameraContactSe
     }
 
     void bind(@NonNull Recipient recipient, boolean isLast) {
-      name.setText(recipient, true, isLast ? null : ",");
+      name.setText(recipient, true, isLast ? null : ",", true);
     }
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/messagedetails/RecipientViewHolder.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/messagedetails/RecipientViewHolder.java
@@ -41,7 +41,7 @@ final class RecipientViewHolder extends RecyclerView.ViewHolder {
 
   void bind(RecipientDeliveryStatus data) {
     unidentifiedDeliveryIcon.setVisibility(TextSecurePreferences.isShowUnidentifiedDeliveryIndicatorsEnabled(itemView.getContext()) && data.isUnidentified() ? View.VISIBLE : View.GONE);
-    fromView.setText(data.getRecipient());
+    fromView.setText(data.getRecipient(), true, null, false);
     avatar.setRecipient(data.getRecipient());
     badge.setBadgeFromRecipient(data.getRecipient());
 


### PR DESCRIPTION

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S22 Ultra, Android 13
 * Virtual device Google Pixel 3a, Android 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixes #13031: Use username in note to self details screen](https://github.com/signalapp/Signal-Android/commit/c4e890818fbfa3f5f8a43025fdc71916919b1899). `Note to Self` is not a person, so it doesn't really make sense in the context of `Read By`. Validated that the `Note to Self` name in the conversation view stays the same.

Screenshots of a working solution:
![image](https://github.com/signalapp/Signal-Android/assets/14223964/49ece8a5-2f35-4f0d-87d9-5df08c5e3421)

Name is unchanged on full conversation view and on conversation list view (below)
![image](https://github.com/signalapp/Signal-Android/assets/14223964/ab7a6c12-d91c-4a63-9032-a61b0aad0655)
![image](https://github.com/signalapp/Signal-Android/assets/14223964/2e9d401f-95c1-4f80-8374-6a65cc0438f8)

