### PR TITLE
Fixes #13351: initial event not triggering onTouchEvent

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/stickers/StickerRolloverTouchListener.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/stickers/StickerRolloverTouchListener.java
@@ -41,6 +41,9 @@ public class StickerRolloverTouchListener implements RecyclerView.OnItemTouchLis
 
   @Override
   public boolean onInterceptTouchEvent(@NonNull RecyclerView recyclerView, @NonNull MotionEvent motionEvent) {
+    if (hoverMode && motionEvent.getAction() == MotionEvent.ACTION_UP)
+      exitHoverMode();
+
     return hoverMode;
   }
 
@@ -49,10 +52,7 @@ public class StickerRolloverTouchListener implements RecyclerView.OnItemTouchLis
     switch (motionEvent.getAction()) {
       case MotionEvent.ACTION_UP:
       case MotionEvent.ACTION_CANCEL:
-        hoverMode = false;
-        popup.dismiss();
-        eventListener.onStickerPopupEnded();
-        currentView.clear();
+        exitHoverMode();
         break;
       default:
         for (int i = 0, len = recyclerView.getChildCount(); i < len; i++) {
@@ -82,6 +82,13 @@ public class StickerRolloverTouchListener implements RecyclerView.OnItemTouchLis
   public void enterHoverMode(@NonNull RecyclerView recyclerView, @NonNull KeyboardStickerListAdapter.Sticker sticker) {
     this.hoverMode = true;
     showSticker(recyclerView, sticker.getUri(), sticker.getStickerRecord().getEmoji());
+  }
+
+  private void exitHoverMode() {
+    hoverMode = false;
+    popup.dismiss();
+    eventListener.onStickerPopupEnded();
+    currentView.clear();
   }
 
   private void showStickerForView(@NonNull RecyclerView recyclerView, @NonNull View view) {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device Redmi Note 10 Pro, Android 14
 * Virtual device Pixel 3a, Android 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
The initial event that make onInterceptTouchEvent return true doesn't trigger the onTouchEvent function thus if the initial event is MouseEvent.ACTION_UP popup.dismiss() wouldn't be called and the popup would be locked.

To reproduce the bug, hold click on a sticker while making sure the mouse doesn't move or the event of moving the mouse will be the initial event.

This pull request addresses the issue #13351
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
