### PR TITLE
Fix white spaces missing on delete account screen

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/delete/DeleteAccountFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/delete/DeleteAccountFragment.java
@@ -85,13 +85,13 @@ public class DeleteAccountFragment extends Fragment {
   }
 
   private @NonNull CharSequence buildBulletsText(@NonNull Optional<String> formattedBalance) {
-    SpannableStringBuilder builder =  new SpannableStringBuilder().append(SpanUtil.bullet(getString(R.string.DeleteAccountFragment__delete_your_account_info_and_profile_photo)))
+    SpannableStringBuilder builder =  new SpannableStringBuilder().append(SpanUtil.bullet(getString(R.string.DeleteAccountFragment__delete_your_account_info_and_profile_photo),8))
                                                                   .append("\n")
-                                                                  .append(SpanUtil.bullet(getString(R.string.DeleteAccountFragment__delete_all_your_messages)));
+                                                                  .append(SpanUtil.bullet(getString(R.string.DeleteAccountFragment__delete_all_your_messages),8));
 
     if (formattedBalance.isPresent()) {
       builder.append("\n");
-      builder.append(SpanUtil.bullet(getString(R.string.DeleteAccountFragment__delete_s_in_your_payments_account, formattedBalance.get())));
+      builder.append(SpanUtil.bullet(getString(R.string.DeleteAccountFragment__delete_s_in_your_payments_account, formattedBalance.get()),8));
     }
 
     return builder;

--- a/app/src/main/java/org/thoughtcrime/securesms/util/SpanUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/SpanUtil.java
@@ -105,10 +105,6 @@ public final class SpanUtil {
     return spannable;
   }
 
-  public static @NonNull CharSequence bullet(@NonNull CharSequence sequence) {
-    return bullet(sequence, BulletSpan.STANDARD_GAP_WIDTH);
-  }
-
   public static @NonNull CharSequence bullet(@NonNull CharSequence sequence, int gapWidth) {
     SpannableString spannable = new SpannableString(sequence);
     spannable.setSpan(new BulletSpan(gapWidth), 0, sequence.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);


### PR DESCRIPTION
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 8
 * Pixel 3
 * Samsung S20 FE
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Padding has been added between the bullet point and text on the Delete Account screen specified in issue #13454.

