### PR TITLE
Fixes #13331: Make toggle button update lifecycle-aware

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ToggleUpdateViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ToggleUpdateViewModel.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.thoughtcrime.securesms.conversation.v2
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+
+class ToggleUpdateViewModel : ViewModel() {
+
+  private val _state = MutableSharedFlow<Unit>(replay = 1)
+  val state = _state.asSharedFlow()
+
+  fun update() = viewModelScope.launch {
+    _state.emit(Unit)
+  }
+}


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Redmi Note 10 Pro, Android 13, MUI 14
 * Samsung Galaxy A14, Android 13
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------
### Issue
Fixes: https://github.com/signalapp/Signal-Android/issues/13331

### Description
Update UI state following the Android lifecycle.

### Videos
✅

https://github.com/signalapp/Signal-Android/assets/7049715/926edb6f-6459-41e0-9d00-ca83dc6f506b


### Tested
### Device info
| **Device**             | **Android Version**                               | **Signal Version** |
|-------------------------|----------------------------------------------------|---------------------|
| Redmi Note 10 Pro       | ![Android Version Image](https://github.com/signalapp/Signal-Android/assets/7049715/03489f64-e196-48e0-b783-3ef48ce0fe71)    | 6.42.3              |
| Samsung Galaxy A14      | ![Android Version Image](https://github.com/signalapp/Signal-Android/assets/7049715/524c1145-90b9-42d3-a452-e26654dbb68b) | 6.42.3 |

