### PR TITLE
Close okhttp response in case of error

### DIFF
--- a/libsignal-service/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java
+++ b/libsignal-service/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java
@@ -1960,9 +1960,19 @@ public class PushServiceSocket {
                                       boolean doNotAddAuthenticationOrUnidentifiedAccessKey)
       throws NonSuccessfulResponseCodeException, PushNetworkException, MalformedResponseException
   {
-    Response response = getServiceConnection(urlFragment, method, body, headers, unidentifiedAccessKey, doNotAddAuthenticationOrUnidentifiedAccessKey);
-    responseCodeHandler.handle(response.code(), response.body());
-    return validateServiceResponse(response);
+    Response response = null;
+    try {
+      response = getServiceConnection(urlFragment, method, body, headers, unidentifiedAccessKey, doNotAddAuthenticationOrUnidentifiedAccessKey);
+      responseCodeHandler.handle(response.code(), response.body());
+      return validateServiceResponse(response);
+    } catch (Exception e) {
+      // If an exception is thrown in the responseCodeHandler or in validateServiceResponse
+      // the response is not returned, and we need to close it here.
+      if (response != null && response.body() != null) {
+        response.body().close();
+      }
+      throw e;
+    }
   }
 
   private Response validateServiceResponse(Response response)


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * OnePlus 8T, Android 13.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
In the makeServiceRequest method, that returns a Response, the response body is not closed if there is an error.
If an exception is thrown in the responseCodeHandler or in validateServiceResponse the response is not returned, and it needs to be closed directly.

```
WARN  OkHttpClient - A connection to https://chat.staging.signal.org/ was leaked. Did you forget to close a response body?
java.lang.Throwable: response.body().close()
        at okhttp3.internal.platform.Platform.getStackTraceForCloseable(Platform.kt:145)
        at okhttp3.internal.connection.RealCall.callStart(RealCall.kt:170)
        at okhttp3.internal.connection.RealCall.execute(RealCall.kt:151)
        at org.whispersystems.signalservice.internal.push.PushServiceSocket.getServiceConnection(PushServiceSocket.java:2054)
        at org.whispersystems.signalservice.internal.push.PushServiceSocket.makeServiceRequest(PushServiceSocket.java:1965)
        at org.whispersystems.signalservice.internal.push.PushServiceSocket.makeServiceRequest(PushServiceSocket.java:1904)
        at org.whispersystems.signalservice.internal.push.PushServiceSocket.makeServiceRequest(PushServiceSocket.java:1898)
        at org.whispersystems.signalservice.internal.push.PushServiceSocket.setAccountAttributes(PushServiceSocket.java:493)
        at org.whispersystems.signalservice.api.SignalServiceAccountManager.setAccountAttributes(SignalServiceAccountManager.java:327)
```
