### PR TITLE
Remove redundant toggle Approve All members callback

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/calls/links/create/CreateCallLinkBottomSheetDialogFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/calls/links/create/CreateCallLinkBottomSheetDialogFragment.kt
@@ -96,7 +96,6 @@ class CreateCallLinkBottomSheetDialogFragment : ComposeBottomSheetDialogFragment
       onJoinClicked = this@CreateCallLinkBottomSheetDialogFragment::onJoinClicked,
       onAddACallNameClicked = this@CreateCallLinkBottomSheetDialogFragment::onAddACallNameClicked,
       onApproveAllMembersChanged = this@CreateCallLinkBottomSheetDialogFragment::setApproveAllMembers,
-      onToggleApproveAllMembersClicked = this@CreateCallLinkBottomSheetDialogFragment::toggleApproveAllMembers,
       onShareViaSignalClicked = this@CreateCallLinkBottomSheetDialogFragment::onShareViaSignalClicked,
       onCopyLinkClicked = this@CreateCallLinkBottomSheetDialogFragment::onCopyLinkClicked,
       onShareLinkClicked = this@CreateCallLinkBottomSheetDialogFragment::onShareLinkClicked,
@@ -117,15 +116,6 @@ class CreateCallLinkBottomSheetDialogFragment : ComposeBottomSheetDialogFragment
 
   private fun setApproveAllMembers(approveAllMembers: Boolean) {
     lifecycleDisposable += viewModel.setApproveAllMembers(approveAllMembers).subscribeBy(onSuccess = {
-      if (it !is UpdateCallLinkResult.Update) {
-        Log.w(TAG, "Failed to update call link restrictions")
-        toastFailure()
-      }
-    }, onError = this::handleError)
-  }
-
-  private fun toggleApproveAllMembers() {
-    lifecycleDisposable += viewModel.toggleApproveAllMembers().subscribeBy(onSuccess = {
       if (it !is UpdateCallLinkResult.Update) {
         Log.w(TAG, "Failed to update call link restrictions")
         toastFailure()
@@ -242,7 +232,6 @@ private fun CreateCallLinkBottomSheetContent(
   onJoinClicked: () -> Unit = {},
   onAddACallNameClicked: () -> Unit = {},
   onApproveAllMembersChanged: (Boolean) -> Unit = {},
-  onToggleApproveAllMembersClicked: () -> Unit = {},
   onShareViaSignalClicked: () -> Unit = {},
   onCopyLinkClicked: () -> Unit = {},
   onShareLinkClicked: () -> Unit = {},
@@ -291,7 +280,6 @@ private fun CreateCallLinkBottomSheetContent(
         checked = callLink.state.restrictions == CallLinkState.Restrictions.ADMIN_APPROVAL,
         text = stringResource(id = R.string.CreateCallLinkBottomSheetDialogFragment__require_admin_approval),
         onCheckChanged = onApproveAllMembersChanged,
-        modifier = Modifier.clickable(onClick = onToggleApproveAllMembersClicked),
         isLoading = isLoadingAdminApprovalChange
       )
 

--- a/app/src/main/java/org/thoughtcrime/securesms/calls/links/create/CreateCallLinkViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/calls/links/create/CreateCallLinkViewModel.kt
@@ -99,11 +99,6 @@ class CreateCallLinkViewModel(
       }
   }
 
-  fun toggleApproveAllMembers(): Single<UpdateCallLinkResult> {
-    return setApproveAllMembers(_callLink.value.state.restrictions != Restrictions.ADMIN_APPROVAL)
-      .observeOn(AndroidSchedulers.mainThread())
-  }
-
   fun setCallName(callName: String): Single<UpdateCallLinkResult> {
     return commitCallLink()
       .flatMap {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device Realme GT NET 3T, Android 14
 * Device Infinix hot 20 Pro, Android 14
 * Virtual device Pixel 8 Pro, Android 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe briefly how you tested that your fix actually works.
-->
Simply remove the redundant callback, as it is already present in the ToggleRow.


One suggestion/feedback,
For the new Loading state in the toggle row, it is a better user interface experience to show the CircularProgressIndicator in the `Switch` composable's `thumbContent` param, this gives a more consistent user experience and won't feel ugly when switching to ProgressIndicator and switching bar to Switch. 