### PR TITLE
Instrumentation test suite passes again

### DIFF
--- a/app/src/androidTest/java/org/thoughtcrime/securesms/conversation/v2/items/V2ConversationItemShapeTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/conversation/v2/items/V2ConversationItemShapeTest.kt
@@ -208,7 +208,7 @@ class V2ConversationItemShapeTest {
 
     private val colorizer = Colorizer()
 
-    override val lifecycleOwner: LifecycleOwner = object: LifecycleOwner {
+    override val lifecycleOwner: LifecycleOwner = object : LifecycleOwner {
       override val lifecycle: Lifecycle = LifecycleRegistry(this)
     }
     override val displayMode: ConversationItemDisplayMode = ConversationItemDisplayMode.Standard

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/conversation/v2/items/V2ConversationItemShapeTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/conversation/v2/items/V2ConversationItemShapeTest.kt
@@ -5,12 +5,16 @@
 
 package org.thoughtcrime.securesms.conversation.v2.items
 
+import android.content.Context
 import android.net.Uri
 import android.view.View
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
 import androidx.lifecycle.Observer
+import androidx.test.core.app.ApplicationProvider
+import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
-import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -204,13 +208,15 @@ class V2ConversationItemShapeTest {
 
     private val colorizer = Colorizer()
 
-    override val lifecycleOwner: LifecycleOwner = mockk(relaxed = true)
+    override val lifecycleOwner: LifecycleOwner = object: LifecycleOwner {
+      override val lifecycle: Lifecycle = LifecycleRegistry(this)
+    }
     override val displayMode: ConversationItemDisplayMode = ConversationItemDisplayMode.Standard
     override val clickListener: ConversationAdapter.ItemClickListener = FakeConversationItemClickListener
     override val selectedItems: Set<MultiselectPart> = emptySet()
     override val isMessageRequestAccepted: Boolean = true
     override val searchQuery: String? = null
-    override val requestManager: RequestManager = mockk()
+    override val requestManager: RequestManager = Glide.with(ApplicationProvider.getApplicationContext() as Context)
     override val isParentInScroll: Boolean = false
     override fun getChatColorsData(): ChatColorsDrawable.ChatColorsData = ChatColorsDrawable.ChatColorsData(null, null)
 


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 8 API 34 emulator
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Currently when I run the connect device suite, e.g., `./gradlew clean :Signal-Android:connectedAndroidTest`, `V2ConversationItemShapeTest` will fail with errors like this:

```console
org.thoughtcrime.securesms.conversation.v2.items.V2ConversationItemShapeTest > givenNextAndPreviousMessageDoNotExist_whenISetMessageShape_thenIExpectSingle[Pixel_8_API_34(AVD) - 14]
        io.mockk.MockKException: Can't instantiate proxy for class com.bumptech.glide.RequestManager
        at io.mockk.impl.instantiation.JvmMockFactory.newProxy(JvmMockFactory.kt:64)
```

Instead of using MockK in the Instrumentation tests, we should probably be using some real objects (or our own fakes). A simple solution, sufficient to get the test passing again, is to replace the mocks with real components.

### Testing
After changes:
```console
./gradlew clean :Signal-Android:connectedAndroidTest

[...snip...]
Finished 298 tests on Pixel_8_API_34(AVD) - 14

BUILD SUCCESSFUL in 28m
463 actionable tasks: 433 executed, 30 up-to-date
```

```console
./gradlew qa

[...snip...]

BUILD SUCCESSFUL in 4m 19s
1020 actionable tasks: 180 executed, 840 up-to-date
```