### PR TITLE
Fixes #13296 : Move attachment constraints check to the background thread

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -35,6 +35,7 @@ import android.widget.Toast;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.WorkerThread;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 
@@ -266,6 +267,8 @@ public class AttachmentManager {
     final SettableFuture<Boolean> result = new SettableFuture<>();
 
     new AsyncTask<Void, Void, Slide>() {
+      private boolean areConstrainsSatisfied = false;
+
       @Override
       protected void onPreExecute() {
         thumbnail.clear(glideRequests);
@@ -275,19 +278,21 @@ public class AttachmentManager {
 
       @Override
       protected @Nullable Slide doInBackground(Void... params) {
+        Slide slide;
         try {
           if (PartAuthority.isLocalUri(uri)) {
-            return getManuallyCalculatedSlideInfo(uri, width, height);
+            slide = getManuallyCalculatedSlideInfo(uri, width, height);
           } else {
             Slide result = getContentResolverSlideInfo(uri, width, height);
-
-            if (result == null) return getManuallyCalculatedSlideInfo(uri, width, height);
-            else                return result;
+            slide = (result == null) ? getManuallyCalculatedSlideInfo(uri, width, height) : result;
           }
         } catch (IOException e) {
           Log.w(TAG, e);
           return null;
         }
+
+        this.areConstrainsSatisfied = areConstraintsSatisfied(context, slide, constraints);
+        return slide;
       }
 
       @Override
@@ -298,7 +303,7 @@ public class AttachmentManager {
                          R.string.ConversationActivity_sorry_there_was_an_error_setting_your_attachment,
                          Toast.LENGTH_SHORT).show();
           result.set(false);
-        } else if (!areConstraintsSatisfied(context, slide, constraints)) {
+        } else if (!areConstrainsSatisfied) {
           attachmentViewStub.get().setVisibility(View.GONE);
           Toast.makeText(context,
                          R.string.ConversationActivity_attachment_exceeds_size_limits,
@@ -524,6 +529,7 @@ public class AttachmentManager {
     }
   }
 
+  @WorkerThread
   private boolean areConstraintsSatisfied(final @NonNull  Context context,
                                           final @Nullable Slide slide,
                                           final @NonNull  MediaConstraints constraints)

--- a/app/src/main/java/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -267,7 +267,7 @@ public class AttachmentManager {
     final SettableFuture<Boolean> result = new SettableFuture<>();
 
     new AsyncTask<Void, Void, Slide>() {
-      private boolean areConstrainsSatisfied = false;
+      private boolean areConstraintsSatisfied = false;
 
       @Override
       protected void onPreExecute() {
@@ -291,7 +291,7 @@ public class AttachmentManager {
           return null;
         }
 
-        this.areConstrainsSatisfied = areConstraintsSatisfied(context, slide, constraints);
+        this.areConstraintsSatisfied = areConstraintsSatisfied(context, slide, constraints);
         return slide;
       }
 
@@ -303,7 +303,7 @@ public class AttachmentManager {
                          R.string.ConversationActivity_sorry_there_was_an_error_setting_your_attachment,
                          Toast.LENGTH_SHORT).show();
           result.set(false);
-        } else if (!areConstrainsSatisfied) {
+        } else if (!areConstraintsSatisfied) {
           attachmentViewStub.get().setVisibility(View.GONE);
           Toast.makeText(context,
                          R.string.ConversationActivity_attachment_exceeds_size_limits,


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Redmi Note 10 Pro, Android 13, MUI 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------
#
### Issue
Fixes: https://github.com/signalapp/Signal-Android/issues/13296

### Videos
Before fix: ❌
https://github.com/signalapp/Signal-Android/assets/7049715/add53da2-1bb1-4991-8fec-1bf0573300d7

After fix: ✅
https://github.com/signalapp/Signal-Android/assets/7049715/55d0f17d-aefe-4bb3-abe0-1645d24e6ef4

### Tested:
| **Device** | **Android Version** | **Signal Version** |
|----------|----------|----------|
| Redmi Note 10 Pro | <img width="330" alt="Screenshot 2023-12-08 at 15 44 34" src="https://github.com/signalapp/Signal-Android/assets/7049715/03489f64-e196-48e0-b783-3ef48ce0fe71">   |  6.41.3 |



