### PR TITLE
Search sticker packs by title in sticker search screen

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/StickerTable.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/StickerTable.java
@@ -167,8 +167,9 @@ public class StickerTable extends DatabaseTable {
   }
 
   public @Nullable Cursor getStickerPacksByTitle(@NonNull String title) {
-    String   query = PACK_TITLE + " LIKE ? AND " + COVER + " = ?";
-    String[] args  = new String[] { "%"+title+"%", "1" };
+    String   textQuery = SqlUtil.buildCaseInsensitiveGlobPattern(title);
+    String   query     = PACK_TITLE + " GLOB ? AND " + COVER + " = ?";
+    String[] args      = new String[] { textQuery, "1" };
 
     return databaseHelper.getSignalReadableDatabase().query(TABLE_NAME, null, query, args, null, null, PACK_ORDER + " ASC");
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/database/StickerTable.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/StickerTable.java
@@ -166,6 +166,13 @@ public class StickerTable extends DatabaseTable {
     return databaseHelper.getSignalReadableDatabase().query(TABLE_NAME, null, query, args, null, null, PACK_ORDER + " ASC", limit);
   }
 
+  public @Nullable Cursor getStickerPacksByTitle(@NonNull String title) {
+    String   query = PACK_TITLE + " LIKE ? AND " + COVER + " = ?";
+    String[] args  = new String[] { "%"+title+"%", "1" };
+
+    return databaseHelper.getSignalReadableDatabase().query(TABLE_NAME, null, query, args, null, null, PACK_ORDER + " ASC");
+  }
+
   public @Nullable Cursor getStickersForPack(@NonNull String packId) {
     SQLiteDatabase db        = databaseHelper.getSignalReadableDatabase();
     String         selection = PACK_ID + " = ? AND " + COVER + " = ?";

--- a/app/src/main/java/org/thoughtcrime/securesms/keyboard/sticker/KeyboardStickerListAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyboard/sticker/KeyboardStickerListAdapter.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.recyclerview.widget.GridLayoutManager
 import com.bumptech.glide.RequestManager
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import org.thoughtcrime.securesms.R
@@ -24,6 +25,22 @@ class KeyboardStickerListAdapter(
   init {
     registerFactory(Sticker::class.java, LayoutFactory(::StickerViewHolder, R.layout.sticker_keyboard_page_list_item))
     registerFactory(StickerHeader::class.java, LayoutFactory(::StickerHeaderViewHolder, R.layout.sticker_grid_header))
+    registerFactory(Separator::class.java, LayoutFactory(::SeparatorHolder, R.layout.sticker_grid_header))
+  }
+
+  fun createLayoutManager(context: Context): GridLayoutManager {
+    val listAdapter = this
+    return GridLayoutManager(context, 2).apply {
+      spanSizeLookup = object : GridLayoutManager.SpanSizeLookup() {
+        override fun getSpanSize(position: Int): Int {
+          val model = listAdapter.getModel(position)
+          if (model.isPresent && model.get() is Header) {
+            return spanCount
+          }
+          return 1
+        }
+      }
+    }
   }
 
   data class Sticker(override val packId: String, val stickerRecord: StickerRecord) : MappingModel<Sticker>, HasPackId {
@@ -82,6 +99,25 @@ class KeyboardStickerListAdapter(
 
     override fun bind(model: StickerHeader) {
       title.text = model.getTitle(context)
+    }
+  }
+
+  private class SeparatorHolder(itemView: View) : MappingViewHolder<Separator>(itemView) {
+
+    private val title: TextView = findViewById(R.id.sticker_grid_header_title)
+
+    override fun bind(model: Separator) {
+      title.text = ""
+    }
+  }
+
+  class Separator : MappingModel<Separator>, Header {
+    override fun areItemsTheSame(newItem: Separator): Boolean {
+      return true
+    }
+
+    override fun areContentsTheSame(newItem: Separator): Boolean {
+      return true
     }
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/keyboard/sticker/StickerKeyboardPageFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyboard/sticker/StickerKeyboardPageFragment.kt
@@ -59,17 +59,7 @@ open class StickerKeyboardPageFragment :
 
     val requestManager = Glide.with(this)
     stickerListAdapter = KeyboardStickerListAdapter(requestManager, this, DeviceProperties.shouldAllowApngStickerAnimation(requireContext()))
-    layoutManager = GridLayoutManager(requireContext(), 2).apply {
-      spanSizeLookup = object : GridLayoutManager.SpanSizeLookup() {
-        override fun getSpanSize(position: Int): Int {
-          val model: Optional<MappingModel<*>> = stickerListAdapter.getModel(position)
-          if (model.isPresent && model.get() is KeyboardStickerListAdapter.Header) {
-            return spanCount
-          }
-          return 1
-        }
-      }
-    }
+    layoutManager = stickerListAdapter.createLayoutManager(requireContext())
     listTouchListener = StickerRolloverTouchListener(requireContext(), requestManager, this, this)
 
     stickerList = view.findViewById(R.id.sticker_keyboard_list)

--- a/app/src/main/java/org/thoughtcrime/securesms/keyboard/sticker/StickerSearchDialogFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyboard/sticker/StickerSearchDialogFragment.kt
@@ -48,7 +48,7 @@ class StickerSearchDialogFragment : DialogFragment(), KeyboardStickerListAdapter
     noResults = view.findViewById(R.id.sticker_search_no_results)
 
     adapter = KeyboardStickerListAdapter(Glide.with(this), this, DeviceProperties.shouldAllowApngStickerAnimation(requireContext()))
-    layoutManager = GridLayoutManager(requireContext(), 2)
+    layoutManager = adapter.createLayoutManager(requireContext())
 
     list.layoutManager = layoutManager
     list.adapter = adapter

--- a/app/src/main/java/org/thoughtcrime/securesms/keyboard/sticker/StickerSearchRepository.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyboard/sticker/StickerSearchRepository.kt
@@ -25,12 +25,11 @@ class StickerSearchRepository {
     }
 
     val maybeEmojiQuery: List<StickerRecord> = findStickersForEmoji(query)
-    val searchResults: List<StickerRecord> = emojiSearchTable.query(query, EMOJI_SEARCH_RESULTS_LIMIT)
-      .map { findStickersForEmoji(it) }
-      .flatten()
-      .plus(
-        StickerPackRecordReader(stickerTable.getStickerPacksByTitle(query)).readAll()
-          .map { pack -> StickerRecordReader(stickerTable.getStickersForPack(pack.packId)).readAll() }
+    val searchResults: List<StickerRecord> =
+      // Match by title first, then by emoji.
+      StickerRecordReader(stickerTable.getStickerPacksByTitle(query)).readAll()
+        .plus(emojiSearchTable.query(query, EMOJI_SEARCH_RESULTS_LIMIT)
+          .map(::findStickersForEmoji)
           .flatten())
 
     return maybeEmojiQuery + searchResults

--- a/app/src/main/java/org/thoughtcrime/securesms/keyboard/sticker/StickerSearchRepository.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyboard/sticker/StickerSearchRepository.kt
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms.keyboard.sticker
 
 import androidx.annotation.WorkerThread
+import org.signal.core.util.SqlUtil.buildCaseInsensitiveGlobPattern
 import org.thoughtcrime.securesms.components.emoji.EmojiUtil
 import org.thoughtcrime.securesms.database.EmojiSearchTable
 import org.thoughtcrime.securesms.database.SignalDatabase

--- a/app/src/main/java/org/thoughtcrime/securesms/keyboard/sticker/StickerSearchViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyboard/sticker/StickerSearchViewModel.kt
@@ -4,15 +4,49 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import org.thoughtcrime.securesms.database.SignalDatabase
+import org.thoughtcrime.securesms.database.StickerTable.StickerRecordReader
+import org.thoughtcrime.securesms.util.adapter.mapping.MappingModelList
 import org.thoughtcrime.securesms.util.livedata.LiveDataUtil
 
 class StickerSearchViewModel(private val searchRepository: StickerSearchRepository) : ViewModel() {
 
   private val searchQuery: MutableLiveData<String> = MutableLiveData("")
 
-  val searchResults: LiveData<List<KeyboardStickerListAdapter.Sticker>> = LiveDataUtil.mapAsync(searchQuery) { q ->
-    searchRepository.search(q)
-      .map { KeyboardStickerListAdapter.Sticker(it.packId, it) }
+  val searchResults: LiveData<MappingModelList> = LiveDataUtil.mapAsync(searchQuery) { q ->
+    val results = searchRepository.search(q)
+    val list = MappingModelList()
+    var needsPackSeparator = false
+    val stickerTable = SignalDatabase.stickers
+    for (sticker in results) {
+      if (sticker.isCover) {
+        // This is a pack. Start with header.
+        val pack = stickerTable.getStickerPack(sticker.packId)
+        if (pack != null) {
+          list += KeyboardStickerListAdapter.StickerHeader(pack.packId, pack.title.orElse(null), null)
+        }
+        // Get stickers for pack.
+        StickerRecordReader(stickerTable.getStickersForPack(sticker.packId)).use {
+          var next = it.next
+          while (next != null) {
+            list += KeyboardStickerListAdapter.Sticker(next.packId, next)
+            next = it.next
+          }
+        }
+        // Add empty header when emoji matches reached to separate them from title matches
+        needsPackSeparator = true
+      } else {
+        // This is a sticker. Add directly.
+        if (needsPackSeparator) {
+          // Add a separator so that emoji matches don't get lumped in with the last matched pack
+          list += KeyboardStickerListAdapter.Separator()
+          needsPackSeparator = false
+        }
+        list += KeyboardStickerListAdapter.Sticker(sticker.packId, sticker)
+      }
+    }
+
+    list
   }
 
   fun query(query: String) {

--- a/app/src/main/java/org/thoughtcrime/securesms/keyboard/sticker/StickerSearchViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyboard/sticker/StickerSearchViewModel.kt
@@ -22,19 +22,19 @@ class StickerSearchViewModel(private val searchRepository: StickerSearchReposito
       if (sticker.isCover) {
         // This is a pack. Start with header.
         val pack = stickerTable.getStickerPack(sticker.packId)
-        if (pack != null) {
+        if (pack != null && pack.isInstalled) {
           list += KeyboardStickerListAdapter.StickerHeader(pack.packId, pack.title.orElse(null), null)
-        }
-        // Get stickers for pack.
-        StickerRecordReader(stickerTable.getStickersForPack(sticker.packId)).use {
-          var next = it.next
-          while (next != null) {
-            list += KeyboardStickerListAdapter.Sticker(next.packId, next)
-            next = it.next
+          // Get stickers for pack.
+          StickerRecordReader(stickerTable.getStickersForPack(pack.packId)).use {
+            var next = it.next
+            while (next != null) {
+              list += KeyboardStickerListAdapter.Sticker(pack.packId, next)
+              next = it.next
+            }
           }
+          // Add empty header when emoji matches reached to separate them from title matches
+          needsPackSeparator = true
         }
-        // Add empty header when emoji matches reached to separate them from title matches
-        needsPackSeparator = true
       } else {
         // This is a sticker. Add directly.
         if (needsPackSeparator) {

--- a/app/src/main/java/org/thoughtcrime/securesms/keyboard/sticker/StickerSearchViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyboard/sticker/StickerSearchViewModel.kt
@@ -20,11 +20,9 @@ class StickerSearchViewModel(private val searchRepository: StickerSearchReposito
     val stickerTable = SignalDatabase.stickers
     for (sticker in results) {
       if (sticker.isCover) {
-        // This is a pack. Start with header.
         val pack = stickerTable.getStickerPack(sticker.packId)
         if (pack != null && pack.isInstalled) {
           list += KeyboardStickerListAdapter.StickerHeader(pack.packId, pack.title.orElse(null), null)
-          // Get stickers for pack.
           StickerRecordReader(stickerTable.getStickersForPack(pack.packId)).use {
             var next = it.next
             while (next != null) {
@@ -32,13 +30,10 @@ class StickerSearchViewModel(private val searchRepository: StickerSearchReposito
               next = it.next
             }
           }
-          // Add empty header when emoji matches reached to separate them from title matches
           needsPackSeparator = true
         }
       } else {
-        // This is a sticker. Add directly.
         if (needsPackSeparator) {
-          // Add a separator so that emoji matches don't get lumped in with the last matched pack
           list += KeyboardStickerListAdapter.Separator()
           needsPackSeparator = false
         }


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 8, Android 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

The sticker search screen currently only allows users to search for sticker by their corresponding emoji. This is inconvenient when a sticker you are trying to find does not have an obvious emoji. On Telegram, sticker search shows sticker packs with a matching title first, followed by emoji matches. These changes to the search screen implement this functionality.

Installed sticker packs with a title that partially or fully matches the search query are displayed in full in the search results. After these results, emoji matches are displayed.

Screenshot of the feature:

![image](https://github.com/signalapp/Signal-Android/assets/25674682/514f2e85-65dc-456d-b71a-6f661519eac7)
