### PR TITLE
Hide default 'Signal' text when calls in call log selected - #13260 

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/calls/log/CallLogFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/calls/log/CallLogFragment.kt
@@ -220,6 +220,10 @@ class CallLogFragment : Fragment(R.layout.call_log_fragment), CallLogAdapter.Cal
     initializeSearchAction()
     AppDependencies.deletedCallEventManager.scheduleIfNecessary()
     viewModel.markAllCallEventsRead()
+
+    if (viewModel.selectionStateSnapshot.isNotEmpty(binding.recycler.adapter!!.itemCount)) {
+      (requireActivity() as AppCompatActivity).supportActionBar?.hide()
+    }
   }
 
   private fun onTimestampTick() {
@@ -513,6 +517,7 @@ class CallLogFragment : Fragment(R.layout.call_log_fragment), CallLogAdapter.Cal
       requireListener<Callback>().onMultiSelectStarted()
       signalBottomActionBarController.setVisibility(true)
       binding.fab.visible = false
+      (requireActivity() as AppCompatActivity).supportActionBar?.hide()
       return actionMode
     }
 
@@ -520,6 +525,7 @@ class CallLogFragment : Fragment(R.layout.call_log_fragment), CallLogAdapter.Cal
       requireListener<Callback>().onMultiSelectFinished()
       signalBottomActionBarController.setVisibility(false)
       binding.fab.visible = true
+      (requireActivity() as AppCompatActivity).supportActionBar?.show()
     }
 
     override fun getResources(): Resources = resources

--- a/app/src/main/java/org/thoughtcrime/securesms/calls/log/CallLogFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/calls/log/CallLogFragment.kt
@@ -517,7 +517,6 @@ class CallLogFragment : Fragment(R.layout.call_log_fragment), CallLogAdapter.Cal
       requireListener<Callback>().onMultiSelectStarted()
       signalBottomActionBarController.setVisibility(true)
       binding.fab.visible = false
-      (requireActivity() as AppCompatActivity).supportActionBar?.hide()
       return actionMode
     }
 
@@ -525,7 +524,6 @@ class CallLogFragment : Fragment(R.layout.call_log_fragment), CallLogAdapter.Cal
       requireListener<Callback>().onMultiSelectFinished()
       signalBottomActionBarController.setVisibility(false)
       binding.fab.visible = true
-      (requireActivity() as AppCompatActivity).supportActionBar?.show()
     }
 
     override fun getResources(): Resources = resources


### PR DESCRIPTION
Fixes issue #13260 where the user would see 'Signal' with "[n] selected" in the ActionBar. 

### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 7, Android 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixed the overlapping text issue that @xtrcv demonstrated.

Achieved by first hiding supportActionBar when ActionMode starts (items selected) and showing supportActionBar when it ends (all items deselected). The supportActionBar also needs to be hidden again in onResume when the user has navigated back to the screen (but only if no items are selected, using viewModel.selectionStateSnapshot.isNotEmpty(...).

I ran gradlw format with no relevant issues.

Video of manual test:
https://github.com/user-attachments/assets/319f01e5-ffa5-4187-aecf-93b5e314f9d3

