### PR TITLE
Fixes #13312:  Delegate onConfigurationChanged to the ViewModel

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
@@ -601,7 +601,7 @@ public class ConversationListFragment extends MainFragment implements ActionMode
   @Override
   public void onConfigurationChanged(@NonNull Configuration newConfig) {
     super.onConfigurationChanged(newConfig);
-    onMegaphoneChanged(viewModel.getMegaphone());
+    viewModel.onConfigurationChanged();
   }
 
   private ContactSearchConfiguration mapSearchStateToConfiguration(@NonNull ContactSearchState state) {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListViewModel.kt
@@ -202,6 +202,12 @@ class ConversationListViewModel(
     }
   }
 
+  fun onConfigurationChanged() {
+    megaphoneRepository.getNextMegaphone { next ->
+      store.update { it.copy(megaphone = next ?: Megaphone.NONE) }
+    }
+  }
+
   private data class ConversationListState(
     val conversations: List<Conversation> = emptyList(),
     val megaphone: Megaphone = Megaphone.NONE,


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Redmi Note 10 Pro, Android 13, MUI 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------
### Issue
Fixes: https://github.com/signalapp/Signal-Android/issues/13312

### Description
In the beginning, I thought the problem had to do with the layout, but it turns out it's more about threads.

To make the layout hierarchy better, I tried taking out `LinearLayout` from `onboarding_megaphone.xml`. Unfortunately, this change didn't fix the issue.

After digging deeper, I found that the `onConfigurationChanged` method inside `ConversationListFragment` was incorrectly calling `onMegaphoneChanged` directly. It should go through `lifecycleDisposable`.

I tried to emit the current `megaphone` object using the following approach, but it didn't work because of the use of `distinctUntilChanged`():
```
fun onConfigurationChanged() {
    store.update { it.copy(megaphone = megaphone) }
}
```

Instead, I fetched the next `megaphone` object from the `repository` and updated the state.
```
fun onConfigurationChanged() {
    megaphoneRepository.getNextMegaphone { next ->
        store.update { it.copy(megaphone = next ?: Megaphone.NONE) }
    }
}
```

Final solution: 
Moved `onConfigurationChanged` handling from `ConversationListFragment` to the `ViewModel`, ensuring consistency in UI updates via `lifecycleDisposable` and maintaining the guarantee of UI observations on the main thread.

### Videos
https://github.com/signalapp/Signal-Android/assets/7049715/456bf33d-e18a-4477-91dc-b47ef72f3dd4

### Tested
| **Device** | **Android Version** | **Signal Version** |
|----------|----------|----------|
| Redmi Note 10 Pro | <img width="330" alt="Screenshot 2023-12-08 at 15 44 34" src="https://github.com/signalapp/Signal-Android/assets/7049715/03489f64-e196-48e0-b783-3ef48ce0fe71">   |  6.42.0 |

