### PR TITLE
Fix racey dialog dismissal in `PlacePickerActivity`

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/conversation/ConversationSettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/conversation/ConversationSettingsFragment.kt
@@ -187,7 +187,7 @@ class ConversationSettingsFragment : DSLSettingsFragment(
     when (requestCode) {
       REQUEST_CODE_ADD_MEMBERS_TO_GROUP -> if (data != null) {
         val selected: List<RecipientId> = requireNotNull(data.getParcelableArrayListExtraCompat(PushContactSelectionActivity.KEY_SELECTED_RECIPIENTS, RecipientId::class.java))
-        val progress: SimpleProgressDialog.DismissibleDialog = SimpleProgressDialog.showDelayed(requireContext(), this)
+        val progress: SimpleProgressDialog.DismissibleDialog = SimpleProgressDialog.showDelayed(requireContext(), viewLifecycleOwner)
 
         viewModel.onAddToGroupComplete(selected) {
           progress.dismiss()

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/conversation/ConversationSettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/conversation/ConversationSettingsFragment.kt
@@ -187,7 +187,7 @@ class ConversationSettingsFragment : DSLSettingsFragment(
     when (requestCode) {
       REQUEST_CODE_ADD_MEMBERS_TO_GROUP -> if (data != null) {
         val selected: List<RecipientId> = requireNotNull(data.getParcelableArrayListExtraCompat(PushContactSelectionActivity.KEY_SELECTED_RECIPIENTS, RecipientId::class.java))
-        val progress: SimpleProgressDialog.DismissibleDialog = SimpleProgressDialog.showDelayed(requireContext())
+        val progress: SimpleProgressDialog.DismissibleDialog = SimpleProgressDialog.showDelayed(requireContext(), this)
 
         viewModel.onAddToGroupComplete(selected) {
           progress.dismiss()

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/mutiselect/forward/MultiselectForwardFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/mutiselect/forward/MultiselectForwardFragment.kt
@@ -247,7 +247,7 @@ class MultiselectForwardFragment :
         MultiselectForwardState.Stage.SendPending -> {
           handler?.removeCallbacksAndMessages(null)
           dismissibleDialog?.dismiss()
-          dismissibleDialog = SimpleProgressDialog.showDelayed(requireContext(), this)
+          dismissibleDialog = SimpleProgressDialog.showDelayed(requireContext(), viewLifecycleOwner)
         }
         MultiselectForwardState.Stage.SomeFailed -> dismissWithSuccess(R.plurals.MultiselectForwardFragment_messages_sent)
         MultiselectForwardState.Stage.AllFailed -> dismissAndShowToast(R.plurals.MultiselectForwardFragment_messages_failed_to_send)

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/mutiselect/forward/MultiselectForwardFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/mutiselect/forward/MultiselectForwardFragment.kt
@@ -247,7 +247,7 @@ class MultiselectForwardFragment :
         MultiselectForwardState.Stage.SendPending -> {
           handler?.removeCallbacksAndMessages(null)
           dismissibleDialog?.dismiss()
-          dismissibleDialog = SimpleProgressDialog.showDelayed(requireContext())
+          dismissibleDialog = SimpleProgressDialog.showDelayed(requireContext(), this)
         }
         MultiselectForwardState.Stage.SomeFailed -> dismissWithSuccess(R.plurals.MultiselectForwardFragment_messages_sent)
         MultiselectForwardState.Stage.AllFailed -> dismissAndShowToast(R.plurals.MultiselectForwardFragment_messages_failed_to_send)

--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
@@ -1300,7 +1300,7 @@ public class ConversationListFragment extends MainFragment implements ActionMode
   }
 
   private void updateMute(@NonNull Collection<Conversation> conversations, long until) {
-    SimpleProgressDialog.DismissibleDialog dialog = SimpleProgressDialog.showDelayed(requireContext(), 250, 250);
+    SimpleProgressDialog.DismissibleDialog dialog = SimpleProgressDialog.showDelayed(requireContext(), this, 250, 250);
 
     SimpleTask.run(SignalExecutors.BOUNDED, () -> {
       List<RecipientId> recipientIds = conversations.stream()

--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
@@ -1300,7 +1300,7 @@ public class ConversationListFragment extends MainFragment implements ActionMode
   }
 
   private void updateMute(@NonNull Collection<Conversation> conversations, long until) {
-    SimpleProgressDialog.DismissibleDialog dialog = SimpleProgressDialog.showDelayed(requireContext(), this, 250, 250);
+    SimpleProgressDialog.DismissibleDialog dialog = SimpleProgressDialog.showDelayed(requireContext(), getViewLifecycleOwner(), 250, 250);
 
     SimpleTask.run(SignalExecutors.BOUNDED, () -> {
       List<RecipientId> recipientIds = conversations.stream()

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/ui/creategroup/CreateGroupActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/ui/creategroup/CreateGroupActivity.java
@@ -188,7 +188,7 @@ public class CreateGroupActivity extends ContactSelectionActivity implements Con
 
   private void handleNextPressed() {
     Stopwatch                              stopwatch         = new Stopwatch("Recipient Refresh");
-    SimpleProgressDialog.DismissibleDialog dismissibleDialog = SimpleProgressDialog.showDelayed(this);
+    SimpleProgressDialog.DismissibleDialog dismissibleDialog = SimpleProgressDialog.showDelayed(this, this);
 
     SimpleTask.run(getLifecycle(), () -> {
       List<RecipientId> ids = contactsFragment.getSelectedContacts()

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/ui/invitesandrequests/invite/GroupLinkInviteFriendsBottomSheetDialogFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/ui/invitesandrequests/invite/GroupLinkInviteFriendsBottomSheetDialogFragment.java
@@ -154,7 +154,7 @@ public final class GroupLinkInviteFriendsBottomSheetDialogFragment extends Botto
   private void setBusy(boolean isBusy) {
     if (isBusy) {
       if (busyDialog == null) {
-        busyDialog = SimpleProgressDialog.showDelayed(requireContext(), this);
+        busyDialog = SimpleProgressDialog.showDelayed(requireContext(), getViewLifecycleOwner());
       }
     } else {
       if (busyDialog != null) {

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/ui/invitesandrequests/invite/GroupLinkInviteFriendsBottomSheetDialogFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/ui/invitesandrequests/invite/GroupLinkInviteFriendsBottomSheetDialogFragment.java
@@ -154,7 +154,7 @@ public final class GroupLinkInviteFriendsBottomSheetDialogFragment extends Botto
   private void setBusy(boolean isBusy) {
     if (isBusy) {
       if (busyDialog == null) {
-        busyDialog = SimpleProgressDialog.showDelayed(requireContext());
+        busyDialog = SimpleProgressDialog.showDelayed(requireContext(), this);
       }
     } else {
       if (busyDialog != null) {

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/ui/migration/GroupsV1MigrationSuggestionsDialog.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/ui/migration/GroupsV1MigrationSuggestionsDialog.java
@@ -74,7 +74,7 @@ public final class GroupsV1MigrationSuggestionsDialog {
   }
 
   private void onAddClicked(@NonNull DialogInterface rootDialog) {
-    SimpleProgressDialog.DismissibleDialog progressDialog = SimpleProgressDialog.showDelayed(fragmentActivity, 300, 0);
+    SimpleProgressDialog.DismissibleDialog progressDialog = SimpleProgressDialog.showDelayed(fragmentActivity, fragmentActivity, 300, 0);
     SimpleTask.run(SignalExecutors.UNBOUNDED, () -> {
       try {
         GroupManager.addMembers(fragmentActivity, groupId.requirePush(), suggestions);

--- a/app/src/main/java/org/thoughtcrime/securesms/maps/PlacePickerActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/maps/PlacePickerActivity.java
@@ -68,12 +68,13 @@ public final class PlacePickerActivity extends AppCompatActivity {
 
   private final DynamicTheme dynamicTheme = new DynamicNoActionBarTheme();
 
-  private SingleAddressBottomSheet bottomSheet;
-  private Address                  currentAddress;
-  private LatLng                   initialLocation;
-  private LatLng                   currentLocation = new LatLng(0, 0);
-  private AddressLookup            addressLookup;
-  private GoogleMap                googleMap;
+  private SingleAddressBottomSheet               bottomSheet;
+  private Address                                currentAddress;
+  private LatLng                                 initialLocation;
+  private LatLng                                 currentLocation = new LatLng(0, 0);
+  private AddressLookup                          addressLookup;
+  private GoogleMap                              googleMap;
+  private SimpleProgressDialog.DismissibleDialog dismissibleDialog;
 
   public static void startActivityForResultAtCurrentLocation(@NonNull Fragment fragment, int requestCode, @ColorInt int chatColor) {
     fragment.startActivityForResult(new Intent(fragment.requireActivity(), PlacePickerActivity.class).putExtra(KEY_CHAT_COLOR, chatColor), requestCode);
@@ -190,12 +191,11 @@ public final class PlacePickerActivity extends AppCompatActivity {
     String      address      = currentAddress != null && currentAddress.getAddressLine(0) != null ? currentAddress.getAddressLine(0) : "";
     AddressData addressData  = new AddressData(currentLocation.latitude, currentLocation.longitude, address);
 
-    SimpleProgressDialog.DismissibleDialog dismissibleDialog = SimpleProgressDialog.showDelayed(this);
+    dismissibleDialog = SimpleProgressDialog.showDelayed(this);
     MapView mapView = findViewById(R.id.map_view);
     SignalMapView.snapshot(currentLocation, mapView).addListener(new ListenableFuture.Listener<>() {
       @Override
       public void onSuccess(Bitmap result) {
-        dismissibleDialog.dismiss();
         byte[] blob = BitmapUtil.toByteArray(result);
         Uri uri = BlobProvider.getInstance()
                               .forData(blob)
@@ -238,6 +238,13 @@ public final class PlacePickerActivity extends AppCompatActivity {
     if (addressLookup != null) {
       addressLookup.cancel(true);
     }
+  }
+
+  @Override protected void onDestroy() {
+    if (dismissibleDialog != null) {
+      dismissibleDialog.dismissNow();
+    }
+    super.onDestroy();
   }
 
   @SuppressLint("StaticFieldLeak")

--- a/app/src/main/java/org/thoughtcrime/securesms/maps/PlacePickerActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/maps/PlacePickerActivity.java
@@ -68,13 +68,12 @@ public final class PlacePickerActivity extends AppCompatActivity {
 
   private final DynamicTheme dynamicTheme = new DynamicNoActionBarTheme();
 
-  private SingleAddressBottomSheet               bottomSheet;
-  private Address                                currentAddress;
-  private LatLng                                 initialLocation;
-  private LatLng                                 currentLocation = new LatLng(0, 0);
-  private AddressLookup                          addressLookup;
-  private GoogleMap                              googleMap;
-  private SimpleProgressDialog.DismissibleDialog dismissibleDialog;
+  private SingleAddressBottomSheet bottomSheet;
+  private Address                  currentAddress;
+  private LatLng                   initialLocation;
+  private LatLng                   currentLocation = new LatLng(0, 0);
+  private AddressLookup            addressLookup;
+  private GoogleMap                googleMap;
 
   public static void startActivityForResultAtCurrentLocation(@NonNull Fragment fragment, int requestCode, @ColorInt int chatColor) {
     fragment.startActivityForResult(new Intent(fragment.requireActivity(), PlacePickerActivity.class).putExtra(KEY_CHAT_COLOR, chatColor), requestCode);
@@ -191,8 +190,8 @@ public final class PlacePickerActivity extends AppCompatActivity {
     String      address      = currentAddress != null && currentAddress.getAddressLine(0) != null ? currentAddress.getAddressLine(0) : "";
     AddressData addressData  = new AddressData(currentLocation.latitude, currentLocation.longitude, address);
 
-    dismissibleDialog = SimpleProgressDialog.showDelayed(this);
-    MapView mapView = findViewById(R.id.map_view);
+    SimpleProgressDialog.DismissibleDialog dismissibleDialog = SimpleProgressDialog.showDelayed(this, this);
+    MapView                                mapView           = findViewById(R.id.map_view);
     SignalMapView.snapshot(currentLocation, mapView).addListener(new ListenableFuture.Listener<>() {
       @Override
       public void onSuccess(Bitmap result) {
@@ -238,13 +237,6 @@ public final class PlacePickerActivity extends AppCompatActivity {
     if (addressLookup != null) {
       addressLookup.cancel(true);
     }
-  }
-
-  @Override protected void onDestroy() {
-    if (dismissibleDialog != null) {
-      dismissibleDialog.dismissNow();
-    }
-    super.onDestroy();
   }
 
   @SuppressLint("StaticFieldLeak")

--- a/app/src/main/java/org/thoughtcrime/securesms/ratelimit/RecaptchaProofActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ratelimit/RecaptchaProofActivity.java
@@ -89,7 +89,7 @@ public class RecaptchaProofActivity extends PassphraseRequiredActivity {
   }
 
   private void handleToken(@NonNull String token) {
-    SimpleProgressDialog.DismissibleDialog dialog = SimpleProgressDialog.showDelayed(this, 1000, 500);
+    SimpleProgressDialog.DismissibleDialog dialog = SimpleProgressDialog.showDelayed(this, this, 1000, 500);
     SimpleTask.run(() -> {
       String challenge = SignalStore.rateLimit().getChallenge();
       if (Util.isEmpty(challenge)) {

--- a/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/sharablegrouplink/ShareableGroupLinkFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/sharablegrouplink/ShareableGroupLinkFragment.kt
@@ -50,7 +50,7 @@ class ShareableGroupLinkFragment : DSLSettingsFragment(
       { busy ->
         if (busy) {
           if (busyDialog == null) {
-            busyDialog = SimpleProgressDialog.showDelayed(requireContext())
+            busyDialog = SimpleProgressDialog.showDelayed(requireContext(), this)
           }
         } else {
           busyDialog?.dismiss()

--- a/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/sharablegrouplink/ShareableGroupLinkFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/sharablegrouplink/ShareableGroupLinkFragment.kt
@@ -50,7 +50,7 @@ class ShareableGroupLinkFragment : DSLSettingsFragment(
       { busy ->
         if (busy) {
           if (busyDialog == null) {
-            busyDialog = SimpleProgressDialog.showDelayed(requireContext(), this)
+            busyDialog = SimpleProgressDialog.showDelayed(requireContext(), viewLifecycleOwner)
           }
         } else {
           busyDialog?.dismiss()

--- a/app/src/main/java/org/thoughtcrime/securesms/util/CommunicationActions.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/CommunicationActions.java
@@ -417,8 +417,8 @@ public class CommunicationActions {
     callContext.startActivity(activityIntent);
   }
 
-  private static void handleE164Link(Activity activity, String e164) {
-    SimpleProgressDialog.DismissibleDialog dialog = SimpleProgressDialog.showDelayed(activity, 500, 500);
+  private static void handleE164Link(FragmentActivity activity, String e164) {
+    SimpleProgressDialog.DismissibleDialog dialog = SimpleProgressDialog.showDelayed(activity, activity, 500, 500);
 
     SimpleTask.run(() -> {
       Recipient recipient = Recipient.external(activity, e164);
@@ -447,8 +447,8 @@ public class CommunicationActions {
     });
   }
 
-  private static void handleUsernameLink(Activity activity, String link) {
-    SimpleProgressDialog.DismissibleDialog dialog = SimpleProgressDialog.showDelayed(activity, 500, 500);
+  private static void handleUsernameLink(FragmentActivity activity, String link) {
+    SimpleProgressDialog.DismissibleDialog dialog = SimpleProgressDialog.showDelayed(activity, activity, 500, 500);
 
     SimpleTask.run(() -> {
       try {

--- a/app/src/main/java/org/thoughtcrime/securesms/util/views/SimpleProgressDialog.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/views/SimpleProgressDialog.java
@@ -1,14 +1,11 @@
 package org.thoughtcrime.securesms.util.views;
 
-import android.app.Activity;
 import android.content.Context;
 
 import androidx.annotation.AnyThread;
 import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.lifecycle.Lifecycle;
 
 import org.signal.core.util.ThreadUtil;
 import org.signal.core.util.logging.Log;
@@ -65,11 +62,6 @@ public final class SimpleProgressDialog {
     AtomicLong                   shownAt               = new AtomicLong();
 
     Runnable showRunnable = () -> {
-      if (!isContextValid(context)) {
-        Log.w(TAG, "Context is no longer valid. Not showing dialog.");
-        return;
-      }
-
       Log.i(TAG, "Taking some time. Showing a progress dialog.");
       shownAt.set(System.currentTimeMillis());
       dialogAtomicReference.set(show(context));
@@ -82,25 +74,13 @@ public final class SimpleProgressDialog {
       public void dismiss() {
         ThreadUtil.cancelRunnableOnMain(showRunnable);
         ThreadUtil.runOnMain(() -> {
-          if (!isContextValid(context)) {
-            Log.w(TAG, "Context is no longer valid. Not dismissing dialog.");
-            return;
-          }
-
           AlertDialog alertDialog = dialogAtomicReference.getAndSet(null);
           if (alertDialog != null) {
             long beenShowingForMs = System.currentTimeMillis() - shownAt.get();
             long remainingTimeMs  = minimumShowTimeMs - beenShowingForMs;
 
             if (remainingTimeMs > 0) {
-              ThreadUtil.runOnMainDelayed(() -> {
-                if (!isContextValid(context)) {
-                  Log.w(TAG, "Context is no longer valid. Not dismissing dialog.");
-                  return;
-                }
-
-                alertDialog.dismiss();
-              }, remainingTimeMs);
+              ThreadUtil.runOnMainDelayed(alertDialog::dismiss, remainingTimeMs);
             } else {
               alertDialog.dismiss();
             }
@@ -119,18 +99,6 @@ public final class SimpleProgressDialog {
         });
       }
     };
-  }
-
-  private static boolean isContextValid(@NonNull Context context) {
-    if (context instanceof AppCompatActivity) {
-      AppCompatActivity activity = (AppCompatActivity) context;
-      return !activity.isFinishing() && !activity.isDestroyed() && activity.getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED);
-    } else if (context instanceof Activity) {
-      Activity activity = (Activity) context;
-      return !activity.isFinishing() && !activity.isDestroyed();
-    } else {
-      return true;
-    }
   }
 
   public interface DismissibleDialog {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * OnePlus Nord / avicii, Android 12
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

The first commit avoids a race condition with closing the location picker map for location sharing where the following exception would occur:

    IllegalArgumentException: View[…] not attached to window manager

This was because `dismiss`, together with its delay, could be executed after the activity that contained the dialog, `PlacePickerActivity`, had already been destroyed. This faulty behavior can be reproduced more easily when artificially increasing the minimum time that the dialog should be shown. Instead of potentially scheduling a dismissal for the future using `dismiss`, `dismissNow` is now called during `onDestroy`.

The second commit avoids similar problems in the future, because it ensures that the delayed dismiss callback is always cancelled when `dismissNow` is called (which it should be whenever the activity containing the progress bar is closed for some reason, which may be in between a `dismiss` call and the `dismiss`-scheduled delayed dismissal.

The second commit could be left out as the first one already fixes the crash I mentioned above, but I would recommend to add it nonetheless.