### PR TITLE
Reproducible Build Fails #13495

### DIFF
--- a/reproducible-builds/Dockerfile
+++ b/reproducible-builds/Dockerfile
@@ -32,3 +32,5 @@ RUN yes | sdkmanager --sdk_root="${ANDROID_HOME}" "platforms;${ANDROID_API_LEVEL
 RUN yes | sdkmanager --licenses --sdk_root="${ANDROID_HOME}"
 
 RUN rm -rf ${ANDROID_HOME}/tools
+
+RUN git config --global --add safe.directory /project


### PR DESCRIPTION
Added git configurations to allow for the reproducible build to run and run successfully. The configuration added puts the /project directory in the safe directory. This makes the /project directory safe and allows for it to pass unchecked.
