### PR TITLE
Fix: Use SqlCipherDeletingErrorHandler in JobDatabase for corruption handling (#13762)

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/JobDatabase.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/JobDatabase.kt
@@ -43,7 +43,7 @@ class JobDatabase(
   null,
   DATABASE_VERSION,
   0,
-  SqlCipherErrorHandler(DATABASE_NAME),
+  SqlCipherDeletingErrorHandler(DATABASE_NAME),
   SqlCipherDatabaseHook(),
   true
 ),

--- a/app/src/test/java/org/thoughtcrime/securesms/database/JobDatabaseTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/database/JobDatabaseTest.kt
@@ -1,0 +1,63 @@
+import android.app.Application
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.unmockkObject
+import io.mockk.verify
+import net.zetetic.database.sqlcipher.SQLiteDatabase
+import net.zetetic.database.sqlcipher.SQLiteOpenHelper
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.thoughtcrime.securesms.crypto.DatabaseSecret
+import org.thoughtcrime.securesms.database.JobDatabase
+import org.thoughtcrime.securesms.database.SqlCipherDeletingErrorHandler
+import org.thoughtcrime.securesms.dependencies.AppDependencies
+
+class JobDatabaseTest {
+
+  private lateinit var mockApplication: Application
+  private lateinit var mockDatabase: SQLiteDatabase
+  private lateinit var sqlCipherDeletingErrorHandler: SqlCipherDeletingErrorHandler
+  private lateinit var databaseSecret: DatabaseSecret
+
+  @Before
+  fun setUp() {
+    mockApplication = mockk(relaxed = true)
+
+    // Set _application field in AppDependencies using reflection
+    val applicationField = AppDependencies::class.java.getDeclaredField("_application")
+    applicationField.isAccessible = true
+    applicationField.set(null, mockApplication)
+
+    databaseSecret = mockk(relaxed = true)
+    mockDatabase = mockk(relaxed = true)
+    every { mockDatabase.rawQuery(any(), any()) } returns mockk()
+    sqlCipherDeletingErrorHandler = spyk(SqlCipherDeletingErrorHandler("signal-jobmanager.db"))
+    every { mockApplication.deleteDatabase("signal-jobmanager.db") } returns true
+  }
+
+  @After
+  fun tearDown() {
+    unmockkObject(AppDependencies)
+  }
+
+  @Test
+  fun `onCorruption deletes database on corruption event`() {
+    sqlCipherDeletingErrorHandler.onCorruption(mockDatabase, "Database corrupted!")
+    verify { mockApplication.deleteDatabase("signal-jobmanager.db") }
+  }
+
+  @Test
+  fun `JobDatabase initializes with SqlCipherDeletingErrorHandler`() {
+    val jobDatabase = JobDatabase(mockApplication, databaseSecret)
+
+    // Use reflection to access the private errorHandler field
+    val errorHandlerField = SQLiteOpenHelper::class.java.getDeclaredField("mErrorHandler")
+    errorHandlerField.isAccessible = true
+    val errorHandler = errorHandlerField.get(jobDatabase)
+    assert(errorHandler is SqlCipherDeletingErrorHandler) {
+      "Expected SqlCipherDeletingErrorHandler, but got ${errorHandler?.javaClass?.name}"
+    }
+  }
+}


### PR DESCRIPTION
Previously, JobDatabase used SqlCipherErrorHandler, which did not delete corrupted `signal-jobmanager.db`. This fix ensures that SqlCipherDeletingErrorHandler is used, which deletes the database upon corruption.

Closes #13762

### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 7a, Android 15
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #13762` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This pull request fixes issue #13762 by ensuring that the `JobDatabase` class uses `SqlCipherDeletingErrorHandler` instead of `SqlCipherErrorHandler` for database corruption handling. The previous implementation did not delete corrupted databases, leading to potential app crashes or unhandled exceptions. 

**Proposed Changes:**
- Updated the `JobDatabase` constructor to initialize with `SqlCipherDeletingErrorHandler`.
- Added tests to verify that the `SqlCipherDeletingErrorHandler` is used and that database corruption triggers its `onCorruption` method, resulting in the deletion and recreation of the database.

**Testing:**
- Verified the changes on the following devices:
  - Pixel 7a, Android 15
- Added Unit tests to test the new change. There was no way to reliably corrupt the `signal-jobmanager.db` in way that would ensure that the SQLCipherErrorHandler's `onCorruption` method would be called. Since it was not possible to recreate the issue/error, best way to test it was Unit testing. Corrupting the data using hex editors doesn't call onCorruption for some reason, this could be something which might need further investigation. For now, this should resolve any issue where `signal-jobmanager.db` gets corrupted enough for our `SQLiteOpenHelper` to trigger a call to `onCorruption` method. By looking closely at the logs provided by the OP, seems like in their case `onCorruption` is being called so at least for users such as them, this fix should resolve the issue.

This fix ensures a better handling of corrupted databases and aligns with best practices for database error management.
