### PR TITLE
Fixes #13299: Enable the camera only if permission is granted

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/AvatarSelectionActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/AvatarSelectionActivity.java
@@ -1,7 +1,9 @@
 package org.thoughtcrime.securesms.mediasend;
 
+import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.graphics.Point;
 import android.net.Uri;
 import android.os.Bundle;
@@ -12,6 +14,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
 
@@ -214,6 +217,10 @@ public class AvatarSelectionActivity extends AppCompatActivity implements Camera
     return !isGalleryFirst();
   }
 
+  private boolean hasCameraPermission() {
+    return ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED;
+  }
+
   private void handleSave() {
     ImageEditorFragment fragment = (ImageEditorFragment) getSupportFragmentManager().findFragmentByTag(IMAGE_EDITOR);
     if (fragment == null) {
@@ -284,6 +291,6 @@ public class AvatarSelectionActivity extends AppCompatActivity implements Camera
 
   @Override
   public boolean isCameraEnabled() {
-    return true;
+    return hasCameraPermission();
   }
 }


### PR DESCRIPTION
### First time contributor checklist

- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Redmi Note 10 Pro, Android 13, MUI 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------
### Issue
Fixes: https://github.com/signalapp/Signal-Android/issues/13299


### **Before fix**
Test case 1:  ✅
- Settings
- Profile image
- Edit photo
- Camera -> Allow permission
- Back
- Photo -> Allow permission

**Result**: The Camera button is visible on the photo picker screen.

Test case 2: ❌
- Settings 
- Profile Image
- Edit photo
- Photo -> Allow permission

**Result**: The Camera button is visible(❌) on the photo picker screen.
**Expected**: The camera button should not be visible if the app doesn't have camera permission.

### **After fix**
Test case 1:  ✅
- Settings
- Profile image
- Edit photo
- Camera -> Allow permission
- Back
- Photo -> Allow permission

**Result**: The Camera button is visible on the photo picker screen.

Test case 2: ✅
- Settings 
- Profile Image
- Edit photo
- Photo -> Allow permission

**Result**: The Camera button is not visible on the photo picker screen.

Both cases were tested several times with a clean app state.

### Tested
| **Device** | **Android Version** | **Signal Version** |
|----------|----------|----------|
| Redmi Note 10 Pro | <img width="330" alt="Screenshot 2023-12-08 at 15 44 34" src="https://github.com/signalapp/Signal-Android/assets/7049715/03489f64-e196-48e0-b783-3ef48ce0fe71">   |  6.41.3 |

