### PR TITLE
Limit number of contacts for Android's "Quick Share"

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/ConversationUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/ConversationUtil.java
@@ -142,7 +142,7 @@ public final class ConversationUtil {
   }
 
   public static int getMaxShortcuts(@NonNull Context context) {
-    return Math.min(ShortcutManagerCompat.getMaxShortcutCountPerActivity(context), 150);
+    return Math.min(ShortcutManagerCompat.getMaxShortcutCountPerActivity(context), 10);
   }
 
   /**


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * None, as I do not currently have a setup to build Signal for Android and no way to test it with real contact data
- [ ] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Work around a bug in Android which leads to non recent conversations showing up in Android's "Quick Share" overlay instead of the most recent conversations. As a side effect, leak less conversation names to the Android OS.

Fixes #13398

Notes:
* The number 10 is arbitrarily chosen, as was the original number 150 if I understand commit 8783d150e8f8c6e1b8962e6cce2b65f10587d49d correctly. On the Android UIs I have seen so far, there are only 4 or 5 "Quick Share" items to be displayed by the OS, but there may be other UIs. Feel free to adapt the number to whatever you think is more useful.
* I don't have access to a machine that is suitable for building and testing this change at the moment. Can someone else please test this change for me?