### PR TITLE
Handle quotes from authors with unknown UUIDs gracefully

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/messages/DataMessageProcessor.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/messages/DataMessageProcessor.kt
@@ -1072,7 +1072,12 @@ object DataMessageProcessor {
       return null
     }
 
-    val authorId = Recipient.externalPush(ServiceId.parseOrThrow(quote.authorAci!!)).id
+    val authorAci = ServiceId.parseOrThrow(quote.authorAci!!)
+    if (authorAci.isUnknown) {
+      warn(timestamp, "Received quote with an unknown author UUID! Ignoring...")
+      return null
+    }
+    val authorId = Recipient.externalPush(authorAci).id
     var quotedMessage = SignalDatabase.messages.getMessageFor(quote.id!!, authorId) as? MmsMessageRecord
 
     if (quotedMessage != null && !quotedMessage.isRemoteDelete) {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 7, Android 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

This PR addresses an issue in the `DataMessageProcessor` class when processing quotes from authors with unknown UUIDs. When a sync message referencing a quote with a missing author UUID is received, the app enters an infinite loop attempting to process the queued message, preventing the user from receiving any further messages. This fix prevents the assertion error in `Recipient.kt` by gracefully ignoring such quotes.

This is a follow-up to commit c938035ec186534caaba9c6fdab4eac63d8b9af1.

A log captured from Signal 7.6.2 showing the issue:

```
05-22 08:12:36.467  3658  5012 I OkHttpWebSocketConnection: [normal:119832381] onOpen() connected
05-22 08:12:36.467  3658  5015 I OkHttpWebSocketConnection: [unidentified:239445548] onOpen() connected
05-22 08:12:36.468  3658  3963 D IncomingMessageObserver: WebSocket State: CONNECTED
05-22 08:12:36.472  3658  5030 D AlarmSleepTimer: Setting an exact alarm to wake up in 30000ms.
05-22 08:12:36.500  3658  3962 I IncomingMessageObserver: Retrieved 3 envelopes!
05-22 08:12:36.501  3658  3962 D IncomingMessageObserver: Beginning database transaction...
05-22 08:12:36.503  3658  3962 I libsignal: rust/protocol/src/session_cipher.rs:454: decrypted Whisper message from ********-****-****-****-*********e8b.2 with current session state (base key 7dbed39e0a48ef31c4c536315669a272c3867ee2168f88456f17d685938fc54c)
05-22 08:12:36.506  3658  3962 D MessageDecryptor: [1716017513104] <ACI:********-****-****-****-*********e8b>:2 | Successfully decrypted the envelope in 4.10 ms  (GUID ********-****-****-****-*********4cf). Delivery latency: 340842981 ms, Urgent: false
05-22 08:12:36.506  3658  3962 I MessageProcessorV2: [1716017513104] Beginning message processing. Sender: RecipientId::1 (********-****-****-****-*********e8b.2)
05-22 08:12:36.506  3658  3962 I MessageProcessorV2: [1716017513104] Processing sent transcript for message with ID 1716017513104
05-22 08:12:36.507  3658  3962 I MessageProcessorV2: [1716017513104] Synchronize sent edit media message for: 213868
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: null
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: java.lang.AssertionError
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.thoughtcrime.securesms.recipients.Recipient$Companion.externalPush(Recipient.kt:969)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.thoughtcrime.securesms.recipients.Recipient$Companion.externalPush(Recipient.kt:927)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.thoughtcrime.securesms.messages.DataMessageProcessor.getValidatedQuote(DataMessageProcessor.kt:1075)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.thoughtcrime.securesms.messages.SyncMessageProcessor.handleSynchronizeSentEditMediaMessage(SyncMessageProcessor.kt:396)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.thoughtcrime.securesms.messages.SyncMessageProcessor.handleSynchronizeSentEditMessage(SyncMessageProcessor.kt:321)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.thoughtcrime.securesms.messages.SyncMessageProcessor.handleSynchronizeSentMessage(SyncMessageProcessor.kt:186)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.thoughtcrime.securesms.messages.SyncMessageProcessor.process(SyncMessageProcessor.kt:144)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.thoughtcrime.securesms.messages.MessageContentProcessor.handleMessage(MessageContentProcessor.kt:445)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.thoughtcrime.securesms.messages.MessageContentProcessor.process(MessageContentProcessor.kt:328)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.thoughtcrime.securesms.messages.MessageContentProcessor.process$default(MessageContentProcessor.kt:325)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.thoughtcrime.securesms.jobs.PushProcessMessageJob$Companion.processOrDefer(PushProcessMessageJob.kt:147)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.thoughtcrime.securesms.messages.IncomingMessageObserver.processMessage(IncomingMessageObserver.kt:296)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.thoughtcrime.securesms.messages.IncomingMessageObserver.processEnvelope(IncomingMessageObserver.kt:278)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.thoughtcrime.securesms.messages.IncomingMessageObserver$MessageRetrievalThread$run$hasMore$1$1$1$1$followUpOperations$1.invoke(IncomingMessageObserver.kt:399)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.thoughtcrime.securesms.messages.IncomingMessageObserver$MessageRetrievalThread$run$hasMore$1$1$1$1$followUpOperations$1.invoke(IncomingMessageObserver.kt:398)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.thoughtcrime.securesms.database.SignalDatabase$Companion$runInTransaction$1.invoke(SignalDatabase.kt:350)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.thoughtcrime.securesms.database.SignalDatabase$Companion$runInTransaction$1.invoke(SignalDatabase.kt:349)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.signal.core.util.SQLiteDatabaseExtensionsKt.withinTransaction(SQLiteDatabaseExtensions.kt:19)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.thoughtcrime.securesms.database.SignalDatabase$Companion.runInTransaction(SignalDatabase.kt:349)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.thoughtcrime.securesms.messages.IncomingMessageObserver$MessageRetrievalThread.run$lambda$4(IncomingMessageObserver.kt:398)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.thoughtcrime.securesms.messages.IncomingMessageObserver$MessageRetrievalThread.$r8$lambda$pFsjOAfLHhrQuHtltxbtS8c-x88(IncomingMessageObserver.kt:0)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.thoughtcrime.securesms.messages.IncomingMessageObserver$MessageRetrievalThread$$ExternalSyntheticLambda0.onMessageBatch(R8$$SyntheticClass:0)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.whispersystems.signalservice.api.SignalWebSocket.readMessageBatch(SignalWebSocket.java:276)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: 	at org.thoughtcrime.securesms.messages.IncomingMessageObserver$MessageRetrievalThread.run(IncomingMessageObserver.kt:389)
05-22 08:12:36.508  3658  3962 W IncomingMessageObserver: Shutting down pipe...
05-22 08:12:36.508  3658  3962 I OkHttpWebSocketConnection: [normal:119832381] disconnect()
05-22 08:12:36.508  3658  3962 D IncomingMessageObserver: WebSocket State: DISCONNECTED
05-22 08:12:36.508  3658  3962 I OkHttpWebSocketConnection: [unidentified:239445548] disconnect()
05-22 08:12:36.509  3658  3962 I IncomingMessageObserver: Looping...
05-22 08:12:36.509  3658  3962 I IncomingMessageObserver: Waiting for websocket state change....
05-22 08:12:36.509  3658  3962 W IncomingMessageObserver: Too many failed connection attempts,  attempts: 5 backing off: 31997
```

