### PR TITLE
Fixes #13852 - Contacts Refresh

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/ContactSelectionListFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ContactSelectionListFragment.java
@@ -370,7 +370,7 @@ public final class ContactSelectionListFragment extends LoggingFragment {
 
               @Override
               public void onRefreshContactsClicked() {
-                if (onRefreshListener != null) {
+                if (onRefreshListener != null && !isRefreshing()) {
                   setRefreshing(true);
                   onRefreshListener.onRefresh();
                 }
@@ -568,6 +568,10 @@ public final class ContactSelectionListFragment extends LoggingFragment {
 
   public void setRefreshing(boolean refreshing) {
     swipeRefresh.setRefreshing(refreshing);
+  }
+
+  public boolean isRefreshing() {
+    return swipeRefresh.isRefreshing();
   }
 
   public void reset() {

--- a/app/src/main/java/org/thoughtcrime/securesms/NewConversationActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/NewConversationActivity.java
@@ -204,8 +204,10 @@ public class NewConversationActivity extends ContactSelectionActivity
   }
 
   private void handleManualRefresh() {
-    contactsFragment.setRefreshing(true);
-    onRefresh();
+    if (!contactsFragment.isRefreshing()) {
+      contactsFragment.setRefreshing(true);
+      onRefresh();
+    }
   }
 
   private void handleCreateGroup() {

--- a/app/src/main/java/org/thoughtcrime/securesms/calls/new/NewCallActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/calls/new/NewCallActivity.kt
@@ -114,6 +114,13 @@ class NewCallActivity : ContactSelectionActivity(), ContactSelectionListFragment
     startActivity(Intent(this, InviteActivity::class.java))
   }
 
+  private fun handleManualRefresh() {
+    if(!contactsFragment.isRefreshing) {
+      contactsFragment.isRefreshing = true
+      onRefresh()
+    }
+  }
+
   private inner class NewCallMenuProvider : MenuProvider {
     override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
       menuInflater.inflate(R.menu.new_call_menu, menu)
@@ -122,7 +129,7 @@ class NewCallActivity : ContactSelectionActivity(), ContactSelectionListFragment
     override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
       when (menuItem.itemId) {
         android.R.id.home -> ActivityCompat.finishAfterTransition(this@NewCallActivity)
-        R.id.menu_refresh -> onRefresh()
+        R.id.menu_refresh -> handleManualRefresh()
         R.id.menu_invite -> startActivity(Intent(this@NewCallActivity, InviteActivity::class.java))
       }
 


### PR DESCRIPTION
Closes #13852 

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device A, Realme GT NEO 3T, 14
 * Device B, Infinix Hot 20 Pro, 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Added function named `isRefreshing` that checks if swiperefresh is already refreshing, if it is, then do not trigger any `onRefresh` call, is isRefreshing is false then we can.
This fixes both problems mentioned in the bug report.