### PR TITLE
re-add system contact shortcut

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
@@ -1306,6 +1306,13 @@ class ConversationFragment :
         optionsMenuCallback.handleConversationSettings()
       }
     }
+
+    if (recipient.isSystemContact) {
+      titleView.setOnLongClickListener {
+        startActivity(Intent(Intent.ACTION_VIEW, recipient.contactUri))
+        return@setOnLongClickListener true
+      }
+    }
   }
 
   private fun presentWallpaper(chatWallpaper: ChatWallpaper?) {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Emulator, Android API 33
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Around half a year ago when the conversation fragment was largely rewritten, the long click shortcut to access the system contact was (accidentally?) removed. I thought I would get used to it, but I'm still missing that option... I would really appreciate it if it was readded.

With this PR merged, long-clicking the contact name in the conversation action bar will open the system contact if available.