### PR TITLE
Use timestamp of last fetch instead of counting them

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/gcm/FcmFetchManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/gcm/FcmFetchManager.kt
@@ -129,14 +129,9 @@ object FcmFetchManager {
       if (highPriority) {
         this.highPriority = true
       }
-      val now = System.nanoTime()
-      val performedReplace = EXECUTOR.enqueue { fetch(context, now) }
-      if (performedReplace) {
-        Log.i(TAG, "Already have one running and one enqueued. Ignoring.")
-      } else {
-        last = now
-        Log.i(TAG, "Updating last event to $last")
-      }
+      last = System.nanoTime()
+      Log.i(TAG, "Updating last event to $last")
+      EXECUTOR.enqueue { fetch(context, last) }
     }
   }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device Pixel 6A, Android 14 (GOS)
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Before, `activeCount` was used to know whether a new fetch was enqueued while the messages were being retrieved. But if somehow, a first fetch is being idle or the count is not correctly decreased, the service is not properly stopped. Previous fetches should be ignored when one succeed.

Previous behavior (activeCount) may result in :
- the "Checking for messages..." notification lasts for a long time (maybe part of #12904)
- Increased battery drain (useless foreground service)

This is part of the log I've seen when the foreground service's notification was lasting

```
Incrementing active count to 1
No more active. Stopping.
Incrementing active count to 1
No more active. Stopping.
Incrementing active count to 1
Incrementing active count to 2
Incrementing active count to 2
Incrementing active count to 2
Incrementing active count to 2
Incrementing active count to 2
```