### PR TITLE
Fix: Limit donation amount input to 9 characters (#13872)

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/subscription/boost/Boost.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/subscription/boost/Boost.kt
@@ -257,6 +257,11 @@ data class Boost(
       val result = dest.subSequence(0, dstart).toString() + source.toString() + dest.subSequence(dend, dest.length)
       val resultWithoutCurrencyPrefix = StringUtil.stripBidiIndicator(result.removePrefix(symbol).removeSuffix(symbol).trim())
 
+      // Enforce maximum length of 9 characters
+      if (resultWithoutCurrencyPrefix.length > 9) {
+        return "" // Reject the new input
+      }
+
       if (resultWithoutCurrencyPrefix.length == 1 && !resultWithoutCurrencyPrefix.isDigitsOnly() && resultWithoutCurrencyPrefix != separator.toString()) {
         return dest.subSequence(dstart, dend)
       }
@@ -278,6 +283,7 @@ data class Boost(
       if (s.isNullOrEmpty()) return
 
       val hasSymbol = s.startsWith(symbol) || s.endsWith(symbol)
+
       if (hasSymbol && symbolPattern.matchEntire(s.toString()) != null) {
         s.clear()
       } else if (!hasSymbol) {
@@ -312,6 +318,13 @@ data class Boost(
       }
 
       val withoutSymbol = s.removePrefix(symbol).removeSuffix(symbol).trim().toString()
+
+      // Check if the value exceeds 9 characters
+      if (withoutSymbol.length > 9) {
+        s.delete(9, s.length) // Trim to the first 9 characters
+        return
+      }
+
       val withoutLeadingZeroes: String = try {
         NumberFormat.getInstance().apply {
           isGroupingUsed = false


### PR DESCRIPTION
- Added validation in MoneyFilter to restrict input to 9 characters.
- Updated both filter and afterTextChanged methods to enforce this limit.
- Ensured edge cases and formatting remain functional.
- Resolves #13872.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
