### PR TITLE
Fixes #13101: Don't crash if new table already exists during migration.

### DIFF
--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/DatabaseConsistencyTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/DatabaseConsistencyTest.kt
@@ -260,7 +260,7 @@ class DatabaseConsistencyTest {
       ),
       Statement(
         name = "message_fts",
-        sql = "CREATE VIRTUAL TABLE message_fts USING fts5(body, thread_id UNINDEXED, content=message, content_rowid=_id)"
+        sql = "CREATE VIRTUAL TABLE IF NOT EXISTS message_fts USING fts5(body, thread_id UNINDEXED, content=message, content_rowid=_id)"
       ),
       Statement(
         name = "remapped_recipients",

--- a/app/src/main/java/org/thoughtcrime/securesms/database/SearchTable.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/SearchTable.kt
@@ -33,7 +33,7 @@ class SearchTable(context: Context, databaseHelper: SignalDatabase) : DatabaseTa
 
     @Language("sql")
     val CREATE_TABLE = arrayOf(
-      "CREATE VIRTUAL TABLE $FTS_TABLE_NAME USING fts5($BODY, $THREAD_ID UNINDEXED, content=${MessageTable.TABLE_NAME}, content_rowid=${MessageTable.ID})"
+      "CREATE VIRTUAL TABLE IF NOT EXISTS $FTS_TABLE_NAME USING fts5($BODY, $THREAD_ID UNINDEXED, content=${MessageTable.TABLE_NAME}, content_rowid=${MessageTable.ID})"
     )
 
     private const val TRIGGER_AFTER_INSERT = "message_ai"

--- a/app/src/main/java/org/thoughtcrime/securesms/database/helpers/migration/V149_LegacyMigrations.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/helpers/migration/V149_LegacyMigrations.kt
@@ -272,7 +272,7 @@ object V149_LegacyMigrations : SignalDatabaseMigration {
 
     if (oldVersion < FULL_TEXT_SEARCH) {
       // language=text
-      db.execSQL("CREATE VIRTUAL TABLE sms_fts USING fts5(body, content=sms, content_rowid=_id)")
+      db.execSQL("CREATE VIRTUAL TABLE IF NOT EXISTS sms_fts USING fts5(body, content=sms, content_rowid=_id)")
       db.execSQL(
         // language=sql
         """
@@ -299,7 +299,7 @@ object V149_LegacyMigrations : SignalDatabaseMigration {
         """.trimIndent()
       )
       // language=text
-      db.execSQL("CREATE VIRTUAL TABLE mms_fts USING fts5(body, content=mms, content_rowid=_id)")
+      db.execSQL("CREATE VIRTUAL TABLE IF NOT EXISTS mms_fts USING fts5(body, content=mms, content_rowid=_id)")
       db.execSQL(
         // language=sql
         """
@@ -441,7 +441,7 @@ object V149_LegacyMigrations : SignalDatabaseMigration {
       db.execSQL("DROP TRIGGER mms_au")
       db.execSQL("DROP TRIGGER mms_ad")
       // language=text
-      db.execSQL("CREATE VIRTUAL TABLE sms_fts USING fts5(body, thread_id UNINDEXED, content=sms, content_rowid=_id)")
+      db.execSQL("CREATE VIRTUAL TABLE IF NOT EXISTS sms_fts USING fts5(body, thread_id UNINDEXED, content=sms, content_rowid=_id)")
       db.execSQL(
         // language=sql
         """
@@ -468,7 +468,7 @@ object V149_LegacyMigrations : SignalDatabaseMigration {
         """.trimIndent()
       )
       // language=text
-      db.execSQL("CREATE VIRTUAL TABLE mms_fts USING fts5(body, thread_id UNINDEXED, content=mms, content_rowid=_id)")
+      db.execSQL("CREATE VIRTUAL TABLE IF NOT EXISTS mms_fts USING fts5(body, thread_id UNINDEXED, content=mms, content_rowid=_id)")
       db.execSQL(
         // language=sql
         """
@@ -1509,7 +1509,7 @@ object V149_LegacyMigrations : SignalDatabaseMigration {
 
     if (oldVersion < EMOJI_SEARCH) {
       // language=text
-      db.execSQL("CREATE VIRTUAL TABLE emoji_search USING fts5(label, emoji UNINDEXED)")
+      db.execSQL("CREATE VIRTUAL TABLE IF NOT EXISTS emoji_search USING fts5(label, emoji UNINDEXED)")
     }
 
     if (oldVersion < SENDER_KEY && !SqlUtil.tableExists(db, "sender_keys")) {

--- a/app/src/main/java/org/thoughtcrime/securesms/database/helpers/migration/V175_FixFullTextSearchLink.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/helpers/migration/V175_FixFullTextSearchLink.kt
@@ -15,7 +15,7 @@ object V175_FixFullTextSearchLink : SignalDatabaseMigration {
     db.execSQL("DROP TRIGGER IF EXISTS mms_ad")
     db.execSQL("DROP TRIGGER IF EXISTS mms_au")
 
-    db.execSQL("CREATE VIRTUAL TABLE message_fts USING fts5(body, thread_id UNINDEXED, content=message, content_rowid=_id)")
+    db.execSQL("CREATE VIRTUAL TABLE IF NOT EXISTS message_fts USING fts5(body, thread_id UNINDEXED, content=message, content_rowid=_id)")
 
     db.execSQL(
       """


### PR DESCRIPTION

- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
- [ ] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This is intended as a fix for #13101, however I have been unable to test this change due to bandwidth and network-related difficulties in my country.