### PR TITLE
Add fix for missing play button when the audio is not sent in offline…

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/AudioView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/AudioView.java
@@ -202,6 +202,7 @@ public final class AudioView extends FrameLayout {
     } else if (showControls && audio.getTransferState() == AttachmentTable.TRANSFER_PROGRESS_STARTED) {
       controlToggle.displayQuick(progressAndPlay);
       seekBar.setEnabled(false);
+      showPlayButton();
       if (circleProgress != null) {
         circleProgress.setVisibility(View.VISIBLE);
         circleProgress.spin();


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device Google Pixel 6 Android 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fix
- #13321 
- This pull request resolves the issue where the play button is hidden in offline mode when sending voice messages. This prevents users from playing and pausing recorded messages in the Signal app.


![Screenshot_20240209-130201](https://github.com/signalapp/Signal-Android/assets/25776029/be9c98b1-21b5-4b15-8e34-80a0fd7f42f2)