### PR TITLE
Storage sync record processing fixes

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/StorageSyncJob.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/StorageSyncJob.java
@@ -411,10 +411,7 @@ public class StorageSyncJob extends BaseJob {
     new GroupV1RecordProcessor(context).process(records.gv1, StorageSyncHelper.KEY_GENERATOR);
     new GroupV2RecordProcessor(context).process(records.gv2, StorageSyncHelper.KEY_GENERATOR);
     new AccountRecordProcessor(context, freshSelf()).process(records.account, StorageSyncHelper.KEY_GENERATOR);
-
-    if (getKnownTypes().contains(ManifestRecord.Identifier.Type.STORY_DISTRIBUTION_LIST.getValue())) {
-      new StoryDistributionListRecordProcessor().process(records.storyDistributionLists, StorageSyncHelper.KEY_GENERATOR);
-    }
+    new StoryDistributionListRecordProcessor().process(records.storyDistributionLists, StorageSyncHelper.KEY_GENERATOR);
   }
 
   private static @NonNull List<StorageId> getAllLocalStorageIds(@NonNull Recipient self) {

--- a/app/src/main/java/org/thoughtcrime/securesms/storage/AccountRecordProcessor.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/storage/AccountRecordProcessor.java
@@ -157,6 +157,7 @@ public class AccountRecordProcessor extends DefaultStorageRecordProcessor<Signal
                                                                    .setPrimarySendsSms(primarySendsSms)
                                                                    .setDefaultReactions(defaultReactions)
                                                                    .setSubscriber(subscriber)
+                                                                   .setStoryViewReceiptsState(storyViewReceiptsState)
                                                                    .setDisplayBadgesOnProfile(displayBadgesOnProfile)
                                                                    .setSubscriptionManuallyCancelled(subscriptionManuallyCancelled)
                                                                    .setKeepMutedChatsArchived(keepMutedChatsArchived)

--- a/app/src/main/java/org/thoughtcrime/securesms/storage/ContactRecordProcessor.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/storage/ContactRecordProcessor.java
@@ -262,7 +262,7 @@ public class ContactRecordProcessor extends DefaultStorageRecordProcessor<Signal
 
   @Override
   public int compare(@NonNull SignalContactRecord lhs, @NonNull SignalContactRecord rhs) {
-    if (Objects.equals(lhs.getAci(), rhs.getAci()) ||
+    if ((lhs.getAci().isPresent() && Objects.equals(lhs.getAci(), rhs.getAci())) ||
         (lhs.getNumber().isPresent() && Objects.equals(lhs.getNumber(), rhs.getNumber())) ||
         (lhs.getPni().isPresent() && Objects.equals(lhs.getPni(), rhs.getPni())))
     {

--- a/app/src/main/java/org/thoughtcrime/securesms/storage/GroupV1RecordProcessor.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/storage/GroupV1RecordProcessor.java
@@ -92,7 +92,8 @@ public final class GroupV1RecordProcessor extends DefaultStorageRecordProcessor<
     } else {
       return new SignalGroupV1Record.Builder(keyGenerator.generate(), remote.getGroupId(), unknownFields)
                                     .setBlocked(blocked)
-                                    .setProfileSharingEnabled(blocked)
+                                    .setProfileSharingEnabled(profileSharing)
+                                    .setArchived(archived)
                                     .setForcedUnread(forcedUnread)
                                     .setMuteUntil(muteUntil)
                                     .build();

--- a/app/src/main/java/org/thoughtcrime/securesms/storage/GroupV2RecordProcessor.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/storage/GroupV2RecordProcessor.java
@@ -85,7 +85,7 @@ public final class GroupV2RecordProcessor extends DefaultStorageRecordProcessor<
     } else {
       return new SignalGroupV2Record.Builder(keyGenerator.generate(), remote.getMasterKeyBytes(), unknownFields)
                                     .setBlocked(blocked)
-                                    .setProfileSharingEnabled(blocked)
+                                    .setProfileSharingEnabled(profileSharing)
                                     .setArchived(archived)
                                     .setForcedUnread(forcedUnread)
                                     .setMuteUntil(muteUntil)


### PR DESCRIPTION
### Description
Some small fixes for issues I found in the storage sync code.

I've split it up into separate commits, but feel free to squash them:
-    Use correct value for setProfileSharingEnabled on GroupV2Record
-    Add missing setArchived call for GroupV1Record
     And use correct value for setProfileSharingEnabled
-    Add missing isPresent check for ACI on contact record
-    Add missing call to set setStoryViewReceiptsState on AccountRecord
-    Remove now unnecessary check for STORY_DISTRIBUTION_LIST
