### PR TITLE
Fix: Chat search doesn't work well in many cases with Japanese IMEs

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/InsetAwareConstraintLayout.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/InsetAwareConstraintLayout.kt
@@ -130,9 +130,9 @@ open class InsetAwareConstraintLayout @JvmOverloads constructor(
 
     if (previousKeyboardHeight != keyboardInsets.bottom) {
       keyboardStateListeners.forEach {
-        if (previousKeyboardHeight <= 0) {
+        if (previousKeyboardHeight <= 0 && keyboardInsets.bottom > 0) {
           it.onKeyboardShown()
-        } else {
+        } else if (previousKeyboardHeight > 0 && keyboardInsets.bottom <= 0) {
           it.onKeyboardHidden()
         }
       }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S22+ One UI 6.0 Android 14
 * AVD Pixel 6a Android 14 Google Play
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

In in-conversation search, you almost cannot use the search function in Japanese because the Gboard (and possibly other keyboards) keeps closing when you type a key. The very similar behavior is there for the emoji search in the chat input panel
 as well. See the screen recordings below for details.

There are quite a few [user reviews in Japanese](https://play.google.com/store/apps/details?id=org.thoughtcrime.securesms&hl=ja) in Google Play that submit the issue. I pasted the screenshots of some of the reviews.

#### Steps to reproduce the bug
1. Set up the device so your Gboard opens in Japanese mode (qwerty)
2. Open Signal, go to a chat (1:1 or group)
3. Menu > Search
4. Enter a consonant (b for example)

**Observed**:
Keyboard closes and the full-width "b" is committed in the edittext. Nothing will be found for the character (in most cases) in the search results.

**Expected**:
Keyboard stays open and the character is not committed, and the search doesn't start. Keep entering a valid word and search should work.

### Screen recordings

**Bug in chat search**

https://github.com/signalapp/Signal-Android/assets/28482/ffd7d132-aae6-4216-8295-75e166b89a81

**Bug in emoji search**

https://github.com/signalapp/Signal-Android/assets/28482/1da931c4-1726-4c9c-9260-27d0d41dbdc7

**After the fix in this PR**

https://github.com/signalapp/Signal-Android/assets/28482/a6b7c956-306e-4edc-acca-4bde6982ae0e

https://github.com/signalapp/Signal-Android/assets/28482/b896aa81-9e87-4c66-9be0-60002ece3473





