### PR TITLE
UI glitches related to device linking

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/DeviceAddFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/DeviceAddFragment.java
@@ -72,8 +72,9 @@ public class DeviceAddFragment extends LoggingFragment {
     return container;
   }
 
-  @Override
-  public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+  @Override public void onStart() {
+    super.onStart();
+
     MenuItem switchCamera = ((DeviceActivity) requireActivity()).getCameraSwitchItem();
 
     if (switchCamera != null) {
@@ -82,6 +83,17 @@ public class DeviceAddFragment extends LoggingFragment {
         scannerView.toggleCamera();
         return true;
       });
+    }
+  }
+
+  @Override public void onStop() {
+    super.onStop();
+
+    MenuItem switchCamera = ((DeviceActivity) requireActivity()).getCameraSwitchItem();
+
+    if (switchCamera != null) {
+      switchCamera.setVisible(false);
+      switchCamera.setOnMenuItemClickListener(null);
     }
   }
 

--- a/app/src/main/res/layout/device_list_fragment.xml
+++ b/app/src/main/res/layout/device_list_fragment.xml
@@ -49,13 +49,16 @@
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/add_device"
-        style="@style/Widget.Material3.FloatingActionButton.Primary"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
         android:layout_margin="16dp"
         android:contentDescription="@string/device_list_fragment__link_new_device"
         android:focusable="true"
-        app:srcCompat="@drawable/ic_plus_24" />
+        android:theme="@style/Widget.Material3.FloatingActionButton.Secondary"
+        app:backgroundTint="@color/signal_colorPrimaryContainer"
+        app:shapeAppearanceOverlay="@style/Signal.ShapeOverlay.Rounded.Fab"
+        app:srcCompat="@drawable/ic_plus_24"
+        app:tint="@color/signal_colorOnSurface" />
 
 </LinearLayout>


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Emulator, Android API 33
- [x] My contribution is fully baked and ready to be merged as is
- [x] ~I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit~ (my two findings were not yet tracked AFAIK)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

- When linking a device, there is an action bar button to switch the camera. That button, however, did not vanish again if QR scan is complete (e.g if QR code was scanned or fragment was left by back button). Commit 704e560ab8792b96dadb0f8c50df6e30e1ee1e8c hides the action bar button again as soon as the Fragment disappears.

- The "+" fab in the linked device list was still using the old material2 style. Commit 384f52107bccddd2b2ead8f1df294a22961f5646 changes it to use the current styles.

![Screenshot_20240120_151527](https://github.com/signalapp/Signal-Android/assets/64581222/31779c95-8123-41b0-9040-3ac41bc902da)

___

OT: 

IMHO the screen looks quite empty if no device is linked yet. I would suggest adding a centered action button "link a device" instead of the "no device linked" text (and hiding the fab in this case). If this is wanted, I can provide a follow-up PR.