### PR TITLE
intpref: remove force emoji and search index download summaries unnecessary back slash symbol

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/internal/InternalSettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/internal/InternalSettingsFragment.kt
@@ -427,7 +427,7 @@ class InternalSettingsFragment : DSLSettingsFragment(R.string.preferences__inter
 
       clickPref(
         title = DSLSettingsText.from("Force emoji download"),
-        summary = DSLSettingsText.from("Download the latest emoji set if it\\'s newer than what we have."),
+        summary = DSLSettingsText.from("Download the latest emoji set if it's newer than what we have."),
         onClick = {
           AppDependencies.jobManager.add(DownloadLatestEmojiDataJob(true))
         }
@@ -435,7 +435,7 @@ class InternalSettingsFragment : DSLSettingsFragment(R.string.preferences__inter
 
       clickPref(
         title = DSLSettingsText.from("Force search index download"),
-        summary = DSLSettingsText.from("Download the latest emoji search index if it\\'s newer than what we have."),
+        summary = DSLSettingsText.from("Download the latest emoji search index if it's newer than what we have."),
         onClick = {
           EmojiSearchIndexDownloadJob.scheduleImmediately()
         }


### PR DESCRIPTION
Note: original file contains two (2) \ yet last release only shows one (1) in UI; I am removing both with this PR, if at least one is needed, let me know so I can adjust properly, otherwise, feel free to merge as this seems to be just a UI thing, doesn't touch any actual code.