### PR TITLE
Fixes #13307: Use ViewCompat.setTransitionName in a safe way

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/main/MainActivityListHostFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/main/MainActivityListHostFragment.kt
@@ -113,19 +113,20 @@ class MainActivityListHostFragment : Fragment(R.layout.main_activity_list_host_f
     if (state.tab == ConversationListTab.CHATS) {
       return
     } else {
-      val cameraFab = requireView().findViewById<View>(R.id.camera_fab)
-      val newConvoFab = requireView().findViewById<View>(R.id.fab)
+      val cameraFab = requireView().findViewById<View?>(R.id.camera_fab)
+      val newConvoFab = requireView().findViewById<View?>(R.id.fab)
 
-      ViewCompat.setTransitionName(cameraFab, "camera_fab")
-      ViewCompat.setTransitionName(newConvoFab, "new_convo_fab")
+      val extras = when  {
+        cameraFab != null && newConvoFab != null -> {
+          ViewCompat.setTransitionName(cameraFab, "camera_fab")
+          ViewCompat.setTransitionName(newConvoFab, "new_convo_fab")
 
-      val extras: Navigator.Extras? = if (cameraFab == null || newConvoFab == null) {
-        null
-      } else {
-        FragmentNavigatorExtras(
-          cameraFab to "camera_fab",
-          newConvoFab to "new_convo_fab"
-        )
+          FragmentNavigatorExtras(
+            cameraFab to "camera_fab",
+            newConvoFab to "new_convo_fab"
+          )
+        }
+        else -> null
       }
 
       val destination = if (state.tab == ConversationListTab.STORIES) {

--- a/app/src/main/java/org/thoughtcrime/securesms/main/MainActivityListHostFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/main/MainActivityListHostFragment.kt
@@ -15,7 +15,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
-import androidx.navigation.Navigator
 import androidx.navigation.findNavController
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.recyclerview.widget.RecyclerView
@@ -116,7 +115,7 @@ class MainActivityListHostFragment : Fragment(R.layout.main_activity_list_host_f
       val cameraFab = requireView().findViewById<View?>(R.id.camera_fab)
       val newConvoFab = requireView().findViewById<View?>(R.id.fab)
 
-      val extras = when  {
+      val extras = when {
         cameraFab != null && newConvoFab != null -> {
           ViewCompat.setTransitionName(cameraFab, "camera_fab")
           ViewCompat.setTransitionName(newConvoFab, "new_convo_fab")


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Redmi Note 10 Pro, Android 13, MUI 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------
### Issue
Fixes: https://github.com/signalapp/Signal-Android/issues/13307

### Description
Use `ViewCompat.setTransitionName` safely.
I am not able to reproduce the crash anymore.

### Tested
| **Device** | **Android Version** | **Signal Version** |
|----------|----------|----------|
| Redmi Note 10 Pro | <img width="330" alt="Screenshot 2023-12-08 at 15 44 34" src="https://github.com/signalapp/Signal-Android/assets/7049715/03489f64-e196-48e0-b783-3ef48ce0fe71">   |  6.41.3 |
