### PR TITLE
Update censorshipConfiguration for China

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/push/SignalServiceNetworkAccess.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/push/SignalServiceNetworkAccess.kt
@@ -70,6 +70,7 @@ open class SignalServiceNetworkAccess(context: Context) {
     private const val COUNTRY_CODE_RUSSIA = 7
     private const val COUNTRY_CODE_VENEZUELA = 58
     private const val COUNTRY_CODE_PAKISTAN = 92
+    private const val COUNTRY_CODE_CHINA = 86
 
     private const val G_HOST = "reflector-nrgwuv7kwq-uc.a.run.app"
     private const val F_SERVICE_HOST = "chat-signal.global.ssl.fastly.net"
@@ -217,7 +218,8 @@ open class SignalServiceNetworkAccess(context: Context) {
     ),
     COUNTRY_CODE_IRAN to fConfig,
     COUNTRY_CODE_CUBA to fConfig,
-    COUNTRY_CODE_RUSSIA to fConfig
+    COUNTRY_CODE_RUSSIA to fConfig,
+    COUNTRY_CODE_CHINA to fConfig
   )
 
   private val defaultCensoredConfiguration: SignalServiceConfiguration = buildGConfiguration(baseGHostConfigs) + fConfig
@@ -232,7 +234,8 @@ open class SignalServiceNetworkAccess(context: Context) {
     COUNTRY_CODE_UZBEKISTAN,
     COUNTRY_CODE_RUSSIA,
     COUNTRY_CODE_VENEZUELA,
-    COUNTRY_CODE_PAKISTAN
+    COUNTRY_CODE_PAKISTAN,
+    COUNTRY_CODE_CHINA
   )
 
   open val uncensoredConfiguration: SignalServiceConfiguration = SignalServiceConfiguration(

--- a/app/src/main/java/org/thoughtcrime/securesms/push/SignalServiceNetworkAccess.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/push/SignalServiceNetworkAccess.kt
@@ -174,7 +174,7 @@ open class SignalServiceNetworkAccess(context: Context) {
     HostConfig("https://inbox.google.com", G_HOST, GMAIL_CONNECTION_SPEC)
   )
 
-  private val fUrls = arrayOf("https://github.githubassets.com", "https://pinterest.com", "https://www.redditstatic.com")
+  private val fUrls = arrayOf("https://fastly.jsdelivr.net", "https://github.githubassets.com", "https://www.python.org", "https://www.gov.uk")
 
   private val fConfig: SignalServiceConfiguration = SignalServiceConfiguration(
     signalServiceUrls = fUrls.map { SignalServiceUrl(it, F_SERVICE_HOST, fTrustStore, APP_CONNECTION_SPEC) }.toTypedArray(),


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Google Pixel 7, Android 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

As for China, currently only one front domain works: `github.githubassets.com`. Most of Google's IPs are blocked, and another 2 domain are blocked by DPI. Therefore, the circumvention works, but is very slow, because Signal has to wait for all others to time out before connecting to `github.githubassets.com`.

This patch:

1. Updated fUrls to use less UGC websites, which is more likely to be blocked, and use more innocent websites.
2. Set domain fronting configuration for China to Fastly.

* `fastly.jsdelivr.net` is used by many programers on their blog, I belive the collateral damage is high.
* `www.python.org` is also programer-related.
* `www.gov.uk`, lol.

My ISP is China Unicom (AS4837), I've built it and tested on my Google Pixel 7 with Android 14. The circumvention works smoothly... Besides the sign up or sign in process, it requires `firebaseinstallations.googleapis.com`, I set one alive IP in the hosts. ~~For Signal, maybe hardcode or delivery alive IPs, I'm considering.~~
