### PR TITLE
Send typing indicator status when voice message is recorded

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
@@ -3801,6 +3801,28 @@ class ConversationFragment :
   //region Input Panel Callbacks
 
   private inner class InputPanelListener : InputPanel.Listener {
+    private fun handleTypingIndicatorOnRecorderStopped() {
+      val typingStatusSender = ApplicationDependencies.getTypingStatusSender()
+      val recipient = viewModel.recipientSnapshot
+
+      if (recipient == null || recipient.isBlocked || recipient.isSelf) {
+        return
+      }
+
+      typingStatusSender.onTypingStoppedWithNotify(args.threadId)
+    }
+
+    private fun handleTypingIndicatorOnRecorderStarted() {
+      val typingStatusSender = ApplicationDependencies.getTypingStatusSender()
+      val recipient = viewModel.recipientSnapshot
+
+      if (recipient == null || recipient.isBlocked || recipient.isSelf) {
+        return
+      }
+
+      typingStatusSender.onTypingStarted(args.threadId)
+    }
+
     override fun onVoiceNoteDraftPlay(audioUri: Uri, progress: Double) {
       getVoiceNoteMediaController().startSinglePlaybackForDraft(audioUri, args.threadId, progress)
     }
@@ -3819,16 +3841,19 @@ class ConversationFragment :
     }
 
     override fun onRecorderStarted() {
+      handleTypingIndicatorOnRecorderStarted()
       voiceMessageRecordingDelegate.onRecorderStarted()
     }
 
     override fun onRecorderLocked() {
       updateToggleButtonState()
+      handleTypingIndicatorOnRecorderStarted()
       voiceMessageRecordingDelegate.onRecorderLocked()
     }
 
     override fun onRecorderFinished() {
       updateToggleButtonState()
+      handleTypingIndicatorOnRecorderStopped()
       voiceMessageRecordingDelegate.onRecorderFinished()
     }
 
@@ -3836,6 +3861,7 @@ class ConversationFragment :
       if (lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED)) {
         updateToggleButtonState()
       }
+      handleTypingIndicatorOnRecorderStopped()
       voiceMessageRecordingDelegate.onRecorderCanceled(byUser)
     }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nothing Phone(1), Android 13
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
_EDIT: It doesn't fix an issue but rather a feature request from the forum_

----------

### Description
As noted in the [following post](https://community.signalusers.org/t/show-an-indicator-when-someone-is-recording-a-voice-message/5694) in the forum, it can be quite confusing to not receive anything from a contact for a few minutes and then suddenly see a voice message pop up. 

This commit has now fixed this, whereby no new recording indicator is introduced but the existing one is extended. This is done by activating / deactivating the indicator when starting / stopping a recording.