### PR TITLE
Disable Google Safe Browsing in WebViews

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -125,6 +125,7 @@
     <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" />
     <meta-data android:name="firebase_messaging_auto_init_enabled" android:value="false" />
     <meta-data android:name="android.webkit.WebView.MetricsOptOut" android:value="true" />
+    <meta-data android:name="android.webkit.WebView.EnableSafeBrowsing" android:value="false" />
 
     <activity android:name=".WebRtcCallActivity"
               android:theme="@style/TextSecure.DarkTheme.WebRTCCall"


### PR DESCRIPTION

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Google Pixel 8, Android 14 (GrapheneOS)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
By default, Google Safe Browsing is enabled in WebView objects; see https://developer.android.com/develop/ui/views/layout/webapps/managing-webview#safe-browsing. Safe Browsing requires sending any URLs loaded in WebViews to Google to check for malicious contents. As the WebView URLs loaded are generally either Signal websites or reputable payment providers for donations, the potential security benefits of Google scanning for phishing websites do not outweigh the privacy issues of sending this information to Google.
