### PR TITLE
Fix Call popup width issue on orientation change

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
@@ -704,6 +704,12 @@ class ConversationFragment :
     super.onConfigurationChanged(newConfig)
     ToolbarDependentMarginListener(binding.toolbar)
     inlineQueryController.onOrientationChange(newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE)
+
+    // Recreate start call dialog on orientation change
+    val recipient: Recipient = viewModel.recipientSnapshot ?: return
+    CommunicationActions.startVoiceCall(this@ConversationFragment, recipient) {
+      YouAreAlreadyInACallSnackbar.show(requireView())
+    }
   }
 
   override fun onDestroyView() {


### PR DESCRIPTION
Fixes Issue #13658: Call popup window has incorrect width when flipping phone after opening a chat #13658

### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 *  Xiaomi Redmi 10, Android 14

- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This PR fixes the issue where the call popup/dialog size would not adjust when the orientation changed, causing it to remain at the size set when the page was first opened, which appeared awkward. Now, after the fix, the dialog/popup will resize appropriately based on the current orientation, regardless of the initial orientation when the page was opened.

### How to test:
      1. Open a chat (on both Portrait and Landscape modes)
      2. Click on Call Icon
      3. Change Orientation

Here's screen recording video after the fix:
https://github.com/user-attachments/assets/9c4e63c1-d300-4804-9916-96395cb01a1f

