### PR TITLE
Fixes #13854 - Showing Null String on Empty search

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/ContactSelectionListAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ContactSelectionListAdapter.kt
@@ -130,7 +130,7 @@ class ContactSelectionListAdapter(
     private val emptyText: TextView = itemView.findViewById(R.id.search_no_results)
 
     override fun bind(model: EmptyModel) {
-      emptyText.text = context.getString(R.string.SearchFragment_no_results, model.empty.query)
+      emptyText.text = context.getString(R.string.SearchFragment_no_results, model.empty.query ?: "")
     }
   }
 


### PR DESCRIPTION
Closes #13854  

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device Realme GT NET 3T, Android 14
 * Device Infinix hot 20 Pro, Android 14
 * Virtual device Pixel 8 Pro, Android 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe briefly how you tested that your fix actually works.
-->
Just handle the null string with Elvis operator, like handled in other similar place. 