### PR TITLE
QA target can pass on ARM MacBook

### DIFF
--- a/libsignal-service/src/test/java/org/whispersystems/signalservice/api/crypto/AttachmentCipherTest.java
+++ b/libsignal-service/src/test/java/org/whispersystems/signalservice/api/crypto/AttachmentCipherTest.java
@@ -29,7 +29,10 @@ import static org.whispersystems.signalservice.testutil.LibSignalLibraryUtil.ass
 public final class AttachmentCipherTest {
 
   static {
-    Security.insertProviderAt(Conscrypt.newProvider(), 1);
+    // https://github.com/google/conscrypt/issues/1034
+    if (!System.getProperty("os.arch").equals("aarch64")) {
+      Security.insertProviderAt(Conscrypt.newProvider(), 1);
+    }
   }
 
   @Test

--- a/libsignal-service/src/test/java/org/whispersystems/signalservice/api/crypto/ProfileCipherTest.java
+++ b/libsignal-service/src/test/java/org/whispersystems/signalservice/api/crypto/ProfileCipherTest.java
@@ -30,7 +30,10 @@ public class ProfileCipherTest {
   }
 
   static {
-    Security.insertProviderAt(Conscrypt.newProvider(), 1);
+    // https://github.com/google/conscrypt/issues/1034
+    if (!System.getProperty("os.arch").equals("aarch64")) {
+      Security.insertProviderAt(Conscrypt.newProvider(), 1);
+    }
   }
 
   @Test

--- a/libsignal-service/src/test/java/org/whispersystems/signalservice/api/crypto/SigningCertificateTest.java
+++ b/libsignal-service/src/test/java/org/whispersystems/signalservice/api/crypto/SigningCertificateTest.java
@@ -19,7 +19,10 @@ import java.security.cert.CertificateException;
 public class SigningCertificateTest extends TestCase {
 
   static {
-    Security.insertProviderAt(Conscrypt.newProvider(), 1);
+    // https://github.com/google/conscrypt/issues/1034
+    if (!System.getProperty("os.arch").equals("aarch64")) {
+      Security.insertProviderAt(Conscrypt.newProvider(), 1);
+    }
   }
 
   public void testGoodSignature() throws CertificateException, NoSuchAlgorithmException, IOException, KeyStoreException, CertPathValidatorException, SignatureException {

--- a/libsignal-service/src/test/java/org/whispersystems/signalservice/api/crypto/UnidentifiedAccessTest.java
+++ b/libsignal-service/src/test/java/org/whispersystems/signalservice/api/crypto/UnidentifiedAccessTest.java
@@ -2,6 +2,7 @@ package org.whispersystems.signalservice.api.crypto;
 
 import junit.framework.TestCase;
 
+import org.conscrypt.Conscrypt;
 import org.conscrypt.OpenSSLProvider;
 import org.signal.libsignal.zkgroup.InvalidInputException;
 import org.signal.libsignal.zkgroup.profiles.ProfileKey;
@@ -12,7 +13,10 @@ import java.util.Arrays;
 public class UnidentifiedAccessTest extends TestCase {
 
   static {
-    Security.insertProviderAt(new OpenSSLProvider(), 1);
+    // https://github.com/google/conscrypt/issues/1034
+    if (!System.getProperty("os.arch").equals("aarch64")) {
+      Security.insertProviderAt(new OpenSSLProvider(), 1);
+    }
   }
 
   private final byte[] EXPECTED_RESULT = {(byte)0x5a, (byte)0x72, (byte)0x3a, (byte)0xce, (byte)0xe5, (byte)0x2c, (byte)0x5e, (byte)0xa0, (byte)0x2b, (byte)0x92, (byte)0xa3, (byte)0xa3, (byte)0x60, (byte)0xc0, (byte)0x95, (byte)0x95};


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * None; this change impacts unit tests running on the local host. I tested it on an M2 MacBook.
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

I identified the need for this change while running `./gradlew qa --parallel` on my MacBook, trying to reproduce what the CI does.

The Conscrypt library does not have a native library suitable for running on the ARM MacBooks. As a result, unit tests that rely on Conscrypt also don't work on this hardware.

Fortunately, though, the tests will pass without Conscrypt anyway. As a workaround, we can avoid using Conscrypt only when running the unit test suite on these machines.

See also: https://github.com/google/conscrypt/issues/1034
