### PR TITLE
Set structured name when creating contacts

### DIFF
--- a/contacts/lib/src/main/java/org/signal/contacts/SystemContactsRepository.kt
+++ b/contacts/lib/src/main/java/org/signal/contacts/SystemContactsRepository.kt
@@ -488,7 +488,12 @@ object SystemContactsRepository {
       // Data entry for name
       ContentProviderOperation.newInsert(dataUri)
         .withValueBackReference(ContactsContract.CommonDataKinds.StructuredName.RAW_CONTACT_ID, operationIndex)
-        .withValue(ContactsContract.CommonDataKinds.StructuredName.DISPLAY_NAME, systemContactInfo.displayName)
+        .withValue(ContactsContract.CommonDataKinds.StructuredName.DISPLAY_NAME, systemContactInfo.name.displayName)
+        .withValue(ContactsContract.CommonDataKinds.StructuredName.GIVEN_NAME, systemContactInfo.name.givenName)
+        .withValue(ContactsContract.CommonDataKinds.StructuredName.FAMILY_NAME, systemContactInfo.name.familyName)
+        .withValue(ContactsContract.CommonDataKinds.StructuredName.PREFIX, systemContactInfo.name.prefix)
+        .withValue(ContactsContract.CommonDataKinds.StructuredName.SUFFIX, systemContactInfo.name.suffix)
+        .withValue(ContactsContract.CommonDataKinds.StructuredName.MIDDLE_NAME, systemContactInfo.name.middleName)
         .withValue(ContactsContract.Data.MIMETYPE, ContactsContract.CommonDataKinds.StructuredName.CONTENT_ITEM_TYPE)
         .build(),
 
@@ -596,15 +601,41 @@ object SystemContactsRepository {
         val systemNumber: String? = contactCursor.requireString(ContactsContract.PhoneLookup.NUMBER)
         if (systemNumber != null && e164Formatter(systemNumber) == e164) {
           val phoneLookupId = contactCursor.requireLong(ContactsContract.PhoneLookup._ID)
+          val idProjection = arrayOf(ContactsContract.RawContacts._ID)
+          val idSelection = "${ContactsContract.RawContacts.CONTACT_ID} = ? "
+          val idArgs = SqlUtil.buildArgs(phoneLookupId)
 
-          context.contentResolver.query(ContactsContract.RawContacts.CONTENT_URI, arrayOf(ContactsContract.RawContacts._ID), "${ContactsContract.RawContacts.CONTACT_ID} = ? ", SqlUtil.buildArgs(phoneLookupId), null)?.use { idCursor ->
+          context.contentResolver.query(ContactsContract.RawContacts.CONTENT_URI, idProjection, idSelection, idArgs, null)?.use { idCursor ->
             if (idCursor.moveToNext()) {
-              return SystemContactInfo(
-                displayName = contactCursor.requireString(ContactsContract.PhoneLookup.DISPLAY_NAME),
-                displayPhone = systemNumber,
-                siblingRawContactId = idCursor.requireLong(ContactsContract.RawContacts._ID),
-                type = contactCursor.requireInt(ContactsContract.PhoneLookup.TYPE)
+              val rawContactId = idCursor.requireLong(ContactsContract.RawContacts._ID)
+              val nameProjection = arrayOf(
+                ContactsContract.CommonDataKinds.StructuredName.DISPLAY_NAME,
+                ContactsContract.CommonDataKinds.StructuredName.GIVEN_NAME,
+                ContactsContract.CommonDataKinds.StructuredName.FAMILY_NAME,
+                ContactsContract.CommonDataKinds.StructuredName.PREFIX,
+                ContactsContract.CommonDataKinds.StructuredName.SUFFIX,
+                ContactsContract.CommonDataKinds.StructuredName.MIDDLE_NAME
               )
+              val nameSelection = "${ContactsContract.Data.RAW_CONTACT_ID} = ? "
+              val nameArgs = SqlUtil.buildArgs(rawContactId)
+
+              context.contentResolver.query(ContactsContract.Data.CONTENT_URI, nameProjection, nameSelection, nameArgs, null)?.use { nameCursor ->
+                if (nameCursor.moveToNext()) {
+                  return SystemContactInfo(
+                    name = NameDetails(
+                      displayName = null,
+                      givenName = nameCursor.requireString(ContactsContract.CommonDataKinds.StructuredName.GIVEN_NAME),
+                      familyName = nameCursor.requireString(ContactsContract.CommonDataKinds.StructuredName.FAMILY_NAME),
+                      prefix = nameCursor.requireString(ContactsContract.CommonDataKinds.StructuredName.PREFIX),
+                      suffix = nameCursor.requireString(ContactsContract.CommonDataKinds.StructuredName.SUFFIX),
+                      middleName = nameCursor.requireString(ContactsContract.CommonDataKinds.StructuredName.MIDDLE_NAME)
+                    ),
+                    displayPhone = systemNumber,
+                    siblingRawContactId = rawContactId,
+                    type = contactCursor.requireInt(ContactsContract.PhoneLookup.TYPE)
+                  )
+                }
+              }
             }
           }
         }
@@ -824,7 +855,7 @@ object SystemContactsRepository {
   )
 
   private data class SystemContactInfo(
-    val displayName: String?,
+    val name: NameDetails,
     val displayPhone: String,
     val siblingRawContactId: Long,
     val type: Int


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual Pixel 3a, Android 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Fixes #12305. When creating copies of contacts, set the structured name fields instead of the unstructured name fields. This fixes bugs where certain types of names are displayed incorrectly because the structured name is inaccurately reconstructed from the unstructured name.

I tested this by running the `org.app.contactstest` app, pressing "Link Contacts", and ensuring (in the Simple Contacts app) that the contact created by this app has a properly formatted name. I tested the first name + suffix format (first: "John", suffix: "Jr.") as well as an example with a multi-word "middle name" (same format as first: "Elaine", middle: "Lan 趙小蘭 (Zhào Xiǎo-lán)", last: "Chao").