### PR TITLE
Migrates a batch of tests from Mockito -> MockK

### DIFF
--- a/app/src/test/java/org/thoughtcrime/securesms/sms/UploadDependencyGraphTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/sms/UploadDependencyGraphTest.kt
@@ -1,14 +1,12 @@
 package org.thoughtcrime.securesms.sms
 
 import android.app.Application
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.kotlin.any
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.thoughtcrime.securesms.attachments.Attachment
@@ -36,17 +34,14 @@ import java.util.concurrent.atomic.AtomicLong
 @RunWith(RobolectricTestRunner::class)
 @Config(application = Application::class)
 class UploadDependencyGraphTest {
-
-  private val jobManager: JobManager = mock()
-
-  private var uniqueLong = AtomicLong(0)
-
-  @Before
-  fun setUp() {
-    whenever(jobManager.startChain(any<Job>())).then {
-      JobManager.Chain(jobManager, listOf(it.getArgument(0)))
+  private val jobManager = mockk<JobManager> {
+    every { startChain(any<Job>()) } answers {
+      val job = args.first() as Job
+      JobManager.Chain(this@mockk, listOf(job))
     }
   }
+
+  private var uniqueLong = AtomicLong(0)
 
   @Test
   fun `Given a list of Uri attachments and a list of Messages, when I get the dependencyMap, then I expect a times m results`() {

--- a/app/src/test/java/org/thoughtcrime/securesms/stories/StoriesTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/stories/StoriesTest.kt
@@ -36,8 +36,8 @@ class StoriesTest {
     RxJavaPlugins.setIoSchedulerHandler { testScheduler }
 
     SignalDatabase.setSignalDatabaseInstanceForTesting(mockSignalDatabase)
-    every { SignalDatabase.attachments } returns mockAttachmentTable 
-    every { AppDependencies.jobManager } returns mockJobManager 
+    every { SignalDatabase.attachments } returns mockAttachmentTable
+    every { AppDependencies.jobManager } returns mockJobManager
     every { mockAttachmentTable.getAttachmentsForMessage(any()) } returns emptyList()
   }
 

--- a/app/src/test/java/org/thoughtcrime/securesms/stories/StoriesTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/stories/StoriesTest.kt
@@ -1,20 +1,17 @@
 package org.thoughtcrime.securesms.stories
 
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
 import io.reactivex.rxjava3.plugins.RxJavaPlugins
 import io.reactivex.rxjava3.schedulers.TestScheduler
 import org.junit.After
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mock
-import org.mockito.MockedStatic
-import org.mockito.junit.MockitoJUnit
-import org.mockito.junit.MockitoRule
-import org.mockito.kotlin.any
-import org.mockito.kotlin.isA
-import org.mockito.kotlin.never
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import org.thoughtcrime.securesms.attachments.AttachmentId
 import org.thoughtcrime.securesms.database.AttachmentTable
 import org.thoughtcrime.securesms.database.FakeMessageRecords
@@ -24,37 +21,24 @@ import org.thoughtcrime.securesms.jobmanager.JobManager
 import org.thoughtcrime.securesms.jobs.AttachmentDownloadJob
 
 class StoriesTest {
-
-  @Rule
-  @JvmField
-  val mockitoRule: MockitoRule = MockitoJUnit.rule()
-
-  @Mock
-  private lateinit var mockAttachmentTable: AttachmentTable
-
-  @Mock
-  private lateinit var mockJobManager: JobManager
-
-  @Mock
-  private lateinit var mockApplicationDependenciesStatic: MockedStatic<AppDependencies>
-
-  @Mock
-  private lateinit var mockSignalDatabaseStatic: MockedStatic<SignalDatabase>
-
-  @Mock
-  private lateinit var mockSignalDatabase: SignalDatabase
-
   private val testScheduler = TestScheduler()
+  private val mockJobManager = mockk<JobManager> {
+    every { add(any()) } just runs
+  }
+  private val mockAttachmentTable = mockk<AttachmentTable>()
+  private val mockSignalDatabase = mockk<SignalDatabase>()
 
   @Before
   fun setUp() {
+    mockkStatic(AppDependencies::class)
+
     RxJavaPlugins.setInitIoSchedulerHandler { testScheduler }
     RxJavaPlugins.setIoSchedulerHandler { testScheduler }
 
     SignalDatabase.setSignalDatabaseInstanceForTesting(mockSignalDatabase)
-    whenever(SignalDatabase.attachments).thenReturn(mockAttachmentTable)
-    whenever(AppDependencies.jobManager).thenReturn(mockJobManager)
-    whenever(mockAttachmentTable.getAttachmentsForMessage(any())).thenReturn(emptyList())
+    every { SignalDatabase.attachments } returns mockAttachmentTable 
+    every { AppDependencies.jobManager } returns mockJobManager 
+    every { mockAttachmentTable.getAttachmentsForMessage(any()) } returns emptyList()
   }
 
   @After
@@ -75,7 +59,7 @@ class StoriesTest {
 
     // THEN
     testObserver.assertComplete()
-    verify(mockJobManager, never()).add(any())
+    verify(exactly = 0) { mockJobManager.add(any()) }
   }
 
   @Test
@@ -95,7 +79,8 @@ class StoriesTest {
 
     // THEN
     testObserver.assertComplete()
-    verify(mockJobManager).add(isA<AttachmentDownloadJob>())
+    val slot = slot<AttachmentDownloadJob>()
+    verify { mockJobManager.add(capture(slot)) }
   }
 
   @Test
@@ -103,7 +88,7 @@ class StoriesTest {
     // GIVEN
     val attachment = FakeMessageRecords.buildDatabaseAttachment()
     val messageRecord = FakeMessageRecords.buildMediaMmsMessageRecord()
-    whenever(mockAttachmentTable.getAttachmentsForMessage(any())).thenReturn(listOf(attachment))
+    every { mockAttachmentTable.getAttachmentsForMessage(any()) } returns listOf(attachment)
 
     // WHEN
     val testObserver = Stories.enqueueAttachmentsFromStoryForDownload(messageRecord, true).test()
@@ -111,6 +96,7 @@ class StoriesTest {
 
     // THEN
     testObserver.assertComplete()
-    verify(mockJobManager).add(isA<AttachmentDownloadJob>())
+    val slot = slot<AttachmentDownloadJob>()
+    verify { mockJobManager.add(capture(slot)) }
   }
 }

--- a/app/src/test/java/org/thoughtcrime/securesms/stories/dialogs/StoryContextMenuTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/stories/dialogs/StoryContextMenuTest.kt
@@ -6,14 +6,14 @@ import android.content.Intent
 import android.net.Uri
 import androidx.fragment.app.Fragment
 import androidx.test.core.app.ApplicationProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.signal.core.util.Base64
@@ -32,11 +32,10 @@ import java.util.Optional
 @RunWith(RobolectricTestRunner::class)
 @Config(application = Application::class)
 class StoryContextMenuTest {
-
   private val context: Context = ApplicationProvider.getApplicationContext()
-  private val intentCaptor = argumentCaptor<Intent>()
-  private val fragment: Fragment = mock {
-    on { requireContext() } doReturn context
+  private val intentSlot = slot<Intent>()
+  private val fragment = mockk<Fragment>(relaxUnitFun = true) {
+    every { requireContext() } returns this@StoryContextMenuTest.context
   }
 
   @Test
@@ -60,9 +59,9 @@ class StoryContextMenuTest {
     StoryContextMenu.share(fragment, storyRecord)
 
     // THEN
-    verify(fragment).startActivity(intentCaptor.capture())
-    val chooserIntent: Intent = intentCaptor.firstValue
-    val targetIntent: Intent = chooserIntent.getParcelableExtraCompat(Intent.EXTRA_INTENT, Intent::class.java)!!
+    verify { fragment.startActivity(capture(intentSlot)) }
+    val chooserIntent = intentSlot.captured
+    val targetIntent = chooserIntent.getParcelableExtraCompat(Intent.EXTRA_INTENT, Intent::class.java)!!
     assertEquals(PartAuthority.getAttachmentPublicUri(PartAuthority.getAttachmentDataUri(attachmentId)), targetIntent.getParcelableExtraCompat(Intent.EXTRA_STREAM, Uri::class.java))
     assertEquals(MediaUtil.IMAGE_JPEG, targetIntent.type)
     assertTrue(Intent.FLAG_GRANT_READ_URI_PERMISSION and chooserIntent.flags == Intent.FLAG_GRANT_READ_URI_PERMISSION)
@@ -81,9 +80,9 @@ class StoryContextMenuTest {
     StoryContextMenu.share(fragment, storyRecord)
 
     // THEN
-    verify(fragment).startActivity(intentCaptor.capture())
-    val chooserIntent: Intent = intentCaptor.firstValue
-    val targetIntent: Intent = chooserIntent.getParcelableExtraCompat(Intent.EXTRA_INTENT, Intent::class.java)!!
+    verify { fragment.startActivity(capture(intentSlot)) }
+    val chooserIntent = intentSlot.captured
+    val targetIntent = chooserIntent.getParcelableExtraCompat(Intent.EXTRA_INTENT, Intent::class.java)!!
     assertEquals(expected, targetIntent.getStringExtra(Intent.EXTRA_TEXT))
   }
 
@@ -101,8 +100,8 @@ class StoryContextMenuTest {
     StoryContextMenu.share(fragment, storyRecord)
 
     // THEN
-    verify(fragment).startActivity(intentCaptor.capture())
-    val chooserIntent: Intent = intentCaptor.firstValue
+    verify { fragment.startActivity(capture(intentSlot)) }
+    val chooserIntent: Intent = intentSlot.captured
     val targetIntent: Intent = chooserIntent.getParcelableExtraCompat(Intent.EXTRA_INTENT, Intent::class.java)!!
     assertEquals(expected, targetIntent.getStringExtra(Intent.EXTRA_TEXT))
   }
@@ -123,8 +122,8 @@ class StoryContextMenuTest {
     StoryContextMenu.share(fragment, storyRecord)
 
     // THEN
-    verify(fragment).startActivity(intentCaptor.capture())
-    val chooserIntent: Intent = intentCaptor.firstValue
+    verify { fragment.startActivity(capture(intentSlot)) }
+    val chooserIntent: Intent = intentSlot.captured
     val targetIntent: Intent = chooserIntent.getParcelableExtraCompat(Intent.EXTRA_INTENT, Intent::class.java)!!
     assertEquals(expected, targetIntent.getStringExtra(Intent.EXTRA_TEXT))
   }

--- a/app/src/test/java/org/thoughtcrime/securesms/stories/viewer/StoryViewerViewModelTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/stories/viewer/StoryViewerViewModelTest.kt
@@ -1,49 +1,34 @@
 package org.thoughtcrime.securesms.stories.viewer
 
+import android.app.Application
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import io.reactivex.rxjava3.core.Single
 import io.reactivex.rxjava3.plugins.RxJavaPlugins
 import io.reactivex.rxjava3.schedulers.TestScheduler
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
-import org.junit.Ignore
-import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mock
-import org.mockito.MockedStatic
-import org.mockito.junit.MockitoJUnit
-import org.mockito.junit.MockitoRule
-import org.mockito.kotlin.any
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import org.thoughtcrime.securesms.recipients.RecipientId
-import org.thoughtcrime.securesms.stories.Stories
 import org.thoughtcrime.securesms.stories.StoryViewerArgs
 
-@Ignore
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, application = Application::class)
 class StoryViewerViewModelTest {
-
-  @Rule
-  @JvmField
-  val mockitoRule: MockitoRule = MockitoJUnit.rule()
-
   private val testScheduler = TestScheduler()
-
-  @Mock
-  private lateinit var repository: StoryViewerRepository
-
-  @Mock
-  private lateinit var mockStoriesStatic: MockedStatic<Stories>
+  private val repository = mockk<StoryViewerRepository>()
 
   @Before
   fun setUp() {
     RxJavaPlugins.setInitComputationSchedulerHandler { testScheduler }
     RxJavaPlugins.setComputationSchedulerHandler { testScheduler }
 
-    whenever(repository.getFirstStory(any(), any())).doReturn(Single.just(mock()))
+    every { repository.getFirstStory(any(), any()) } returns Single.just(mockk()) 
   }
 
   @After
@@ -69,7 +54,7 @@ class StoryViewerViewModelTest {
     testScheduler.triggerActions()
 
     // THEN
-    verify(repository, never()).getStories(any(), any())
+    verify(exactly=0) { repository.getStories(any(), any()) }
     assertEquals(injectedStories, testSubject.stateSnapshot.pages)
   }
 
@@ -78,7 +63,7 @@ class StoryViewerViewModelTest {
     // GIVEN
     val stories: List<RecipientId> = (1L..5L).map(RecipientId::from)
     val startStory = RecipientId.from(2L)
-    whenever(repository.getStories(any(), any())).doReturn(Single.just(stories))
+    every { repository.getStories(any(), any()) } returns Single.just(stories) 
 
     // WHEN
     val testSubject = StoryViewerViewModel(
@@ -102,7 +87,7 @@ class StoryViewerViewModelTest {
     // GIVEN
     val stories: List<RecipientId> = (1L..5L).map(RecipientId::from)
     val startStory = RecipientId.from(1L)
-    whenever(repository.getStories(any(), any())).doReturn(Single.just(stories))
+    every { repository.getStories(any(), any()) } returns Single.just(stories) 
     val testSubject = StoryViewerViewModel(
       StoryViewerArgs(
         recipientId = startStory,
@@ -129,7 +114,7 @@ class StoryViewerViewModelTest {
     // GIVEN
     val stories: List<RecipientId> = (1L..5L).map(RecipientId::from)
     val startStory = stories.last()
-    whenever(repository.getStories(any(), any())).doReturn(Single.just(stories))
+    every { repository.getStories(any(), any()) } returns Single.just(stories) 
     val testSubject = StoryViewerViewModel(
       StoryViewerArgs(
         recipientId = startStory,
@@ -156,7 +141,7 @@ class StoryViewerViewModelTest {
     // GIVEN
     val stories: List<RecipientId> = (1L..5L).map(RecipientId::from)
     val startStory = stories.last()
-    whenever(repository.getStories(any(), any())).doReturn(Single.just(stories))
+    every { repository.getStories(any(), any()) } returns Single.just(stories) 
     val testSubject = StoryViewerViewModel(
       StoryViewerArgs(
         recipientId = startStory,
@@ -183,7 +168,7 @@ class StoryViewerViewModelTest {
     // GIVEN
     val stories: List<RecipientId> = (1L..5L).map(RecipientId::from)
     val startStory = stories.first()
-    whenever(repository.getStories(any(), any())).doReturn(Single.just(stories))
+    every { repository.getStories(any(), any()) } returns Single.just(stories) 
     val testSubject = StoryViewerViewModel(
       StoryViewerArgs(
         recipientId = startStory,
@@ -210,7 +195,7 @@ class StoryViewerViewModelTest {
     // GIVEN
     val stories: List<RecipientId> = (1L..5L).map(RecipientId::from)
     val startStory = stories.first()
-    whenever(repository.getStories(any(), any())).doReturn(Single.just(stories))
+    every { repository.getStories(any(), any()) } returns Single.just(stories) 
     val testSubject = StoryViewerViewModel(
       StoryViewerArgs(
         recipientId = startStory,

--- a/app/src/test/java/org/thoughtcrime/securesms/stories/viewer/StoryViewerViewModelTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/stories/viewer/StoryViewerViewModelTest.kt
@@ -28,7 +28,7 @@ class StoryViewerViewModelTest {
     RxJavaPlugins.setInitComputationSchedulerHandler { testScheduler }
     RxJavaPlugins.setComputationSchedulerHandler { testScheduler }
 
-    every { repository.getFirstStory(any(), any()) } returns Single.just(mockk()) 
+    every { repository.getFirstStory(any(), any()) } returns Single.just(mockk())
   }
 
   @After
@@ -54,7 +54,7 @@ class StoryViewerViewModelTest {
     testScheduler.triggerActions()
 
     // THEN
-    verify(exactly=0) { repository.getStories(any(), any()) }
+    verify(exactly = 0) { repository.getStories(any(), any()) }
     assertEquals(injectedStories, testSubject.stateSnapshot.pages)
   }
 
@@ -63,7 +63,7 @@ class StoryViewerViewModelTest {
     // GIVEN
     val stories: List<RecipientId> = (1L..5L).map(RecipientId::from)
     val startStory = RecipientId.from(2L)
-    every { repository.getStories(any(), any()) } returns Single.just(stories) 
+    every { repository.getStories(any(), any()) } returns Single.just(stories)
 
     // WHEN
     val testSubject = StoryViewerViewModel(
@@ -87,7 +87,7 @@ class StoryViewerViewModelTest {
     // GIVEN
     val stories: List<RecipientId> = (1L..5L).map(RecipientId::from)
     val startStory = RecipientId.from(1L)
-    every { repository.getStories(any(), any()) } returns Single.just(stories) 
+    every { repository.getStories(any(), any()) } returns Single.just(stories)
     val testSubject = StoryViewerViewModel(
       StoryViewerArgs(
         recipientId = startStory,
@@ -114,7 +114,7 @@ class StoryViewerViewModelTest {
     // GIVEN
     val stories: List<RecipientId> = (1L..5L).map(RecipientId::from)
     val startStory = stories.last()
-    every { repository.getStories(any(), any()) } returns Single.just(stories) 
+    every { repository.getStories(any(), any()) } returns Single.just(stories)
     val testSubject = StoryViewerViewModel(
       StoryViewerArgs(
         recipientId = startStory,
@@ -141,7 +141,7 @@ class StoryViewerViewModelTest {
     // GIVEN
     val stories: List<RecipientId> = (1L..5L).map(RecipientId::from)
     val startStory = stories.last()
-    every { repository.getStories(any(), any()) } returns Single.just(stories) 
+    every { repository.getStories(any(), any()) } returns Single.just(stories)
     val testSubject = StoryViewerViewModel(
       StoryViewerArgs(
         recipientId = startStory,
@@ -168,7 +168,7 @@ class StoryViewerViewModelTest {
     // GIVEN
     val stories: List<RecipientId> = (1L..5L).map(RecipientId::from)
     val startStory = stories.first()
-    every { repository.getStories(any(), any()) } returns Single.just(stories) 
+    every { repository.getStories(any(), any()) } returns Single.just(stories)
     val testSubject = StoryViewerViewModel(
       StoryViewerArgs(
         recipientId = startStory,
@@ -195,7 +195,7 @@ class StoryViewerViewModelTest {
     // GIVEN
     val stories: List<RecipientId> = (1L..5L).map(RecipientId::from)
     val startStory = stories.first()
-    every { repository.getStories(any(), any()) } returns Single.just(stories) 
+    every { repository.getStories(any(), any()) } returns Single.just(stories)
     val testSubject = StoryViewerViewModel(
       StoryViewerArgs(
         recipientId = startStory,

--- a/app/src/test/java/org/thoughtcrime/securesms/stories/viewer/page/StoryViewerPageViewModelTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/stories/viewer/page/StoryViewerPageViewModelTest.kt
@@ -34,7 +34,7 @@ class StoryViewerPageViewModelTest {
 
     RxAndroidPlugins.setMainThreadSchedulerHandler { testScheduler }
 
-    every { repository.forceDownload(any()) } returns Completable.complete() 
+    every { repository.forceDownload(any()) } returns Completable.complete()
   }
 
   @After
@@ -46,7 +46,7 @@ class StoryViewerPageViewModelTest {
   fun `Given first page and first post, when I goToPreviousPost, then I expect storyIndex to be 0`() {
     // GIVEN
     val storyPosts = createStoryPosts(3) { true }
-    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts) 
+    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts)
     val testSubject = createTestSubject()
     testSubject.setIsFirstPage(true)
     testScheduler.triggerActions()
@@ -65,7 +65,7 @@ class StoryViewerPageViewModelTest {
   fun `Given first page and second post, when I goToPreviousPost, then I expect storyIndex to be 0`() {
     // GIVEN
     val storyPosts = createStoryPosts(3) { true }
-    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts) 
+    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts)
     val testSubject = createTestSubject()
     testSubject.setIsFirstPage(true)
     testScheduler.triggerActions()
@@ -86,7 +86,7 @@ class StoryViewerPageViewModelTest {
   fun `Given no initial story and 3 records all viewed, when I initialize, then I expect storyIndex to be 0`() {
     // GIVEN
     val storyPosts = createStoryPosts(3) { true }
-    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts) 
+    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts)
 
     // WHEN
     val testSubject = createTestSubject()
@@ -102,7 +102,7 @@ class StoryViewerPageViewModelTest {
   fun `Given no initial story and 3 records all not viewed, when I initialize, then I expect storyIndex to be 0`() {
     // GIVEN
     val storyPosts = createStoryPosts(3) { false }
-    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts) 
+    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts)
 
     // WHEN
     val testSubject = createTestSubject()
@@ -118,7 +118,7 @@ class StoryViewerPageViewModelTest {
   fun `Given no initial story and 3 records with 2nd is not viewed, when I initialize, then I expect storyIndex to be 1`() {
     // GIVEN
     val storyPosts = createStoryPosts(3) { it % 2 != 0 }
-    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts) 
+    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts)
 
     // WHEN
     val testSubject = createTestSubject()
@@ -134,7 +134,7 @@ class StoryViewerPageViewModelTest {
   fun `Given no initial story and 3 records with 1st and 3rd not viewed, when I goToNext, then I expect storyIndex to be 2`() {
     // GIVEN
     val storyPosts = createStoryPosts(3) { it % 2 == 0 }
-    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts) 
+    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts)
 
     // WHEN
     val testSubject = createTestSubject()
@@ -152,7 +152,7 @@ class StoryViewerPageViewModelTest {
   fun `Given no unread and jump to next unread enabled, when I goToNext, then I expect storyIndex to be size`() {
     // GIVEN
     val storyPosts = createStoryPosts(3) { true }
-    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts) 
+    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts)
 
     // WHEN
     val testSubject = createTestSubject(isJumpForwardToUnviewed = true)
@@ -170,7 +170,7 @@ class StoryViewerPageViewModelTest {
   fun `Given a single story, when I goToPrevious, then I expect storyIndex to be -1`() {
     // GIVEN
     val storyPosts = createStoryPosts(1)
-    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts) 
+    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts)
 
     // WHEN
     val testSubject = createTestSubject()
@@ -215,7 +215,7 @@ class StoryViewerPageViewModelTest {
         hasSelfViewed = isViewed(it)
       ).apply {
         val messageRecord = FakeMessageRecords.buildMediaMmsMessageRecord()
-        every { conversationMessage.messageRecord } returns messageRecord 
+        every { conversationMessage.messageRecord } returns messageRecord
       }
     }
   }

--- a/app/src/test/java/org/thoughtcrime/securesms/stories/viewer/page/StoryViewerPageViewModelTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/stories/viewer/page/StoryViewerPageViewModelTest.kt
@@ -1,6 +1,8 @@
 package org.thoughtcrime.securesms.stories.viewer.page
 
 import android.app.Application
+import io.mockk.every
+import io.mockk.mockk
 import io.reactivex.rxjava3.android.plugins.RxAndroidPlugins
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Observable
@@ -10,9 +12,6 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.kotlin.any
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.thoughtcrime.securesms.database.FakeMessageRecords
@@ -22,9 +21,7 @@ import org.thoughtcrime.securesms.recipients.RecipientId
 @RunWith(RobolectricTestRunner::class)
 @Config(application = Application::class)
 class StoryViewerPageViewModelTest {
-
-  private val repository: StoryViewerPageRepository = mock()
-
+  private val repository = mockk<StoryViewerPageRepository>(relaxed = true)
   private val testScheduler = TestScheduler()
 
   @Before
@@ -37,7 +34,7 @@ class StoryViewerPageViewModelTest {
 
     RxAndroidPlugins.setMainThreadSchedulerHandler { testScheduler }
 
-    whenever(repository.forceDownload(any())).thenReturn(Completable.complete())
+    every { repository.forceDownload(any()) } returns Completable.complete() 
   }
 
   @After
@@ -49,7 +46,7 @@ class StoryViewerPageViewModelTest {
   fun `Given first page and first post, when I goToPreviousPost, then I expect storyIndex to be 0`() {
     // GIVEN
     val storyPosts = createStoryPosts(3) { true }
-    whenever(repository.getStoryPostsFor(any(), any())).thenReturn(Observable.just(storyPosts))
+    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts) 
     val testSubject = createTestSubject()
     testSubject.setIsFirstPage(true)
     testScheduler.triggerActions()
@@ -68,7 +65,7 @@ class StoryViewerPageViewModelTest {
   fun `Given first page and second post, when I goToPreviousPost, then I expect storyIndex to be 0`() {
     // GIVEN
     val storyPosts = createStoryPosts(3) { true }
-    whenever(repository.getStoryPostsFor(any(), any())).thenReturn(Observable.just(storyPosts))
+    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts) 
     val testSubject = createTestSubject()
     testSubject.setIsFirstPage(true)
     testScheduler.triggerActions()
@@ -89,7 +86,7 @@ class StoryViewerPageViewModelTest {
   fun `Given no initial story and 3 records all viewed, when I initialize, then I expect storyIndex to be 0`() {
     // GIVEN
     val storyPosts = createStoryPosts(3) { true }
-    whenever(repository.getStoryPostsFor(any(), any())).thenReturn(Observable.just(storyPosts))
+    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts) 
 
     // WHEN
     val testSubject = createTestSubject()
@@ -105,7 +102,7 @@ class StoryViewerPageViewModelTest {
   fun `Given no initial story and 3 records all not viewed, when I initialize, then I expect storyIndex to be 0`() {
     // GIVEN
     val storyPosts = createStoryPosts(3) { false }
-    whenever(repository.getStoryPostsFor(any(), any())).thenReturn(Observable.just(storyPosts))
+    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts) 
 
     // WHEN
     val testSubject = createTestSubject()
@@ -121,7 +118,7 @@ class StoryViewerPageViewModelTest {
   fun `Given no initial story and 3 records with 2nd is not viewed, when I initialize, then I expect storyIndex to be 1`() {
     // GIVEN
     val storyPosts = createStoryPosts(3) { it % 2 != 0 }
-    whenever(repository.getStoryPostsFor(any(), any())).thenReturn(Observable.just(storyPosts))
+    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts) 
 
     // WHEN
     val testSubject = createTestSubject()
@@ -137,7 +134,7 @@ class StoryViewerPageViewModelTest {
   fun `Given no initial story and 3 records with 1st and 3rd not viewed, when I goToNext, then I expect storyIndex to be 2`() {
     // GIVEN
     val storyPosts = createStoryPosts(3) { it % 2 == 0 }
-    whenever(repository.getStoryPostsFor(any(), any())).thenReturn(Observable.just(storyPosts))
+    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts) 
 
     // WHEN
     val testSubject = createTestSubject()
@@ -155,7 +152,7 @@ class StoryViewerPageViewModelTest {
   fun `Given no unread and jump to next unread enabled, when I goToNext, then I expect storyIndex to be size`() {
     // GIVEN
     val storyPosts = createStoryPosts(3) { true }
-    whenever(repository.getStoryPostsFor(any(), any())).thenReturn(Observable.just(storyPosts))
+    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts) 
 
     // WHEN
     val testSubject = createTestSubject(isJumpForwardToUnviewed = true)
@@ -173,7 +170,7 @@ class StoryViewerPageViewModelTest {
   fun `Given a single story, when I goToPrevious, then I expect storyIndex to be -1`() {
     // GIVEN
     val storyPosts = createStoryPosts(1)
-    whenever(repository.getStoryPostsFor(any(), any())).thenReturn(Observable.just(storyPosts))
+    every { repository.getStoryPostsFor(any(), any()) } returns Observable.just(storyPosts) 
 
     // WHEN
     val testSubject = createTestSubject()
@@ -198,7 +195,7 @@ class StoryViewerPageViewModelTest {
         groupReplyStartPosition = -1
       ),
       repository,
-      mock()
+      mockk()
     )
   }
 
@@ -212,13 +209,13 @@ class StoryViewerPageViewModelTest {
         viewCount = 0,
         replyCount = 0,
         dateInMilliseconds = it.toLong(),
-        content = StoryPost.Content.TextContent(mock(), it.toLong(), false, 0),
-        conversationMessage = mock(),
+        content = StoryPost.Content.TextContent(mockk(), it.toLong(), false, 0),
+        conversationMessage = mockk(),
         allowsReplies = true,
         hasSelfViewed = isViewed(it)
       ).apply {
         val messageRecord = FakeMessageRecords.buildMediaMmsMessageRecord()
-        whenever(conversationMessage.messageRecord).thenReturn(messageRecord)
+        every { conversationMessage.messageRecord } returns messageRecord 
       }
     }
   }

--- a/app/src/test/java/org/thoughtcrime/securesms/util/BackupUtilTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/util/BackupUtilTest.kt
@@ -1,18 +1,18 @@
 package org.thoughtcrime.securesms.util
 
 import androidx.documentfile.provider.DocumentFile
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.fail
+import org.junit.Assert.assertThrows
 import org.junit.BeforeClass
 import org.junit.Test
-import org.mockito.Mockito.doReturn
-import org.mockito.Mockito.mock
 import org.signal.core.util.logging.Log
 import org.thoughtcrime.securesms.testutil.EmptyLogger
+import org.thoughtcrime.securesms.util.BackupUtil.BackupFileException
 
 class BackupUtilTest {
-
   companion object {
     private const val TEST_NAME = "1920837192.backup"
 
@@ -23,28 +23,24 @@ class BackupUtilTest {
     }
   }
 
-  private val documentFile = mock(DocumentFile::class.java)
+  private val documentFile = mockk<DocumentFile>(relaxed = true)
 
   @Test
   fun `Given a non-existent uri, when I getBackupInfoFromSingleDocumentFile, then I expect NOT_FOUND`() {
-    try {
+    val error = assertThrows("Expected a BackupFileException", BackupFileException::class.java) {
       BackupUtil.getBackupInfoFromSingleDocumentFile(documentFile)
-      fail("Expected a BackupFileException")
-    } catch (e: BackupUtil.BackupFileException) {
-      assertEquals(BackupUtil.BackupFileState.NOT_FOUND, e.state)
     }
+    assertEquals(BackupUtil.BackupFileState.NOT_FOUND, error.state)
   }
 
   @Test
   fun `Given an existent but unreadable uri, when I getBackupInfoFromSingleDocumentFile, then I expect NOT_READABLE`() {
     givenFileExists()
 
-    try {
+    val error = assertThrows("Expected a BackupFileException", BackupFileException::class.java) {
       BackupUtil.getBackupInfoFromSingleDocumentFile(documentFile)
-      fail("Expected a BackupFileException")
-    } catch (e: BackupUtil.BackupFileException) {
-      assertEquals(BackupUtil.BackupFileState.NOT_READABLE, e.state)
     }
+    assertEquals(BackupUtil.BackupFileState.NOT_READABLE, error.state)
   }
 
   @Test
@@ -52,12 +48,10 @@ class BackupUtilTest {
     givenFileExists()
     givenFileIsReadable()
 
-    try {
+    val error = assertThrows("Expected a BackupFileException", BackupFileException::class.java) {
       BackupUtil.getBackupInfoFromSingleDocumentFile(documentFile)
-      fail("Expected a BackupFileException")
-    } catch (e: BackupUtil.BackupFileException) {
-      assertEquals(BackupUtil.BackupFileState.UNSUPPORTED_FILE_EXTENSION, e.state)
     }
+    assertEquals(BackupUtil.BackupFileState.UNSUPPORTED_FILE_EXTENSION, error.state)
   }
 
   @Test
@@ -71,14 +65,14 @@ class BackupUtilTest {
   }
 
   private fun givenFileExists() {
-    doReturn(true).`when`(documentFile).exists()
+    every { documentFile.exists() } returns true
   }
 
   private fun givenFileIsReadable() {
-    doReturn(true).`when`(documentFile).canRead()
+    every { documentFile.canRead() } returns true
   }
 
   private fun givenFileHasCorrectExtension() {
-    doReturn(TEST_NAME).`when`(documentFile).name
+    every { documentFile.name } returns TEST_NAME
   }
 }

--- a/app/src/test/java/org/thoughtcrime/securesms/video/exo/ExoPlayerPoolTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/video/exo/ExoPlayerPoolTest.kt
@@ -1,17 +1,13 @@
 package org.thoughtcrime.securesms.video.exo
 
 import androidx.media3.exoplayer.ExoPlayer
+import io.mockk.mockk
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.mockito.Mockito.mock
 
-@RunWith(JUnit4::class)
 class ExoPlayerPoolTest {
-
   @Test
   fun `Given an empty pool, when I require a player, then I expect a player`() {
     // GIVEN
@@ -24,16 +20,16 @@ class ExoPlayerPoolTest {
     assertNotNull(player)
   }
 
-  @Test(expected = IllegalStateException::class)
+  @Test
   fun `Given a pool without available players, when I require a player, then I expect an exception`() {
     // GIVEN
     val testSubject = createTestSubject(1, 0)
 
-    // WHEN
-    testSubject.require("")
-
     // THEN
-    fail("Expected an IllegalStateException")
+    assertThrows(IllegalStateException::class.java) {
+      // WHEN
+      testSubject.require("")
+    }
   }
 
   @Test
@@ -63,17 +59,17 @@ class ExoPlayerPoolTest {
     assertTrue(morePlayers.all { it != null })
   }
 
-  @Test(expected = IllegalArgumentException::class)
+  @Test
   fun `Given an ExoPlayer not in the pool, when I pool it, then I expect an IllegalArgumentException`() {
     // GIVEN
-    val player = mock(ExoPlayer::class.java)
+    val player = mockk<ExoPlayer>()
     val pool = createTestSubject(1, 10)
 
-    // WHEN
-    pool.pool(player)
-
     // THEN
-    fail("Expected an IllegalArgumentException to be thrown")
+    assertThrows(IllegalArgumentException::class.java) {
+      // WHEN
+      pool.pool(player)
+    }
   }
 
   private fun createTestSubject(
@@ -82,7 +78,7 @@ class ExoPlayerPoolTest {
   ): ExoPlayerPool<ExoPlayer> {
     return object : ExoPlayerPool<ExoPlayer>(maximumReservedPlayers) {
       override fun createPlayer(): ExoPlayer {
-        return mock(ExoPlayer::class.java)
+        return mockk<ExoPlayer>(relaxUnitFun = true)
       }
 
       override fun getMaxSimultaneousPlayback(): Int {


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * MacBook Pro (unit test suite run)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Continuing to work towards removing Mockito.

This PR updates a batch of tests, migrating off of Mockito and towards MockK. I just did a grep for `import.*mockito` and grabbed a handful to update:

1. `app/src/test/java/org/thoughtcrime/securesms/sms/UploadDependencyGraphTest.kt`
2. `app/src/test/java/org/thoughtcrime/securesms/stories/StoriesTest.kt`
3. `app/src/test/java/org/thoughtcrime/securesms/stories/StoryFirstTimeNavigationViewTest.kt`
4. `app/src/test/java/org/thoughtcrime/securesms/stories/dialogs/StoryContextMenuTest.kt`
5. `app/src/test/java/org/thoughtcrime/securesms/stories/viewer/StoryViewerViewModelTest.kt`
6. `app/src/test/java/org/thoughtcrime/securesms/stories/viewer/page/StoryViewerPageViewModelTest.kt`
7. `app/src/test/java/org/thoughtcrime/securesms/util/BackupUtilTest.kt`
8. `app/src/test/java/org/thoughtcrime/securesms/video/exo/ExoPlayerPoolTest.kt`


After this, there are 10 more tests using Mockito. I'll put up a separate PR to migrate those ones.

### Testing
This still passes:

```console
./gradlew qa
```