### PR TITLE
Inject SignalWebSocket into IncomingMessageObserver

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/dependencies/AppDependencies.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/dependencies/AppDependencies.kt
@@ -339,7 +339,7 @@ object AppDependencies {
     fun provideMegaphoneRepository(): MegaphoneRepository
     fun provideEarlyMessageCache(): EarlyMessageCache
     fun provideMessageNotifier(): MessageNotifier
-    fun provideIncomingMessageObserver(): IncomingMessageObserver
+    fun provideIncomingMessageObserver(signalWebSocket: SignalWebSocket): IncomingMessageObserver
     fun provideTrimThreadsByDateManager(): TrimThreadsByDateManager
     fun provideViewOnceMessageManager(): ViewOnceMessageManager
     fun provideExpiringStoriesManager(): ExpiringStoriesManager

--- a/app/src/main/java/org/thoughtcrime/securesms/dependencies/ApplicationDependencyProvider.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/dependencies/ApplicationDependencyProvider.java
@@ -207,8 +207,8 @@ public class ApplicationDependencyProvider implements AppDependencies.Provider {
   }
 
   @Override
-  public @NonNull IncomingMessageObserver provideIncomingMessageObserver() {
-    return new IncomingMessageObserver(context);
+  public @NonNull IncomingMessageObserver provideIncomingMessageObserver(@NonNull SignalWebSocket signalWebSocket) {
+    return new IncomingMessageObserver(context, signalWebSocket);
   }
 
   @Override

--- a/app/src/main/java/org/thoughtcrime/securesms/dependencies/NetworkDependenciesModule.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/dependencies/NetworkDependenciesModule.kt
@@ -75,7 +75,7 @@ class NetworkDependenciesModule(
   val signalServiceMessageSender: SignalServiceMessageSender by _signalServiceMessageSender
 
   val incomingMessageObserver: IncomingMessageObserver by lazy {
-    provider.provideIncomingMessageObserver()
+    provider.provideIncomingMessageObserver(signalWebSocket)
   }
 
   val pushServiceSocket: PushServiceSocket by lazy {

--- a/app/src/test/java/org/thoughtcrime/securesms/dependencies/MockApplicationDependencyProvider.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/dependencies/MockApplicationDependencyProvider.kt
@@ -101,7 +101,7 @@ class MockApplicationDependencyProvider : AppDependencies.Provider {
     return mockk()
   }
 
-  override fun provideIncomingMessageObserver(): IncomingMessageObserver {
+  override fun provideIncomingMessageObserver(signalWebSocket: SignalWebSocket): IncomingMessageObserver {
     return mockk()
   }
 


### PR DESCRIPTION
### Description

This PR updates `IncomingMessageObserver` to accept `SignalWebSocket` as a constructor parameter. This change ensures each IncomingMessageObserver is explicitly tied to the SignalWebSocket instance owned by its `NetworkDependenciesModule`, resolving a race condition that could occur during a network reset.

Before this, `IncomingMessageObserver` got its `SignalWebSocket` from `AppDependencies`. During network resets (`AppDependencies.resetNetwork()`), NetworkDependenciesModule and its SignalWebSocket were recreated. If the old IncomingMessageObserver was still terminating asynchronously (`terminateAsync()`), it could accidentally reference and manipulate the new SignalWebSocket. So when `disconnect()` is called, it may disconnect the current SignalWebSocket, even if it is intended to disconnect the previous one. This led to issues like the old observer disconnecting the new socket, and the old socket remaining connected, appearing as if two observers were running simultaneously in the logs.

By directly injecting the corresponding SignalWebSocket, we eliminate the shared dependency and resolve the race condition.
