### PR TITLE
Fix default video record zoom level (Assistance needed)

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/CameraXVideoCaptureHelper.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/CameraXVideoCaptureHelper.java
@@ -74,7 +74,7 @@ class CameraXVideoCaptureHelper implements CameraButtonView.VideoCaptureListener
         } else {
           try {
             debouncer.clear();
-            cameraController.setZoomRatio(Objects.requireNonNull(cameraController.getZoomState().getValue()).getMinZoomRatio());
+            cameraController.setZoomRatio(1.0f);
             memoryFileDescriptor.seek(0);
             callback.onVideoSaved(memoryFileDescriptor.getFileDescriptor());
           } catch (IOException e) {
@@ -142,7 +142,7 @@ class CameraXVideoCaptureHelper implements CameraButtonView.VideoCaptureListener
   @SuppressLint("RestrictedApi")
   private void beginCameraRecording() {
     cameraXModePolicy.setToVideo(cameraController);
-    this.cameraController.setZoomRatio(Objects.requireNonNull(this.cameraController.getZoomState().getValue()).getMinZoomRatio());
+    this.cameraController.setZoomRatio(1.0f);
     callback.onVideoRecordStarted();
     shrinkCaptureArea();
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 7a, Android 14
- [ ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

This addresses #13017 

When recording video, the zoom ratio is set to minZoomRatio by default. On devices with wide angle cameras, the minZoomRatio is actually less than 1.0x. This means that if a device has a wide angle camera, then Signal will start recording with it instead of the main camera. This change ensures that when recording starts, the zoom level is always at 1.0x.

However, the behavior is still broken when zooming and I haven't been able to figure out how to fix it. The recording now properly starts at 1.0x, but when you start to zoom it jumps back to 0.5x. 

If I change `cameraController.setZoomRatio((range * increment) + zoomState.getMinZoomRatio());` in `onZoomIncremented()` to `cameraController.setZoomRatio((range * increment) + 1.0f);` then zooming works smoothly, but you can no longer zoom out to anything below 1.0x.

I'm not an Android dev, so any help would be greatly appreciated! Thanks :)

---

Before: Recording starts at 0.5x


https://github.com/signalapp/Signal-Android/assets/123981212/df1d005e-dda5-4e37-a3a3-bf18b9aaae65



---

After: Recording starts at 1.0x, but zoom starts at 0.5x


https://github.com/signalapp/Signal-Android/assets/123981212/745018af-58ee-484f-b523-e3e57615a7fd

