### PR TITLE
A suggestion about changing AES/CTR to AES/GCM #13543

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/crypto/ModernDecryptingPartInputStream.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/crypto/ModernDecryptingPartInputStream.java
@@ -51,8 +51,11 @@ public class ModernDecryptingPartInputStream {
       Conversions.longTo4ByteArray(iv, 12, offset / 16);
 
       byte[] key    = mac.doFinal(random);
-      Cipher cipher = Cipher.getInstance("AES/CTR/NoPadding");
-      cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, "AES"), new IvParameterSpec(iv));
+
+     
+      Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+      cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, "AES"), new GCMParameterSpec(128, iv));
+
 
       long skipped = inputStream.skip(offset - remainder);
 

--- a/app/src/main/java/org/thoughtcrime/securesms/crypto/ModernEncryptingPartOutputStream.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/crypto/ModernEncryptingPartOutputStream.java
@@ -39,11 +39,14 @@ public class ModernEncryptingPartOutputStream {
       mac.init(new SecretKeySpec(attachmentSecret.getModernKey(), "HmacSHA256"));
 
       FileOutputStream fileOutputStream = new FileOutputStream(file);
-      byte[]           iv               = new byte[16];
+      byte[]           iv               = new byte[12];
+      new SecureRandom().nextBytes(iv);
       byte[]           key              = mac.doFinal(random);
 
-      Cipher cipher = Cipher.getInstance("AES/CTR/NoPadding");
-      cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"), new IvParameterSpec(iv));
+     
+      Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+      cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"), new GCMParameterSpec(128, iv)); 
+
 
       if (inline) {
         fileOutputStream.write(random);


### PR DESCRIPTION
changing AES/CTR to AES/GCM #13543: The current implementation uses AES in CTR mode which doesn't provide authentication. It also uses a static IV (initialization vector), which can lead to security vulnerabilities because the same encryption key and IV combination should not be used more than once.