### PR TITLE
Close unidentified websocket when the app is in background

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/messages/IncomingMessageObserver.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/messages/IncomingMessageObserver.kt
@@ -172,6 +172,13 @@ class IncomingMessageObserver(private val context: Application) {
     }
   }
 
+  private fun shouldKeepAliveUnidentified(): Boolean {
+    val timeIdle = lock.withLock {
+      if (appVisible) 0 else System.currentTimeMillis() - lastInteractionTime
+    }
+    return timeIdle <= websocketReadTimeout
+  }
+
   private fun isConnectionNecessary(): Boolean {
     val timeIdle: Long
     val keepAliveEntries: Set<Pair<String, Long>>
@@ -379,7 +386,7 @@ class IncomingMessageObserver(private val context: Application) {
           decryptionDrained = false
         }
 
-        signalWebSocket.connect()
+        signalWebSocket.connect(shouldKeepAliveUnidentified())
         try {
           while (isConnectionNecessary()) {
             try {
@@ -430,11 +437,12 @@ class IncomingMessageObserver(private val context: Application) {
               }
             } catch (e: WebSocketUnavailableException) {
               Log.i(TAG, "Pipe unexpectedly unavailable, connecting")
-              signalWebSocket.connect()
+              signalWebSocket.connect(shouldKeepAliveUnidentified())
             } catch (e: TimeoutException) {
               Log.w(TAG, "Application level read timeout...")
               attempts = 0
             }
+            signalWebSocket.setKeepAliveUnidentified(shouldKeepAliveUnidentified())
           }
 
           if (!appVisible) {

--- a/libsignal-service/src/main/java/org/whispersystems/signalservice/api/websocket/HealthMonitor.java
+++ b/libsignal-service/src/main/java/org/whispersystems/signalservice/api/websocket/HealthMonitor.java
@@ -4,7 +4,7 @@ package org.whispersystems.signalservice.api.websocket;
  * Callbacks to provide WebSocket health information to a monitor.
  */
 public interface HealthMonitor {
-  void onKeepAliveResponse(long sentTimestamp, boolean isIdentifiedWebSocket);
+  void onKeepAliveResponse(long sentTimestamp, boolean isIdentifiedWebSocket, boolean keepMonitoring);
 
   void onMessageError(int status, boolean isIdentifiedWebSocket);
 }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 6A, Android 14
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/) > This is related to #12341, but it requires some feedback before considering it fixed.

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
At present, Signal behaves in the same way in the background as it does when you're using the application : it keeps the 2 websockets connected (unidentified and identified). But only the identified one is necessary. Having the unidentified websocket connected is a useless resource consumption, and if it fails, then it restart the websockets for nothing.

This patch change the behavior of the IncomingMessageObserver to close the unidentified websocket when it goes in background, after a timeout. This will reduce the number of reconnection, and the number of websocket messages, and the resources used by Signal.
When the user needs the unidentified socket, it connects again.

---
#### Before, you can see the unidentified websocket in use:
```
2023-12-29 14:27:07.381  3498-4728  IncomingMessageObserver D  [Needs Connection] Network: true, Foreground: false, Time Since Last Interaction: 951192 ms (over limit), FCM: false, Stay open requests: [], Registered: true, Proxy: false, Force websocket: truePushAvailable: false
2023-12-29 14:27:07.381  3498-4728  IncomingMessageObserver D  Reading message...
2023-12-29 14:27:36.291  3498-4747  WebSocketConnection     I  [normal:97882913] Sending keep alive...
2023-12-29 14:27:36.315  3498-4747  WebSocketConnection     I  [unidentified:84802253] Sending keep alive...
2023-12-29 14:28:06.291  3498-4747  WebSocketConnection     I  [normal:97882913] Sending keep alive...
2023-12-29 14:28:06.313  3498-4747  WebSocketConnection     I  [unidentified:84802253] Sending keep alive...
2023-12-29 14:28:07.396  3498-4728  IncomingMessageObserver W  Application level read timeout...
2023-12-29 14:28:07.475  3498-4728  IncomingMessageObserver D  [Needs Connection] Network: true, Foreground: false, Time Since Last Interaction: 1011326 ms (over limit), FCM: false, Stay open requests: [], Registered: true, Proxy: false, Force websocket: truePushAvailable: false
2023-12-29 14:28:07.476  3498-4728  IncomingMessageObserver D  Reading message...
2023-12-29 14:28:36.293  3498-4747  WebSocketConnection     I  [normal:97882913] Sending keep alive...
2023-12-29 14:28:36.304  3498-4747  WebSocketConnection     I  [unidentified:84802253] Sending keep alive...
2023-12-29 14:29:06.295  3498-4747  WebSocketConnection     I  [normal:97882913] Sending keep alive...
2023-12-29 14:29:06.302  3498-4747  WebSocketConnection     I  [unidentified:84802253] Sending keep alive...
2023-12-29 14:29:08.371  3498-4728  IncomingMessageObserver W  Application level read timeout...
2023-12-29 14:29:08.428  3498-4728  IncomingMessageObserver D  [Needs Connection] Network: true, Foreground: false, Time Since Last Interaction: 1072301 ms (over limit), FCM: false, Stay open requests: [], Registered: true, Proxy: false, Force websocket: truePushAvailable: false
2023-12-29 14:29:08.428  3498-4728  IncomingMessageObserver D  Reading message...
2023-12-29 14:29:36.293  3498-4747  WebSocketConnection     I  [normal:97882913] Sending keep alive...
2023-12-29 14:29:36.302  3498-4747  WebSocketConnection     I  [unidentified:84802253] Sending keep alive...
2023-12-29 14:30:06.297  3498-4747  WebSocketConnection     I  [normal:97882913] Sending keep alive...
2023-12-29 14:30:06.318  3498-4747  WebSocketConnection     I  [unidentified:84802253] Sending keep alive...
2023-12-29 14:30:08.441  3498-4728  IncomingMessageObserver W  Application level read timeout...
2023-12-29 14:30:08.548  3498-4728  IncomingMessageObserver D  [Needs Connection] Network: true, Foreground: false, Time Since Last Interaction: 1132371 ms (over limit), FCM: false, Stay open requests: [], Registered: true, Proxy: false, Force websocket: truePushAvailable: false
2023-12-29 14:30:08.548  3498-4728  IncomingMessageObserver D  Reading message...
2023-12-29 14:30:36.970  3498-4747  WebSocketConnection     I  [normal:97882913] Sending keep alive...
2023-12-29 14:30:36.982  3498-4747  WebSocketConnection     I  [unidentified:84802253] Sending keep alive...
2023-12-29 14:31:06.971  3498-4747  WebSocketConnection     I  [normal:97882913] Sending keep alive...
2023-12-29 14:31:06.992  3498-4747  WebSocketConnection     I  [unidentified:84802253] Sending keep alive...
2023-12-29 14:31:08.563  3498-4728  IncomingMessageObserver W  Application level read timeout...
2023-12-29 14:31:08.635  3498-4728  IncomingMessageObserver D  [Needs Connection] Network: true, Foreground: false, Time Since Last Interaction: 1192493 ms (over limit), FCM: false, Stay open requests: [], Registered: true, Proxy: false, Force websocket: truePushAvailable: false
2023-12-29 14:31:08.635  3498-4728  IncomingMessageObserver D  Reading message...
2023-12-29 14:31:36.973  3498-4747  WebSocketConnection     I  [normal:97882913] Sending keep alive...
2023-12-29 14:31:36.993  3498-4747  WebSocketConnection     I  [unidentified:84802253] Sending keep alive...
2023-12-29 14:31:59.827  3498-3498  IncomingMessageObserver D  Background service started.
2023-12-29 14:31:59.827  3498-3498  IncomingMessageObserver D  Background service started.
2023-12-29 14:32:06.974  3498-4747  WebSocketConnection     I  [normal:97882913] Sending keep alive...
2023-12-29 14:32:06.982  3498-4747  WebSocketConnection     I  [unidentified:84802253] Sending keep alive...
2023-12-29 14:32:08.650  3498-4728  IncomingMessageObserver W  Application level read timeout...
2023-12-29 14:32:08.716  3498-4728  IncomingMessageObserver D  [Needs Connection] Network: true, Foreground: true, Time Since Last Interaction: N/A, FCM: false, Stay open requests: [], Registered: true, Proxy: false, Force websocket: truePushAvailable: false
2023-12-29 14:32:08.717  3498-4728  IncomingMessageObserver D  Reading message...
2023-12-29 14:32:36.974  3498-4747  WebSocketConnection     I  [normal:97882913] Sending keep alive...
2023-12-29 14:32:36.989  3498-4747  WebSocketConnection     I  [unidentified:84802253] Sending keep alive...
```

#### After, you can see the unidentified websocket being closed. It is open again when I open a conversation:

```
2023-12-29 15:30:04.568  9040-9089  IncomingMessageObserver D  [Needs Connection] Network: true, Foreground: false, Time Since Last Interaction: 3469 ms (within limit), FCM: false, Stay open requests: [], Registered: true, Proxy: false, Force websocket: truePushAvailable: false
2023-12-29 15:30:04.568  9040-9089  IncomingMessageObserver D  Reading message...
2023-12-29 15:30:04.574  9040-9089  IncomingMessageObserver D  Disconnecting unidentified websocket
2023-12-29 15:30:04.621  9040-9626  WebSocketConnection     I  [unidentified:18212726] onClosing()
2023-12-29 15:30:04.622  9040-9626  WebSocketConnection     I  [unidentified:18212726] onClose()
2023-12-29 15:30:34.577  9040-9630  WebSocketConnection     I  [normal:58528127] Sending keep alive...
2023-12-29 15:31:04.589  9040-9630  WebSocketConnection     I  [normal:58528127] Sending keep alive...
2023-12-29 15:31:04.698  9040-9089  IncomingMessageObserver W  Application level read timeout...
2023-12-29 15:31:04.720  9040-9089  IncomingMessageObserver D  [Needs Connection] Network: true, Foreground: false, Time Since Last Interaction: 63617 ms (within limit), FCM: false, Stay open requests: [], Registered: true, Proxy: false, Force websocket: truePushAvailable: false
2023-12-29 15:31:04.721  9040-9089  IncomingMessageObserver D  Reading message...
2023-12-29 15:31:04.726  9040-9089  IncomingMessageObserver D  Disconnecting unidentified websocket
2023-12-29 15:31:34.614  9040-9630  WebSocketConnection     I  [normal:58528127] Sending keep alive...
2023-12-29 15:32:04.631  9040-9630  WebSocketConnection     I  [normal:58528127] Sending keep alive...
2023-12-29 15:32:04.734  9040-9089  IncomingMessageObserver W  Application level read timeout...
2023-12-29 15:32:04.759  9040-9089  IncomingMessageObserver D  [Needs Connection] Network: true, Foreground: false, Time Since Last Interaction: 123653 ms (over limit), FCM: false, Stay open requests: [], Registered: true, Proxy: false, Force websocket: truePushAvailable: false
2023-12-29 15:32:04.760  9040-9089  IncomingMessageObserver D  Reading message...
2023-12-29 15:32:34.646  9040-9630  WebSocketConnection     I  [normal:58528127] Sending keep alive...
2023-12-29 15:33:04.657  9040-9630  WebSocketConnection     I  [normal:58528127] Sending keep alive...
2023-12-29 15:33:04.775  9040-9089  IncomingMessageObserver W  Application level read timeout...
2023-12-29 15:33:04.810  9040-9089  IncomingMessageObserver D  [Needs Connection] Network: true, Foreground: false, Time Since Last Interaction: 183695 ms (over limit), FCM: false, Stay open requests: [], Registered: true, Proxy: false, Force websocket: truePushAvailable: false
2023-12-29 15:33:04.810  9040-9089  IncomingMessageObserver D  Reading message...
2023-12-29 15:33:34.679  9040-9630  WebSocketConnection     I  [normal:58528127] Sending keep alive...
2023-12-29 15:34:04.696  9040-9630  WebSocketConnection     I  [normal:58528127] Sending keep alive...
2023-12-29 15:34:04.831  9040-9089  IncomingMessageObserver W  Application level read timeout...
2023-12-29 15:34:04.859  9040-9089  IncomingMessageObserver D  [Needs Connection] Network: true, Foreground: false, Time Since Last Interaction: 243750 ms (over limit), FCM: false, Stay open requests: [], Registered: true, Proxy: false, Force websocket: truePushAvailable: false
2023-12-29 15:34:04.859  9040-9089  IncomingMessageObserver D  Reading message...
2023-12-29 15:34:34.718  9040-9630  WebSocketConnection     I  [normal:58528127] Sending keep alive...
2023-12-29 15:35:04.737  9040-9630  WebSocketConnection     I  [normal:58528127] Sending keep alive...
2023-12-29 15:35:04.876  9040-9089  IncomingMessageObserver W  Application level read timeout...
2023-12-29 15:35:04.907  9040-9089  IncomingMessageObserver D  [Needs Connection] Network: true, Foreground: false, Time Since Last Interaction: 303796 ms (over limit), FCM: false, Stay open requests: [], Registered: true, Proxy: false, Force websocket: truePushAvailable: false
2023-12-29 15:35:04.907  9040-9089  IncomingMessageObserver D  Reading message...
2023-12-29 15:35:34.755  9040-9630  WebSocketConnection     I  [normal:58528127] Sending keep alive...
2023-12-29 15:36:04.776  9040-9630  WebSocketConnection     I  [normal:58528127] Sending keep alive...
2023-12-29 15:36:04.923  9040-9089  IncomingMessageObserver W  Application level read timeout...
2023-12-29 15:36:04.968  9040-9089  IncomingMessageObserver D  [Needs Connection] Network: true, Foreground: false, Time Since Last Interaction: 363843 ms (over limit), FCM: false, Stay open requests: [], Registered: true, Proxy: false, Force websocket: truePushAvailable: false
2023-12-29 15:36:04.968  9040-9089  IncomingMessageObserver D  Reading message...
2023-12-29 15:36:34.781  9040-9630  WebSocketConnection     I  [normal:58528127] Sending keep alive...
2023-12-29 15:37:04.807  9040-9630  WebSocketConnection     I  [normal:58528127] Sending keep alive...
2023-12-29 15:37:04.992  9040-9089  IncomingMessageObserver W  Application level read timeout...
2023-12-29 15:37:05.023  9040-9089  IncomingMessageObserver D  [Needs Connection] Network: true, Foreground: false, Time Since Last Interaction: 423911 ms (over limit), FCM: false, Stay open requests: [], Registered: true, Proxy: false, Force websocket: truePushAvailable: false
2023-12-29 15:37:05.023  9040-9089  IncomingMessageObserver D  Reading message...
2023-12-29 15:37:34.826  9040-9630  WebSocketConnection     I  [normal:58528127] Sending keep alive...

// Here, I open the app and a conversation

2023-12-29 15:37:37.699  9040-9040  IncomingMessageObserver D  Background service started.
2023-12-29 15:37:40.665  9040-9101  WebSocketConnection     I  [unidentified:166711988] connect()
2023-12-29 15:37:41.270  9040-9761  WebSocketConnection     I  [unidentified:166711988] onOpen() connected
```

Edit: I've force-pushed a change, the check in mayDisconnectUnidentified wasn't correct