### PR TITLE
 added a plural for AboutSheet instead of string for English (Fixes #13362)

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/about/AboutSheet.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/about/AboutSheet.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -216,7 +217,11 @@ private fun AboutSheetContent(
     val groupsInCommonText = if (recipient.hasGroupsInCommon()) {
       stringResource(id = R.string.AboutSheet__d_groups_in_common, groupsInCommonCount)
     } else {
-      stringResource(id = R.string.AboutSheet__you_have_no_groups_in_common)
+      pluralStringResource(
+        id = R.plurals.AboutSheet__d_groups_in_common,
+        groupsInCommonCount,
+        groupsInCommonCount
+      )
     }
 
     AboutRow(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1897,7 +1897,10 @@
     <!-- Notice when a user is not a connection to review requests carefully -->
     <string name="AboutSheet__review_requests_carefully">Review requests carefully</string>
     <!-- Text used when user has groups in common. Placeholder is the count -->
-    <string name="AboutSheet__d_groups_in_common">%1$d groups in common</string>
+    <plurals name="AboutSheet__d_groups_in_common">
+        <item quantity="one">%1$d group in common</item>
+        <item quantity="other">%1$d groups in common</item>
+    </plurals>
     <!-- Text displayed in title for external recipients -->
     <string name="AboutSheet__about">About</string>
     <!-- Text displayed in title for you -->


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [ ] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

I changed the `app\src\main\res\values\strings.xml` file and used a plurals resource for it instead of string resource, then changed the usage according to the new plural in `app\src\main\java\org\thoughtcrime\securesms\recipients\ui\about\AboutSheet.kt` by importing a plural from jetpack compose and changing the string the usage.

The resource files for other languages ( ` `app\src\main\res\values\`) need to be changed similarly but as I only knew English language, I changed only for it accordingly.
