### PR TITLE
More fts table fixes

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/helpers/migration/V239_MessageFullTextSearchEmojiSupport.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/helpers/migration/V239_MessageFullTextSearchEmojiSupport.kt
@@ -43,6 +43,8 @@ object V239_MessageFullTextSearchEmojiSupport : SignalDatabaseMigration {
 
     db.execSQL("""CREATE VIRTUAL TABLE message_fts USING fts5(body, thread_id UNINDEXED, content=message, content_rowid=_id, tokenize = "unicode61 categories 'L* N* Co Sc So'")""")
 
+    db.execSQL("INSERT INTO message_fts(message_fts) VALUES ('rebuild')")
+    
     db.execSQL(
       """
       CREATE TRIGGER message_ai AFTER INSERT ON message BEGIN

--- a/app/src/main/java/org/thoughtcrime/securesms/database/helpers/migration/V242_MessageFullTextSearchEmojiSupportV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/helpers/migration/V242_MessageFullTextSearchEmojiSupportV2.kt
@@ -34,7 +34,8 @@ object V242_MessageFullTextSearchEmojiSupportV2 : SignalDatabaseMigration {
 
     db.execSQL("""CREATE VIRTUAL TABLE message_fts USING fts5(body, thread_id UNINDEXED, content=message, content_rowid=_id, tokenize = "unicode61 categories 'L* N* Co Sc So'")""")
     db.execSQL("INSERT INTO $FTS_TABLE_NAME ($FTS_TABLE_NAME, rank) VALUES('secure-delete', 1)")
-
+    db.execSQL("INSERT INTO $FTS_TABLE_NAME ($FTS_TABLE_NAME) VALUES('rebuild')")
+    
     db.execSQL(
       """
       CREATE TRIGGER message_ai AFTER INSERT ON message BEGIN


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

This is strongly related to #13809. The exact same FTS-table-drop-and-recreate pattern is used in these two migrations (239, and 242). These will certainly again cause database corruptions. For more information, please see #13809.

I am not currently aware of open issues caused by this problem (I only found them now just by `grep`ping for "message_fts" through the migration-helpers), and I have not tested these two 1-liners, but both the problem and solution are identical to #13809 (which was thoroughly investigated and tested).

If i'm understanding everything right, some people may already have inconsistent FTS tables due to these migrations, so I strongly suggest a new database version and a migration like this:
```
object V2XX_EnsureSearchTableConsistency : SignalDatabaseMigration {

  private const val FTS_TABLE_NAME = "message_fts"
  db.execSQL("INSERT INTO $FTS_TABLE_NAME ($FTS_TABLE_NAME) VALUES('rebuild')")

}
```
I'd be willing to write a patch like this if requested. Then after that, it should just be a matter of _keeping_ the table consistent.

Thanks!