### PR TITLE
Fix navbar color in multiple instances

### DIFF
--- a/app/src/main/res/values-v21/themes.xml
+++ b/app/src/main/res/values-v21/themes.xml
@@ -32,13 +32,13 @@
     </style>
 
     <style name="TextSecure.LightRegistrationTheme" parent="TextSecure.LightNoActionBar">
-        <item name="android:statusBarColor">@color/core_grey_60</item>
-        <item name="android:navigationBarColor">@color/core_black</item>
+        <item name="android:statusBarColor">@color/signal_colorBackground</item>
+        <item name="android:navigationBarColor">@color/signal_colorBackground</item>
     </style>
 
     <style name="TextSecure.DarkRegistrationTheme" parent="TextSecure.DarkNoActionBar">
         <item name="android:statusBarColor">@color/signal_colorBackground</item>
-        <item name="android:navigationBarColor">@color/core_black</item>
+        <item name="android:navigationBarColor">@color/signal_colorBackground</item>
     </style>
 
     <style name="TextSecure.MediaPreview" parent="@style/TextSecure.BaseMediaPreview">

--- a/app/src/main/res/values-v23/themes.xml
+++ b/app/src/main/res/values-v23/themes.xml
@@ -14,13 +14,13 @@
     <style name="TextSecure.LightRegistrationTheme" parent="TextSecure.LightNoActionBar">
         <item name="android:windowLightStatusBar">true</item>
         <item name="android:statusBarColor">@color/signal_colorBackground</item>
-        <item name="android:navigationBarColor">@color/core_black</item>
+        <item name="android:navigationBarColor">@color/signal_colorBackground</item>
     </style>
 
     <style name="TextSecure.DarkRegistrationTheme" parent="TextSecure.DarkNoActionBar">
         <item name="android:windowLightStatusBar">false</item>
         <item name="android:statusBarColor">@color/signal_colorBackground</item>
-        <item name="android:navigationBarColor">@color/core_black</item>
+        <item name="android:navigationBarColor">@color/signal_colorBackground</item>
     </style>
 
     <style name="TextSecure.LightNoActionBar" parent="TextSecure.BaseLightNoActionBar">

--- a/app/src/main/res/values-v27/themes.xml
+++ b/app/src/main/res/values-v27/themes.xml
@@ -11,14 +11,14 @@
     <style name="TextSecure.DarkTheme" parent="TextSecure.BaseDarkTheme">
         <item name="android:statusBarColor">@color/signal_colorBackground</item>
         <item name="android:windowLightStatusBar">false</item>
-        <item name="android:navigationBarColor">@color/core_black</item>
+        <item name="android:navigationBarColor">@color/signal_colorBackground</item>
         <item name="android:windowLightNavigationBar">false</item>
     </style>
 
     <style name="TextSecure.LightRegistrationTheme" parent="TextSecure.LightNoActionBar">
         <item name="android:windowLightStatusBar">true</item>
         <item name="android:statusBarColor">@color/signal_colorBackground</item>
-        <item name="android:navigationBarColor">@color/core_black</item>
+        <item name="android:navigationBarColor">@color/signal_colorBackground</item>
         <item name="android:windowLightNavigationBar">false</item>
     </style>
 
@@ -47,7 +47,7 @@
         <item name="android:windowIsFloating">false</item>
         <item name="android:statusBarColor">@color/transparent</item>
         <item name="android:windowLightStatusBar">false</item>
-        <item name="android:navigationBarColor">@color/core_black</item>
+        <item name="android:navigationBarColor">@color/signal_colorBackground</item>
         <item name="android:windowLightNavigationBar">false</item>
     </style>
 </resources>


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
This PR fixes the dark mode navbar color for two screens
* Debug logs screen
* Message details screen



| Screen | Before  | After |
| ------------- | ------------- | ------------- |
| Debug Logs Screen | ![debug-screen-before,50%](https://github.com/signalapp/Signal-Android/assets/123981212/df183485-f2da-47db-bd4c-08e701215f1f) | ![debug-screen-after](https://github.com/signalapp/Signal-Android/assets/123981212/cfdde65e-9b2b-4bf6-aa5a-e136c11f59b1) 
| Message Details Screen | ![details-screen-before](https://github.com/signalapp/Signal-Android/assets/123981212/b15d83bb-2cf4-457b-8877-80d36c69d2c0)  | ![details-screen-after](https://github.com/signalapp/Signal-Android/assets/123981212/0f7fdc77-5fff-4d17-885f-375aa713d9d8) |