### PR TITLE
Fix incorrect badge description when donation is made by a friend

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/badges/models/LargeBadge.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/badges/models/LargeBadge.kt
@@ -46,7 +46,10 @@ data class LargeBadge(
       description.text = if (model.largeBadge.badge.isSubscription()) {
         context.getString(R.string.ViewBadgeBottomSheetDialogFragment__s_supports_signal_with_a_monthly, model.shortName)
       } else {
-        context.getString(R.string.ViewBadgeBottomSheetDialogFragment__s_supports_signal_with_a_donation, model.shortName)
+        if (model.largeBadge.badge.isGift())
+          context.getString(R.string.ViewBadgeBottomSheetDialogFragment__a_friend_made_a_donation_to_signal_on_behalf_of_s, model.shortName)
+        else
+          context.getString(R.string.ViewBadgeBottomSheetDialogFragment__s_supports_signal_with_a_donation, model.shortName)
       }
 
       description.setLines(model.maxLines)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4715,6 +4715,8 @@
     <string name="ViewBadgeBottomSheetDialogFragment__s_supports_signal_with_a_monthly">%1$s supports Signal with a monthly donation. Signal is a nonprofit with no advertisers or investors, supported only by people like you.</string>
     <!-- Description of a page in the bottom sheet of a one-time badge. Placeholder is a user\'s short-name -->
     <string name="ViewBadgeBottomSheetDialogFragment__s_supports_signal_with_a_donation">%1$s supports Signal with a donation. Signal is a nonprofit with no advertisers or investors, supported only by people like you.</string>
+    <!-- Description of a page in the bottom sheet of a one-time badge gifted by a friend. Placeholder is a user\'s short-name -->
+    <string name="ViewBadgeBottomSheetDialogFragment__a_friend_made_a_donation_to_signal_on_behalf_of_s">A friend made a donation to Signal on behalf of %1$s. Signal is a nonprofit with no advertisers or investors, supported only by people like you.</string>
 
     <string name="ImageView__badge">Badge</string>
 


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
The badge description for a user when a payment is made by a friend to Signal on their behalf was incorrect. Added an 'if-else' check to the message. If the badge is a gift, the badge description should indicate the same.
