### PR TITLE
Resolve some gradle deprecations

### DIFF
--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -76,6 +76,8 @@ dependencies {
 
 androidComponents {
     beforeVariants(selector().all()) {
-        it.enabled = it.buildType == "benchmark"
+        if (it.buildType != "benchmark") {
+            it.enable = false
+        }
     }
 }

--- a/build-logic/plugins/build.gradle.kts
+++ b/build-logic/plugins/build.gradle.kts
@@ -14,8 +14,10 @@ java {
   targetCompatibility = signalJavaVersion
 }
 
-kotlinDslPluginOptions {
-  jvmTarget.set(signalKotlinJvmTarget)
+kotlin {
+  jvmToolchain {
+    languageVersion.set(JavaLanguageVersion.of(signalKotlinJvmTarget))
+  }
 }
 
 dependencies {

--- a/build-logic/plugins/src/main/java/signal-library.gradle.kts
+++ b/build-logic/plugins/src/main/java/signal-library.gradle.kts
@@ -27,7 +27,6 @@ android {
 
   defaultConfig {
     minSdk = signalMinSdkVersion
-    targetSdk = signalTargetSdkVersion
   }
 
   compileOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,7 +87,7 @@ tasks.register("qa") {
 }
 
 tasks.register("clean", Delete::class) {
-  delete(rootProject.buildDir)
+  delete(rootProject.layout.buildDirectory)
 }
 
 tasks.register("format") {

--- a/microbenchmark/build.gradle.kts
+++ b/microbenchmark/build.gradle.kts
@@ -30,8 +30,6 @@ android {
 
   defaultConfig {
     minSdk = signalMinSdkVersion
-    targetSdk = signalTargetSdkVersion
-
     testInstrumentationRunner = "androidx.benchmark.junit4.AndroidBenchmarkRunner"
   }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,11 +21,6 @@ dependencyResolutionManagement {
     maven {
       url = uri("https://dl.cloudsmith.io/qxAgwaeEE1vN8aLU/mobilecoin/mobilecoin/maven/")
     }
-    jcenter {
-      content {
-        includeVersion("mobi.upod", "time-duration-picker", "1.1.3")
-      }
-    }
   }
 }
 


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

### Description

Resolves a batch of Gradle warnings that occur when running running a build / `qa` task:

1. The getter for `Project.buildDir` was deprecated in Gradle 8. It can be replaced with `rootProject.layout.buildDirectory`.
2. `kotlinDslPluginOptions.jvmTarget` was deprecated in Gradle 8. It. can be replaced by setting the `kotlin.jvmToolchain` 
3. `enabled` on the `ComponentBuilder` interface (used in `beforeVariants()`) was deprecated in Gradle 8. It can be replaced with `enable` (sans the `d`)
4. `targetSdk` has been deprecated _for Android library projects_ as of *AGP* 8. It is still a valid and important field for application projects. A solution is just to remove it from library projects.
5. The `jcenter` repository is deprecated and it appears no longer has any meaningful use in this project. (I checked `./gradlew :Signal-Android:dependencies --configuration implementaion` for `mobi.upod`, and didn't see any usages.)