### PR TITLE
Accessibility: Add emoji to content description in EmojiImageView (fixes #13358)

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiImageView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiImageView.java
@@ -34,6 +34,7 @@ public class EmojiImageView extends AppCompatImageView {
       setImageResource(R.drawable.ic_emoji);
     } else {
       setImageDrawable(EmojiProvider.getEmojiDrawable(getContext(), emoji, forceJumboEmoji));
+      setContentDescription(emoji);
     }
   }
 }


### PR DESCRIPTION
This is needed so that screen readers can read the emoji.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Pixel 3, Android 13
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
In issue #13358, screen readers can't read emoji reactions to messages. This fixes the issue by adding the emoji as a content description.

Manually verified that this fixes it by enabling Talkback and selecting the reactions pill and then listening. Talkback says the emoji name instead of "unlabeled".