### PR TITLE
Migrate kt tests off hamcrest

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -615,6 +615,7 @@ dependencies {
   androidTestImplementation(testLibs.androidx.test.core)
   androidTestImplementation(testLibs.androidx.test.core.ktx)
   androidTestImplementation(testLibs.androidx.test.ext.junit.ktx)
+  androidTestImplementation(testLibs.assertk)
   androidTestImplementation(testLibs.mockk.android)
   androidTestImplementation(testLibs.square.okhttp.mockserver)
   androidTestImplementation(testLibs.diff.utils)

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/AttachmentTableTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/AttachmentTableTest.kt
@@ -5,6 +5,9 @@ import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.FlakyTest
 import androidx.test.platform.app.InstrumentationRegistry
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
@@ -33,9 +36,6 @@ import org.whispersystems.signalservice.internal.crypto.PaddingInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.Optional
-import assertk.assertThat
-import assertk.assertions.isEqualTo
-import assertk.assertions.isNotEqualTo
 
 @RunWith(AndroidJUnit4::class)
 class AttachmentTableTest {

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/AttachmentTableTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/AttachmentTableTest.kt
@@ -22,8 +22,6 @@ import org.thoughtcrime.securesms.attachments.UriAttachment
 import org.thoughtcrime.securesms.mms.MediaStream
 import org.thoughtcrime.securesms.mms.SentMediaQuality
 import org.thoughtcrime.securesms.providers.BlobProvider
-import org.thoughtcrime.securesms.testing.assertIs
-import org.thoughtcrime.securesms.testing.assertIsNot
 import org.thoughtcrime.securesms.util.MediaUtil
 import org.thoughtcrime.securesms.util.Util
 import org.whispersystems.signalservice.api.crypto.AttachmentCipherInputStream
@@ -35,6 +33,9 @@ import org.whispersystems.signalservice.internal.crypto.PaddingInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.Optional
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
 
 @RunWith(AndroidJUnit4::class)
 class AttachmentTableTest {
@@ -142,8 +143,8 @@ class AttachmentTableTest {
     val highInfo = SignalDatabase.attachments.getDataFileInfo(highDatabaseAttachment.attachmentId)!!
 
     assertNotEquals(standardInfo, highInfo)
-    highInfo.file assertIsNot standardInfo.file
-    highInfo.file.exists() assertIs true
+    assertThat(highInfo.file).isNotEqualTo(standardInfo.file)
+    assertThat(highInfo.file.exists()).isEqualTo(true)
   }
 
   /**
@@ -174,10 +175,10 @@ class AttachmentTableTest {
     val highInfo = SignalDatabase.attachments.getDataFileInfo(highDatabaseAttachment.attachmentId)!!
     val secondHighInfo = SignalDatabase.attachments.getDataFileInfo(secondHighDatabaseAttachment.attachmentId)!!
 
-    highInfo.file assertIsNot standardInfo.file
-    secondHighInfo.file assertIs highInfo.file
-    standardInfo.file.exists() assertIs true
-    highInfo.file.exists() assertIs true
+    assertThat(highInfo.file).isNotEqualTo(standardInfo.file)
+    assertThat(secondHighInfo.file).isEqualTo(highInfo.file)
+    assertThat(standardInfo.file.exists()).isEqualTo(true)
+    assertThat(highInfo.file.exists()).isEqualTo(true)
   }
 
   @Test

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/BackupMediaSnapshotTableTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/BackupMediaSnapshotTableTest.kt
@@ -8,7 +8,8 @@ import org.signal.core.util.count
 import org.signal.core.util.readToSingleInt
 import org.thoughtcrime.securesms.backup.v2.ArchivedMediaObject
 import org.thoughtcrime.securesms.testing.SignalActivityRule
-import org.thoughtcrime.securesms.testing.assertIs
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 
 @RunWith(AndroidJUnit4::class)
 class BackupMediaSnapshotTableTest {
@@ -27,7 +28,7 @@ class BackupMediaSnapshotTableTest {
 
     val count = getSyncedItemCount(pendingSyncTime)
 
-    count.assertIs(0)
+    assertThat(count).isEqualTo(0)
   }
 
   @Test
@@ -38,7 +39,7 @@ class BackupMediaSnapshotTableTest {
 
     val count = getSyncedItemCount(pendingSyncTime)
 
-    count.assertIs(SEQUENCE_COUNT)
+    assertThat(count).isEqualTo(SEQUENCE_COUNT)
   }
 
   @Test
@@ -56,7 +57,7 @@ class BackupMediaSnapshotTableTest {
       .run()
       .readToSingleInt(-1)
 
-    count.assertIs(50)
+    assertThat(count).isEqualTo(50)
   }
 
   @Test
@@ -77,8 +78,8 @@ class BackupMediaSnapshotTableTest {
 
     val total = getTotalItemCount()
 
-    count.assertIs(50)
-    total.assertIs(SEQUENCE_COUNT)
+    assertThat(count).isEqualTo(50)
+    assertThat(total).isEqualTo(SEQUENCE_COUNT)
   }
 
   @Test
@@ -96,7 +97,7 @@ class BackupMediaSnapshotTableTest {
 
     val total = getTotalItemCount()
 
-    total.assertIs(50)
+    assertThat(total).isEqualTo(50)
   }
 
   private fun getTotalItemCount(): Int {

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/BackupMediaSnapshotTableTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/BackupMediaSnapshotTableTest.kt
@@ -1,6 +1,8 @@
 package org.thoughtcrime.securesms.database
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -8,8 +10,6 @@ import org.signal.core.util.count
 import org.signal.core.util.readToSingleInt
 import org.thoughtcrime.securesms.backup.v2.ArchivedMediaObject
 import org.thoughtcrime.securesms.testing.SignalActivityRule
-import assertk.assertThat
-import assertk.assertions.isEqualTo
 
 @RunWith(AndroidJUnit4::class)
 class BackupMediaSnapshotTableTest {

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/InAppPaymentSubscriberTableTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/InAppPaymentSubscriberTableTest.kt
@@ -1,6 +1,9 @@
 package org.thoughtcrime.securesms.database
 
 import android.database.sqlite.SQLiteConstraintException
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule
@@ -15,9 +18,6 @@ import org.thoughtcrime.securesms.testing.SignalActivityRule
 import org.whispersystems.signalservice.api.storage.IAPSubscriptionId
 import org.whispersystems.signalservice.api.subscriptions.SubscriberId
 import java.util.Currency
-import assertk.assertThat
-import assertk.assertions.isEqualTo
-import assertk.assertions.isNull
 
 class InAppPaymentSubscriberTableTest {
   @get:Rule

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/InAppPaymentSubscriberTableTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/InAppPaymentSubscriberTableTest.kt
@@ -12,10 +12,12 @@ import org.thoughtcrime.securesms.components.settings.app.subscription.InAppPaym
 import org.thoughtcrime.securesms.database.model.InAppPaymentSubscriberRecord
 import org.thoughtcrime.securesms.database.model.databaseprotos.InAppPaymentData
 import org.thoughtcrime.securesms.testing.SignalActivityRule
-import org.thoughtcrime.securesms.testing.assertIs
 import org.whispersystems.signalservice.api.storage.IAPSubscriptionId
 import org.whispersystems.signalservice.api.subscriptions.SubscriberId
 import java.util.Currency
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
 
 class InAppPaymentSubscriberTableTest {
   @get:Rule
@@ -191,11 +193,11 @@ class InAppPaymentSubscriberTableTest {
       .run()
       .readToSingleInt()
 
-    subscriberCount assertIs 1
+    assertThat(subscriberCount).isEqualTo(1)
 
     val subscriber = InAppPaymentsRepository.requireSubscriber(InAppPaymentSubscriberRecord.Type.BACKUP)
-    subscriber.iapSubscriptionId?.originalTransactionId assertIs null
-    subscriber.iapSubscriptionId?.purchaseToken assertIs "testToken"
-    subscriber.subscriberId assertIs googleSubscriber.subscriberId
+    assertThat(subscriber.iapSubscriptionId?.originalTransactionId).isNull()
+    assertThat(subscriber.iapSubscriptionId?.purchaseToken).isEqualTo("testToken")
+    assertThat(subscriber.subscriberId).isEqualTo(googleSubscriber.subscriberId)
   }
 }

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/InAppPaymentTableTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/InAppPaymentTableTest.kt
@@ -6,6 +6,8 @@
 package org.thoughtcrime.securesms.database
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -14,8 +16,6 @@ import org.signal.core.util.deleteAll
 import org.signal.donations.InAppPaymentType
 import org.thoughtcrime.securesms.database.model.databaseprotos.InAppPaymentData
 import org.thoughtcrime.securesms.testing.SignalActivityRule
-import assertk.assertThat
-import assertk.assertions.isEqualTo
 
 @RunWith(AndroidJUnit4::class)
 class InAppPaymentTableTest {

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/InAppPaymentTableTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/InAppPaymentTableTest.kt
@@ -14,7 +14,8 @@ import org.signal.core.util.deleteAll
 import org.signal.donations.InAppPaymentType
 import org.thoughtcrime.securesms.database.model.databaseprotos.InAppPaymentData
 import org.thoughtcrime.securesms.testing.SignalActivityRule
-import org.thoughtcrime.securesms.testing.assertIs
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 
 @RunWith(AndroidJUnit4::class)
 class InAppPaymentTableTest {
@@ -37,13 +38,13 @@ class InAppPaymentTableTest {
     )
 
     val paymentBeforeUpdate = SignalDatabase.inAppPayments.getById(inAppPaymentId)
-    paymentBeforeUpdate?.state assertIs InAppPaymentTable.State.CREATED
+    assertThat(paymentBeforeUpdate?.state).isEqualTo(InAppPaymentTable.State.CREATED)
 
     SignalDatabase.inAppPayments.update(
       inAppPayment = paymentBeforeUpdate!!.copy(state = InAppPaymentTable.State.PENDING)
     )
 
     val paymentAfterUpdate = SignalDatabase.inAppPayments.getById(inAppPaymentId)
-    paymentAfterUpdate?.state assertIs InAppPaymentTable.State.PENDING
+    assertThat(paymentAfterUpdate?.state).isEqualTo(InAppPaymentTable.State.PENDING)
   }
 }

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/LogDatabaseTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/LogDatabaseTest.kt
@@ -5,6 +5,10 @@
 
 package org.thoughtcrime.securesms.database
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
 import org.junit.Test
 import org.signal.core.util.forEach
 import org.signal.core.util.requireLong
@@ -13,10 +17,6 @@ import org.signal.core.util.select
 import org.signal.core.util.updateAll
 import org.thoughtcrime.securesms.crash.CrashConfig
 import org.thoughtcrime.securesms.dependencies.AppDependencies
-import assertk.assertThat
-import assertk.assertions.isEqualTo
-import assertk.assertions.isFalse
-import assertk.assertions.isTrue
 
 class LogDatabaseTest {
 

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/LogDatabaseTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/LogDatabaseTest.kt
@@ -13,7 +13,10 @@ import org.signal.core.util.select
 import org.signal.core.util.updateAll
 import org.thoughtcrime.securesms.crash.CrashConfig
 import org.thoughtcrime.securesms.dependencies.AppDependencies
-import org.thoughtcrime.securesms.testing.assertIs
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
 
 class LogDatabaseTest {
 
@@ -37,7 +40,7 @@ class LogDatabaseTest {
       promptThreshold = currentTime
     )
 
-    foundMatch assertIs true
+    assertThat(foundMatch).isTrue()
   }
 
   @Test
@@ -58,7 +61,7 @@ class LogDatabaseTest {
       promptThreshold = currentTime
     )
 
-    foundMatch assertIs true
+    assertThat(foundMatch).isTrue()
   }
 
   @Test
@@ -79,7 +82,7 @@ class LogDatabaseTest {
       promptThreshold = currentTime
     )
 
-    foundMatch assertIs true
+    assertThat(foundMatch).isTrue()
   }
 
   @Test
@@ -100,7 +103,7 @@ class LogDatabaseTest {
       promptThreshold = currentTime
     )
 
-    foundMatch assertIs true
+    assertThat(foundMatch).isTrue()
   }
 
   @Test
@@ -121,7 +124,7 @@ class LogDatabaseTest {
       promptThreshold = currentTime
     )
 
-    foundMatch assertIs true
+    assertThat(foundMatch).isTrue()
   }
 
   @Test
@@ -142,7 +145,7 @@ class LogDatabaseTest {
       promptThreshold = currentTime
     )
 
-    foundMatch assertIs true
+    assertThat(foundMatch).isTrue()
   }
 
   @Test
@@ -163,7 +166,7 @@ class LogDatabaseTest {
       promptThreshold = currentTime
     )
 
-    foundMatch assertIs false
+    assertThat(foundMatch).isFalse()
   }
 
   @Test
@@ -184,7 +187,7 @@ class LogDatabaseTest {
       promptThreshold = currentTime
     )
 
-    foundMatch assertIs false
+    assertThat(foundMatch).isFalse()
   }
 
   @Test
@@ -205,7 +208,7 @@ class LogDatabaseTest {
       promptThreshold = currentTime
     )
 
-    foundMatch assertIs false
+    assertThat(foundMatch).isFalse()
   }
 
   @Test
@@ -231,7 +234,7 @@ class LogDatabaseTest {
       promptThreshold = currentTime - 100
     )
 
-    foundMatch assertIs false
+    assertThat(foundMatch).isFalse()
   }
 
   @Test
@@ -245,7 +248,7 @@ class LogDatabaseTest {
       promptThreshold = currentTime - 100
     )
 
-    foundMatch assertIs false
+    assertThat(foundMatch).isFalse()
   }
 
   @Test
@@ -279,9 +282,9 @@ class LogDatabaseTest {
       .run()
       .forEach {
         if (it.requireNonNullString(LogDatabase.CrashTable.NAME) == "TestName") {
-          it.requireLong(LogDatabase.CrashTable.LAST_PROMPTED_AT) assertIs currentTime
+          assertThat(it.requireLong(LogDatabase.CrashTable.LAST_PROMPTED_AT)).isEqualTo(currentTime)
         } else {
-          it.requireLong(LogDatabase.CrashTable.LAST_PROMPTED_AT) assertIs 0
+          assertThat(it.requireLong(LogDatabase.CrashTable.LAST_PROMPTED_AT)).isEqualTo(0)
         }
       }
   }

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/NameCollisionTablesTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/NameCollisionTablesTest.kt
@@ -18,7 +18,8 @@ import org.thoughtcrime.securesms.recipients.Recipient
 import org.thoughtcrime.securesms.recipients.RecipientId
 import org.thoughtcrime.securesms.testing.GroupTestingUtils
 import org.thoughtcrime.securesms.testing.SignalActivityRule
-import org.thoughtcrime.securesms.testing.assertIsSize
+import assertk.assertions.hasSize
+import assertk.assertThat
 
 @RunWith(AndroidJUnit4::class)
 class NameCollisionTablesTest {
@@ -43,7 +44,7 @@ class NameCollisionTablesTest {
     SignalDatabase.threads.getOrCreateThreadIdFor(Recipient.resolved(threadRecipientId))
     val actual = SignalDatabase.nameCollisions.getCollisionsForThreadRecipientId(threadRecipientId)
 
-    actual assertIsSize 0
+    assertThat(actual).hasSize(0)
   }
 
   @Test
@@ -55,8 +56,8 @@ class NameCollisionTablesTest {
     val actualAlice = SignalDatabase.nameCollisions.getCollisionsForThreadRecipientId(alice)
     val actualBob = SignalDatabase.nameCollisions.getCollisionsForThreadRecipientId(bob)
 
-    actualAlice assertIsSize 2
-    actualBob assertIsSize 2
+    assertThat(actualAlice).hasSize(2)
+    assertThat(actualBob).hasSize(2)
   }
 
   @Test
@@ -68,8 +69,8 @@ class NameCollisionTablesTest {
     val actualAlice = SignalDatabase.nameCollisions.getCollisionsForThreadRecipientId(alice)
     val actualBob = SignalDatabase.nameCollisions.getCollisionsForThreadRecipientId(bob)
 
-    actualAlice assertIsSize 0
-    actualBob assertIsSize 0
+    assertThat(actualAlice).hasSize(0)
+    assertThat(actualBob).hasSize(0)
   }
 
   @Test
@@ -83,9 +84,9 @@ class NameCollisionTablesTest {
     val actualBob = SignalDatabase.nameCollisions.getCollisionsForThreadRecipientId(bob)
     val actualCharlie = SignalDatabase.nameCollisions.getCollisionsForThreadRecipientId(charlie)
 
-    actualAlice assertIsSize 0
-    actualBob assertIsSize 2
-    actualCharlie assertIsSize 2
+    assertThat(actualAlice).hasSize(0)
+    assertThat(actualBob).hasSize(2)
+    assertThat(actualCharlie).hasSize(2)
   }
 
   @Test
@@ -99,7 +100,7 @@ class NameCollisionTablesTest {
 
     val actualAlice = SignalDatabase.nameCollisions.getCollisionsForThreadRecipientId(alice)
 
-    actualAlice assertIsSize 2
+    assertThat(actualAlice).hasSize(2)
   }
 
   @Test
@@ -110,7 +111,7 @@ class NameCollisionTablesTest {
 
     val actualCollisions = SignalDatabase.nameCollisions.getCollisionsForThreadRecipientId(alice)
 
-    actualCollisions assertIsSize 0
+    assertThat(actualCollisions).hasSize(0)
   }
 
   @Test
@@ -124,7 +125,7 @@ class NameCollisionTablesTest {
 
     val actualCollisions = SignalDatabase.nameCollisions.getCollisionsForThreadRecipientId(alice)
 
-    actualCollisions assertIsSize 0
+    assertThat(actualCollisions).hasSize(0)
   }
 
   @Test
@@ -137,7 +138,7 @@ class NameCollisionTablesTest {
 
     val actualCollisions = SignalDatabase.nameCollisions.getCollisionsForThreadRecipientId(bob)
 
-    actualCollisions assertIsSize 2
+    assertThat(actualCollisions).hasSize(2)
   }
 
   @Test
@@ -154,7 +155,7 @@ class NameCollisionTablesTest {
 
     val collisions = SignalDatabase.nameCollisions.getCollisionsForThreadRecipientId(info.recipientId)
 
-    collisions assertIsSize 2
+    assertThat(collisions).hasSize(2)
   }
 
   @Test
@@ -173,7 +174,7 @@ class NameCollisionTablesTest {
 
     val collisions = SignalDatabase.nameCollisions.getCollisionsForThreadRecipientId(info.recipientId)
 
-    collisions assertIsSize 0
+    assertThat(collisions).hasSize(0)
   }
 
   @Test
@@ -190,7 +191,7 @@ class NameCollisionTablesTest {
 
     val collisions = SignalDatabase.nameCollisions.getCollisionsForThreadRecipientId(info.recipientId)
 
-    collisions assertIsSize 0
+    assertThat(collisions).hasSize(0)
   }
 
   private fun setUpRecipient(recipientId: RecipientId): RecipientId {

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/NameCollisionTablesTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/NameCollisionTablesTest.kt
@@ -6,6 +6,8 @@
 package org.thoughtcrime.securesms.database
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.hasSize
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -18,8 +20,6 @@ import org.thoughtcrime.securesms.recipients.Recipient
 import org.thoughtcrime.securesms.recipients.RecipientId
 import org.thoughtcrime.securesms.testing.GroupTestingUtils
 import org.thoughtcrime.securesms.testing.SignalActivityRule
-import assertk.assertions.hasSize
-import assertk.assertThat
 
 @RunWith(AndroidJUnit4::class)
 class NameCollisionTablesTest {

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/RecipientTableTest_applyStorageSyncContactUpdate.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/RecipientTableTest_applyStorageSyncContactUpdate.kt
@@ -6,6 +6,9 @@
 package org.thoughtcrime.securesms.database
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,9 +21,6 @@ import org.thoughtcrime.securesms.util.MessageTableTestUtils
 import org.whispersystems.signalservice.api.storage.SignalContactRecord
 import org.whispersystems.signalservice.api.storage.toSignalContactRecord
 import org.whispersystems.signalservice.internal.storage.protos.ContactRecord
-import assertk.assertThat
-import assertk.assertions.isEqualTo
-import assertk.assertions.isTrue
 
 @Suppress("ClassName")
 @RunWith(AndroidJUnit4::class)

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/RecipientTableTest_applyStorageSyncContactUpdate.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/RecipientTableTest_applyStorageSyncContactUpdate.kt
@@ -14,11 +14,13 @@ import org.thoughtcrime.securesms.recipients.Recipient
 import org.thoughtcrime.securesms.storage.StorageRecordUpdate
 import org.thoughtcrime.securesms.storage.StorageSyncModels
 import org.thoughtcrime.securesms.testing.SignalActivityRule
-import org.thoughtcrime.securesms.testing.assertIs
 import org.thoughtcrime.securesms.util.MessageTableTestUtils
 import org.whispersystems.signalservice.api.storage.SignalContactRecord
 import org.whispersystems.signalservice.api.storage.toSignalContactRecord
 import org.whispersystems.signalservice.internal.storage.protos.ContactRecord
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
 
 @Suppress("ClassName")
 @RunWith(AndroidJUnit4::class)
@@ -52,10 +54,10 @@ class RecipientTableTest_applyStorageSyncContactUpdate {
     val newVerifiedStatus: IdentityTable.VerifiedStatus = identities.getIdentityRecord(other.id).get().verifiedStatus
 
     // THEN
-    oldVerifiedStatus assertIs IdentityTable.VerifiedStatus.VERIFIED
-    newVerifiedStatus assertIs IdentityTable.VerifiedStatus.DEFAULT
+    assertThat(oldVerifiedStatus).isEqualTo(IdentityTable.VerifiedStatus.VERIFIED)
+    assertThat(newVerifiedStatus).isEqualTo(IdentityTable.VerifiedStatus.DEFAULT)
 
     val messages = MessageTableTestUtils.getMessages(SignalDatabase.threads.getThreadIdFor(other.id)!!)
-    messages.first().isIdentityDefault assertIs true
+    assertThat(messages.first().isIdentityDefault).isTrue()
   }
 }

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/RecipientTableTest_getAndPossiblyMerge.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/RecipientTableTest_getAndPossiblyMerge.kt
@@ -3,8 +3,6 @@ package org.thoughtcrime.securesms.database
 import android.database.Cursor
 import androidx.core.content.contentValuesOf
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.hamcrest.MatcherAssert
-import org.hamcrest.Matchers
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -46,6 +44,8 @@ import org.whispersystems.signalservice.api.push.ServiceId.ACI
 import org.whispersystems.signalservice.api.push.ServiceId.PNI
 import java.util.Optional
 import java.util.UUID
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertThat
 
 @Suppress("ClassName")
 @RunWith(AndroidJUnit4::class)
@@ -977,13 +977,16 @@ class RecipientTableTest_getAndPossiblyMerge {
     val updatedProfile1: NotificationProfile = SignalDatabase.notificationProfiles.getProfile(profile1.id)!!
     val updatedProfile2: NotificationProfile = SignalDatabase.notificationProfiles.getProfile(profile2.id)!!
 
-    MatcherAssert.assertThat("Notification Profile 1 should now only contain ACI $recipientIdAci", updatedProfile1.allowedMembers, Matchers.containsInAnyOrder(recipientIdAci))
-    MatcherAssert.assertThat("Notification Profile 2 should now contain ACI A ($recipientIdAci) and ACI B ($recipientIdAciB)", updatedProfile2.allowedMembers, Matchers.containsInAnyOrder(recipientIdAci, recipientIdAciB))
+    assertThat(updatedProfile1.allowedMembers, "Notification Profile 1 should now only contain ACI $recipientIdAci")
+      .containsExactlyInAnyOrder(recipientIdAci)
+    assertThat(updatedProfile2.allowedMembers, "Notification Profile 2 should now contain ACI A ($recipientIdAci) and ACI B ($recipientIdAciB)")
+      .containsExactlyInAnyOrder(recipientIdAci, recipientIdAciB)
 
     // Distribution List validation
     val updatedList: DistributionListRecord = SignalDatabase.distributionLists.getList(distributionListId)!!
 
-    MatcherAssert.assertThat("Distribution list should have updated $recipientIdE164 to $recipientIdAci", updatedList.members, Matchers.containsInAnyOrder(recipientIdAci, recipientIdAciB))
+    assertThat(updatedList.members, "Distribution list should have updated $recipientIdE164 to $recipientIdAci")
+      .containsExactlyInAnyOrder(recipientIdAci, recipientIdAciB)
   }
 
   private fun smsMessage(sender: RecipientId, time: Long = 0, body: String = "", groupId: Optional<GroupId> = Optional.empty()): IncomingMessage {

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/RecipientTableTest_getAndPossiblyMerge.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/RecipientTableTest_getAndPossiblyMerge.kt
@@ -3,6 +3,8 @@ package org.thoughtcrime.securesms.database
 import android.database.Cursor
 import androidx.core.content.contentValuesOf
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.containsExactlyInAnyOrder
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -44,8 +46,6 @@ import org.whispersystems.signalservice.api.push.ServiceId.ACI
 import org.whispersystems.signalservice.api.push.ServiceId.PNI
 import java.util.Optional
 import java.util.UUID
-import assertk.assertions.containsExactlyInAnyOrder
-import assertk.assertThat
 
 @Suppress("ClassName")
 @RunWith(AndroidJUnit4::class)

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/SmsDatabaseTest_collapseJoinRequestEventsIfPossible.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/SmsDatabaseTest_collapseJoinRequestEventsIfPossible.kt
@@ -1,10 +1,6 @@
 package org.thoughtcrime.securesms.database
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.`is`
-import org.hamcrest.Matchers.notNullValue
-import org.hamcrest.Matchers.nullValue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -25,6 +21,12 @@ import org.thoughtcrime.securesms.recipients.RecipientId
 import org.whispersystems.signalservice.api.push.ServiceId.ACI
 import org.whispersystems.signalservice.api.push.ServiceId.PNI
 import java.util.UUID
+import org.thoughtcrime.securesms.isAbsent
+import assertk.assertThat
+import assertk.assertions.isPresent
+import assertk.assertions.isNull
+import assertk.assertions.isEqualTo
+import org.thoughtcrime.securesms.database.MessageTable.InsertResult
 
 @Suppress("ClassName", "TestFunctionName")
 @RunWith(AndroidJUnit4::class)
@@ -70,7 +72,7 @@ class SmsDatabaseTest_collapseJoinRequestEventsIfPossible {
       )
     )
 
-    assertThat("result is null when not collapsing", result.orElse(null), nullValue())
+    assertThat(result, "result is null when not collapsing").isAbsent()
   }
 
   /**
@@ -92,7 +94,7 @@ class SmsDatabaseTest_collapseJoinRequestEventsIfPossible {
       )
     )
 
-    assertThat("result is null when not collapsing", result.orElse(null), nullValue())
+    assertThat(result, "result is null when not collapsing").isAbsent()
   }
 
   /**
@@ -123,7 +125,7 @@ class SmsDatabaseTest_collapseJoinRequestEventsIfPossible {
       )
     )
 
-    assertThat("result is null when not collapsing", result.orElse(null), nullValue())
+    assertThat(result, "result is null when not collapsing").isAbsent()
   }
 
   /**
@@ -154,7 +156,7 @@ class SmsDatabaseTest_collapseJoinRequestEventsIfPossible {
       )
     )
 
-    assertThat("result is null when not collapsing", result.orElse(null), nullValue())
+    assertThat(result, "result is null when not collapsing").isAbsent()
   }
 
   /**
@@ -185,8 +187,12 @@ class SmsDatabaseTest_collapseJoinRequestEventsIfPossible {
       )
     )
 
-    assertThat("result is not null when collapsing", result.orElse(null), notNullValue())
-    assertThat("result message id should be same as latest message", result.get().messageId, `is`(latestMessage.messageId))
+    assertThat(result, "result is not null when collapsing")
+      .isPresent()
+      .given { result: InsertResult ->
+        assertThat(result.messageId, "result message id should be same as latest message")
+          .isEqualTo(latestMessage.messageId)
+      }
   }
 
   /**
@@ -221,8 +227,12 @@ class SmsDatabaseTest_collapseJoinRequestEventsIfPossible {
       )
     )
 
-    assertThat("result is not null when collapsing", result.orElse(null), notNullValue())
-    assertThat("result message id should be same as latest message", result.get().messageId, `is`(latestMessage.messageId))
+    assertThat(result, "result is not null when collapsing")
+      .isPresent()
+      .given { result: InsertResult ->
+        assertThat(result.messageId, "result message id should be same as latest message")
+          .isEqualTo(latestMessage.messageId)
+      }
   }
 
   /**
@@ -267,9 +277,13 @@ class SmsDatabaseTest_collapseJoinRequestEventsIfPossible {
       )
     )
 
-    assertThat("result is not null when collapsing", result.orElse(null), notNullValue())
-    assertThat("result message id should be same as second latest message", result.get().messageId, `is`(secondLatestMessage.messageId))
-    assertThat("latest message should be deleted", sms.getMessageRecordOrNull(latestMessage.messageId), nullValue())
+    assertThat(result, "result is not null when collapsing")
+      .isPresent()
+      .given { result: InsertResult ->
+        assertThat(result.messageId, "result message id should be same as second latest message")
+          .isEqualTo(secondLatestMessage.messageId)
+        assertThat(sms.getMessageRecordOrNull(latestMessage.messageId), "latest message should be deleted").isNull()
+      }
   }
 
   private fun smsMessage(sender: RecipientId, body: String? = ""): IncomingMessage {

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/SmsDatabaseTest_collapseJoinRequestEventsIfPossible.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/SmsDatabaseTest_collapseJoinRequestEventsIfPossible.kt
@@ -1,11 +1,16 @@
 package org.thoughtcrime.securesms.database
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import assertk.assertions.isPresent
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.signal.core.util.Hex
 import org.signal.libsignal.zkgroup.groups.GroupMasterKey
+import org.thoughtcrime.securesms.database.MessageTable.InsertResult
 import org.thoughtcrime.securesms.database.model.GroupsV2UpdateMessageConverter
 import org.thoughtcrime.securesms.database.model.databaseprotos.DecryptedGroupV2Context
 import org.thoughtcrime.securesms.database.model.databaseprotos.GV2UpdateDescription
@@ -15,18 +20,13 @@ import org.thoughtcrime.securesms.database.model.databaseprotos.deleteRequesting
 import org.thoughtcrime.securesms.database.model.databaseprotos.groupChange
 import org.thoughtcrime.securesms.database.model.databaseprotos.groupContext
 import org.thoughtcrime.securesms.groups.GroupId
+import org.thoughtcrime.securesms.isAbsent
 import org.thoughtcrime.securesms.keyvalue.SignalStore
 import org.thoughtcrime.securesms.mms.IncomingMessage
 import org.thoughtcrime.securesms.recipients.RecipientId
 import org.whispersystems.signalservice.api.push.ServiceId.ACI
 import org.whispersystems.signalservice.api.push.ServiceId.PNI
 import java.util.UUID
-import org.thoughtcrime.securesms.isAbsent
-import assertk.assertThat
-import assertk.assertions.isPresent
-import assertk.assertions.isNull
-import assertk.assertions.isEqualTo
-import org.thoughtcrime.securesms.database.MessageTable.InsertResult
 
 @Suppress("ClassName", "TestFunctionName")
 @RunWith(AndroidJUnit4::class)

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/StorySendTableTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/StorySendTableTest.kt
@@ -1,6 +1,11 @@
 package org.thoughtcrime.securesms.database
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.hasSize
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -19,11 +24,6 @@ import org.thoughtcrime.securesms.testing.SignalActivityRule
 import org.whispersystems.signalservice.api.push.DistributionId
 import org.whispersystems.signalservice.api.push.ServiceId.ACI
 import java.util.UUID
-import assertk.assertThat
-import assertk.assertions.containsExactlyInAnyOrder
-import assertk.assertions.hasSize
-import assertk.assertions.isTrue
-import assertk.assertions.isFalse
 
 @RunWith(AndroidJUnit4::class)
 class StorySendTableTest {

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/StorySendTableTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/StorySendTableTest.kt
@@ -1,10 +1,6 @@
 package org.thoughtcrime.securesms.database
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.containsInAnyOrder
-import org.hamcrest.Matchers.hasSize
-import org.hamcrest.Matchers.`is`
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -23,6 +19,11 @@ import org.thoughtcrime.securesms.testing.SignalActivityRule
 import org.whispersystems.signalservice.api.push.DistributionId
 import org.whispersystems.signalservice.api.push.ServiceId.ACI
 import java.util.UUID
+import assertk.assertThat
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.hasSize
+import assertk.assertions.isTrue
+import assertk.assertions.isFalse
 
 @RunWith(AndroidJUnit4::class)
 class StorySendTableTest {
@@ -96,11 +97,11 @@ class StorySendTableTest {
     val recipientIdsForMessage1 = storySends.getRecipientsToSendTo(messageId1, 100, false)
     val recipientIdsForMessage2 = storySends.getRecipientsToSendTo(messageId2, 200, true)
 
-    assertThat(recipientIdsForMessage1, hasSize(10))
-    assertThat(recipientIdsForMessage1, containsInAnyOrder(*recipients1to10.toTypedArray()))
+    assertThat(recipientIdsForMessage1).hasSize(10)
+    assertThat(recipientIdsForMessage1).containsExactlyInAnyOrder(*recipients1to10.toTypedArray())
 
-    assertThat(recipientIdsForMessage2, hasSize(10))
-    assertThat(recipientIdsForMessage2, containsInAnyOrder(*recipients11to20.toTypedArray()))
+    assertThat(recipientIdsForMessage2).hasSize(10)
+    assertThat(recipientIdsForMessage2).containsExactlyInAnyOrder(*recipients11to20.toTypedArray())
   }
 
   @Test
@@ -111,11 +112,11 @@ class StorySendTableTest {
     val recipientIdsForMessage1 = storySends.getRecipientsToSendTo(messageId1, 100, false)
     val recipientIdsForMessage2 = storySends.getRecipientsToSendTo(messageId2, 100, true)
 
-    assertThat(recipientIdsForMessage1, hasSize(5))
-    assertThat(recipientIdsForMessage1, containsInAnyOrder(*recipients1to10.take(5).toTypedArray()))
+    assertThat(recipientIdsForMessage1).hasSize(5)
+    assertThat(recipientIdsForMessage1).containsExactlyInAnyOrder(*recipients1to10.take(5).toTypedArray())
 
-    assertThat(recipientIdsForMessage2, hasSize(10))
-    assertThat(recipientIdsForMessage2, containsInAnyOrder(*recipients6to15.toTypedArray()))
+    assertThat(recipientIdsForMessage2).hasSize(10)
+    assertThat(recipientIdsForMessage2).containsExactlyInAnyOrder(*recipients6to15.toTypedArray())
   }
 
   @Test
@@ -131,13 +132,13 @@ class StorySendTableTest {
     val recipientIdsForMessage2 = storySends.getRecipientsToSendTo(messageId2, 100, true)
     val recipientIdsForMessage3 = storySends.getRecipientsToSendTo(messageId3, 100, true)
 
-    assertThat(recipientIdsForMessage1, hasSize(0))
+    assertThat(recipientIdsForMessage1).hasSize(0)
 
-    assertThat(recipientIdsForMessage2, hasSize(1))
-    assertThat(recipientIdsForMessage2, containsInAnyOrder(recipient1))
+    assertThat(recipientIdsForMessage2).hasSize(1)
+    assertThat(recipientIdsForMessage2).containsExactlyInAnyOrder(recipient1)
 
-    assertThat(recipientIdsForMessage3, hasSize(1))
-    assertThat(recipientIdsForMessage3, containsInAnyOrder(recipient2))
+    assertThat(recipientIdsForMessage3).hasSize(1)
+    assertThat(recipientIdsForMessage3).containsExactlyInAnyOrder(recipient2)
   }
 
   @Test
@@ -148,11 +149,11 @@ class StorySendTableTest {
     val recipientIdsForMessage1 = storySends.getRecipientsToSendTo(messageId1, 100, true)
     val recipientIdsForMessage2 = storySends.getRecipientsToSendTo(messageId2, 100, false)
 
-    assertThat(recipientIdsForMessage1, hasSize(10))
-    assertThat(recipientIdsForMessage1, containsInAnyOrder(*recipients6to15.toTypedArray()))
+    assertThat(recipientIdsForMessage1).hasSize(10)
+    assertThat(recipientIdsForMessage1).containsExactlyInAnyOrder(*recipients6to15.toTypedArray())
 
-    assertThat(recipientIdsForMessage2, hasSize(5))
-    assertThat(recipientIdsForMessage2, containsInAnyOrder(*recipients1to10.take(5).toTypedArray()))
+    assertThat(recipientIdsForMessage2).hasSize(5)
+    assertThat(recipientIdsForMessage2).containsExactlyInAnyOrder(*recipients1to10.take(5).toTypedArray())
   }
 
   @Test
@@ -164,11 +165,11 @@ class StorySendTableTest {
     val recipientIdsForMessage1 = storySends.getRemoteDeleteRecipients(messageId1, 100)
     val recipientIdsForMessage2 = storySends.getRemoteDeleteRecipients(messageId2, 200)
 
-    assertThat(recipientIdsForMessage1, hasSize(10))
-    assertThat(recipientIdsForMessage1, containsInAnyOrder(*recipients1to10.toTypedArray()))
+    assertThat(recipientIdsForMessage1).hasSize(10)
+    assertThat(recipientIdsForMessage1).containsExactlyInAnyOrder(*recipients1to10.toTypedArray())
 
-    assertThat(recipientIdsForMessage2, hasSize(10))
-    assertThat(recipientIdsForMessage2, containsInAnyOrder(*recipients11to20.toTypedArray()))
+    assertThat(recipientIdsForMessage2).hasSize(10)
+    assertThat(recipientIdsForMessage2).containsExactlyInAnyOrder(*recipients11to20.toTypedArray())
   }
 
   @Test
@@ -179,11 +180,11 @@ class StorySendTableTest {
     val recipientIdsForMessage1 = storySends.getRemoteDeleteRecipients(messageId1, 200)
     val recipientIdsForMessage2 = storySends.getRemoteDeleteRecipients(messageId2, 200)
 
-    assertThat(recipientIdsForMessage1, hasSize(5))
-    assertThat(recipientIdsForMessage1, containsInAnyOrder(*recipients1to10.take(5).toTypedArray()))
+    assertThat(recipientIdsForMessage1).hasSize(5)
+    assertThat(recipientIdsForMessage1).containsExactlyInAnyOrder(*recipients1to10.take(5).toTypedArray())
 
-    assertThat(recipientIdsForMessage2, hasSize(5))
-    assertThat(recipientIdsForMessage2, containsInAnyOrder(*recipients6to15.takeLast(5).toTypedArray()))
+    assertThat(recipientIdsForMessage2).hasSize(5)
+    assertThat(recipientIdsForMessage2).containsExactlyInAnyOrder(*recipients6to15.takeLast(5).toTypedArray())
   }
 
   @Test
@@ -195,8 +196,8 @@ class StorySendTableTest {
 
     val recipientIdsForMessage2 = storySends.getRemoteDeleteRecipients(messageId2, 200)
 
-    assertThat(recipientIdsForMessage2, hasSize(10))
-    assertThat(recipientIdsForMessage2, containsInAnyOrder(*recipients6to15.toTypedArray()))
+    assertThat(recipientIdsForMessage2).hasSize(10)
+    assertThat(recipientIdsForMessage2).containsExactlyInAnyOrder(*recipients6to15.toTypedArray())
   }
 
   @Test
@@ -205,7 +206,7 @@ class StorySendTableTest {
 
     val canReply = storySends.canReply(recipients1to10[0], 200)
 
-    assertThat(canReply, `is`(true))
+    assertThat(canReply).isTrue()
   }
 
   @Test
@@ -214,7 +215,7 @@ class StorySendTableTest {
 
     val canReply = storySends.canReply(recipients1to10[0], 200)
 
-    assertThat(canReply, `is`(false))
+    assertThat(canReply).isFalse()
   }
 
   @Test
@@ -225,8 +226,8 @@ class StorySendTableTest {
     val message1OnlyRecipientCanReply = storySends.canReply(recipients1to10[0], 200)
     val message2RecipientCanReply = storySends.canReply(recipients6to10[0], 200)
 
-    assertThat(message1OnlyRecipientCanReply, `is`(false))
-    assertThat(message2RecipientCanReply, `is`(true))
+    assertThat(message1OnlyRecipientCanReply).isFalse()
+    assertThat(message2RecipientCanReply).isTrue()
   }
 
   @Test

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/helpers/migration/FixInAppCurrencyIfAbleTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/helpers/migration/FixInAppCurrencyIfAbleTest.kt
@@ -24,10 +24,12 @@ import org.thoughtcrime.securesms.database.model.InAppPaymentSubscriberRecord
 import org.thoughtcrime.securesms.database.model.databaseprotos.FiatValue
 import org.thoughtcrime.securesms.database.model.databaseprotos.InAppPaymentData
 import org.thoughtcrime.securesms.testing.SignalDatabaseRule
-import org.thoughtcrime.securesms.testing.assertIs
 import org.whispersystems.signalservice.api.subscriptions.SubscriberId
 import java.math.BigDecimal
 import java.util.Currency
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isEmpty
 
 @RunWith(AndroidJUnit4::class)
 class FixInAppCurrencyIfAbleTest {
@@ -46,7 +48,7 @@ class FixInAppCurrencyIfAbleTest {
     clearCurrencyCode(subscriber)
     migrate()
 
-    getCurrencyCode(subscriber) assertIs ""
+    assertThat(getCurrencyCode(subscriber)).isEmpty()
   }
 
   @Test
@@ -57,7 +59,7 @@ class FixInAppCurrencyIfAbleTest {
     clearCurrencyCode(subscriber)
     migrate()
 
-    getCurrencyCode(subscriber) assertIs ""
+    assertThat(getCurrencyCode(subscriber)).isEmpty()
   }
 
   @Test
@@ -67,7 +69,7 @@ class FixInAppCurrencyIfAbleTest {
     clearCurrencyCode(subscriber)
     migrate()
 
-    getCurrencyCode(subscriber) assertIs ""
+    assertThat(getCurrencyCode(subscriber)).isEmpty()
   }
 
   @Test
@@ -77,7 +79,7 @@ class FixInAppCurrencyIfAbleTest {
     clearCurrencyCode(subscriber)
     migrate()
 
-    getCurrencyCode(subscriber) assertIs "USD"
+    assertThat(getCurrencyCode(subscriber)).isEqualTo("USD")
   }
 
   @Test

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/database/helpers/migration/FixInAppCurrencyIfAbleTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/database/helpers/migration/FixInAppCurrencyIfAbleTest.kt
@@ -8,6 +8,9 @@ package org.thoughtcrime.securesms.database.helpers.migration
 import android.app.Application
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -27,9 +30,6 @@ import org.thoughtcrime.securesms.testing.SignalDatabaseRule
 import org.whispersystems.signalservice.api.subscriptions.SubscriberId
 import java.math.BigDecimal
 import java.util.Currency
-import assertk.assertThat
-import assertk.assertions.isEqualTo
-import assertk.assertions.isEmpty
 
 @RunWith(AndroidJUnit4::class)
 class FixInAppCurrencyIfAbleTest {

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/jobs/AttachmentCompressionJobTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/jobs/AttachmentCompressionJobTest.kt
@@ -8,6 +8,8 @@ package org.thoughtcrime.securesms.jobs
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import assertk.assertThat
+import assertk.assertions.isTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -24,8 +26,6 @@ import org.thoughtcrime.securesms.testing.SignalActivityRule
 import org.thoughtcrime.securesms.util.MediaUtil
 import java.util.Optional
 import java.util.concurrent.CountDownLatch
-import assertk.assertions.isTrue
-import assertk.assertThat
 
 @RunWith(AndroidJUnit4::class)
 class AttachmentCompressionJobTest {

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/jobs/AttachmentCompressionJobTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/jobs/AttachmentCompressionJobTest.kt
@@ -21,10 +21,11 @@ import org.thoughtcrime.securesms.jobmanager.Job
 import org.thoughtcrime.securesms.mms.SentMediaQuality
 import org.thoughtcrime.securesms.providers.BlobProvider
 import org.thoughtcrime.securesms.testing.SignalActivityRule
-import org.thoughtcrime.securesms.testing.assertIs
 import org.thoughtcrime.securesms.util.MediaUtil
 import java.util.Optional
 import java.util.concurrent.CountDownLatch
+import assertk.assertions.isTrue
+import assertk.assertThat
 
 @RunWith(AndroidJUnit4::class)
 class AttachmentCompressionJobTest {
@@ -69,8 +70,8 @@ class AttachmentCompressionJobTest {
 
     jobThread.join()
 
-    firstJobResult!!.isSuccess assertIs true
-    secondJobResult!!.isSuccess assertIs true
+    assertThat(firstJobResult!!.isSuccess).isTrue()
+    assertThat(secondJobResult!!.isSuccess).isTrue()
   }
 
   private fun createAttachment(id: Long, uri: Uri, transformProperties: AttachmentTable.TransformProperties): UriAttachment {

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/jobs/InAppPaymentAuthCheckJobTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/jobs/InAppPaymentAuthCheckJobTest.kt
@@ -2,7 +2,6 @@ package org.thoughtcrime.securesms.jobs
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import okhttp3.mockwebserver.MockResponse
-import org.hamcrest.Matchers
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -21,11 +20,13 @@ import org.thoughtcrime.securesms.database.model.databaseprotos.InAppPaymentData
 import org.thoughtcrime.securesms.dependencies.InstrumentationApplicationDependencyProvider
 import org.thoughtcrime.securesms.testing.Get
 import org.thoughtcrime.securesms.testing.SignalActivityRule
-import org.thoughtcrime.securesms.testing.assert
 import org.thoughtcrime.securesms.testing.success
 import org.thoughtcrime.securesms.util.TestStripePaths
 import java.math.BigDecimal
 import java.util.Currency
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertThat
 
 @RunWith(AndroidJUnit4::class)
 class InAppPaymentAuthCheckJobTest {
@@ -65,7 +66,7 @@ class InAppPaymentAuthCheckJobTest {
     InAppPaymentAuthCheckJob().run()
 
     val receipts = SignalDatabase.donationReceipts.getReceipts(InAppPaymentReceiptRecord.Type.ONE_TIME_DONATION)
-    receipts assert Matchers.empty()
+    assertThat(receipts).isEmpty()
   }
 
   @Test
@@ -89,7 +90,7 @@ class InAppPaymentAuthCheckJobTest {
     InAppPaymentAuthCheckJob().run()
 
     val receipts = SignalDatabase.donationReceipts.getReceipts(InAppPaymentReceiptRecord.Type.ONE_TIME_DONATION)
-    receipts assert Matchers.hasSize(1)
+    assertThat(receipts).hasSize(1)
   }
 
   private fun initializeMockGetPaymentIntent(status: StripeIntentStatus) {

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/jobs/InAppPaymentAuthCheckJobTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/jobs/InAppPaymentAuthCheckJobTest.kt
@@ -1,6 +1,9 @@
 package org.thoughtcrime.securesms.jobs
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
 import okhttp3.mockwebserver.MockResponse
 import org.junit.Before
 import org.junit.Rule
@@ -24,9 +27,6 @@ import org.thoughtcrime.securesms.testing.success
 import org.thoughtcrime.securesms.util.TestStripePaths
 import java.math.BigDecimal
 import java.util.Currency
-import assertk.assertions.hasSize
-import assertk.assertions.isEmpty
-import assertk.assertThat
 
 @RunWith(AndroidJUnit4::class)
 class InAppPaymentAuthCheckJobTest {

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/messages/EditMessageSyncProcessorTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/messages/EditMessageSyncProcessorTest.kt
@@ -20,12 +20,13 @@ import org.thoughtcrime.securesms.mms.OutgoingMessage
 import org.thoughtcrime.securesms.recipients.Recipient
 import org.thoughtcrime.securesms.testing.MessageContentFuzzer
 import org.thoughtcrime.securesms.testing.SignalActivityRule
-import org.thoughtcrime.securesms.testing.assertIs
 import org.thoughtcrime.securesms.util.MessageTableTestUtils
 import org.whispersystems.signalservice.internal.push.Content
 import org.whispersystems.signalservice.internal.push.EditMessage
 import org.whispersystems.signalservice.internal.push.SyncMessage
 import kotlin.time.Duration.Companion.seconds
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 
 @RunWith(AndroidJUnit4::class)
 class EditMessageSyncProcessorTest {
@@ -201,12 +202,12 @@ class EditMessageSyncProcessorTest {
     fun assert() {
       syncMessages.zip(localMessages)
         .forEach { (v2, v1) ->
-          v2.assertIs(v1)
+          assertThat(v2).isEqualTo(v1)
         }
 
       syncAttachments.zip(localAttachments)
         .forEach { (v2, v1) ->
-          v2.assertIs(v1)
+          assertThat(v2).isEqualTo(v1)
         }
     }
 

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/messages/EditMessageSyncProcessorTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/messages/EditMessageSyncProcessorTest.kt
@@ -3,6 +3,8 @@ package org.thoughtcrime.securesms.messages
 import android.database.Cursor
 import android.util.Base64
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -25,8 +27,6 @@ import org.whispersystems.signalservice.internal.push.Content
 import org.whispersystems.signalservice.internal.push.EditMessage
 import org.whispersystems.signalservice.internal.push.SyncMessage
 import kotlin.time.Duration.Companion.seconds
-import assertk.assertThat
-import assertk.assertions.isEqualTo
 
 @RunWith(AndroidJUnit4::class)
 class EditMessageSyncProcessorTest {

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/messages/MessageContentProcessor__recipientStatusTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/messages/MessageContentProcessor__recipientStatusTest.kt
@@ -13,10 +13,12 @@ import org.thoughtcrime.securesms.testing.GroupTestingUtils
 import org.thoughtcrime.securesms.testing.GroupTestingUtils.asMember
 import org.thoughtcrime.securesms.testing.MessageContentFuzzer
 import org.thoughtcrime.securesms.testing.SignalActivityRule
-import org.thoughtcrime.securesms.testing.assertIs
 import org.thoughtcrime.securesms.util.MessageTableTestUtils
 import org.whispersystems.signalservice.internal.push.DataMessage
 import org.whispersystems.signalservice.internal.push.GroupContextV2
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
 
 @Suppress("ClassName")
 @RunWith(AndroidJUnit4::class)
@@ -71,14 +73,14 @@ class MessageContentProcessor__recipientStatusTest {
     val secondSyncMessages = MessageTableTestUtils.getMessages(threadId)
     val secondReceiptInfo = SignalDatabase.groupReceipts.getGroupReceiptInfo(firstMessageId)
 
-    firstSyncMessages.size assertIs 1
-    firstSyncMessages[0].body assertIs initialTextMessage.body
-    firstReceiptInfo.first { it.recipientId == harness.others[0] }.status assertIs GroupReceiptTable.STATUS_UNDELIVERED
-    firstReceiptInfo.first { it.recipientId == harness.others[1] }.status assertIs GroupReceiptTable.STATUS_UNKNOWN
+    assertThat(firstSyncMessages).hasSize(1)
+    assertThat(firstSyncMessages[0].body).isEqualTo(initialTextMessage.body)
+    assertThat(firstReceiptInfo.first { it.recipientId == harness.others[0] }.status).isEqualTo(GroupReceiptTable.STATUS_UNDELIVERED)
+    assertThat(firstReceiptInfo.first { it.recipientId == harness.others[1] }.status).isEqualTo(GroupReceiptTable.STATUS_UNKNOWN)
 
-    secondSyncMessages.size assertIs 1
-    secondSyncMessages[0].body assertIs initialTextMessage.body
-    secondReceiptInfo.first { it.recipientId == harness.others[0] }.status assertIs GroupReceiptTable.STATUS_UNDELIVERED
-    secondReceiptInfo.first { it.recipientId == harness.others[1] }.status assertIs GroupReceiptTable.STATUS_UNDELIVERED
+    assertThat(secondSyncMessages).hasSize(1)
+    assertThat(secondSyncMessages[0].body).isEqualTo(initialTextMessage.body)
+    assertThat(secondReceiptInfo.first { it.recipientId == harness.others[0] }.status).isEqualTo(GroupReceiptTable.STATUS_UNDELIVERED)
+    assertThat(secondReceiptInfo.first { it.recipientId == harness.others[1] }.status).isEqualTo(GroupReceiptTable.STATUS_UNDELIVERED)
   }
 }

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/messages/MessageContentProcessor__recipientStatusTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/messages/MessageContentProcessor__recipientStatusTest.kt
@@ -1,6 +1,9 @@
 package org.thoughtcrime.securesms.messages
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
 import okio.ByteString.Companion.toByteString
 import org.junit.Before
 import org.junit.Rule
@@ -16,9 +19,6 @@ import org.thoughtcrime.securesms.testing.SignalActivityRule
 import org.thoughtcrime.securesms.util.MessageTableTestUtils
 import org.whispersystems.signalservice.internal.push.DataMessage
 import org.whispersystems.signalservice.internal.push.GroupContextV2
-import assertk.assertThat
-import assertk.assertions.hasSize
-import assertk.assertions.isEqualTo
 
 @Suppress("ClassName")
 @RunWith(AndroidJUnit4::class)

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/messages/SyncMessageProcessorTest_readSyncs.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/messages/SyncMessageProcessorTest_readSyncs.kt
@@ -6,6 +6,8 @@
 package org.thoughtcrime.securesms.messages
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -13,8 +15,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.thoughtcrime.securesms.database.SignalDatabase
 import org.thoughtcrime.securesms.testing.SignalActivityRule
-import assertk.assertThat
-import assertk.assertions.isEqualTo
 
 @Suppress("ClassName")
 @RunWith(AndroidJUnit4::class)

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/messages/SyncMessageProcessorTest_readSyncs.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/messages/SyncMessageProcessorTest_readSyncs.kt
@@ -13,7 +13,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.thoughtcrime.securesms.database.SignalDatabase
 import org.thoughtcrime.securesms.testing.SignalActivityRule
-import org.thoughtcrime.securesms.testing.assertIs
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 
 @Suppress("ClassName")
 @RunWith(AndroidJUnit4::class)
@@ -41,12 +42,12 @@ class SyncMessageProcessorTest_readSyncs {
 
     val threadId = SignalDatabase.threads.getThreadIdFor(messageHelper.alice)!!
     var threadRecord = SignalDatabase.threads.getThreadRecord(threadId)!!
-    threadRecord.unreadCount assertIs 2
+    assertThat(threadRecord.unreadCount).isEqualTo(2)
 
     messageHelper.syncReadMessage(messageHelper.alice to message1Timestamp, messageHelper.alice to message2Timestamp)
 
     threadRecord = SignalDatabase.threads.getThreadRecord(threadId)!!
-    threadRecord.unreadCount assertIs 0
+    assertThat(threadRecord.unreadCount).isEqualTo(0)
   }
 
   @Test
@@ -56,12 +57,12 @@ class SyncMessageProcessorTest_readSyncs {
 
     val threadId = SignalDatabase.threads.getThreadIdFor(messageHelper.alice)!!
     var threadRecord = SignalDatabase.threads.getThreadRecord(threadId)!!
-    threadRecord.unreadCount assertIs 2
+    assertThat(threadRecord.unreadCount).isEqualTo(2)
 
     messageHelper.syncReadMessage(messageHelper.alice to message2Timestamp)
 
     threadRecord = SignalDatabase.threads.getThreadRecord(threadId)!!
-    threadRecord.unreadCount assertIs 0
+    assertThat(threadRecord.unreadCount).isEqualTo(0)
   }
 
   @Test
@@ -76,12 +77,12 @@ class SyncMessageProcessorTest_readSyncs {
 
     val threadId = SignalDatabase.threads.getThreadIdFor(messageHelper.alice)!!
     var threadRecord = SignalDatabase.threads.getThreadRecord(threadId)!!
-    threadRecord.unreadCount assertIs 2
+    assertThat(threadRecord.unreadCount).isEqualTo(2)
 
     messageHelper.syncReadMessage(messageHelper.alice to message2Timestamp, messageHelper.alice to editMessage1Timestamp1, messageHelper.alice to editMessage1Timestamp2)
 
     threadRecord = SignalDatabase.threads.getThreadRecord(threadId)!!
-    threadRecord.unreadCount assertIs 0
+    assertThat(threadRecord.unreadCount).isEqualTo(0)
   }
 
   @Test
@@ -97,11 +98,11 @@ class SyncMessageProcessorTest_readSyncs {
 
     val threadId = SignalDatabase.threads.getThreadIdFor(messageHelper.group.recipientId)!!
     var threadRecord = SignalDatabase.threads.getThreadRecord(threadId)!!
-    threadRecord.unreadCount assertIs 2
+    assertThat(threadRecord.unreadCount).isEqualTo(2)
 
     messageHelper.syncReadMessage(messageHelper.bob to message2Timestamp, messageHelper.alice to editMessage1Timestamp1, messageHelper.alice to editMessage1Timestamp2)
 
     threadRecord = SignalDatabase.threads.getThreadRecord(threadId)!!
-    threadRecord.unreadCount assertIs 0
+    assertThat(threadRecord.unreadCount).isEqualTo(0)
   }
 }

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/messages/SyncMessageProcessorTest_synchronizeDeleteForMe.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/messages/SyncMessageProcessorTest_synchronizeDeleteForMe.kt
@@ -27,11 +27,6 @@ import org.thoughtcrime.securesms.recipients.Recipient
 import org.thoughtcrime.securesms.recipients.RecipientId
 import org.thoughtcrime.securesms.testing.MessageContentFuzzer.DeleteForMeSync
 import org.thoughtcrime.securesms.testing.SignalActivityRule
-import org.thoughtcrime.securesms.testing.assert
-import org.thoughtcrime.securesms.testing.assertIs
-import org.thoughtcrime.securesms.testing.assertIsNot
-import org.thoughtcrime.securesms.testing.assertIsNotNull
-import org.thoughtcrime.securesms.testing.assertIsSize
 import org.thoughtcrime.securesms.util.IdentityUtil
 import org.thoughtcrime.securesms.util.Util
 import org.whispersystems.signalservice.api.attachment.AttachmentUploadResult
@@ -39,6 +34,12 @@ import org.whispersystems.signalservice.api.messages.SignalServiceAttachmentRemo
 import java.util.UUID
 import assertk.assertThat
 import assertk.assertions.isGreaterThan
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
 
 @Suppress("ClassName")
 @RunWith(AndroidJUnit4::class)
@@ -71,7 +72,7 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
 
     val threadId = SignalDatabase.threads.getThreadIdFor(messageHelper.alice)!!
     var messageCount = SignalDatabase.messages.getMessageCountForThread(threadId)
-    messageCount assertIs 2
+    assertThat(messageCount).isEqualTo(2)
 
     // WHEN
     messageHelper.syncDeleteForMeMessage(
@@ -80,7 +81,7 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
 
     // THEN
     messageCount = SignalDatabase.messages.getMessageCountForThread(threadId)
-    messageCount assertIs 1
+    assertThat(messageCount).isEqualTo(1)
   }
 
   @Test
@@ -91,7 +92,7 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
 
     val threadId = SignalDatabase.threads.getThreadIdFor(messageHelper.alice)!!
     var messageCount = SignalDatabase.messages.getMessageCountForThread(threadId)
-    messageCount assertIs 2
+    assertThat(messageCount).isEqualTo(2)
 
     // WHEN
     messageHelper.syncDeleteForMeMessage(
@@ -100,7 +101,7 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
 
     // THEN
     messageCount = SignalDatabase.messages.getMessageCountForThread(threadId)
-    messageCount assertIs 1
+    assertThat(messageCount).isEqualTo(1)
   }
 
   @Test
@@ -112,7 +113,7 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
 
     val threadId = SignalDatabase.threads.getThreadIdFor(messageHelper.group.recipientId)!!
     var messageCount = SignalDatabase.messages.getMessageCountForThread(threadId)
-    messageCount assertIs 3
+    assertThat(messageCount).isEqualTo(3)
 
     // WHEN
     messageHelper.syncDeleteForMeMessage(
@@ -121,7 +122,7 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
 
     // THEN
     messageCount = SignalDatabase.messages.getMessageCountForThread(threadId)
-    messageCount assertIs 2
+    assertThat(messageCount).isEqualTo(2)
   }
 
   @Test
@@ -133,7 +134,7 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
 
     val threadId = SignalDatabase.threads.getThreadIdFor(messageHelper.group.recipientId)!!
     var messageCount = SignalDatabase.messages.getMessageCountForThread(threadId)
-    messageCount assertIs 3
+    assertThat(messageCount).isEqualTo(3)
 
     // WHEN
     messageHelper.syncDeleteForMeMessage(
@@ -142,7 +143,7 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
 
     // THEN
     messageCount = SignalDatabase.messages.getMessageCountForThread(threadId)
-    messageCount assertIs 1
+    assertThat(messageCount).isEqualTo(1)
   }
 
   @Test
@@ -153,7 +154,7 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
 
     val threadId = SignalDatabase.threads.getThreadIdFor(messageHelper.alice)!!
     var messageCount = SignalDatabase.messages.getMessageCountForThread(threadId)
-    messageCount assertIs 2
+    assertThat(messageCount).isEqualTo(2)
 
     // WHEN
     messageHelper.syncDeleteForMeMessage(
@@ -162,10 +163,10 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
 
     // THEN
     messageCount = SignalDatabase.messages.getMessageCountForThread(threadId)
-    messageCount assertIs 0
+    assertThat(messageCount).isEqualTo(0)
 
     val threadRecord = SignalDatabase.threads.getThreadRecord(threadId)
-    threadRecord assertIs null
+    assertThat(threadRecord).isNull()
   }
 
   @Test
@@ -175,7 +176,7 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
 
     val threadId = SignalDatabase.threads.getThreadIdFor(messageHelper.alice)!!
     var messageCount = SignalDatabase.messages.getMessageCountForThread(threadId)
-    messageCount assertIs 1
+    assertThat(messageCount).isEqualTo(1)
 
     // WHEN
     val nextTextMessageTimestamp = messageHelper.nextStartTime(2)
@@ -186,7 +187,7 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
 
     // THEN
     messageCount = SignalDatabase.messages.getMessageCountForThread(threadId)
-    messageCount assertIs 1
+    assertThat(messageCount).isEqualTo(1)
   }
 
   @Test
@@ -200,11 +201,11 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
 
     val aliceThreadId = SignalDatabase.threads.getThreadIdFor(messageHelper.alice)!!
     var aliceMessageCount = SignalDatabase.messages.getMessageCountForThread(aliceThreadId)
-    aliceMessageCount assertIs 2
+    assertThat(aliceMessageCount).isEqualTo(2)
 
     val bobThreadId = SignalDatabase.threads.getThreadIdFor(messageHelper.bob)!!
     var bobMessageCount = SignalDatabase.messages.getMessageCountForThread(bobThreadId)
-    bobMessageCount assertIs 2
+    assertThat(bobMessageCount).isEqualTo(2)
 
     // WHEN
     messageHelper.syncDeleteForMeMessage(
@@ -214,10 +215,10 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
 
     // THEN
     aliceMessageCount = SignalDatabase.messages.getMessageCountForThread(aliceThreadId)
-    aliceMessageCount assertIs 1
+    assertThat(aliceMessageCount).isEqualTo(1)
 
     bobMessageCount = SignalDatabase.messages.getMessageCountForThread(bobThreadId)
-    bobMessageCount assertIs 1
+    assertThat(bobMessageCount).isEqualTo(1)
   }
 
   @Test
@@ -231,7 +232,7 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
     }
 
     val threadId = SignalDatabase.threads.getThreadIdFor(messageHelper.alice)!!
-    SignalDatabase.messages.getMessageCountForThread(threadId) assertIs 20
+    assertThat(SignalDatabase.messages.getMessageCountForThread(threadId)).isEqualTo(20)
 
     // WHEN
     messageHelper.syncDeleteForMeConversation(
@@ -243,8 +244,8 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
     )
 
     // THEN
-    SignalDatabase.messages.getMessageCountForThread(threadId) assertIs 0
-    SignalDatabase.threads.getThreadRecord(threadId) assertIs null
+    assertThat(SignalDatabase.messages.getMessageCountForThread(threadId)).isEqualTo(0)
+    assertThat(SignalDatabase.threads.getThreadRecord(threadId)).isNull()
   }
 
   @Test
@@ -258,7 +259,7 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
     }
 
     val threadId = SignalDatabase.threads.getThreadIdFor(messageHelper.alice)!!
-    SignalDatabase.messages.getMessageCountForThread(threadId) assertIs 20
+    assertThat(SignalDatabase.messages.getMessageCountForThread(threadId)).isEqualTo(20)
 
     // WHEN
     val randomFutureMessages = (1..5).map {
@@ -270,11 +271,11 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
     )
 
     // THEN
-    SignalDatabase.messages.getMessageCountForThread(threadId) assertIs 20
-    SignalDatabase.threads.getThreadRecord(threadId).assertIsNotNull()
+    assertThat(SignalDatabase.messages.getMessageCountForThread(threadId)).isEqualTo(20)
+    assertThat(SignalDatabase.threads.getThreadRecord(threadId)).isNotNull()
 
     harness.inMemoryLogger.flush()
-    harness.inMemoryLogger.entries().filter { it.message?.contains("Unable to find most recent received at timestamp") == true }.size assertIs 1
+    assertThat(harness.inMemoryLogger.entries().filter { it.message?.contains("Unable to find most recent received at timestamp") == true }).hasSize(1)
   }
 
   @Test
@@ -288,7 +289,7 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
     }
 
     val threadId = SignalDatabase.threads.getThreadIdFor(messageHelper.alice)!!
-    SignalDatabase.messages.getMessageCountForThread(threadId) assertIs 20
+    assertThat(SignalDatabase.messages.getMessageCountForThread(threadId)).isEqualTo(20)
 
     // WHEN
     val nonExpiringMessages = messages.takeLast(5).map { it.recipientId to it.timetamp }
@@ -302,11 +303,11 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
     )
 
     // THEN
-    SignalDatabase.messages.getMessageCountForThread(threadId) assertIs 0
-    SignalDatabase.threads.getThreadRecord(threadId) assertIs null
+    assertThat(SignalDatabase.messages.getMessageCountForThread(threadId)).isEqualTo(0)
+    assertThat(SignalDatabase.threads.getThreadRecord(threadId)).isNull()
 
     harness.inMemoryLogger.flush()
-    harness.inMemoryLogger.entries().filter { it.message?.contains("Using backup non-expiring messages") == true }.size assertIs 1
+    assertThat(harness.inMemoryLogger.entries().filter { it.message?.contains("Using backup non-expiring messages") == true }).hasSize(1)
   }
 
   @Test
@@ -329,7 +330,7 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
     SignalDatabase.calls.insertOneToOneCall(1, System.currentTimeMillis(), alice.id, CallTable.Type.AUDIO_CALL, CallTable.Direction.OUTGOING, CallTable.Event.ACCEPTED)
 
     val threadId = SignalDatabase.threads.getThreadIdFor(messageHelper.alice)!!
-    SignalDatabase.messages.getMessageCountForThread(threadId) assertIs 23
+    assertThat(SignalDatabase.messages.getMessageCountForThread(threadId)).isEqualTo(23)
 
     // WHEN
     Log.v(TAG, "Processing sync message")
@@ -342,8 +343,8 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
     )
 
     // THEN
-    SignalDatabase.messages.getMessageCountForThread(threadId) assertIs 0
-    SignalDatabase.threads.getThreadRecord(threadId) assertIs null
+    assertThat(SignalDatabase.messages.getMessageCountForThread(threadId)).isEqualTo(0)
+    assertThat(SignalDatabase.threads.getThreadRecord(threadId)).isNull()
   }
 
   @Test
@@ -362,7 +363,7 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
     SignalDatabase.calls.insertOneToOneCall(1, System.currentTimeMillis(), alice.id, CallTable.Type.AUDIO_CALL, CallTable.Direction.OUTGOING, CallTable.Event.ACCEPTED)
 
     val threadId = SignalDatabase.threads.getThreadIdFor(messageHelper.alice)!!
-    SignalDatabase.messages.getMessageCountForThread(threadId) assertIs 23
+    assertThat(SignalDatabase.messages.getMessageCountForThread(threadId)).isEqualTo(23)
 
     // WHEN
     messageHelper.syncDeleteForMeConversation(
@@ -374,8 +375,8 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
     )
 
     // THEN
-    SignalDatabase.messages.getMessageCountForThread(threadId) assertIs 3
-    SignalDatabase.threads.getThreadRecord(threadId).assertIsNotNull()
+    assertThat(SignalDatabase.messages.getMessageCountForThread(threadId)).isEqualTo(3)
+    assertThat(SignalDatabase.threads.getThreadRecord(threadId)).isNotNull()
   }
 
   @Test
@@ -403,8 +404,8 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
     )
 
     // THEN
-    SignalDatabase.messages.getMessageCountForThread(threadId) assertIs 0
-    SignalDatabase.threads.getThreadRecord(threadId) assertIs null
+    assertThat(SignalDatabase.messages.getMessageCountForThread(threadId)).isEqualTo(0)
+    assertThat(SignalDatabase.threads.getThreadRecord(threadId)).isNull()
   }
 
   @Test
@@ -423,9 +424,9 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
     }
 
     val threadIds = allMessages.keys.map { SignalDatabase.threads.getThreadIdFor(it)!! }
-    threadIds.forEach { SignalDatabase.messages.getMessageCountForThread(it) assertIs 20 }
+    threadIds.forEach { assertThat(SignalDatabase.messages.getMessageCountForThread(it)).isEqualTo(20) }
 
-    // WHEN
+      // WHEN
     messageHelper.syncDeleteForMeConversation(
       DeleteForMeSync(conversationId = messageHelper.alice, allMessages[messageHelper.alice]!!.takeLast(5).map { it.recipientId to it.timetamp }, isFullDelete = true),
       DeleteForMeSync(conversationId = messageHelper.bob, allMessages[messageHelper.bob]!!.takeLast(5).map { it.recipientId to it.timetamp }, isFullDelete = true)
@@ -433,8 +434,8 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
 
     // THEN
     threadIds.forEach {
-      SignalDatabase.messages.getMessageCountForThread(it) assertIs 0
-      SignalDatabase.threads.getThreadRecord(it) assertIs null
+      assertThat(SignalDatabase.messages.getMessageCountForThread(it)).isEqualTo(0)
+      assertThat(SignalDatabase.threads.getThreadRecord(it)).isNull()
     }
   }
 
@@ -461,8 +462,8 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
     messageHelper.syncDeleteForMeLocalOnlyConversation(messageHelper.alice)
 
     // THEN
-    SignalDatabase.messages.getMessageCountForThread(aliceThreadId) assertIs 0
-    SignalDatabase.threads.getThreadRecord(aliceThreadId) assertIs null
+    assertThat(SignalDatabase.messages.getMessageCountForThread(aliceThreadId)).isEqualTo(0)
+    assertThat(SignalDatabase.threads.getThreadRecord(aliceThreadId)).isNull()
   }
 
   @Ignore("counts are consistent for some reason")
@@ -517,19 +518,19 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
     SignalDatabase.messages.deleteMessage(messageId = groupPlaceholderMessage, threadId = aliceThreadId, notify = false, updateThread = false)
 
     SignalDatabase.rawDatabase.withinTransaction {
-      SignalDatabase.messages.getMessageCountForThread(aliceThreadId) assertIs 16
-      SignalDatabase.messages.getMessageCountForThread(groupThreadId) assertIs 10
+      assertThat(SignalDatabase.messages.getMessageCountForThread(aliceThreadId)).isEqualTo(16)
+      assertThat(SignalDatabase.messages.getMessageCountForThread(groupThreadId)).isEqualTo(10)
     }
 
     // WHEN
     messageHelper.syncDeleteForMeLocalOnlyConversation(messageHelper.alice, messageHelper.group.recipientId)
 
     // THEN
-    SignalDatabase.messages.getMessageCountForThread(aliceThreadId) assertIs 0
-    SignalDatabase.threads.getThreadRecord(aliceThreadId) assertIs null
+    assertThat(SignalDatabase.messages.getMessageCountForThread(aliceThreadId)).isEqualTo(0)
+    assertThat(SignalDatabase.threads.getThreadRecord(aliceThreadId)).isNull()
 
-    SignalDatabase.messages.getMessageCountForThread(groupThreadId) assertIs 0
-    SignalDatabase.threads.getThreadRecord(groupThreadId) assertIs null
+    assertThat(SignalDatabase.messages.getMessageCountForThread(groupThreadId)).isEqualTo(0)
+    assertThat(SignalDatabase.threads.getThreadRecord(groupThreadId)).isNull()
   }
 
   @Test
@@ -543,17 +544,17 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
     }
 
     val threadId = SignalDatabase.threads.getThreadIdFor(messageHelper.alice)!!
-    SignalDatabase.messages.getMessageCountForThread(threadId) assertIs 20
+    assertThat(SignalDatabase.messages.getMessageCountForThread(threadId)).isEqualTo(20)
 
     // WHEN
     messageHelper.syncDeleteForMeLocalOnlyConversation(messageHelper.alice)
 
     // THEN
-    SignalDatabase.messages.getMessageCountForThread(threadId) assertIs 20
-    SignalDatabase.threads.getThreadRecord(threadId).assertIsNotNull()
+    assertThat(SignalDatabase.messages.getMessageCountForThread(threadId)).isEqualTo(20)
+    assertThat(SignalDatabase.threads.getThreadRecord(threadId)).isNotNull()
 
     harness.inMemoryLogger.flush()
-    harness.inMemoryLogger.entries().filter { it.message?.contains("Thread is not local only") == true }.size assertIs 1
+    assertThat(harness.inMemoryLogger.entries().filter { it.message?.contains("Thread is not local only") == true }).hasSize(1)
   }
 
   @Test
@@ -571,10 +572,10 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
     }
 
     var attachments = SignalDatabase.attachments.getAttachmentsForMessage(message1.messageId)
-    attachments assertIsSize 4
+    assertThat(attachments).hasSize(4)
 
     val threadId = SignalDatabase.threads.getThreadIdFor(messageHelper.alice)!!
-    SignalDatabase.messages.getMessageCountForThread(threadId) assertIs 1
+    assertThat(SignalDatabase.messages.getMessageCountForThread(threadId)).isEqualTo(1)
 
     // Has all three
     SignalDatabase.attachments.finalizeAttachmentAfterUpload(
@@ -621,10 +622,10 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
       attachments[0].dataHash
     )
 
-    SignalDatabase.messages.getMessageCountForThread(threadId) assertIs 1
+    assertThat(SignalDatabase.messages.getMessageCountForThread(threadId)).isEqualTo(1)
     var updatedAttachments = SignalDatabase.attachments.getAttachmentsForMessage(message1.messageId)
-    updatedAttachments assertIsSize 3
-    updatedAttachments.forEach { it.attachmentId assertIsNot attachments[0].attachmentId }
+    assertThat(updatedAttachments).hasSize(3)
+    updatedAttachments.forEach { assertThat(it.attachmentId).isNotEqualTo(attachments[0].attachmentId) }
 
     messageHelper.syncDeleteForMeAttachment(
       conversationId = messageHelper.alice,
@@ -634,10 +635,10 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
       attachments[1].dataHash
     )
 
-    SignalDatabase.messages.getMessageCountForThread(threadId) assertIs 1
+    assertThat(SignalDatabase.messages.getMessageCountForThread(threadId)).isEqualTo(1)
     updatedAttachments = SignalDatabase.attachments.getAttachmentsForMessage(message1.messageId)
-    updatedAttachments assertIsSize 2
-    updatedAttachments.forEach { it.attachmentId assertIsNot attachments[1].attachmentId }
+    assertThat(updatedAttachments).hasSize(2)
+    updatedAttachments.forEach { assertThat(it.attachmentId).isNotEqualTo(attachments[1].attachmentId) }
 
     messageHelper.syncDeleteForMeAttachment(
       conversationId = messageHelper.alice,
@@ -647,10 +648,10 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
       attachments[2].dataHash
     )
 
-    SignalDatabase.messages.getMessageCountForThread(threadId) assertIs 1
+    assertThat(SignalDatabase.messages.getMessageCountForThread(threadId)).isEqualTo(1)
     updatedAttachments = SignalDatabase.attachments.getAttachmentsForMessage(message1.messageId)
-    updatedAttachments assertIsSize 1
-    updatedAttachments.forEach { it.attachmentId assertIsNot attachments[2].attachmentId }
+    assertThat(updatedAttachments).hasSize(1)
+    updatedAttachments.forEach { assertThat(it.attachmentId).isNotEqualTo(attachments[2].attachmentId) }
 
     messageHelper.syncDeleteForMeAttachment(
       conversationId = messageHelper.alice,
@@ -660,11 +661,11 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
       attachments[3].dataHash
     )
 
-    SignalDatabase.messages.getMessageCountForThread(threadId) assertIs 0
+    assertThat(SignalDatabase.messages.getMessageCountForThread(threadId)).isEqualTo(0)
     updatedAttachments = SignalDatabase.attachments.getAttachmentsForMessage(message1.messageId)
-    updatedAttachments assertIsSize 0
+    assertThat(updatedAttachments).isEmpty()
 
-    SignalDatabase.threads.getThreadRecord(threadId) assertIs null
+    assertThat(SignalDatabase.threads.getThreadRecord(threadId)).isNull()
   }
 
   private fun DatabaseAttachment.copy(

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/messages/SyncMessageProcessorTest_synchronizeDeleteForMe.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/messages/SyncMessageProcessorTest_synchronizeDeleteForMe.kt
@@ -6,7 +6,6 @@
 package org.thoughtcrime.securesms.messages
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.hamcrest.Matchers.greaterThan
 import org.junit.After
 import org.junit.Before
 import org.junit.Ignore
@@ -38,6 +37,8 @@ import org.thoughtcrime.securesms.util.Util
 import org.whispersystems.signalservice.api.attachment.AttachmentUploadResult
 import org.whispersystems.signalservice.api.messages.SignalServiceAttachmentRemoteId
 import java.util.UUID
+import assertk.assertThat
+import assertk.assertions.isGreaterThan
 
 @Suppress("ClassName")
 @RunWith(AndroidJUnit4::class)
@@ -454,7 +455,7 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
 
     // Cleanup and confirm setup
     SignalDatabase.messages.deleteMessage(messageId = oneToOnePlaceHolderMessage, threadId = aliceThreadId, notify = false, updateThread = false)
-    SignalDatabase.messages.getMessageCountForThread(aliceThreadId) assert greaterThan(0)
+    assertThat(SignalDatabase.messages.getMessageCountForThread(aliceThreadId)).isGreaterThan(0)
 
     // WHEN
     messageHelper.syncDeleteForMeLocalOnlyConversation(messageHelper.alice)

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/messages/SyncMessageProcessorTest_synchronizeDeleteForMe.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/messages/SyncMessageProcessorTest_synchronizeDeleteForMe.kt
@@ -6,6 +6,14 @@
 package org.thoughtcrime.securesms.messages
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import org.junit.After
 import org.junit.Before
 import org.junit.Ignore
@@ -32,14 +40,6 @@ import org.thoughtcrime.securesms.util.Util
 import org.whispersystems.signalservice.api.attachment.AttachmentUploadResult
 import org.whispersystems.signalservice.api.messages.SignalServiceAttachmentRemoteId
 import java.util.UUID
-import assertk.assertThat
-import assertk.assertions.isGreaterThan
-import assertk.assertions.isEqualTo
-import assertk.assertions.isNotEqualTo
-import assertk.assertions.isNotNull
-import assertk.assertions.isNull
-import assertk.assertions.hasSize
-import assertk.assertions.isEmpty
 
 @Suppress("ClassName")
 @RunWith(AndroidJUnit4::class)
@@ -426,7 +426,7 @@ class SyncMessageProcessorTest_synchronizeDeleteForMe {
     val threadIds = allMessages.keys.map { SignalDatabase.threads.getThreadIdFor(it)!! }
     threadIds.forEach { assertThat(SignalDatabase.messages.getMessageCountForThread(it)).isEqualTo(20) }
 
-      // WHEN
+    // WHEN
     messageHelper.syncDeleteForMeConversation(
       DeleteForMeSync(conversationId = messageHelper.alice, allMessages[messageHelper.alice]!!.takeLast(5).map { it.recipientId to it.timetamp }, isFullDelete = true),
       DeleteForMeSync(conversationId = messageHelper.bob, allMessages[messageHelper.bob]!!.takeLast(5).map { it.recipientId to it.timetamp }, isFullDelete = true)

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/migrations/GooglePlayBillingPurchaseTokenMigrationJobTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/migrations/GooglePlayBillingPurchaseTokenMigrationJobTest.kt
@@ -17,9 +17,10 @@ import org.thoughtcrime.securesms.database.model.InAppPaymentSubscriberRecord
 import org.thoughtcrime.securesms.database.model.databaseprotos.InAppPaymentData
 import org.thoughtcrime.securesms.dependencies.AppDependencies
 import org.thoughtcrime.securesms.testing.SignalActivityRule
-import org.thoughtcrime.securesms.testing.assertIs
 import org.whispersystems.signalservice.api.storage.IAPSubscriptionId
 import org.whispersystems.signalservice.api.subscriptions.SubscriberId
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 
 @RunWith(AndroidJUnit4::class)
 class GooglePlayBillingPurchaseTokenMigrationJobTest {
@@ -101,7 +102,7 @@ class GooglePlayBillingPurchaseTokenMigrationJobTest {
 
     val sub = SignalDatabase.inAppPaymentSubscribers.getBackupsSubscriber()
 
-    sub?.iapSubscriptionId?.purchaseToken assertIs "-"
+    assertThat(sub?.iapSubscriptionId?.purchaseToken).isEqualTo("-")
   }
 
   @Test
@@ -126,7 +127,7 @@ class GooglePlayBillingPurchaseTokenMigrationJobTest {
 
     val sub = SignalDatabase.inAppPaymentSubscribers.getBackupsSubscriber()
 
-    sub?.iapSubscriptionId?.purchaseToken assertIs "-"
+    assertThat(sub?.iapSubscriptionId?.purchaseToken).isEqualTo("-")
   }
 
   @Test
@@ -157,6 +158,6 @@ class GooglePlayBillingPurchaseTokenMigrationJobTest {
 
     val sub = SignalDatabase.inAppPaymentSubscribers.getBackupsSubscriber()
 
-    sub?.iapSubscriptionId?.purchaseToken assertIs "purchaseToken"
+    assertThat(sub?.iapSubscriptionId?.purchaseToken).isEqualTo("purchaseToken")
   }
 }

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/migrations/GooglePlayBillingPurchaseTokenMigrationJobTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/migrations/GooglePlayBillingPurchaseTokenMigrationJobTest.kt
@@ -1,6 +1,8 @@
 package org.thoughtcrime.securesms.migrations
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import io.mockk.Called
 import io.mockk.coEvery
 import io.mockk.verify
@@ -19,8 +21,6 @@ import org.thoughtcrime.securesms.dependencies.AppDependencies
 import org.thoughtcrime.securesms.testing.SignalActivityRule
 import org.whispersystems.signalservice.api.storage.IAPSubscriptionId
 import org.whispersystems.signalservice.api.subscriptions.SubscriberId
-import assertk.assertThat
-import assertk.assertions.isEqualTo
 
 @RunWith(AndroidJUnit4::class)
 class GooglePlayBillingPurchaseTokenMigrationJobTest {

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/migrations/SubscriberIdMigrationJobTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/migrations/SubscriberIdMigrationJobTest.kt
@@ -1,6 +1,10 @@
 package org.thoughtcrime.securesms.migrations
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.signal.core.util.count
@@ -13,10 +17,6 @@ import org.thoughtcrime.securesms.database.model.databaseprotos.InAppPaymentData
 import org.thoughtcrime.securesms.keyvalue.SignalStore
 import org.whispersystems.signalservice.api.subscriptions.SubscriberId
 import java.util.Currency
-import assertk.assertThat
-import assertk.assertions.isEqualTo
-import assertk.assertions.isTrue
-import assertk.assertions.isNotNull
 
 @RunWith(AndroidJUnit4::class)
 class SubscriberIdMigrationJobTest {

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/migrations/SubscriberIdMigrationJobTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/migrations/SubscriberIdMigrationJobTest.kt
@@ -11,10 +11,12 @@ import org.thoughtcrime.securesms.database.SignalDatabase
 import org.thoughtcrime.securesms.database.model.InAppPaymentSubscriberRecord
 import org.thoughtcrime.securesms.database.model.databaseprotos.InAppPaymentData
 import org.thoughtcrime.securesms.keyvalue.SignalStore
-import org.thoughtcrime.securesms.testing.assertIs
-import org.thoughtcrime.securesms.testing.assertIsNotNull
 import org.whispersystems.signalservice.api.subscriptions.SubscriberId
 import java.util.Currency
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
+import assertk.assertions.isNotNull
 
 @RunWith(AndroidJUnit4::class)
 class SubscriberIdMigrationJobTest {
@@ -30,7 +32,7 @@ class SubscriberIdMigrationJobTest {
       .run()
       .readToSingleInt()
 
-    actual assertIs 0
+    assertThat(actual).isEqualTo(0)
   }
 
   @Test
@@ -45,11 +47,14 @@ class SubscriberIdMigrationJobTest {
 
     val actual = SignalDatabase.inAppPaymentSubscribers.getByCurrencyCode("USD")
 
-    actual.assertIsNotNull()
-    actual!!.subscriberId.bytes assertIs subscriberId.bytes
-    actual.paymentMethodType assertIs InAppPaymentData.PaymentMethodType.PAYPAL
-    actual.requiresCancel assertIs true
-    actual.currency assertIs Currency.getInstance("USD")
-    actual.type assertIs InAppPaymentSubscriberRecord.Type.DONATION
+    assertThat(actual)
+      .isNotNull()
+      .given {
+        assertThat(it.subscriberId.bytes).isEqualTo(subscriberId.bytes)
+        assertThat(it.paymentMethodType).isEqualTo(InAppPaymentData.PaymentMethodType.PAYPAL)
+        assertThat(it.requiresCancel).isTrue()
+        assertThat(it.currency).isEqualTo(Currency.getInstance("USD"))
+        assertThat(it.type).isEqualTo(InAppPaymentSubscriberRecord.Type.DONATION)
+      }
   }
 }

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/profiles/manage/UsernameEditFragmentTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/profiles/manage/UsernameEditFragmentTest.kt
@@ -18,6 +18,9 @@ import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import io.reactivex.rxjava3.schedulers.TestScheduler
 import okhttp3.mockwebserver.MockResponse
 import org.junit.After
@@ -34,9 +37,6 @@ import org.thoughtcrime.securesms.testing.success
 import org.whispersystems.signalservice.api.util.Usernames
 import org.whispersystems.signalservice.internal.push.ReserveUsernameResponse
 import java.util.concurrent.TimeUnit
-import assertk.assertThat
-import assertk.assertions.isNotNull
-import assertk.assertions.isNull
 
 @RunWith(AndroidJUnit4::class)
 class UsernameEditFragmentTest {

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/profiles/manage/UsernameEditFragmentTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/profiles/manage/UsernameEditFragmentTest.kt
@@ -30,12 +30,13 @@ import org.thoughtcrime.securesms.dependencies.InstrumentationApplicationDepende
 import org.thoughtcrime.securesms.testing.Put
 import org.thoughtcrime.securesms.testing.RxTestSchedulerRule
 import org.thoughtcrime.securesms.testing.SignalActivityRule
-import org.thoughtcrime.securesms.testing.assertIsNotNull
-import org.thoughtcrime.securesms.testing.assertIsNull
 import org.thoughtcrime.securesms.testing.success
 import org.whispersystems.signalservice.api.util.Usernames
 import org.whispersystems.signalservice.internal.push.ReserveUsernameResponse
 import java.util.concurrent.TimeUnit
+import assertk.assertThat
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 
 @RunWith(AndroidJUnit4::class)
 class UsernameEditFragmentTest {
@@ -65,10 +66,9 @@ class UsernameEditFragmentTest {
     scenario.moveToState(Lifecycle.State.RESUMED)
 
     onView(withId(R.id.toolbar)).check { view, noViewFoundException ->
-      noViewFoundException.assertIsNull()
+      assertThat(noViewFoundException).isNull()
       val toolbar = view as Toolbar
-
-      toolbar.navigationIcon.assertIsNotNull()
+      assertThat(toolbar.navigationIcon).isNotNull()
     }
 
     onView(withText(R.string.UsernameEditFragment_username)).check(matches(isDisplayed()))

--- a/app/src/androidTest/java/org/thoughtcrime/securesms/testing/TestUtils.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/testing/TestUtils.kt
@@ -1,13 +1,6 @@
 package org.thoughtcrime.securesms.testing
 
 import android.database.Cursor
-import org.hamcrest.Matcher
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.hasSize
-import org.hamcrest.Matchers.`is`
-import org.hamcrest.Matchers.not
-import org.hamcrest.Matchers.notNullValue
-import org.hamcrest.Matchers.nullValue
 import org.signal.core.util.Hex
 import org.signal.core.util.logging.Log
 import org.signal.core.util.readToList
@@ -33,32 +26,6 @@ fun runSync(runnable: () -> Unit) {
     }
   }.start()
   lock.await()
-}
-
-/* Various kotlin-ifications of hamcrest matchers */
-
-fun <T : Any?> T.assertIsNull() {
-  assertThat(this, nullValue())
-}
-
-fun <T : Any?> T.assertIsNotNull() {
-  assertThat(this, notNullValue())
-}
-
-infix fun <T : Any?> T.assertIs(expected: T) {
-  assertThat(this, `is`(expected))
-}
-
-infix fun <T : Any> T.assertIsNot(expected: T) {
-  assertThat(this, not(`is`(expected)))
-}
-
-infix fun <E, T : Collection<E>> T.assertIsSize(expected: Int) {
-  assertThat(this, hasSize(expected))
-}
-
-infix fun <T : Any> T.assert(matcher: Matcher<T>) {
-  assertThat(this, matcher)
 }
 
 fun CountDownLatch.awaitFor(duration: Duration) {

--- a/app/src/test/java/org/thoughtcrime/securesms/backup/v2/ArchivedMediaObjectIteratorTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/backup/v2/ArchivedMediaObjectIteratorTest.kt
@@ -1,10 +1,11 @@
 package org.thoughtcrime.securesms.backup.v2
 
+import assertk.assertThat
+import assertk.assertions.hasSize
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Test
 import org.thoughtcrime.securesms.MockCursor
-import org.thoughtcrime.securesms.assertIsSize
 
 class ArchivedMediaObjectIteratorTest {
   private val cursor = mockk<MockCursor>(relaxed = true) {
@@ -32,6 +33,6 @@ class ArchivedMediaObjectIteratorTest {
 
     val list = iterator.asSequence().toList()
 
-    list.assertIsSize(size)
+    assertThat(list).hasSize(size)
   }
 }

--- a/app/src/test/java/org/thoughtcrime/securesms/components/settings/app/subscription/RecurringInAppPaymentRepositoryTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/components/settings/app/subscription/RecurringInAppPaymentRepositoryTest.kt
@@ -2,6 +2,8 @@ package org.thoughtcrime.securesms.components.settings.app.subscription
 
 import android.app.Application
 import androidx.lifecycle.AtomicReference
+import assertk.assertThat
+import assertk.assertions.isNotEqualTo
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -18,7 +20,6 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.signal.donations.InAppPaymentType
 import org.signal.donations.PaymentSourceType
-import org.thoughtcrime.securesms.assertIsNot
 import org.thoughtcrime.securesms.components.settings.app.subscription.errors.DonationError
 import org.thoughtcrime.securesms.database.InAppPaymentTable
 import org.thoughtcrime.securesms.database.SignalDatabase
@@ -106,7 +107,7 @@ class RecurringInAppPaymentRepositoryTest {
 
     val newSubscriber = ref.get()
 
-    newSubscriber assertIsNot initialSubscriber
+    assertThat(newSubscriber).isNotEqualTo(initialSubscriber)
   }
 
   @Test
@@ -124,7 +125,7 @@ class RecurringInAppPaymentRepositoryTest {
 
     val newSubscriber = ref.get()
 
-    newSubscriber assertIsNot initialSubscriber
+    assertThat(newSubscriber).isNotEqualTo(initialSubscriber)
   }
 
   @Test
@@ -136,7 +137,7 @@ class RecurringInAppPaymentRepositoryTest {
     rxRule.defaultScheduler.triggerActions()
     testObserver.assertComplete()
 
-    ref.get() assertIsNot null
+    assertThat(ref.get()).isNotEqualTo(null)
     verify(inverse = true) {
       AppDependencies.donationsService.cancelSubscription(any())
     }
@@ -152,7 +153,7 @@ class RecurringInAppPaymentRepositoryTest {
     rxRule.defaultScheduler.triggerActions()
     testObserver.assertComplete()
 
-    ref.get() assertIsNot null
+    assertThat(ref.get()).isNotEqualTo(null)
     verify {
       AppDependencies.donationsService.cancelSubscription(any())
     }

--- a/app/src/test/java/org/thoughtcrime/securesms/components/webrtc/CallParticipantListUpdateTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/components/webrtc/CallParticipantListUpdateTest.kt
@@ -1,9 +1,9 @@
 package org.thoughtcrime.securesms.components.webrtc
 
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.containsInAnyOrder
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import assertk.assertThat
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
 import org.junit.Test
 import org.thoughtcrime.securesms.events.CallParticipant
 import org.thoughtcrime.securesms.events.CallParticipant.Companion.createRemote
@@ -21,8 +21,8 @@ class CallParticipantListUpdateTest {
     val update = CallParticipantListUpdate(added, removed)
 
     // THEN
-    assertTrue(update.hasNoChanges())
-    assertFalse(update.hasSingleChange())
+    assertThat(update.hasNoChanges()).isTrue()
+    assertThat(update.hasSingleChange()).isFalse()
   }
 
   @Test
@@ -33,8 +33,8 @@ class CallParticipantListUpdateTest {
     val update = CallParticipantListUpdate(added, removed)
 
     // THEN
-    assertFalse(update.hasNoChanges())
-    assertFalse(update.hasSingleChange())
+    assertThat(update.hasNoChanges()).isFalse()
+    assertThat(update.hasSingleChange()).isFalse()
   }
 
   @Test
@@ -45,8 +45,8 @@ class CallParticipantListUpdateTest {
     val update = CallParticipantListUpdate(added, removed)
 
     // THEN
-    assertFalse(update.hasNoChanges())
-    assertFalse(update.hasSingleChange())
+    assertThat(update.hasNoChanges()).isFalse()
+    assertThat(update.hasSingleChange()).isFalse()
   }
 
   @Test
@@ -57,8 +57,8 @@ class CallParticipantListUpdateTest {
     val update = CallParticipantListUpdate(added, removed)
 
     // THEN
-    assertFalse(update.hasNoChanges())
-    assertTrue(update.hasSingleChange())
+    assertThat(update.hasNoChanges()).isFalse()
+    assertThat(update.hasSingleChange()).isTrue()
   }
 
   @Test
@@ -70,9 +70,9 @@ class CallParticipantListUpdateTest {
     val update = CallParticipantListUpdate.computeDeltaUpdate(emptyList(), newList)
 
     // THEN
-    assertFalse(update.hasNoChanges())
-    assertTrue(update.removed.isEmpty())
-    assertThat(update.added, containsInAnyOrder(*createWrappers(1, 2, 3, 4, 5)))
+    assertThat(update.hasNoChanges()).isFalse()
+    assertThat(update.removed.isEmpty()).isTrue()
+    assertThat(update.added).containsExactlyInAnyOrder(*createWrappers(1, 2, 3, 4, 5))
   }
 
   @Test
@@ -84,7 +84,7 @@ class CallParticipantListUpdateTest {
     val update = CallParticipantListUpdate.computeDeltaUpdate(newList, newList)
 
     // THEN
-    assertTrue(update.hasNoChanges())
+    assertThat(update.hasNoChanges()).isTrue()
   }
 
   @Test
@@ -96,7 +96,7 @@ class CallParticipantListUpdateTest {
     val update = CallParticipantListUpdate.computeDeltaUpdate(emptyList(), newList)
 
     // THEN
-    assertTrue(update.hasNoChanges())
+    assertThat(update.hasNoChanges()).isTrue()
   }
 
   @Test
@@ -109,9 +109,9 @@ class CallParticipantListUpdateTest {
     val update = CallParticipantListUpdate.computeDeltaUpdate(list1, list2)
 
     // THEN
-    assertFalse(update.hasNoChanges())
-    assertThat(update.added, containsInAnyOrder(*createWrappers(6)))
-    assertThat(update.removed, containsInAnyOrder(*createWrappers(1)))
+    assertThat(update.hasNoChanges()).isFalse()
+    assertThat(update.added).containsExactlyInAnyOrder(*createWrappers(6))
+    assertThat(update.removed).containsExactlyInAnyOrder(*createWrappers(1))
   }
 
   @Test
@@ -124,7 +124,7 @@ class CallParticipantListUpdateTest {
 
     // THEN
     val isPrimaryList = update.added.map { it.callParticipant.isPrimary }.toList()
-    assertThat(isPrimaryList, containsInAnyOrder(true, false, false))
+    assertThat(isPrimaryList).containsExactlyInAnyOrder(true, false, false)
   }
 
   companion object {

--- a/app/src/test/java/org/thoughtcrime/securesms/conversation/MessageStylerTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/conversation/MessageStylerTest.kt
@@ -8,19 +8,25 @@ package org.thoughtcrime.securesms.conversation
 import android.app.Application
 import android.text.Spannable
 import android.text.SpannableString
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.prop
+import assertk.assertions.single
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import org.thoughtcrime.securesms.assertIs
-import org.thoughtcrime.securesms.assertIsNull
+import org.thoughtcrime.securesms.database.model.databaseprotos.BodyRangeList.BodyRange
 import org.thoughtcrime.securesms.database.model.databaseprotos.BodyRangeList.BodyRange.Style
 
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, application = Application::class)
 class MessageStylerTest {
-
   private lateinit var text: Spannable
 
   @Before
@@ -33,21 +39,23 @@ class MessageStylerTest {
     MessageStyler.toggleStyle(Style.BOLD, text, 0, 5)
     MessageStyler.toggleStyle(Style.ITALIC, text, 10, 15)
 
-    val bodyRange = MessageStyler.getStyling(text)!!
+    val bodyRange = MessageStyler.getStyling(text)
 
-    bodyRange.ranges.size assertIs 2
-
-    bodyRange.ranges[0].apply {
-      style assertIs Style.BOLD
-      start assertIs 0
-      length assertIs 5
-    }
-
-    bodyRange.ranges[1].apply {
-      style assertIs Style.ITALIC
-      start assertIs 10
-      length assertIs 5
-    }
+    assertThat(bodyRange)
+      .isNotNull()
+      .transform {
+        assertThat(it.ranges).hasSize(2)
+        assertThat(it.ranges[0]).all {
+          prop(BodyRange::style).isEqualTo(Style.BOLD)
+          prop(BodyRange::start).isEqualTo(0)
+          prop(BodyRange::length).isEqualTo(5)
+        }
+        assertThat(it.ranges[1]).all {
+          prop(BodyRange::style).isEqualTo(Style.ITALIC)
+          prop(BodyRange::start).isEqualTo(10)
+          prop(BodyRange::length).isEqualTo(5)
+        }
+      }
   }
 
   @Test
@@ -55,21 +63,23 @@ class MessageStylerTest {
     MessageStyler.toggleStyle(Style.BOLD, text, 0, 5)
     MessageStyler.toggleStyle(Style.ITALIC, text, 3, 10)
 
-    val bodyRange = MessageStyler.getStyling(text)!!
+    val bodyRange = MessageStyler.getStyling(text)
 
-    bodyRange.ranges.size assertIs 2
-
-    bodyRange.ranges[0].apply {
-      style assertIs Style.BOLD
-      start assertIs 0
-      length assertIs 5
-    }
-
-    bodyRange.ranges[1].apply {
-      style assertIs Style.ITALIC
-      start assertIs 3
-      length assertIs 7
-    }
+    assertThat(bodyRange)
+      .isNotNull()
+      .transform {
+        assertThat(it.ranges).hasSize(2)
+        assertThat(it.ranges[0]).all {
+          prop(BodyRange::style).isEqualTo(Style.BOLD)
+          prop(BodyRange::start).isEqualTo(0)
+          prop(BodyRange::length).isEqualTo(5)
+        }
+        assertThat(it.ranges[1]).all {
+          prop(BodyRange::style).isEqualTo(Style.ITALIC)
+          prop(BodyRange::start).isEqualTo(3)
+          prop(BodyRange::length).isEqualTo(7)
+        }
+      }
   }
 
   @Test
@@ -77,15 +87,17 @@ class MessageStylerTest {
     MessageStyler.toggleStyle(Style.BOLD, text, 3, 10)
     MessageStyler.toggleStyle(Style.BOLD, text, 0, 5)
 
-    val bodyRange = MessageStyler.getStyling(text)!!
+    val bodyRange = MessageStyler.getStyling(text)
 
-    bodyRange.ranges.size assertIs 1
-
-    bodyRange.ranges[0].apply {
-      style assertIs Style.BOLD
-      start assertIs 0
-      length assertIs 10
-    }
+    assertThat(bodyRange)
+      .isNotNull()
+      .transform { it.ranges }
+      .single()
+      .all {
+        prop(BodyRange::style).isEqualTo(Style.BOLD)
+        prop(BodyRange::start).isEqualTo(0)
+        prop(BodyRange::length).isEqualTo(10)
+      }
   }
 
   @Test
@@ -93,15 +105,17 @@ class MessageStylerTest {
     MessageStyler.toggleStyle(Style.BOLD, text, 0, 5)
     MessageStyler.toggleStyle(Style.BOLD, text, 3, 10)
 
-    val bodyRange = MessageStyler.getStyling(text)!!
+    val bodyRange = MessageStyler.getStyling(text)
 
-    bodyRange.ranges.size assertIs 1
-
-    bodyRange.ranges[0].apply {
-      style assertIs Style.BOLD
-      start assertIs 0
-      length assertIs 10
-    }
+    assertThat(bodyRange)
+      .isNotNull()
+      .transform { it.ranges }
+      .single()
+      .all {
+        prop(BodyRange::style).isEqualTo(Style.BOLD)
+        prop(BodyRange::start).isEqualTo(0)
+        prop(BodyRange::length).isEqualTo(10)
+      }
   }
 
   @Test
@@ -109,21 +123,23 @@ class MessageStylerTest {
     MessageStyler.toggleStyle(Style.BOLD, text, 0, 10)
     MessageStyler.toggleStyle(Style.BOLD, text, 4, 6)
 
-    val bodyRange = MessageStyler.getStyling(text)!!
+    val bodyRange = MessageStyler.getStyling(text)
 
-    bodyRange.ranges.size assertIs 2
-
-    bodyRange.ranges[0].apply {
-      style assertIs Style.BOLD
-      start assertIs 0
-      length assertIs 4
-    }
-
-    bodyRange.ranges[1].apply {
-      style assertIs Style.BOLD
-      start assertIs 6
-      length assertIs 4
-    }
+    assertThat(bodyRange)
+      .isNotNull()
+      .transform {
+        assertThat(it.ranges).hasSize(2)
+        assertThat(it.ranges[0]).all {
+          prop(BodyRange::style).isEqualTo(Style.BOLD)
+          prop(BodyRange::start).isEqualTo(0)
+          prop(BodyRange::length).isEqualTo(4)
+        }
+        assertThat(it.ranges[1]).all {
+          prop(BodyRange::style).isEqualTo(Style.BOLD)
+          prop(BodyRange::start).isEqualTo(6)
+          prop(BodyRange::length).isEqualTo(4)
+        }
+      }
   }
 
   @Test
@@ -131,15 +147,17 @@ class MessageStylerTest {
     MessageStyler.toggleStyle(Style.BOLD, text, 4, 6)
     MessageStyler.toggleStyle(Style.BOLD, text, 0, 10)
 
-    val bodyRange = MessageStyler.getStyling(text)!!
+    val bodyRange = MessageStyler.getStyling(text)
 
-    bodyRange.ranges.size assertIs 1
-
-    bodyRange.ranges[0].apply {
-      style assertIs Style.BOLD
-      start assertIs 0
-      length assertIs 10
-    }
+    assertThat(bodyRange)
+      .isNotNull()
+      .transform { it.ranges }
+      .single()
+      .all {
+        prop(BodyRange::style).isEqualTo(Style.BOLD)
+        prop(BodyRange::start).isEqualTo(0)
+        prop(BodyRange::length).isEqualTo(10)
+      }
   }
 
   @Test
@@ -149,7 +167,7 @@ class MessageStylerTest {
 
     val bodyRange = MessageStyler.getStyling(text)
 
-    bodyRange.assertIsNull()
+    assertThat(bodyRange).isNull()
   }
 
   @Test
@@ -158,15 +176,17 @@ class MessageStylerTest {
     MessageStyler.toggleStyle(Style.BOLD, text, 6, 8)
     MessageStyler.toggleStyle(Style.BOLD, text, 0, 10)
 
-    val bodyRange = MessageStyler.getStyling(text)!!
+    val bodyRange = MessageStyler.getStyling(text)
 
-    bodyRange.ranges.size assertIs 1
-
-    bodyRange.ranges[0].apply {
-      style assertIs Style.BOLD
-      start assertIs 0
-      length assertIs 10
-    }
+    assertThat(bodyRange)
+      .isNotNull()
+      .transform { it.ranges }
+      .single()
+      .all {
+        prop(BodyRange::style).isEqualTo(Style.BOLD)
+        prop(BodyRange::start).isEqualTo(0)
+        prop(BodyRange::length).isEqualTo(10)
+      }
   }
 
   @Test
@@ -175,15 +195,17 @@ class MessageStylerTest {
     MessageStyler.toggleStyle(Style.BOLD, text, 6, 8)
     MessageStyler.toggleStyle(Style.BOLD, text, 2, 7)
 
-    val bodyRange = MessageStyler.getStyling(text)!!
+    val bodyRange = MessageStyler.getStyling(text)
 
-    bodyRange.ranges.size assertIs 1
-
-    bodyRange.ranges[0].apply {
-      style assertIs Style.BOLD
-      start assertIs 0
-      length assertIs 8
-    }
+    assertThat(bodyRange)
+      .isNotNull()
+      .transform { it.ranges }
+      .single()
+      .all {
+        prop(BodyRange::style).isEqualTo(Style.BOLD)
+        prop(BodyRange::start).isEqualTo(0)
+        prop(BodyRange::length).isEqualTo(8)
+      }
   }
 
   @Test
@@ -191,20 +213,22 @@ class MessageStylerTest {
     MessageStyler.toggleStyle(Style.BOLD, text, 0, 10)
     MessageStyler.clearStyling(text, 3, 7)
 
-    val bodyRange = MessageStyler.getStyling(text)!!
+    val bodyRange = MessageStyler.getStyling(text)
 
-    bodyRange.ranges.size assertIs 2
-
-    bodyRange.ranges[0].apply {
-      style assertIs Style.BOLD
-      start assertIs 0
-      length assertIs 3
-    }
-
-    bodyRange.ranges[1].apply {
-      style assertIs Style.BOLD
-      start assertIs 7
-      length assertIs 3
-    }
+    assertThat(bodyRange)
+      .isNotNull()
+      .transform {
+        assertThat(it.ranges).hasSize(2)
+        assertThat(it.ranges[0]).all {
+          prop(BodyRange::style).isEqualTo(Style.BOLD)
+          prop(BodyRange::start).isEqualTo(0)
+          prop(BodyRange::length).isEqualTo(3)
+        }
+        assertThat(it.ranges[1]).all {
+          prop(BodyRange::style).isEqualTo(Style.BOLD)
+          prop(BodyRange::start).isEqualTo(7)
+          prop(BodyRange::length).isEqualTo(3)
+        }
+      }
   }
 }

--- a/app/src/test/java/org/thoughtcrime/securesms/crash/CrashConfigTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/crash/CrashConfigTest.kt
@@ -1,6 +1,9 @@
 package org.thoughtcrime.securesms.crash
 
 import android.app.Application
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEmpty
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
@@ -11,7 +14,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import org.thoughtcrime.securesms.assertIs
 import org.thoughtcrime.securesms.keyvalue.SignalStore
 import org.thoughtcrime.securesms.testutil.MockAppDependenciesRule
 import org.thoughtcrime.securesms.util.RemoteConfig
@@ -21,7 +23,6 @@ import java.util.UUID
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, application = Application::class)
 class CrashConfigTest {
-
   @get:Rule
   val appDependencies = MockAppDependenciesRule()
 
@@ -41,25 +42,26 @@ class CrashConfigTest {
   @Test
   fun `simple name pattern`() {
     every { RemoteConfig.crashPromptConfig } returns """[ { "name": "test", "percent": 100 } ]"""
-    CrashConfig.computePatterns() assertIs listOf(CrashConfig.CrashPattern(namePattern = "test"))
+    assertThat(CrashConfig.computePatterns()).containsExactly(CrashConfig.CrashPattern(namePattern = "test"))
   }
 
   @Test
   fun `simple message pattern`() {
     every { RemoteConfig.crashPromptConfig } returns """[ { "message": "test", "percent": 100 } ]"""
-    CrashConfig.computePatterns() assertIs listOf(CrashConfig.CrashPattern(messagePattern = "test"))
+    assertThat(CrashConfig.computePatterns()).containsExactly(CrashConfig.CrashPattern(messagePattern = "test"))
   }
 
   @Test
   fun `simple stackTrace pattern`() {
     every { RemoteConfig.crashPromptConfig } returns """[ { "stackTrace": "test", "percent": 100 } ]"""
-    CrashConfig.computePatterns() assertIs listOf(CrashConfig.CrashPattern(stackTracePattern = "test"))
+    assertThat(CrashConfig.computePatterns()).containsExactly(CrashConfig.CrashPattern(stackTracePattern = "test"))
   }
 
   @Test
   fun `all fields set`() {
     every { RemoteConfig.crashPromptConfig } returns """[ { "name": "test1", "message": "test2", "stackTrace": "test3", "percent": 100 } ]"""
-    CrashConfig.computePatterns() assertIs listOf(CrashConfig.CrashPattern(namePattern = "test1", messagePattern = "test2", stackTracePattern = "test3"))
+    assertThat(CrashConfig.computePatterns())
+      .containsExactly(CrashConfig.CrashPattern(namePattern = "test1", messagePattern = "test2", stackTracePattern = "test3"))
   }
 
   @Test
@@ -73,7 +75,7 @@ class CrashConfigTest {
       ]
       """
 
-    CrashConfig.computePatterns() assertIs listOf(
+    assertThat(CrashConfig.computePatterns()).containsExactly(
       CrashConfig.CrashPattern(namePattern = "test1"),
       CrashConfig.CrashPattern(messagePattern = "test2"),
       CrashConfig.CrashPattern(stackTracePattern = "test3")
@@ -91,7 +93,7 @@ class CrashConfigTest {
       ]
       """
 
-    CrashConfig.computePatterns() assertIs listOf(
+    assertThat(CrashConfig.computePatterns()).containsExactly(
       CrashConfig.CrashPattern(namePattern = "test1"),
       CrashConfig.CrashPattern(messagePattern = "test2")
     )
@@ -100,30 +102,30 @@ class CrashConfigTest {
   @Test
   fun `ignore zero percent`() {
     every { RemoteConfig.crashPromptConfig } returns """[ { "name": "test", "percent": 0 } ]"""
-    CrashConfig.computePatterns() assertIs emptyList()
+    assertThat(CrashConfig.computePatterns()).isEmpty()
   }
 
   @Test
   fun `not setting percent is the same as zero percent`() {
     every { RemoteConfig.crashPromptConfig } returns """[ { "name": "test" } ]"""
-    CrashConfig.computePatterns() assertIs emptyList()
+    assertThat(CrashConfig.computePatterns()).isEmpty()
   }
 
   @Test
   fun `ignore configs without a pattern`() {
     every { RemoteConfig.crashPromptConfig } returns """[ { "percent": 100 } ]"""
-    CrashConfig.computePatterns() assertIs emptyList()
+    assertThat(CrashConfig.computePatterns()).isEmpty()
   }
 
   @Test
   fun `ignore invalid json`() {
     every { RemoteConfig.crashPromptConfig } returns "asdf"
-    CrashConfig.computePatterns() assertIs emptyList()
+    assertThat(CrashConfig.computePatterns()).isEmpty()
   }
 
   @Test
   fun `ignore empty json`() {
     every { RemoteConfig.crashPromptConfig } returns ""
-    CrashConfig.computePatterns() assertIs emptyList()
+    assertThat(CrashConfig.computePatterns()).isEmpty()
   }
 }

--- a/app/src/test/java/org/thoughtcrime/securesms/database/MentionUtilTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/database/MentionUtilTest.kt
@@ -1,8 +1,8 @@
 package org.thoughtcrime.securesms.database
 
 import android.app.Application
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -13,14 +13,13 @@ import org.thoughtcrime.securesms.recipients.RecipientId
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, application = Application::class)
 class MentionUtilTest {
-
   @Test
   fun vanillaUpdate() {
     val mentions = listOf(Mention(RecipientId.from(1L), 0, 1))
 
     val update: MentionUtil.UpdatedBodyAndMentions = MentionUtil.update("T test", mentions) { it.recipientId.toString() }
 
-    assertThat(update.body.toString(), Matchers.`is`("RecipientId::1 test"))
+    assertThat(update.body.toString()).isEqualTo("RecipientId::1 test")
   }
 
   @Test
@@ -32,7 +31,7 @@ class MentionUtilTest {
 
     val update: MentionUtil.UpdatedBodyAndMentions = MentionUtil.update("ONETWO test", mentions) { it.recipientId.toString() }
 
-    assertThat(update.body.toString(), Matchers.`is`("RecipientId::1RecipientId::2 test"))
+    assertThat(update.body.toString()).isEqualTo("RecipientId::1RecipientId::2 test")
   }
 
   @Test
@@ -44,6 +43,6 @@ class MentionUtilTest {
 
     val update: MentionUtil.UpdatedBodyAndMentions = MentionUtil.update("T test", mentions) { it.recipientId.toString() }
 
-    assertThat(update.body.toString(), Matchers.`is`("RecipientId::1est"))
+    assertThat(update.body.toString()).isEqualTo("RecipientId::1est")
   }
 }

--- a/app/src/test/java/org/thoughtcrime/securesms/database/NotificationProfileTablesTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/database/NotificationProfileTablesTest.kt
@@ -149,13 +149,14 @@ class NotificationProfileTablesTest {
         enabled = true,
         start = 800,
         end = 1800,
-        daysEnabled = setOf(DayOfWeek.SUNDAY, DayOfWeek.FRIDAY)),
+        daysEnabled = setOf(DayOfWeek.SUNDAY, DayOfWeek.FRIDAY)
+      )
     )
     var updated = database.getProfile(profile.id)!!
     assertThat(updated.schedule.enabled).isTrue()
     assertThat(updated.schedule.start).isEqualTo(800)
     assertThat(updated.schedule.end).isEqualTo(1800)
-    assertThat( updated.schedule.daysEnabled, "Contains updated days days")
+    assertThat(updated.schedule.daysEnabled, "Contains updated days days")
       .containsExactlyInAnyOrder(DayOfWeek.SUNDAY, DayOfWeek.FRIDAY)
 
     database.updateSchedule(profile.schedule)
@@ -172,7 +173,7 @@ class NotificationProfileTablesTest {
           enabled = true,
           start = 800,
           end = 1800,
-          daysEnabled = setOf(DayOfWeek.SUNDAY, DayOfWeek.FRIDAY),
+          daysEnabled = setOf(DayOfWeek.SUNDAY, DayOfWeek.FRIDAY)
         )
       )
     ).profile

--- a/app/src/test/java/org/thoughtcrime/securesms/database/NotificationProfileTablesTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/database/NotificationProfileTablesTest.kt
@@ -3,12 +3,13 @@ package org.thoughtcrime.securesms.database
 import android.app.Application
 import android.database.sqlite.SQLiteDatabase
 import androidx.test.core.app.ApplicationProvider
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.containsInAnyOrder
+import assertk.assertThat
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import assertk.assertions.single
 import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -25,7 +26,6 @@ import java.time.DayOfWeek
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, application = Application::class)
 class NotificationProfileTablesTest {
-
   @get:Rule
   val appDependencies = MockAppDependenciesRule()
 
@@ -63,20 +63,23 @@ class NotificationProfileTablesTest {
       createdAt = 1000L
     ).profile
 
-    assertEquals(1, profile.id)
-    assertEquals("Profile", profile.name)
-    assertEquals("avatar", profile.emoji)
-    assertEquals(1000L, profile.createdAt)
-    assertEquals(1, profile.schedule.id)
+    assertThat(profile.id).isEqualTo(1)
+    assertThat(profile.name).isEqualTo("Profile")
+    assertThat(profile.emoji).isEqualTo("avatar")
+    assertThat(profile.createdAt).isEqualTo(1000L)
+    assertThat(profile.schedule.id).isEqualTo(1)
 
     val profiles = database.getProfiles()
 
-    assertEquals(1, profiles.size)
-    assertEquals(1, profiles[0].id)
-    assertEquals("Profile", profiles[0].name)
-    assertEquals("avatar", profiles[0].emoji)
-    assertEquals(1000L, profiles[0].createdAt)
-    assertEquals(1, profiles[0].schedule.id)
+    assertThat(profiles)
+      .single()
+      .transform {
+        assertThat(it.id).isEqualTo(1)
+        assertThat(it.name).isEqualTo("Profile")
+        assertThat(it.emoji).isEqualTo("avatar")
+        assertThat(it.createdAt).isEqualTo(1000L)
+        assertThat(it.schedule.id).isEqualTo(1)
+      }
   }
 
   @Test
@@ -97,11 +100,11 @@ class NotificationProfileTablesTest {
       )
     ).profile
 
-    assertEquals("Profile 2", updatedProfile.name)
-    assertEquals("avatar 2", updatedProfile.emoji)
-    assertEquals(1000L, updatedProfile.createdAt)
-    assertTrue(updatedProfile.allowAllCalls)
-    assertTrue(updatedProfile.allowAllMentions)
+    assertThat(updatedProfile.name).isEqualTo("Profile 2")
+    assertThat(updatedProfile.emoji).isEqualTo("avatar 2")
+    assertThat(updatedProfile.createdAt).isEqualTo(1000L)
+    assertThat(updatedProfile.allowAllCalls).isTrue()
+    assertThat(updatedProfile.allowAllMentions).isTrue()
   }
 
   @Test
@@ -112,19 +115,19 @@ class NotificationProfileTablesTest {
       color = AvatarColor.A210,
       createdAt = 1000L
     ).profile
-    assertFalse(profile.isRecipientAllowed(RecipientId.from(1)))
+    assertThat(profile.isRecipientAllowed(RecipientId.from(1))).isFalse()
 
     var updated = database.addAllowedRecipient(profile.id, RecipientId.from(1))
-    assertTrue(updated.isRecipientAllowed(RecipientId.from(1)))
+    assertThat(updated.isRecipientAllowed(RecipientId.from(1))).isTrue()
 
     updated = database.removeAllowedRecipient(profile.id, RecipientId.from(1))
-    assertFalse(updated.isRecipientAllowed(RecipientId.from(1)))
+    assertThat(updated.isRecipientAllowed(RecipientId.from(1))).isFalse()
 
     updated = database.updateProfile(updated.copy(allowedMembers = setOf(RecipientId.from(1)))).profile
-    assertTrue(updated.isRecipientAllowed(RecipientId.from(1)))
+    assertThat(updated.isRecipientAllowed(RecipientId.from(1))).isTrue()
 
     updated = database.updateProfile(updated.copy(allowedMembers = emptySet())).profile
-    assertFalse(updated.isRecipientAllowed(RecipientId.from(1)))
+    assertThat(updated.isRecipientAllowed(RecipientId.from(1))).isFalse()
   }
 
   @Test
@@ -135,36 +138,56 @@ class NotificationProfileTablesTest {
       color = AvatarColor.A210,
       createdAt = 1000L
     ).profile
-    assertFalse(profile.schedule.enabled)
-    assertEquals(900, profile.schedule.start)
-    assertEquals(1700, profile.schedule.end)
-    assertThat("Contains correct default days", profile.schedule.daysEnabled, containsInAnyOrder(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY, DayOfWeek.FRIDAY))
+    assertThat(profile.schedule.enabled).isFalse()
+    assertThat(profile.schedule.start).isEqualTo(900)
+    assertThat(profile.schedule.end).isEqualTo(1700)
+    assertThat(profile.schedule.daysEnabled, "Contains correct default days")
+      .containsExactlyInAnyOrder(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY, DayOfWeek.FRIDAY)
 
-    database.updateSchedule(profile.schedule.copy(enabled = true, start = 800, end = 1800, daysEnabled = setOf(DayOfWeek.SUNDAY, DayOfWeek.FRIDAY)))
+    database.updateSchedule(
+      profile.schedule.copy(
+        enabled = true,
+        start = 800,
+        end = 1800,
+        daysEnabled = setOf(DayOfWeek.SUNDAY, DayOfWeek.FRIDAY)),
+    )
     var updated = database.getProfile(profile.id)!!
-    assertTrue(updated.schedule.enabled)
-    assertEquals(800, updated.schedule.start)
-    assertEquals(1800, updated.schedule.end)
-    assertThat("Contains updated days days", updated.schedule.daysEnabled, containsInAnyOrder(DayOfWeek.SUNDAY, DayOfWeek.FRIDAY))
+    assertThat(updated.schedule.enabled).isTrue()
+    assertThat(updated.schedule.start).isEqualTo(800)
+    assertThat(updated.schedule.end).isEqualTo(1800)
+    assertThat( updated.schedule.daysEnabled, "Contains updated days days")
+      .containsExactlyInAnyOrder(DayOfWeek.SUNDAY, DayOfWeek.FRIDAY)
 
     database.updateSchedule(profile.schedule)
     updated = database.getProfile(profile.id)!!
-    assertFalse(updated.schedule.enabled)
-    assertEquals(900, updated.schedule.start)
-    assertEquals(1700, updated.schedule.end)
-    assertThat("Contains correct default days", updated.schedule.daysEnabled, containsInAnyOrder(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY, DayOfWeek.FRIDAY))
+    assertThat(updated.schedule.enabled).isFalse()
+    assertThat(updated.schedule.start).isEqualTo(900)
+    assertThat(updated.schedule.end).isEqualTo(1700)
+    assertThat(updated.schedule.daysEnabled, "Contains correct default days")
+      .containsExactlyInAnyOrder(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY, DayOfWeek.FRIDAY)
 
-    updated = database.updateProfile(profile.copy(schedule = profile.schedule.copy(enabled = true, start = 800, end = 1800, daysEnabled = setOf(DayOfWeek.SUNDAY, DayOfWeek.FRIDAY)))).profile
-    assertTrue(updated.schedule.enabled)
-    assertEquals(800, updated.schedule.start)
-    assertEquals(1800, updated.schedule.end)
-    assertThat("Contains updated days days", updated.schedule.daysEnabled, containsInAnyOrder(DayOfWeek.SUNDAY, DayOfWeek.FRIDAY))
+    updated = database.updateProfile(
+      profile.copy(
+        schedule = profile.schedule.copy(
+          enabled = true,
+          start = 800,
+          end = 1800,
+          daysEnabled = setOf(DayOfWeek.SUNDAY, DayOfWeek.FRIDAY),
+        )
+      )
+    ).profile
+    assertThat(updated.schedule.enabled).isTrue()
+    assertThat(updated.schedule.start).isEqualTo(800)
+    assertThat(updated.schedule.end).isEqualTo(1800)
+    assertThat(updated.schedule.daysEnabled, "Contains updated days days")
+      .containsExactlyInAnyOrder(DayOfWeek.SUNDAY, DayOfWeek.FRIDAY)
 
     updated = database.updateProfile(profile).profile
-    assertFalse(updated.schedule.enabled)
-    assertEquals(900, updated.schedule.start)
-    assertEquals(1700, updated.schedule.end)
-    assertThat("Contains correct default days", updated.schedule.daysEnabled, containsInAnyOrder(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY, DayOfWeek.FRIDAY))
+    assertThat(updated.schedule.enabled).isFalse()
+    assertThat(updated.schedule.start).isEqualTo(900)
+    assertThat(updated.schedule.end).isEqualTo(1700)
+    assertThat(updated.schedule.daysEnabled, "Contains correct default days")
+      .containsExactlyInAnyOrder(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY, DayOfWeek.FRIDAY)
   }
 }
 

--- a/app/src/test/java/org/thoughtcrime/securesms/database/SmsDatabaseTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/database/SmsDatabaseTest.kt
@@ -2,10 +2,11 @@ package org.thoughtcrime.securesms.database
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
-import org.hamcrest.MatcherAssert.assertThat
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
 import org.junit.After
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -13,12 +14,10 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.thoughtcrime.securesms.testing.TestDatabaseUtil
 import android.database.sqlite.SQLiteDatabase as AndroidSQLiteDatabase
-import org.hamcrest.CoreMatchers.`is` as isEqual
 
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, application = Application::class)
 class SmsDatabaseTest {
-
   private lateinit var db: AndroidSQLiteDatabase
   private lateinit var messageTable: MessageTable
 
@@ -42,52 +41,52 @@ class SmsDatabaseTest {
 
   @Test
   fun `getThreadIdForMessage when no message absent for id, return -1`() {
-    assertThat(messageTable.getThreadIdForMessage(1), isEqual(-1))
+    assertThat(messageTable.getThreadIdForMessage(1)).isEqualTo(-1)
   }
 
   @Test
   fun `getThreadIdForMessage when message present for id, return thread id`() {
     TestSms.insert(db)
-    assertThat(messageTable.getThreadIdForMessage(1), isEqual(1))
+    assertThat(messageTable.getThreadIdForMessage(1)).isEqualTo(1)
   }
 
   @Test
   fun `hasMeaningfulMessage when no messages, return false`() {
-    assertFalse(messageTable.hasMeaningfulMessage(1))
+    assertThat(messageTable.hasMeaningfulMessage(1)).isFalse()
   }
 
   @Test
   fun `hasMeaningfulMessage when normal message, return true`() {
     TestSms.insert(db)
-    assertTrue(messageTable.hasMeaningfulMessage(1))
+    assertThat(messageTable.hasMeaningfulMessage(1)).isTrue()
   }
 
   @Test
   fun `hasMeaningfulMessage when GV2 create message only, return true`() {
     TestSms.insert(db, type = MessageTypes.BASE_INBOX_TYPE or MessageTypes.SECURE_MESSAGE_BIT or MessageTypes.GROUP_V2_BIT or MessageTypes.GROUP_UPDATE_BIT)
-    assertTrue(messageTable.hasMeaningfulMessage(1))
+    assertThat(messageTable.hasMeaningfulMessage(1)).isTrue()
   }
 
   @Test
   fun `hasMeaningfulMessage when empty and then with ignored types, always return false`() {
-    assertFalse(messageTable.hasMeaningfulMessage(1))
+    assertThat(messageTable.hasMeaningfulMessage(1)).isFalse()
 
     TestSms.insert(db, type = MessageTypes.IGNORABLE_TYPESMASK_WHEN_COUNTING)
-    assertFalse(messageTable.hasMeaningfulMessage(1))
+    assertThat(messageTable.hasMeaningfulMessage(1)).isFalse()
 
     TestSms.insert(db, type = MessageTypes.PROFILE_CHANGE_TYPE)
-    assertFalse(messageTable.hasMeaningfulMessage(1))
+    assertThat(messageTable.hasMeaningfulMessage(1)).isFalse()
 
     TestSms.insert(db, type = MessageTypes.CHANGE_NUMBER_TYPE)
-    assertFalse(messageTable.hasMeaningfulMessage(1))
+    assertThat(messageTable.hasMeaningfulMessage(1)).isFalse()
 
     TestSms.insert(db, type = MessageTypes.RELEASE_CHANNEL_DONATION_REQUEST_TYPE)
-    assertFalse(messageTable.hasMeaningfulMessage(1))
+    assertThat(messageTable.hasMeaningfulMessage(1)).isFalse()
 
     TestSms.insert(db, type = MessageTypes.SMS_EXPORT_TYPE)
-    assertFalse(messageTable.hasMeaningfulMessage(1))
+    assertThat(messageTable.hasMeaningfulMessage(1)).isFalse()
 
     TestSms.insert(db, type = MessageTypes.BASE_INBOX_TYPE or MessageTypes.GROUP_V2_LEAVE_BITS)
-    assertFalse(messageTable.hasMeaningfulMessage(1))
+    assertThat(messageTable.hasMeaningfulMessage(1)).isFalse()
   }
 }

--- a/app/src/test/java/org/thoughtcrime/securesms/groups/GroupManagerV2Test_edit.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/groups/GroupManagerV2Test_edit.kt
@@ -1,18 +1,16 @@
-@file:Suppress("ClassName")
-
 package org.thoughtcrime.securesms.groups
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers
-import org.hamcrest.Matchers.`is`
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -30,7 +28,6 @@ import org.signal.libsignal.zkgroup.groups.GroupSecretParams
 import org.signal.storageservice.protos.groups.GroupChangeResponse
 import org.signal.storageservice.protos.groups.Member
 import org.signal.storageservice.protos.groups.local.DecryptedGroup
-import org.signal.storageservice.protos.groups.local.DecryptedMember
 import org.thoughtcrime.securesms.TestZkGroupServer
 import org.thoughtcrime.securesms.database.GroupStateTestData
 import org.thoughtcrime.securesms.database.GroupTable
@@ -50,10 +47,10 @@ import org.whispersystems.signalservice.api.push.ServiceId.PNI
 import org.whispersystems.signalservice.api.push.ServiceIds
 import java.util.UUID
 
+@Suppress("ClassName")
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, application = Application::class)
 class GroupManagerV2Test_edit {
-
   companion object {
     val server: TestZkGroupServer = TestZkGroupServer()
     val masterKey: GroupMasterKey = GroupMasterKey(Hex.fromStringCondensed("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"))
@@ -64,8 +61,6 @@ class GroupManagerV2Test_edit {
     val selfPni: PNI = PNI.from(UUID.randomUUID())
     val serviceIds: ServiceIds = ServiceIds(selfAci, selfPni)
     val otherAci: ACI = ACI.from(UUID.randomUUID())
-    val selfAndOthers: List<DecryptedMember> = listOf(member(selfAci), member(otherAci))
-    val others: List<DecryptedMember> = listOf(member(otherAci))
   }
 
   @get:Rule
@@ -163,9 +158,9 @@ class GroupManagerV2Test_edit {
     }
 
     then { patchedGroup ->
-      assertThat("Revision updated by one", patchedGroup.revision, `is`(6))
-      assertThat("Self is no longer in the group", patchedGroup.members.find { it.aciBytes == selfAci.toByteString() }, Matchers.nullValue())
-      assertThat("Other is now an admin in the group", patchedGroup.members.find { it.aciBytes == otherAci.toByteString() }?.role, `is`(Member.Role.ADMINISTRATOR))
+      assertThat(patchedGroup.revision, "Revision updated by one").isEqualTo(6)
+      assertThat(patchedGroup.members.find { it.aciBytes == selfAci.toByteString() }, "Self is no longer in the group").isNull()
+      assertThat(patchedGroup.members.find { it.aciBytes == otherAci.toByteString() }?.role, "Other is now an admin in the group").isEqualTo(Member.Role.ADMINISTRATOR)
     }
   }
 }

--- a/app/src/test/java/org/thoughtcrime/securesms/groups/v2/processing/GroupsV2StateProcessorTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/groups/v2/processing/GroupsV2StateProcessorTest.kt
@@ -2,6 +2,10 @@ package org.thoughtcrime.securesms.groups.v2.processing
 
 import android.annotation.SuppressLint
 import android.app.Application
+import assertk.assertThat
+import assertk.assertions.any
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
@@ -11,9 +15,6 @@ import io.mockk.spyk
 import io.mockk.unmockkAll
 import io.mockk.unmockkStatic
 import io.mockk.verify
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.hasItem
-import org.hamcrest.Matchers.`is`
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -207,7 +208,7 @@ class GroupsV2StateProcessorTest {
       timestamp = 0
     )
 
-    assertThat("local and server match revisions", result.updateStatus, `is`(GroupUpdateResult.UpdateStatus.GROUP_CONSISTENT_OR_AHEAD))
+    assertThat(result.updateStatus, "local and server match revisions").isEqualTo(GroupUpdateResult.UpdateStatus.GROUP_CONSISTENT_OR_AHEAD)
   }
 
   @Test
@@ -224,7 +225,7 @@ class GroupsV2StateProcessorTest {
       timestamp = 0
     )
 
-    assertThat("local and server match revisions", result.updateStatus, `is`(GroupUpdateResult.UpdateStatus.GROUP_CONSISTENT_OR_AHEAD))
+    assertThat(result.updateStatus, "local and server match revisions").isEqualTo(GroupUpdateResult.UpdateStatus.GROUP_CONSISTENT_OR_AHEAD)
   }
 
   @Test
@@ -252,8 +253,8 @@ class GroupsV2StateProcessorTest {
       timestamp = 0
     )
 
-    assertThat("local should update to server", result.updateStatus, `is`(GroupUpdateResult.UpdateStatus.GROUP_UPDATED))
-    assertThat("title changed to match server", result.latestServer!!.title, `is`("Asdf"))
+    assertThat(result.updateStatus, "local should update to server").isEqualTo(GroupUpdateResult.UpdateStatus.GROUP_UPDATED)
+    assertThat(result.latestServer!!.title, "title changed to match server").isEqualTo("Asdf")
 
     verify { groupTable.update(masterKey, result.latestServer!!, null) }
   }
@@ -289,9 +290,9 @@ class GroupsV2StateProcessorTest {
       timestamp = 0
     )
 
-    assertThat("local should update to server", result.updateStatus, `is`(GroupUpdateResult.UpdateStatus.GROUP_UPDATED))
-    assertThat("revision matches server", result.latestServer!!.revision, `is`(7))
-    assertThat("title changed on server to final result", result.latestServer!!.title, `is`("Asdf!"))
+    assertThat(result.updateStatus, "local should update to server").isEqualTo(GroupUpdateResult.UpdateStatus.GROUP_UPDATED)
+    assertThat(result.latestServer!!.revision, "revision matches server").isEqualTo(7)
+    assertThat(result.latestServer!!.title, "title changed on server to final result").isEqualTo("Asdf!")
 
     verify { groupTable.update(masterKey, result.latestServer!!, null) }
   }
@@ -332,10 +333,10 @@ class GroupsV2StateProcessorTest {
       timestamp = 0
     )
 
-    assertThat("local should update to server", result.updateStatus, `is`(GroupUpdateResult.UpdateStatus.GROUP_UPDATED))
-    assertThat("revision matches server", result.latestServer!!.revision, `is`(111))
-    assertThat("title changed on server to final result", result.latestServer!!.title, `is`("And beyond"))
-    assertThat("Description updated in change after full snapshot", result.latestServer!!.description, `is`("Description"))
+    assertThat(result.updateStatus, "local should update to server").isEqualTo(GroupUpdateResult.UpdateStatus.GROUP_UPDATED)
+    assertThat(result.latestServer!!.revision, "revision matches server").isEqualTo(111)
+    assertThat(result.latestServer!!.title, "title changed on server to final result").isEqualTo("And beyond")
+    assertThat(result.latestServer!!.description, "Description updated in change after full snapshot").isEqualTo("Description")
 
     verify { groupTable.update(masterKey, result.latestServer!!, null) }
   }
@@ -362,8 +363,8 @@ class GroupsV2StateProcessorTest {
       serverGuid = UUID.randomUUID().toString()
     )
 
-    assertThat("revision matches peer change", result.latestServer!!.revision, `is`(6))
-    assertThat("timer changed by peer change", result.latestServer!!.disappearingMessagesTimer!!.duration, `is`(5000))
+    assertThat(result.latestServer!!.revision, "revision matches peer change").isEqualTo(6)
+    assertThat(result.latestServer!!.disappearingMessagesTimer!!.duration, "timer changed by peer change").isEqualTo(5000)
 
     verify { groupTable.update(masterKey, result.latestServer!!, null) }
   }
@@ -393,8 +394,8 @@ class GroupsV2StateProcessorTest {
       serverGuid = UUID.randomUUID().toString()
     )
 
-    assertThat("revision matches peer change", result.latestServer!!.revision, `is`(6))
-    assertThat("member promoted by peer change", result.latestServer!!.members.map { it.aciBytes }, hasItem(selfAci.toByteString()))
+    assertThat(result.latestServer!!.revision, "revision matches peer change").isEqualTo(6)
+    assertThat(result.latestServer!!.members.map { it.aciBytes }, "member promoted by peer change").contains(selfAci.toByteString())
 
     verify { jobManager.add(ofType(DirectoryRefreshJob::class)) }
     verify { groupTable.update(masterKey, result.latestServer!!, null) }
@@ -437,8 +438,8 @@ class GroupsV2StateProcessorTest {
       serverGuid = UUID.randomUUID().toString()
     )
 
-    assertThat("local should update to server", result.updateStatus, `is`(GroupUpdateResult.UpdateStatus.GROUP_UPDATED))
-    assertThat("revision matches server", result.latestServer!!.revision, `is`(2))
+    assertThat(result.updateStatus, "local should update to server").isEqualTo(GroupUpdateResult.UpdateStatus.GROUP_UPDATED)
+    assertThat(result.latestServer!!.revision, "revision matches server").isEqualTo(2)
 
     verify { groupsV2API.getGroupHistoryPage(secretParams, 1, any(), false, 0) }
 
@@ -501,8 +502,8 @@ class GroupsV2StateProcessorTest {
       serverGuid = UUID.randomUUID().toString()
     )
 
-    assertThat("local should update to server", result.updateStatus, `is`(GroupUpdateResult.UpdateStatus.GROUP_UPDATED))
-    assertThat("revision matches server", result.latestServer!!.revision, `is`(3))
+    assertThat(result.updateStatus, "local should update to server").isEqualTo(GroupUpdateResult.UpdateStatus.GROUP_UPDATED)
+    assertThat(result.latestServer!!.revision, "revision matches server").isEqualTo(3)
 
     verify { groupTable.update(masterKey, result.latestServer!!, null) }
   }
@@ -529,8 +530,8 @@ class GroupsV2StateProcessorTest {
       timestamp = 0
     )
 
-    assertThat("local should update to server", result.updateStatus, `is`(GroupUpdateResult.UpdateStatus.GROUP_UPDATED))
-    assertThat("revision matches server", result.latestServer!!.revision, `is`(2))
+    assertThat(result.updateStatus, "local should update to server").isEqualTo(GroupUpdateResult.UpdateStatus.GROUP_UPDATED)
+    assertThat(result.latestServer!!.revision, "revision matches server").isEqualTo(2)
 
     verify { groupTable.create(masterKey, result.latestServer!!, null) }
   }
@@ -565,9 +566,9 @@ class GroupsV2StateProcessorTest {
       timestamp = 0
     )
 
-    assertThat("local should update to revision added", result.updateStatus, `is`(GroupUpdateResult.UpdateStatus.GROUP_UPDATED))
-    assertThat("revision matches peer revision added", result.latestServer!!.revision, `is`(2))
-    assertThat("title matches that as it was in revision added", result.latestServer!!.title, `is`("Baking Signal for Science"))
+    assertThat(result.updateStatus, "local should update to revision added").isEqualTo(GroupUpdateResult.UpdateStatus.GROUP_UPDATED)
+    assertThat(result.latestServer!!.revision, "revision matches peer revision added").isEqualTo(2)
+    assertThat(result.latestServer!!.title, "title matches that as it was in revision added").isEqualTo("Baking Signal for Science")
 
     verify { jobManager.add(ofType(RequestGroupV2InfoJob::class)) }
     verify { groupTable.create(masterKey, result.latestServer!!, null) }
@@ -593,8 +594,8 @@ class GroupsV2StateProcessorTest {
       timestamp = 0
     )
 
-    assertThat("local should update to server", result.updateStatus, `is`(GroupUpdateResult.UpdateStatus.GROUP_UPDATED))
-    assertThat("revision matches latest server", result.latestServer!!.revision, `is`(10))
+    assertThat(result.updateStatus, "local should update to server").isEqualTo(GroupUpdateResult.UpdateStatus.GROUP_UPDATED)
+    assertThat(result.latestServer!!.revision, "revision matches latest server").isEqualTo(10)
 
     verify { groupTable.update(masterKey, result.latestServer!!, null) }
   }
@@ -629,8 +630,8 @@ class GroupsV2StateProcessorTest {
       timestamp = 0
     )
 
-    assertThat("local should update to server", result.updateStatus, `is`(GroupUpdateResult.UpdateStatus.GROUP_UPDATED))
-    assertThat("revision matches server", result.latestServer!!.revision, `is`(3))
+    assertThat(result.updateStatus, "local should update to server").isEqualTo(GroupUpdateResult.UpdateStatus.GROUP_UPDATED)
+    assertThat(result.latestServer!!.revision, "revision matches server").isEqualTo(3)
 
     verify { groupTable.update(masterKey, result.latestServer!!, null) }
   }
@@ -676,9 +677,9 @@ class GroupsV2StateProcessorTest {
       timestamp = 0
     )
 
-    assertThat("local should update to server", result.updateStatus, `is`(GroupUpdateResult.UpdateStatus.GROUP_UPDATED))
-    assertThat("revision matches revision approved at", result.latestServer!!.revision, `is`(3))
-    assertThat("title matches revision approved at", result.latestServer!!.title, `is`("Beam me up"))
+    assertThat(result.updateStatus, "local should update to server").isEqualTo(GroupUpdateResult.UpdateStatus.GROUP_UPDATED)
+    assertThat(result.latestServer!!.revision, "revision matches revision approved at").isEqualTo(3)
+    assertThat(result.latestServer!!.title, "title matches revision approved at").isEqualTo("Beam me up")
 
     verify { jobManager.add(ofType(RequestGroupV2InfoJob::class)) }
     verify { groupTable.update(masterKey, result.latestServer!!, null) }
@@ -721,8 +722,8 @@ class GroupsV2StateProcessorTest {
       timestamp = 0
     )
 
-    assertThat("local should update to server", result.updateStatus, `is`(GroupUpdateResult.UpdateStatus.GROUP_UPDATED))
-    assertThat("revision matches latest revision on server", result.latestServer!!.revision, `is`(101))
+    assertThat(result.updateStatus, "local should update to server").isEqualTo(GroupUpdateResult.UpdateStatus.GROUP_UPDATED)
+    assertThat(result.latestServer!!.revision, "revision matches latest revision on server").isEqualTo(101)
 
     verify { groupTable.update(masterKey, result.latestServer!!, null) }
   }
@@ -770,10 +771,10 @@ class GroupsV2StateProcessorTest {
       timestamp = 0
     )
 
-    assertThat("local should update to server", result.updateStatus, `is`(GroupUpdateResult.UpdateStatus.GROUP_UPDATED))
-    assertThat("members contains second other", result.latestServer!!.members, hasItem(secondOther))
+    assertThat(result.updateStatus, "local should update to server").isEqualTo(GroupUpdateResult.UpdateStatus.GROUP_UPDATED)
+    assertThat(result.latestServer!!.members, "members contains second other").contains(secondOther)
 
-    assertThat("group update messages contains new member add", updateMessageContextArgs.map { it.change!!.newMembers }, hasItem(hasItem(secondOther)))
+    assertThat(updateMessageContextArgs.map { it.change!!.newMembers }, "group update messages contains new member add").any { it.contains(secondOther) }
 
     verify { groupTable.update(masterKey, result.latestServer!!, null) }
   }
@@ -805,11 +806,11 @@ class GroupsV2StateProcessorTest {
     every { profileAndMessageHelper.storeMessage(capture(updateMessageContextArgs), any(), any()) } returns Unit
 
     val result = processor.forceSanityUpdateFromServer(0)
-    assertThat("local should update to server", result.updateStatus, `is`(GroupUpdateResult.UpdateStatus.GROUP_UPDATED))
-    assertThat("members contains second other", result.latestServer!!.members, hasItem(secondOther))
-    assertThat("title should be updated", result.latestServer!!.title, `is`("Changed"))
-    assertThat("group update messages contains new member add", updateMessageContextArgs.map { it.change!!.newMembers }, hasItem(hasItem(secondOther)))
-    assertThat("group update messages contains title change", updateMessageContextArgs.mapNotNull { it.change!!.newTitle }.any { it.value_ == "Changed" })
+    assertThat(result.updateStatus, "local should update to server").isEqualTo(GroupUpdateResult.UpdateStatus.GROUP_UPDATED)
+    assertThat(result.latestServer!!.members, "members contains second other").contains(secondOther)
+    assertThat(result.latestServer!!.title, "title should be updated").isEqualTo("Changed")
+    assertThat(updateMessageContextArgs.map { it.change!!.newMembers }, "group update messages contains new member add").any { it.contains(secondOther) }
+    assertThat(updateMessageContextArgs.map { it.change!!.newTitle!!.value_ }, "group update messages contains title change").contains("Changed")
 
     verify { groupTable.update(masterKey, result.latestServer!!, null) }
   }
@@ -833,7 +834,7 @@ class GroupsV2StateProcessorTest {
     }
 
     val result = processor.forceSanityUpdateFromServer(0)
-    assertThat("local should be unchanged", result.updateStatus, `is`(GroupUpdateResult.UpdateStatus.GROUP_CONSISTENT_OR_AHEAD))
+    assertThat(result.updateStatus, "local should be unchanged").isEqualTo(GroupUpdateResult.UpdateStatus.GROUP_CONSISTENT_OR_AHEAD)
   }
 
   /** No local group state fails gracefully during force update */
@@ -842,7 +843,7 @@ class GroupsV2StateProcessorTest {
     given { }
 
     val result = processor.forceSanityUpdateFromServer(0)
-    assertThat("local should be unchanged", result.updateStatus, `is`(GroupUpdateResult.UpdateStatus.GROUP_CONSISTENT_OR_AHEAD))
+    assertThat(result.updateStatus, "local should be unchanged").isEqualTo(GroupUpdateResult.UpdateStatus.GROUP_CONSISTENT_OR_AHEAD)
   }
 
   @Test(expected = GroupNotAMemberException::class)
@@ -889,9 +890,9 @@ class GroupsV2StateProcessorTest {
 
     val result = processor.forceSanityUpdateFromServer(0)
 
-    assertThat("local should update to server", result.updateStatus, `is`(GroupUpdateResult.UpdateStatus.GROUP_UPDATED))
-    assertThat("revision matches server", result.latestServer!!.revision, `is`(10))
-    assertThat("title changed on server to final result", result.latestServer!!.title, `is`("Asdf!"))
+    assertThat(result.updateStatus, "local should update to server").isEqualTo(GroupUpdateResult.UpdateStatus.GROUP_UPDATED)
+    assertThat(result.latestServer!!.revision, "revision matches server").isEqualTo(10)
+    assertThat(result.latestServer!!.title, "title changed on server to final result").isEqualTo("Asdf!")
 
     verify { groupTable.update(masterKey, result.latestServer!!, null) }
   }

--- a/app/src/test/java/org/thoughtcrime/securesms/groups/v2/processing/GroupsV2StateProcessorTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/groups/v2/processing/GroupsV2StateProcessorTest.kt
@@ -392,7 +392,6 @@ class GroupsV2StateProcessorTest {
           }
       }
 
-
     verify { groupTable.update(masterKey, result.latestServer!!, null) }
   }
 

--- a/app/src/test/java/org/thoughtcrime/securesms/jobmanager/migrations/GroupCallPeekJobDataMigrationTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/jobmanager/migrations/GroupCallPeekJobDataMigrationTest.kt
@@ -1,7 +1,8 @@
 package org.thoughtcrime.securesms.jobmanager.migrations
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import org.junit.Test
-import org.thoughtcrime.securesms.assertIs
 import org.thoughtcrime.securesms.jobmanager.JobMigration
 import org.thoughtcrime.securesms.jobmanager.JsonJobData
 import org.thoughtcrime.securesms.jobs.protos.GroupCallPeekJobData
@@ -19,9 +20,9 @@ class GroupCallPeekJobDataMigrationTest {
 
     val data = GroupCallPeekJobData.ADAPTER.decode(result.data!!)
 
-    data.groupRecipientId assertIs groupRecipientId
-    data.senderRecipientId assertIs Recipient.UNKNOWN.id.toLong()
-    data.serverTimestamp assertIs 0L
+    assertThat(data.groupRecipientId).isEqualTo(groupRecipientId)
+    assertThat(data.senderRecipientId).isEqualTo(Recipient.UNKNOWN.id.toLong())
+    assertThat(data.serverTimestamp).isEqualTo(0L)
   }
 
   @Test
@@ -32,9 +33,9 @@ class GroupCallPeekJobDataMigrationTest {
 
     val data = GroupCallPeekJobData.ADAPTER.decode(result.data!!)
 
-    data.groupRecipientId assertIs groupRecipientId
-    data.senderRecipientId assertIs Recipient.UNKNOWN.id.toLong()
-    data.serverTimestamp assertIs 0L
+    assertThat(data.groupRecipientId).isEqualTo(groupRecipientId)
+    assertThat(data.senderRecipientId).isEqualTo(Recipient.UNKNOWN.id.toLong())
+    assertThat(data.serverTimestamp).isEqualTo(0L)
   }
 
   @Test
@@ -43,7 +44,7 @@ class GroupCallPeekJobDataMigrationTest {
     val jobData = createJobData(factoryKey = "ASDF", groupRecipientId = groupRecipientId)
     val result = testSubject.migrate(jobData)
 
-    result assertIs jobData
+    assertThat(result).isEqualTo(jobData)
   }
 
   @Test
@@ -52,7 +53,7 @@ class GroupCallPeekJobDataMigrationTest {
     val jobData = createJobData(groupRecipientId = groupRecipientId, data = null)
     val result = testSubject.migrate(jobData)
 
-    result assertIs jobData
+    assertThat(result).isEqualTo(jobData)
   }
 
   @Test
@@ -61,7 +62,7 @@ class GroupCallPeekJobDataMigrationTest {
     val jobData = createJobData(groupRecipientId = groupRecipientId, data = JsonJobData.Builder().putString("asdf", groupRecipientId.toString()).serialize())
     val result = testSubject.migrate(jobData)
 
-    result assertIs jobData
+    assertThat(result).isEqualTo(jobData)
   }
 
   @Test
@@ -70,7 +71,7 @@ class GroupCallPeekJobDataMigrationTest {
     val jobData = createJobData(groupRecipientId = groupRecipientId, data = GroupCallPeekJobData().encode())
     val result = testSubject.migrate(jobData)
 
-    result assertIs jobData
+    assertThat(result).isEqualTo(jobData)
   }
 
   private fun createJobData(

--- a/app/src/test/java/org/thoughtcrime/securesms/jobs/FastJobStorageTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/jobs/FastJobStorageTest.kt
@@ -1,13 +1,15 @@
 package org.thoughtcrime.securesms.jobs
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.prop
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Test
-import org.thoughtcrime.securesms.assertIs
-import org.thoughtcrime.securesms.assertIsNot
-import org.thoughtcrime.securesms.assertIsNotNull
-import org.thoughtcrime.securesms.assertIsNull
 import org.thoughtcrime.securesms.database.JobDatabase
 import org.thoughtcrime.securesms.jobmanager.Job
 import org.thoughtcrime.securesms.jobmanager.persistence.ConstraintSpec
@@ -77,8 +79,8 @@ class FastJobStorageTest {
     val subject = FastJobStorage(mockDatabase())
     subject.insertJobs(DataSet1.FULL_SPECS)
 
-    subject.getJobSpec(DataSet1.JOB_1.id) assertIs DataSet1.JOB_1
-    subject.getJobSpec(DataSet1.JOB_2.id) assertIs DataSet1.JOB_2
+    assertThat(subject.getJobSpec(DataSet1.JOB_1.id)).isEqualTo(DataSet1.JOB_1)
+    assertThat(subject.getJobSpec(DataSet1.JOB_2.id)).isEqualTo(DataSet1.JOB_2)
   }
 
   @Test
@@ -98,8 +100,8 @@ class FastJobStorageTest {
     subject.init()
     subject.updateAllJobsToBePending()
 
-    subject.getJobSpec("1")!!.isRunning assertIs false
-    subject.getJobSpec("2")!!.isRunning assertIs false
+    assertThat(subject.getJobSpec("1")!!.isRunning).isEqualTo(false)
+    assertThat(subject.getJobSpec("2")!!.isRunning).isEqualTo(false)
   }
 
   @Test
@@ -167,9 +169,9 @@ class FastJobStorageTest {
     subject.init()
     subject.updateJobs(listOf(update1, update2))
 
-    subject.getJobSpec("1") assertIs update1
-    subject.getJobSpec("2") assertIs update2
-    subject.getJobSpec("3") assertIs fullSpec3.jobSpec
+    assertThat(subject.getJobSpec("1")).isEqualTo(update1)
+    assertThat(subject.getJobSpec("2")).isEqualTo(update2)
+    assertThat(subject.getJobSpec("3")).isEqualTo(fullSpec3.jobSpec)
   }
 
   @Test
@@ -232,9 +234,9 @@ class FastJobStorageTest {
       }
     }
 
-    subject.getJobSpec("1") assertIs update1
-    subject.getJobSpec("2") assertIs update2
-    subject.getJobSpec("3") assertIs fullSpec3.jobSpec
+    assertThat(subject.getJobSpec("1")).isEqualTo(update1)
+    assertThat(subject.getJobSpec("2")).isEqualTo(update2)
+    assertThat(subject.getJobSpec("3")).isEqualTo(fullSpec3.jobSpec)
   }
 
   @Test
@@ -256,8 +258,8 @@ class FastJobStorageTest {
 
     subject.markJobAsRunning(id = DataSet1.JOB_1.id, currentTime = 42)
 
-    subject.getJobSpec(DataSet1.JOB_1.id)!!.isRunning assertIs true
-    subject.getJobSpec(DataSet1.JOB_1.id)!!.lastRunAttemptTime assertIs 42
+    assertThat(subject.getJobSpec(DataSet1.JOB_1.id)!!.isRunning).isEqualTo(true)
+    assertThat(subject.getJobSpec(DataSet1.JOB_1.id)!!.lastRunAttemptTime).isEqualTo(42)
   }
 
   @Test
@@ -313,11 +315,11 @@ class FastJobStorageTest {
 
     val job = subject.getJobSpec("1")
     check(job != null)
-    job.isRunning assertIs false
-    job.lastRunAttemptTime assertIs 3
-    job.runAttempt assertIs 2
-    job.nextBackoffInterval assertIs 10
-    job.serializedData!!.toString(Charset.defaultCharset()) assertIs "a"
+    assertThat(job.isRunning).isEqualTo(false)
+    assertThat(job.lastRunAttemptTime).isEqualTo(3)
+    assertThat(job.runAttempt).isEqualTo(2)
+    assertThat(job.nextBackoffInterval).isEqualTo(10)
+    assertThat(job.serializedData!!.toString(Charset.defaultCharset())).isEqualTo("a")
   }
 
   @Test
@@ -328,7 +330,7 @@ class FastJobStorageTest {
     val subject = FastJobStorage(mockDatabase(listOf(fullSpec1, fullSpec2)))
     subject.init()
 
-    subject.getNextEligibleJob(1, NO_PREDICATE) assertIs null
+    assertThat(subject.getNextEligibleJob(1, NO_PREDICATE)).isEqualTo(null)
   }
 
   @Test
@@ -338,7 +340,7 @@ class FastJobStorageTest {
     val subject = FastJobStorage(mockDatabase(listOf(fullSpec)))
     subject.init()
 
-    subject.getNextEligibleJob(10, NO_PREDICATE) assertIs null
+    assertThat(subject.getNextEligibleJob(10, NO_PREDICATE)).isEqualTo(null)
   }
 
   @Test
@@ -349,7 +351,7 @@ class FastJobStorageTest {
     val subject = FastJobStorage(mockDatabase(listOf(fullSpec)))
     subject.init()
 
-    subject.getNextEligibleJob(currentTime, NO_PREDICATE) assertIs null
+    assertThat(subject.getNextEligibleJob(currentTime, NO_PREDICATE)).isEqualTo(null)
   }
 
   @Test
@@ -360,7 +362,7 @@ class FastJobStorageTest {
     val subject = FastJobStorage(mockDatabase(listOf(fullSpec1, fullSpec2)))
     subject.init()
 
-    subject.getNextEligibleJob(0, NO_PREDICATE) assertIs null
+    assertThat(subject.getNextEligibleJob(0, NO_PREDICATE)).isEqualTo(null)
   }
 
   @Test
@@ -370,7 +372,7 @@ class FastJobStorageTest {
     val subject = FastJobStorage(mockDatabase(listOf(fullSpec)))
     subject.init()
 
-    subject.getNextEligibleJob(10, NO_PREDICATE) assertIs fullSpec.jobSpec
+    assertThat(subject.getNextEligibleJob(10, NO_PREDICATE)).isEqualTo(fullSpec.jobSpec)
   }
 
   @Test
@@ -381,10 +383,10 @@ class FastJobStorageTest {
     val subject = FastJobStorage(mockDatabase(listOf(fullSpec1, fullSpec2)))
     subject.init()
 
-    subject.getNextEligibleJob(10, NO_PREDICATE) assertIs fullSpec1.jobSpec
+    assertThat(subject.getNextEligibleJob(10, NO_PREDICATE)).isEqualTo(fullSpec1.jobSpec)
     subject.deleteJob(fullSpec1.jobSpec.id)
 
-    subject.getNextEligibleJob(10, NO_PREDICATE) assertIs fullSpec2.jobSpec
+    assertThat(subject.getNextEligibleJob(10, NO_PREDICATE)).isEqualTo(fullSpec2.jobSpec)
   }
 
   @Test
@@ -396,8 +398,9 @@ class FastJobStorageTest {
     subject.init()
 
     val job = subject.getNextEligibleJob(10, NO_PREDICATE)
-    job.assertIsNotNull()
-    job.id assertIs fullSpec2.jobSpec.id
+    assertThat(job).isNotNull()
+      .prop(JobSpec::id)
+      .isEqualTo(fullSpec2.jobSpec.id)
   }
 
   @Test
@@ -409,8 +412,9 @@ class FastJobStorageTest {
     subject.init()
 
     val job = subject.getNextEligibleJob(10, NO_PREDICATE)
-    job.assertIsNotNull()
-    job.id assertIs fullSpec1.jobSpec.id
+    assertThat(job).isNotNull()
+      .prop(JobSpec::id)
+      .isEqualTo(fullSpec1.jobSpec.id)
   }
 
   @Test
@@ -423,8 +427,9 @@ class FastJobStorageTest {
     subject.init()
 
     val job = subject.getNextEligibleJob(10, NO_PREDICATE)
-    job.assertIsNotNull()
-    job.id assertIs fullSpec2.jobSpec.id
+    assertThat(job).isNotNull()
+      .prop(JobSpec::id)
+      .isEqualTo(fullSpec2.jobSpec.id)
   }
 
   @Test
@@ -445,40 +450,40 @@ class FastJobStorageTest {
     val subject = FastJobStorage(mockDatabase(listOf(fullSpec1, fullSpec2, fullSpec3, fullSpec4, fullSpec5, fullSpec6, fullSpec7, fullSpec8, fullSpec9, fullSpec10, fullSpec11, fullSpec12)))
     subject.init()
 
-    subject.getNextEligibleJob(10, NO_PREDICATE) assertIs fullSpec2.jobSpec
+    assertThat(subject.getNextEligibleJob(10, NO_PREDICATE)).isEqualTo(fullSpec2.jobSpec)
     subject.deleteJob(fullSpec2.jobSpec.id)
 
-    subject.getNextEligibleJob(10, NO_PREDICATE) assertIs fullSpec6.jobSpec
+    assertThat(subject.getNextEligibleJob(10, NO_PREDICATE)).isEqualTo(fullSpec6.jobSpec)
     subject.deleteJob(fullSpec6.jobSpec.id)
 
-    subject.getNextEligibleJob(10, NO_PREDICATE) assertIs fullSpec11.jobSpec
+    assertThat(subject.getNextEligibleJob(10, NO_PREDICATE)).isEqualTo(fullSpec11.jobSpec)
     subject.deleteJob(fullSpec11.jobSpec.id)
 
-    subject.getNextEligibleJob(10, NO_PREDICATE) assertIs fullSpec10.jobSpec
+    assertThat(subject.getNextEligibleJob(10, NO_PREDICATE)).isEqualTo(fullSpec10.jobSpec)
     subject.deleteJob(fullSpec10.jobSpec.id)
 
-    subject.getNextEligibleJob(10, NO_PREDICATE) assertIs fullSpec12.jobSpec
+    assertThat(subject.getNextEligibleJob(10, NO_PREDICATE)).isEqualTo(fullSpec12.jobSpec)
     subject.deleteJob(fullSpec12.jobSpec.id)
 
-    subject.getNextEligibleJob(10, NO_PREDICATE) assertIs fullSpec3.jobSpec
+    assertThat(subject.getNextEligibleJob(10, NO_PREDICATE)).isEqualTo(fullSpec3.jobSpec)
     subject.deleteJob(fullSpec3.jobSpec.id)
 
-    subject.getNextEligibleJob(10, NO_PREDICATE) assertIs fullSpec5.jobSpec
+    assertThat(subject.getNextEligibleJob(10, NO_PREDICATE)).isEqualTo(fullSpec5.jobSpec)
     subject.deleteJob(fullSpec5.jobSpec.id)
 
-    subject.getNextEligibleJob(10, NO_PREDICATE) assertIs fullSpec9.jobSpec
+    assertThat(subject.getNextEligibleJob(10, NO_PREDICATE)).isEqualTo(fullSpec9.jobSpec)
     subject.deleteJob(fullSpec9.jobSpec.id)
 
-    subject.getNextEligibleJob(10, NO_PREDICATE) assertIs fullSpec1.jobSpec
+    assertThat(subject.getNextEligibleJob(10, NO_PREDICATE)).isEqualTo(fullSpec1.jobSpec)
     subject.deleteJob(fullSpec1.jobSpec.id)
 
-    subject.getNextEligibleJob(10, NO_PREDICATE) assertIs fullSpec4.jobSpec
+    assertThat(subject.getNextEligibleJob(10, NO_PREDICATE)).isEqualTo(fullSpec4.jobSpec)
     subject.deleteJob(fullSpec4.jobSpec.id)
 
-    subject.getNextEligibleJob(10, NO_PREDICATE) assertIs fullSpec7.jobSpec
+    assertThat(subject.getNextEligibleJob(10, NO_PREDICATE)).isEqualTo(fullSpec7.jobSpec)
     subject.deleteJob(fullSpec7.jobSpec.id)
 
-    subject.getNextEligibleJob(10, NO_PREDICATE) assertIs fullSpec8.jobSpec
+    assertThat(subject.getNextEligibleJob(10, NO_PREDICATE)).isEqualTo(fullSpec8.jobSpec)
   }
 
   @Test
@@ -491,8 +496,9 @@ class FastJobStorageTest {
     subject.init()
 
     val job = subject.getNextEligibleJob(10, NO_PREDICATE)
-    job.assertIsNotNull()
-    job.id assertIs fullSpec2.jobSpec.id
+    assertThat(job).isNotNull()
+      .prop(JobSpec::id)
+      .isEqualTo(fullSpec2.jobSpec.id)
   }
 
   @Test
@@ -504,8 +510,9 @@ class FastJobStorageTest {
     subject.init()
 
     val job = subject.getNextEligibleJob(10, NO_PREDICATE)
-    job.assertIsNotNull()
-    job.id assertIs fullSpec2.jobSpec.id
+    assertThat(job).isNotNull()
+      .prop(JobSpec::id)
+      .isEqualTo(fullSpec2.jobSpec.id)
   }
 
   @Test
@@ -518,8 +525,9 @@ class FastJobStorageTest {
     subject.init()
 
     val job = subject.getNextEligibleJob(currentTime, NO_PREDICATE)
-    job.assertIsNotNull()
-    job.id assertIs fullSpec1.jobSpec.id
+    assertThat(job).isNotNull()
+      .prop(JobSpec::id)
+      .isEqualTo(fullSpec1.jobSpec.id)
   }
 
   @Test
@@ -531,8 +539,9 @@ class FastJobStorageTest {
     subject.init()
 
     val job = subject.getNextEligibleJob(10, NO_PREDICATE)
-    job.assertIsNotNull()
-    job.id assertIs migrationSpec.jobSpec.id
+    assertThat(job).isNotNull()
+      .prop(JobSpec::id)
+      .isEqualTo(migrationSpec.jobSpec.id)
   }
 
   @Test
@@ -543,7 +552,7 @@ class FastJobStorageTest {
     val subject = FastJobStorage(mockDatabase(listOf(plainSpec, migrationSpec)))
     subject.init()
 
-    subject.getNextEligibleJob(10, NO_PREDICATE).assertIsNull()
+    assertThat(subject.getNextEligibleJob(10, NO_PREDICATE)).isNull()
   }
 
   @Test
@@ -554,7 +563,7 @@ class FastJobStorageTest {
     val subject = FastJobStorage(mockDatabase(listOf(migrationSpec1, migrationSpec2)))
     subject.init()
 
-    subject.getNextEligibleJob(10, NO_PREDICATE).assertIsNull()
+    assertThat(subject.getNextEligibleJob(10, NO_PREDICATE)).isNull()
   }
 
   @Test
@@ -566,8 +575,9 @@ class FastJobStorageTest {
     subject.init()
 
     val job = subject.getNextEligibleJob(10, NO_PREDICATE)
-    job.assertIsNotNull()
-    job.id assertIs migrationSpec1.jobSpec.id
+    assertThat(job).isNotNull()
+      .prop(JobSpec::id)
+      .isEqualTo(migrationSpec1.jobSpec.id)
   }
 
   @Test
@@ -580,7 +590,7 @@ class FastJobStorageTest {
     val subject = FastJobStorage(mockDatabase(listOf(migrationSpec1, migrationSpec2)))
     subject.init()
 
-    subject.getNextEligibleJob(currentTime, NO_PREDICATE).assertIsNull()
+    assertThat(subject.getNextEligibleJob(currentTime, NO_PREDICATE)).isNull()
   }
 
   @Test
@@ -588,10 +598,10 @@ class FastJobStorageTest {
     val subject = FastJobStorage(mockDatabase(DataSet1.FULL_SPECS))
     subject.init()
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIs DataSet1.JOB_1
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isEqualTo(DataSet1.JOB_1)
     subject.deleteJob(DataSet1.JOB_1.id)
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIsNot DataSet1.JOB_1
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isNotEqualTo(DataSet1.JOB_1)
   }
 
   @Test
@@ -609,10 +619,10 @@ class FastJobStorageTest {
     )
     subject.init()
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIs firstJob
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isEqualTo(firstJob)
     subject.deleteJob(firstJob.id)
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIs secondJob
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isEqualTo(secondJob)
   }
 
   @Test
@@ -632,13 +642,13 @@ class FastJobStorageTest {
     )
     subject.init()
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIs secondJob
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isEqualTo(secondJob)
     subject.deleteJob(secondJob.id)
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIs thirdJob
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isEqualTo(thirdJob)
     subject.deleteJob(thirdJob.id)
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIs firstJob
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isEqualTo(firstJob)
     subject.deleteJob(firstJob.id)
   }
 
@@ -659,13 +669,13 @@ class FastJobStorageTest {
     )
     subject.init()
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIs secondJob
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isEqualTo(secondJob)
     subject.deleteJob(secondJob.id)
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIs thirdJob
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isEqualTo(thirdJob)
     subject.deleteJob(thirdJob.id)
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIs firstJob
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isEqualTo(firstJob)
     subject.deleteJob(firstJob.id)
   }
 
@@ -674,10 +684,10 @@ class FastJobStorageTest {
     val subject = FastJobStorage(mockDatabase(DataSet1.FULL_SPECS))
     subject.init()
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIs DataSet1.JOB_1
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isEqualTo(DataSet1.JOB_1)
     subject.markJobAsRunning(DataSet1.JOB_1.id, 1)
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIsNot DataSet1.JOB_1
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isNotEqualTo(DataSet1.JOB_1)
   }
 
   @Test
@@ -685,10 +695,10 @@ class FastJobStorageTest {
     val subject = FastJobStorage(mockDatabase(DataSet1.FULL_SPECS))
     subject.init()
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIs DataSet1.JOB_1
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isEqualTo(DataSet1.JOB_1)
     subject.updateJobAfterRetry(DataSet1.JOB_1.id, 1, 1000, 1_000_000, null)
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIsNot DataSet1.JOB_1
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isNotEqualTo(DataSet1.JOB_1)
   }
 
   @Test
@@ -697,11 +707,11 @@ class FastJobStorageTest {
     subject.init()
 
     subject.markJobAsRunning(DataSet1.JOB_1.id, 1)
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIsNot DataSet1.JOB_1
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isNotEqualTo(DataSet1.JOB_1)
 
     subject.updateAllJobsToBePending()
 
-    subject.getNextEligibleJob(100, NO_PREDICATE)?.id assertIs DataSet1.JOB_1.id // The last run attempt time changes, so some fields will be different
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)?.id).isEqualTo(DataSet1.JOB_1.id) // The last run attempt time changes, so some fields will be different
   }
 
   @Test
@@ -709,10 +719,10 @@ class FastJobStorageTest {
     val subject = FastJobStorage(mockDatabase(DataSet1.FULL_SPECS))
     subject.init()
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIs DataSet1.JOB_1
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isEqualTo(DataSet1.JOB_1)
     subject.updateJobs(listOf(DataSet1.JOB_1.copy(isRunning = true)))
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIsNot DataSet1.JOB_1
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isNotEqualTo(DataSet1.JOB_1)
   }
 
   @Test
@@ -720,12 +730,12 @@ class FastJobStorageTest {
     val subject = FastJobStorage(mockDatabase(DataSet1.FULL_SPECS))
     subject.init()
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIs DataSet1.JOB_1
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isEqualTo(DataSet1.JOB_1)
 
     val higherPriorityJob = DataSet1.JOB_1.copy(id = "id-bigboi", globalPriority = Job.Parameters.PRIORITY_HIGH)
     subject.insertJobs(listOf(FullSpec(jobSpec = higherPriorityJob, constraintSpecs = emptyList(), dependencySpecs = emptyList())))
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIs higherPriorityJob
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isEqualTo(higherPriorityJob)
   }
 
   @Test
@@ -733,12 +743,12 @@ class FastJobStorageTest {
     val subject = FastJobStorage(mockDatabase(DataSet1.FULL_SPECS))
     subject.init()
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIs DataSet1.JOB_1
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isEqualTo(DataSet1.JOB_1)
 
     val higherPriorityJob = DataSet1.JOB_1.copy(id = "id-bigboi", queuePriority = Job.Parameters.PRIORITY_HIGH)
     subject.insertJobs(listOf(FullSpec(jobSpec = higherPriorityJob, constraintSpecs = emptyList(), dependencySpecs = emptyList())))
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIs higherPriorityJob
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isEqualTo(higherPriorityJob)
   }
 
   @Test
@@ -749,12 +759,12 @@ class FastJobStorageTest {
     val lowerPriorityJob = DataSet1.JOB_1.copy(id = "id-bigboi", globalPriority = Job.Parameters.PRIORITY_LOW)
     subject.insertJobs(listOf(FullSpec(jobSpec = lowerPriorityJob, constraintSpecs = emptyList(), dependencySpecs = emptyList())))
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIs DataSet1.JOB_1
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isEqualTo(DataSet1.JOB_1)
 
     val higherPriorityJob = lowerPriorityJob.copy(globalPriority = Job.Parameters.PRIORITY_HIGH)
     subject.updateJobs(listOf(higherPriorityJob))
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIs higherPriorityJob
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isEqualTo(higherPriorityJob)
   }
 
   @Test
@@ -765,12 +775,12 @@ class FastJobStorageTest {
     val lowerPriorityJob = DataSet1.JOB_1.copy(id = "id-bigboi", queuePriority = Job.Parameters.PRIORITY_LOW)
     subject.insertJobs(listOf(FullSpec(jobSpec = lowerPriorityJob, constraintSpecs = emptyList(), dependencySpecs = emptyList())))
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIs DataSet1.JOB_1
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isEqualTo(DataSet1.JOB_1)
 
     val higherPriorityJob = lowerPriorityJob.copy(queuePriority = Job.Parameters.PRIORITY_HIGH)
     subject.updateJobs(listOf(higherPriorityJob))
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIs higherPriorityJob
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isEqualTo(higherPriorityJob)
   }
 
   @Test
@@ -781,12 +791,12 @@ class FastJobStorageTest {
     val newerJob = DataSet1.JOB_1.copy(id = "id-bigboi", createTime = 1000)
     subject.insertJobs(listOf(FullSpec(jobSpec = newerJob, constraintSpecs = emptyList(), dependencySpecs = emptyList())))
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIs DataSet1.JOB_1
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isEqualTo(DataSet1.JOB_1)
 
     val olderJob = newerJob.copy(createTime = 0)
     subject.updateJobs(listOf(olderJob))
 
-    subject.getNextEligibleJob(100, NO_PREDICATE) assertIs olderJob
+    assertThat(subject.getNextEligibleJob(100, NO_PREDICATE)).isEqualTo(olderJob)
   }
 
   @Test
@@ -826,13 +836,13 @@ class FastJobStorageTest {
     val constraints = subject.debugGetConstraintSpecs(1000)
     val dependencies = subject.debugGetAllDependencySpecs()
 
-    jobs.size assertIs 2
-    jobs[0] assertIs DataSet1.JOB_2
-    jobs[1] assertIs DataSet1.JOB_3
-    constraints.size assertIs 1
-    constraints[0] assertIs DataSet1.CONSTRAINT_2
-    dependencies.size assertIs 1
-    subject.getJobSpec("id1") assertIs null
+    assertThat(jobs.size).isEqualTo(2)
+    assertThat(jobs[0]).isEqualTo(DataSet1.JOB_2)
+    assertThat(jobs[1]).isEqualTo(DataSet1.JOB_3)
+    assertThat(constraints.size).isEqualTo(1)
+    assertThat(constraints[0]).isEqualTo(DataSet1.CONSTRAINT_2)
+    assertThat(dependencies.size).isEqualTo(1)
+    assertThat(subject.getJobSpec("id1")).isEqualTo(null)
   }
 
   @Test
@@ -841,9 +851,9 @@ class FastJobStorageTest {
     subject.init()
 
     val result = subject.getDependencySpecsThatDependOnJob("id1")
-    result.size assertIs 2
-    result[0] assertIs DataSet1.DEPENDENCY_2
-    result[1] assertIs DataSet1.DEPENDENCY_3
+    assertThat(result.size).isEqualTo(2)
+    assertThat(result[0]).isEqualTo(DataSet1.DEPENDENCY_2)
+    assertThat(result[1]).isEqualTo(DataSet1.DEPENDENCY_3)
   }
 
   @Test
@@ -852,8 +862,8 @@ class FastJobStorageTest {
     subject.init()
 
     val result = subject.getDependencySpecsThatDependOnJob("id2")
-    result.size assertIs 1
-    result[0] assertIs DataSet1.DEPENDENCY_3
+    assertThat(result.size).isEqualTo(1)
+    assertThat(result[0]).isEqualTo(DataSet1.DEPENDENCY_3)
   }
 
   @Test
@@ -862,7 +872,7 @@ class FastJobStorageTest {
     subject.init()
 
     val result = subject.getDependencySpecsThatDependOnJob("id3")
-    result.size assertIs 0
+    assertThat(result.size).isEqualTo(0)
   }
 
   @Test
@@ -871,7 +881,7 @@ class FastJobStorageTest {
     subject.init()
 
     val result = subject.getJobsInQueue("x")
-    result.size assertIs 0
+    assertThat(result.size).isEqualTo(0)
   }
 
   @Test
@@ -880,8 +890,8 @@ class FastJobStorageTest {
     subject.init()
 
     val result = subject.getJobsInQueue("q1")
-    result.size assertIs 1
-    result[0].id assertIs "id1"
+    assertThat(result.size).isEqualTo(1)
+    assertThat(result[0].id).isEqualTo("id1")
   }
 
   @Test
@@ -889,8 +899,8 @@ class FastJobStorageTest {
     val subject = FastJobStorage(mockDatabase(DataSet1.FULL_SPECS))
     subject.init()
 
-    subject.getJobCountForFactory("f1") assertIs 1
-    subject.getJobCountForFactory("does-not-exist") assertIs 0
+    assertThat(subject.getJobCountForFactory("f1")).isEqualTo(1)
+    assertThat(subject.getJobCountForFactory("does-not-exist")).isEqualTo(0)
   }
 
   @Test
@@ -898,9 +908,9 @@ class FastJobStorageTest {
     val subject = FastJobStorage(mockDatabase(DataSet1.FULL_SPECS))
     subject.init()
 
-    subject.getJobCountForFactoryAndQueue("f1", "q1") assertIs 1
-    subject.getJobCountForFactoryAndQueue("f2", "q1") assertIs 0
-    subject.getJobCountForFactoryAndQueue("f1", "does-not-exist") assertIs 0
+    assertThat(subject.getJobCountForFactoryAndQueue("f1", "q1")).isEqualTo(1)
+    assertThat(subject.getJobCountForFactoryAndQueue("f2", "q1")).isEqualTo(0)
+    assertThat(subject.getJobCountForFactoryAndQueue("f1", "does-not-exist")).isEqualTo(0)
   }
 
   @Test
@@ -908,8 +918,8 @@ class FastJobStorageTest {
     val subject = FastJobStorage(mockDatabase(DataSet1.FULL_SPECS))
     subject.init()
 
-    subject.areQueuesEmpty(TestHelpers.setOf("q1")) assertIs false
-    subject.areQueuesEmpty(TestHelpers.setOf("q1", "q2")) assertIs false
+    assertThat(subject.areQueuesEmpty(TestHelpers.setOf("q1"))).isEqualTo(false)
+    assertThat(subject.areQueuesEmpty(TestHelpers.setOf("q1", "q2"))).isEqualTo(false)
   }
 
   @Test
@@ -917,7 +927,7 @@ class FastJobStorageTest {
     val subject = FastJobStorage(mockDatabase(DataSet1.FULL_SPECS))
     subject.init()
 
-    subject.areQueuesEmpty(TestHelpers.setOf("q1", "q5")) assertIs false
+    assertThat(subject.areQueuesEmpty(TestHelpers.setOf("q1", "q5"))).isEqualTo(false)
   }
 
   @Test
@@ -925,8 +935,8 @@ class FastJobStorageTest {
     val subject = FastJobStorage(mockDatabase(DataSet1.FULL_SPECS))
     subject.init()
 
-    subject.areQueuesEmpty(TestHelpers.setOf("q4")) assertIs true
-    subject.areQueuesEmpty(TestHelpers.setOf("q4", "q5")) assertIs true
+    assertThat(subject.areQueuesEmpty(TestHelpers.setOf("q4"))).isEqualTo(true)
+    assertThat(subject.areQueuesEmpty(TestHelpers.setOf("q4", "q5"))).isEqualTo(true)
   }
 
   private fun mockDatabase(fullSpecs: List<FullSpec> = emptyList()): JobDatabase {
@@ -1008,11 +1018,11 @@ class FastJobStorageTest {
     }
     every { mock.getMostEligibleJobInQueue(any()) } answers {
       jobs
+        .asSequence()
         .filter { it.queueKey == firstArg() }
         .sortedBy { it.createTime }
         .sortedByDescending { it.queuePriority }
-        .sortedByDescending { it.globalPriority }
-        .firstOrNull()
+        .maxByOrNull { it.globalPriority }
     }
 
     return mock
@@ -1118,22 +1128,22 @@ class FastJobStorageTest {
     val FULL_SPEC_3 = FullSpec(JOB_3, emptyList(), listOf(DEPENDENCY_3))
     val FULL_SPECS = listOf(FULL_SPEC_1, FULL_SPEC_2, FULL_SPEC_3)
     fun assertJobsMatch(jobs: List<JobSpec?>) {
-      jobs.size assertIs 3
-      jobs.contains(JOB_1) assertIs true
-      jobs.contains(JOB_2) assertIs true
-      jobs.contains(JOB_3) assertIs true
+      assertThat(jobs.size).isEqualTo(3)
+      assertThat(jobs.contains(JOB_1)).isEqualTo(true)
+      assertThat(jobs.contains(JOB_2)).isEqualTo(true)
+      assertThat(jobs.contains(JOB_3)).isEqualTo(true)
     }
 
     fun assertConstraintsMatch(constraints: List<ConstraintSpec?>) {
-      constraints.size assertIs 2
-      constraints.contains(CONSTRAINT_1) assertIs true
-      constraints.contains(CONSTRAINT_2) assertIs true
+      assertThat(constraints.size).isEqualTo(2)
+      assertThat(constraints.contains(CONSTRAINT_1)).isEqualTo(true)
+      assertThat(constraints.contains(CONSTRAINT_2)).isEqualTo(true)
     }
 
     fun assertDependenciesMatch(dependencies: List<DependencySpec?>) {
-      dependencies.size assertIs 2
-      dependencies.contains(DEPENDENCY_2) assertIs true
-      dependencies.contains(DEPENDENCY_3) assertIs true
+      assertThat(dependencies.size).isEqualTo(2)
+      assertThat(dependencies.contains(DEPENDENCY_2)).isEqualTo(true)
+      assertThat(dependencies.contains(DEPENDENCY_3)).isEqualTo(true)
     }
   }
 
@@ -1222,20 +1232,20 @@ class FastJobStorageTest {
     val FULL_SPECS = listOf(FULL_SPEC_1, FULL_SPEC_2, FULL_SPEC_3)
 
     fun assertJobsMatch(jobs: List<JobSpec?>) {
-      jobs.size assertIs 3
-      jobs.contains(JOB_1) assertIs true
-      jobs.contains(JOB_2) assertIs true
-      jobs.contains(JOB_3) assertIs true
+      assertThat(jobs.size).isEqualTo(3)
+      assertThat(jobs.contains(JOB_1)).isEqualTo(true)
+      assertThat(jobs.contains(JOB_2)).isEqualTo(true)
+      assertThat(jobs.contains(JOB_3)).isEqualTo(true)
     }
 
     fun assertConstraintsMatch(constraints: List<ConstraintSpec?>) {
-      constraints.size assertIs 0
+      assertThat(constraints.size).isEqualTo(0)
     }
 
     fun assertDependenciesMatch(dependencies: List<DependencySpec?>) {
-      dependencies.size assertIs 1
-      dependencies.contains(DEPENDENCY_1) assertIs false
-      dependencies.contains(DEPENDENCY_3) assertIs true
+      assertThat(dependencies.size).isEqualTo(1)
+      assertThat(dependencies.contains(DEPENDENCY_1)).isEqualTo(false)
+      assertThat(dependencies.contains(DEPENDENCY_3)).isEqualTo(true)
     }
   }
 }

--- a/app/src/test/java/org/thoughtcrime/securesms/megaphone/RemoteMegaphoneRepositoryTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/megaphone/RemoteMegaphoneRepositoryTest.kt
@@ -2,14 +2,14 @@ package org.thoughtcrime.securesms.megaphone
 
 import android.app.Application
 import android.net.Uri
+import assertk.assertThat
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.notNullValue
-import org.hamcrest.Matchers.nullValue
 import org.json.JSONObject
 import org.junit.After
 import org.junit.AfterClass
@@ -53,7 +53,7 @@ class RemoteMegaphoneRepositoryTest {
     val record = RemoteMegaphoneRepository.getRemoteMegaphoneToShow(0)
 
     // THEN
-    assertThat(record, nullValue())
+    assertThat(record).isNull()
   }
 
   @Test
@@ -65,7 +65,7 @@ class RemoteMegaphoneRepositoryTest {
     val record = RemoteMegaphoneRepository.getRemoteMegaphoneToShow(0)
 
     // THEN
-    assertThat(record, notNullValue())
+    assertThat(record).isNotNull()
   }
 
   @Test
@@ -85,7 +85,7 @@ class RemoteMegaphoneRepositoryTest {
     val record = RemoteMegaphoneRepository.getRemoteMegaphoneToShow(now.toMillis())
 
     // THEN
-    assertThat(record, nullValue())
+    assertThat(record).isNull()
   }
 
   @Test
@@ -105,7 +105,7 @@ class RemoteMegaphoneRepositoryTest {
     val record = RemoteMegaphoneRepository.getRemoteMegaphoneToShow(now.toMillis())
 
     // THEN
-    assertThat(record, notNullValue())
+    assertThat(record).isNotNull()
   }
 
   @Test
@@ -125,7 +125,7 @@ class RemoteMegaphoneRepositoryTest {
     val record = RemoteMegaphoneRepository.getRemoteMegaphoneToShow(now.toMillis())
 
     // THEN
-    assertThat(record, notNullValue())
+    assertThat(record).isNotNull()
   }
 
   companion object {

--- a/app/src/test/java/org/thoughtcrime/securesms/notifications/DeviceSpecificNotificationConfigTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/notifications/DeviceSpecificNotificationConfigTest.kt
@@ -2,6 +2,8 @@ package org.thoughtcrime.securesms.notifications
 
 import android.app.Application
 import android.os.Build
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
@@ -12,7 +14,6 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.util.ReflectionHelpers
-import org.thoughtcrime.securesms.assertIs
 import org.thoughtcrime.securesms.util.RemoteConfig
 
 @RunWith(RobolectricTestRunner::class)
@@ -32,20 +33,21 @@ class DeviceSpecificNotificationConfigTest {
   @Test
   fun `empty config`() {
     every { RemoteConfig.deviceSpecificNotificationConfig } returns ""
-    DeviceSpecificNotificationConfig.computeConfig() assertIs DeviceSpecificNotificationConfig.Config()
+    assertThat(DeviceSpecificNotificationConfig.computeConfig()).isEqualTo(DeviceSpecificNotificationConfig.Config())
   }
 
   @Test
   fun `invalid config`() {
     every { RemoteConfig.deviceSpecificNotificationConfig } returns "bad"
-    DeviceSpecificNotificationConfig.computeConfig() assertIs DeviceSpecificNotificationConfig.Config()
+    assertThat(DeviceSpecificNotificationConfig.computeConfig()).isEqualTo(DeviceSpecificNotificationConfig.Config())
   }
 
   @Test
   fun `simple device match`() {
     ReflectionHelpers.setStaticField(Build::class.java, "MODEL", "test")
     every { RemoteConfig.deviceSpecificNotificationConfig } returns """[ { "model": "test", "link": "test.com", "showConditionCode": "always", "localePercent": "*:500000", "version": 3 } ]"""
-    DeviceSpecificNotificationConfig.computeConfig() assertIs DeviceSpecificNotificationConfig.Config(model = "test", link = "test.com", showConditionCode = "always", localePercent = "*:500000", version = 3)
+    assertThat(DeviceSpecificNotificationConfig.computeConfig())
+      .isEqualTo(DeviceSpecificNotificationConfig.Config(model = "test", link = "test.com", showConditionCode = "always", localePercent = "*:500000", version = 3))
   }
 
   @Test
@@ -60,14 +62,16 @@ class DeviceSpecificNotificationConfigTest {
         { "model": "test-11*", "showConditionCode": "never", "localePercent": "*:40000", "version": 4 }
       ]
       """.trimMargin()
-    DeviceSpecificNotificationConfig.computeConfig() assertIs DeviceSpecificNotificationConfig.Config(model = "test-1", showConditionCode = "has-battery-optimization-on", localePercent = "*:20000", version = 2)
+    assertThat(DeviceSpecificNotificationConfig.computeConfig())
+      .isEqualTo(DeviceSpecificNotificationConfig.Config(model = "test-1", showConditionCode = "has-battery-optimization-on", localePercent = "*:20000", version = 2))
   }
 
   @Test
   fun `simple wildcard device match`() {
     ReflectionHelpers.setStaticField(Build::class.java, "MODEL", "test1")
     every { RemoteConfig.deviceSpecificNotificationConfig } returns """[ { "model": "test*", "link": "test.com", "showConditionCode": "never", "localePercent": "*:500000", "version": 1 } ]"""
-    DeviceSpecificNotificationConfig.currentConfig assertIs DeviceSpecificNotificationConfig.Config(model = "test*", link = "test.com", showConditionCode = "never", localePercent = "*:500000", version = 1)
+    assertThat(DeviceSpecificNotificationConfig.currentConfig)
+      .isEqualTo(DeviceSpecificNotificationConfig.Config(model = "test*", link = "test.com", showConditionCode = "never", localePercent = "*:500000", version = 1))
   }
 
   @Test
@@ -81,21 +85,24 @@ class DeviceSpecificNotificationConfigTest {
         { "model": "test-", "showConditionCode": "never", "localePercent": "*:30000", "version": 3 }
       ]
       """.trimMargin()
-    DeviceSpecificNotificationConfig.computeConfig() assertIs DeviceSpecificNotificationConfig.Config(model = "*", showConditionCode = "always", localePercent = "*:10000", version = 1)
+    assertThat(DeviceSpecificNotificationConfig.computeConfig())
+      .isEqualTo(DeviceSpecificNotificationConfig.Config(model = "*", showConditionCode = "always", localePercent = "*:10000", version = 1))
   }
 
   @Test
   fun `no device match`() {
     ReflectionHelpers.setStaticField(Build::class.java, "MODEL", "bad")
     every { RemoteConfig.deviceSpecificNotificationConfig } returns """[ { "model": "test", "link": "test.com", "showConditionCode": "always", "localePercent": "*:500000", "version": 1 } ]"""
-    DeviceSpecificNotificationConfig.computeConfig() assertIs DeviceSpecificNotificationConfig.Config()
+    assertThat(DeviceSpecificNotificationConfig.computeConfig())
+      .isEqualTo(DeviceSpecificNotificationConfig.Config())
   }
 
   @Test
   fun `default fields is zero percent`() {
     ReflectionHelpers.setStaticField(Build::class.java, "MODEL", "test")
     every { RemoteConfig.deviceSpecificNotificationConfig } returns """[ { "model": "test" } ]"""
-    DeviceSpecificNotificationConfig.computeConfig() assertIs DeviceSpecificNotificationConfig.Config(model = "test", localePercent = "*", version = 0)
+    assertThat(DeviceSpecificNotificationConfig.computeConfig())
+      .isEqualTo(DeviceSpecificNotificationConfig.Config(model = "test", localePercent = "*", version = 0))
   }
 
   @Test
@@ -108,7 +115,8 @@ class DeviceSpecificNotificationConfigTest {
         { "manufacturer": "test-manufacturer", "showConditionCode": "always", "localePercent": "*:10000", "version": 1 }
       ]
       """.trimMargin()
-    DeviceSpecificNotificationConfig.computeConfig() assertIs DeviceSpecificNotificationConfig.Config(manufacturer = "test-manufacturer", showConditionCode = "always", localePercent = "*:10000", version = 1)
+    assertThat(DeviceSpecificNotificationConfig.computeConfig())
+      .isEqualTo(DeviceSpecificNotificationConfig.Config(manufacturer = "test-manufacturer", showConditionCode = "always", localePercent = "*:10000", version = 1))
   }
 
   @Test
@@ -122,6 +130,7 @@ class DeviceSpecificNotificationConfigTest {
         { "model": "test-model", "showConditionCode": "has-battery-optimization-on", "localePercent": "*:20000", "version": 2 }
       ]
       """.trimMargin()
-    DeviceSpecificNotificationConfig.computeConfig() assertIs DeviceSpecificNotificationConfig.Config(model = "test-model", showConditionCode = "has-battery-optimization-on", localePercent = "*:20000", version = 2)
+    assertThat(DeviceSpecificNotificationConfig.computeConfig())
+      .isEqualTo(DeviceSpecificNotificationConfig.Config(model = "test-model", showConditionCode = "has-battery-optimization-on", localePercent = "*:20000", version = 2))
   }
 }

--- a/app/src/test/java/org/thoughtcrime/securesms/notifications/profiles/NotificationProfileScheduleTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/notifications/profiles/NotificationProfileScheduleTest.kt
@@ -1,9 +1,9 @@
 package org.thoughtcrime.securesms.notifications.profiles
 
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.`is`
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
 import org.junit.BeforeClass
 import org.junit.Test
 import org.thoughtcrime.securesms.util.toMillis
@@ -13,7 +13,6 @@ import java.time.ZoneOffset
 import java.util.TimeZone
 
 class NotificationProfileScheduleTest {
-
   private val sunday0am: LocalDateTime = LocalDateTime.of(2021, 7, 4, 0, 0, 0)
   private val sunday1am: LocalDateTime = LocalDateTime.of(2021, 7, 4, 1, 0, 0)
   private val sunday9am: LocalDateTime = LocalDateTime.of(2021, 7, 4, 9, 0, 0)
@@ -41,111 +40,111 @@ class NotificationProfileScheduleTest {
   fun `when time is within enabled schedule 9am to 5pm then return true`() {
     val schedule = NotificationProfileSchedule(id = 1L, enabled = true, start = 900, end = 1700, daysEnabled = setOf(DayOfWeek.SUNDAY))
 
-    assertTrue(schedule.isCurrentlyActive(sunday9am.toMillis(ZoneOffset.UTC)))
-    assertTrue(schedule.isCurrentlyActive(sunday9am.plusHours(1).toMillis(ZoneOffset.UTC)))
+    assertThat(schedule.isCurrentlyActive(sunday9am.toMillis(ZoneOffset.UTC))).isTrue()
+    assertThat(schedule.isCurrentlyActive(sunday9am.plusHours(1).toMillis(ZoneOffset.UTC))).isTrue()
   }
 
   @Test
   fun `when time is outside enabled schedule 9am to 5pm then return false`() {
     val schedule = NotificationProfileSchedule(id = 1L, enabled = true, start = 900, end = 1700, daysEnabled = setOf(DayOfWeek.SUNDAY))
 
-    assertFalse(schedule.isCurrentlyActive(sunday1am.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(sunday10pm.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(monday1am.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(monday9am.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(monday10pm.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(tuesday9am.toMillis(ZoneOffset.UTC)))
+    assertThat(schedule.isCurrentlyActive(sunday1am.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(sunday10pm.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(monday1am.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(monday9am.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(monday10pm.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(tuesday9am.toMillis(ZoneOffset.UTC))).isFalse()
   }
 
   @Test
   fun `when time is inside enabled with day wrapping schedule 10pm to 2am then return true`() {
     val schedule = NotificationProfileSchedule(id = 1L, enabled = true, start = 2100, end = 200, daysEnabled = setOf(DayOfWeek.MONDAY))
 
-    assertTrue(schedule.isCurrentlyActive(monday10pm.toMillis(ZoneOffset.UTC)))
-    assertTrue(schedule.isCurrentlyActive(tuesday1am.toMillis(ZoneOffset.UTC)))
+    assertThat(schedule.isCurrentlyActive(monday10pm.toMillis(ZoneOffset.UTC))).isTrue()
+    assertThat(schedule.isCurrentlyActive(tuesday1am.toMillis(ZoneOffset.UTC))).isTrue()
   }
 
   @Test
   fun `when time is outside enabled with day wrapping schedule 10pm to 2am then return false`() {
     val schedule = NotificationProfileSchedule(id = 1L, enabled = true, start = 2100, end = 200, daysEnabled = setOf(DayOfWeek.MONDAY))
 
-    assertFalse(schedule.isCurrentlyActive(sunday1am.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(sunday10pm.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(monday1am.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(monday9am.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(tuesday9am.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(tuesday10pm.toMillis(ZoneOffset.UTC)))
+    assertThat(schedule.isCurrentlyActive(sunday1am.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(sunday10pm.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(monday1am.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(monday9am.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(tuesday9am.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(tuesday10pm.toMillis(ZoneOffset.UTC))).isFalse()
   }
 
   @Test
   fun `when time is inside enabled schedule 12am to 10am then return true`() {
     val schedule = NotificationProfileSchedule(id = 1L, enabled = true, start = 0, end = 1000, daysEnabled = setOf(DayOfWeek.SUNDAY))
 
-    assertTrue(schedule.isCurrentlyActive(sunday0am.toMillis(ZoneOffset.UTC)))
-    assertTrue(schedule.isCurrentlyActive(sunday1am.toMillis(ZoneOffset.UTC)))
-    assertTrue(schedule.isCurrentlyActive(sunday9am.toMillis(ZoneOffset.UTC)))
+    assertThat(schedule.isCurrentlyActive(sunday0am.toMillis(ZoneOffset.UTC))).isTrue()
+    assertThat(schedule.isCurrentlyActive(sunday1am.toMillis(ZoneOffset.UTC))).isTrue()
+    assertThat(schedule.isCurrentlyActive(sunday9am.toMillis(ZoneOffset.UTC))).isTrue()
   }
 
   @Test
   fun `when time is inside enabled schedule 12am to 12am then return true`() {
     val schedule = NotificationProfileSchedule(id = 1L, enabled = true, start = 0, end = 0, daysEnabled = setOf(DayOfWeek.SUNDAY))
 
-    assertTrue(schedule.isCurrentlyActive(sunday0am.toMillis(ZoneOffset.UTC)))
-    assertTrue(schedule.isCurrentlyActive(sunday1am.toMillis(ZoneOffset.UTC)))
-    assertTrue(schedule.isCurrentlyActive(sunday9am.toMillis(ZoneOffset.UTC)))
-    assertTrue(schedule.isCurrentlyActive(sunday10pm.toMillis(ZoneOffset.UTC)))
+    assertThat(schedule.isCurrentlyActive(sunday0am.toMillis(ZoneOffset.UTC))).isTrue()
+    assertThat(schedule.isCurrentlyActive(sunday1am.toMillis(ZoneOffset.UTC))).isTrue()
+    assertThat(schedule.isCurrentlyActive(sunday9am.toMillis(ZoneOffset.UTC))).isTrue()
+    assertThat(schedule.isCurrentlyActive(sunday10pm.toMillis(ZoneOffset.UTC))).isTrue()
   }
 
   @Test
   fun `when time is outside enabled schedule 12am to 12am then return false`() {
     val schedule = NotificationProfileSchedule(id = 1L, enabled = true, start = 0, end = 0, daysEnabled = setOf(DayOfWeek.SUNDAY))
 
-    assertFalse(schedule.isCurrentlyActive(monday0am.plusMinutes(1).toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(monday1am.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(monday9am.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(monday10pm.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(tuesday1am.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(tuesday9am.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(tuesday10pm.toMillis(ZoneOffset.UTC)))
+    assertThat(schedule.isCurrentlyActive(monday0am.plusMinutes(1).toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(monday1am.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(monday9am.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(monday10pm.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(tuesday1am.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(tuesday9am.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(tuesday10pm.toMillis(ZoneOffset.UTC))).isFalse()
   }
 
   @Test
   fun `when enabled schedule 12am to 12am for all days then return true`() {
     val schedule = NotificationProfileSchedule(id = 1L, enabled = true, start = 0, end = 0, daysEnabled = DayOfWeek.entries.toSet())
 
-    assertTrue(schedule.isCurrentlyActive(sunday0am.toMillis(ZoneOffset.UTC)))
-    assertTrue(schedule.isCurrentlyActive(sunday1am.toMillis(ZoneOffset.UTC)))
-    assertTrue(schedule.isCurrentlyActive(sunday9am.toMillis(ZoneOffset.UTC)))
-    assertTrue(schedule.isCurrentlyActive(sunday10pm.toMillis(ZoneOffset.UTC)))
-    assertTrue(schedule.isCurrentlyActive(monday0am.toMillis(ZoneOffset.UTC)))
-    assertTrue(schedule.isCurrentlyActive(monday1am.toMillis(ZoneOffset.UTC)))
-    assertTrue(schedule.isCurrentlyActive(monday9am.toMillis(ZoneOffset.UTC)))
-    assertTrue(schedule.isCurrentlyActive(monday10pm.toMillis(ZoneOffset.UTC)))
-    assertTrue(schedule.isCurrentlyActive(tuesday1am.toMillis(ZoneOffset.UTC)))
-    assertTrue(schedule.isCurrentlyActive(tuesday9am.toMillis(ZoneOffset.UTC)))
-    assertTrue(schedule.isCurrentlyActive(tuesday10pm.toMillis(ZoneOffset.UTC)))
+    assertThat(schedule.isCurrentlyActive(sunday0am.toMillis(ZoneOffset.UTC))).isTrue()
+    assertThat(schedule.isCurrentlyActive(sunday1am.toMillis(ZoneOffset.UTC))).isTrue()
+    assertThat(schedule.isCurrentlyActive(sunday9am.toMillis(ZoneOffset.UTC))).isTrue()
+    assertThat(schedule.isCurrentlyActive(sunday10pm.toMillis(ZoneOffset.UTC))).isTrue()
+    assertThat(schedule.isCurrentlyActive(monday0am.toMillis(ZoneOffset.UTC))).isTrue()
+    assertThat(schedule.isCurrentlyActive(monday1am.toMillis(ZoneOffset.UTC))).isTrue()
+    assertThat(schedule.isCurrentlyActive(monday9am.toMillis(ZoneOffset.UTC))).isTrue()
+    assertThat(schedule.isCurrentlyActive(monday10pm.toMillis(ZoneOffset.UTC))).isTrue()
+    assertThat(schedule.isCurrentlyActive(tuesday1am.toMillis(ZoneOffset.UTC))).isTrue()
+    assertThat(schedule.isCurrentlyActive(tuesday9am.toMillis(ZoneOffset.UTC))).isTrue()
+    assertThat(schedule.isCurrentlyActive(tuesday10pm.toMillis(ZoneOffset.UTC))).isTrue()
   }
 
   @Test
   fun `when disabled schedule 12am to 12am for all days then return false`() {
     val schedule = NotificationProfileSchedule(id = 1L, enabled = false, start = 0, end = 0, daysEnabled = DayOfWeek.entries.toSet())
 
-    assertFalse(schedule.isCurrentlyActive(sunday0am.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(sunday1am.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(sunday9am.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(sunday10pm.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(monday0am.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(monday1am.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(monday9am.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(monday10pm.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(tuesday1am.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(tuesday9am.toMillis(ZoneOffset.UTC)))
-    assertFalse(schedule.isCurrentlyActive(tuesday10pm.toMillis(ZoneOffset.UTC)))
+    assertThat(schedule.isCurrentlyActive(sunday0am.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(sunday1am.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(sunday9am.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(sunday10pm.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(monday0am.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(monday1am.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(monday9am.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(monday10pm.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(tuesday1am.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(tuesday9am.toMillis(ZoneOffset.UTC))).isFalse()
+    assertThat(schedule.isCurrentlyActive(tuesday10pm.toMillis(ZoneOffset.UTC))).isFalse()
   }
 
   @Test
   fun `when end time is midnight return midnight of next day from now`() {
     val schedule = NotificationProfileSchedule(id = 1L, enabled = false, start = 0, end = 0, daysEnabled = DayOfWeek.entries.toSet())
-    assertThat(schedule.endDateTime(sunday930am), `is`(monday0am))
+    assertThat(schedule.endDateTime(sunday930am)).isEqualTo(monday0am)
   }
 }

--- a/app/src/test/java/org/thoughtcrime/securesms/notifications/profiles/NotificationProfilesTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/notifications/profiles/NotificationProfilesTest.kt
@@ -1,13 +1,13 @@
 package org.thoughtcrime.securesms.notifications.profiles
 
 import android.app.Application
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.`is`
-import org.hamcrest.Matchers.nullValue
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -27,7 +27,6 @@ import java.time.ZoneOffset
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, application = Application::class)
 class NotificationProfilesTest {
-
   @get:Rule
   val appDependencies = MockAppDependenciesRule()
 
@@ -72,13 +71,13 @@ class NotificationProfilesTest {
 
   @Test
   fun `when no profiles then return null`() {
-    assertThat("no active profile", NotificationProfiles.getActiveProfile(emptyList(), 1000L, utc), nullValue())
+    assertThat(NotificationProfiles.getActiveProfile(emptyList(), 1000L, utc), "no active profile").isNull()
   }
 
   @Test
   fun `when no manually enabled or schedule profiles then return null`() {
     val profiles = listOf(first, second)
-    assertThat("no active profile", NotificationProfiles.getActiveProfile(profiles, 3000L, utc), nullValue())
+    assertThat(NotificationProfiles.getActiveProfile(profiles, 3000L, utc), "no active profile").isNull()
   }
 
   @Test
@@ -88,14 +87,14 @@ class NotificationProfilesTest {
     every { notificationProfileValues.manuallyDisabledAt } returns 5000L
 
     val profiles = listOf(first, second)
-    assertThat("active profile is profile second", NotificationProfiles.getActiveProfile(profiles, 3000L, utc), `is`(profiles[1]))
+    assertThat(NotificationProfiles.getActiveProfile(profiles, 3000L, utc), "active profile is profile second").isEqualTo(profiles[1])
   }
 
   @Test
   fun `when first is scheduled and second is not manually enabled and now is within schedule return first`() {
     val schedule = NotificationProfileSchedule(id = 3L, true, start = 700, daysEnabled = setOf(DayOfWeek.SUNDAY))
     val profiles = listOf(first.copy(schedule = schedule), second)
-    assertThat("active profile is first", NotificationProfiles.getActiveProfile(profiles, sunday9am.toMillis(ZoneOffset.UTC), utc), `is`(profiles[0]))
+    assertThat(NotificationProfiles.getActiveProfile(profiles, sunday9am.toMillis(ZoneOffset.UTC), utc), "active profile is first").isEqualTo(profiles[0])
   }
 
   @Test
@@ -106,7 +105,7 @@ class NotificationProfilesTest {
 
     val schedule = NotificationProfileSchedule(id = 3L, true, start = 700, daysEnabled = setOf(DayOfWeek.SUNDAY))
     val profiles = listOf(first.copy(schedule = schedule), second)
-    assertThat("active profile is first", NotificationProfiles.getActiveProfile(profiles, sunday9am.toMillis(ZoneOffset.UTC), utc), `is`(profiles[1]))
+    assertThat(NotificationProfiles.getActiveProfile(profiles, sunday9am.toMillis(ZoneOffset.UTC), utc), "active profile is first").isEqualTo(profiles[1])
   }
 
   @Test
@@ -118,7 +117,7 @@ class NotificationProfilesTest {
     val schedule = NotificationProfileSchedule(id = 3L, true, start = 900, daysEnabled = setOf(DayOfWeek.SUNDAY))
     val profiles = listOf(first.copy(schedule = schedule), second)
 
-    assertThat("active profile is first", NotificationProfiles.getActiveProfile(profiles, sunday930am.toMillis(ZoneOffset.UTC), utc), `is`(profiles[0]))
+    assertThat(NotificationProfiles.getActiveProfile(profiles, sunday930am.toMillis(ZoneOffset.UTC), utc), "active profile is first").isEqualTo(profiles[0])
   }
 
   @Test
@@ -127,7 +126,7 @@ class NotificationProfilesTest {
     val secondSchedule = NotificationProfileSchedule(id = 4L, true, start = 800, daysEnabled = setOf(DayOfWeek.SUNDAY))
     val profiles = listOf(first.copy(schedule = firstSchedule), second.copy(schedule = secondSchedule))
 
-    assertThat("active profile is second", NotificationProfiles.getActiveProfile(profiles, sunday9am.toMillis(ZoneOffset.UTC), utc), `is`(profiles[1]))
+    assertThat(NotificationProfiles.getActiveProfile(profiles, sunday9am.toMillis(ZoneOffset.UTC), utc), "active profile is second").isEqualTo(profiles[1])
   }
 
   @Test
@@ -140,7 +139,7 @@ class NotificationProfilesTest {
     val secondSchedule = NotificationProfileSchedule(id = 4L, true, start = 700, daysEnabled = setOf(DayOfWeek.SUNDAY))
     val profiles = listOf(first.copy(schedule = firstSchedule), second.copy(schedule = secondSchedule))
 
-    assertThat("active profile is first", NotificationProfiles.getActiveProfile(profiles, sunday9am.toMillis(ZoneOffset.UTC), utc), `is`(profiles[0]))
+    assertThat(NotificationProfiles.getActiveProfile(profiles, sunday9am.toMillis(ZoneOffset.UTC), utc), "active profile is first").isEqualTo(profiles[0])
   }
 
   @Test
@@ -151,7 +150,7 @@ class NotificationProfilesTest {
 
     val schedule = NotificationProfileSchedule(id = 3L, true, start = 700, end = 845, daysEnabled = setOf(DayOfWeek.SUNDAY))
     val profiles = listOf(first.copy(schedule = schedule))
-    assertThat("active profile is first", NotificationProfiles.getActiveProfile(profiles, sunday9am.toMillis(ZoneOffset.UTC), utc), `is`(profiles[0]))
+    assertThat(NotificationProfiles.getActiveProfile(profiles, sunday9am.toMillis(ZoneOffset.UTC), utc), "active profile is first").isEqualTo(profiles[0])
   }
 
   @Test
@@ -162,7 +161,7 @@ class NotificationProfilesTest {
 
     val schedule = NotificationProfileSchedule(id = 3L, true, start = 700, end = 1000, daysEnabled = setOf(DayOfWeek.SUNDAY))
     val profiles = listOf(first.copy(schedule = schedule))
-    assertThat("active profile is null", NotificationProfiles.getActiveProfile(profiles, sunday930am.toMillis(ZoneOffset.UTC), utc), nullValue())
+    assertThat(NotificationProfiles.getActiveProfile(profiles, sunday930am.toMillis(ZoneOffset.UTC), utc), "active profile is null").isNull()
   }
 
   @Test
@@ -173,7 +172,7 @@ class NotificationProfilesTest {
 
     val schedule = NotificationProfileSchedule(id = 3L, enabled = true, start = 700, end = 900, daysEnabled = setOf(DayOfWeek.SUNDAY, DayOfWeek.MONDAY))
     val profiles = listOf(first.copy(schedule = schedule))
-    assertThat("active profile is first", NotificationProfiles.getActiveProfile(profiles, monday830am.toMillis(ZoneOffset.UTC), utc), `is`(profiles[0]))
+    assertThat(NotificationProfiles.getActiveProfile(profiles, monday830am.toMillis(ZoneOffset.UTC), utc), "active profile is first").isEqualTo(profiles[0])
   }
 
   @Test
@@ -184,6 +183,6 @@ class NotificationProfilesTest {
 
     val schedule = NotificationProfileSchedule(id = 3L, enabled = true, start = 2200, end = 1000, daysEnabled = DayOfWeek.entries.toSet())
     val profiles = listOf(first.copy(schedule = schedule))
-    assertThat("active profile is null", NotificationProfiles.getActiveProfile(profiles, sunday9am.toMillis(ZoneOffset.UTC), utc), nullValue())
+    assertThat(NotificationProfiles.getActiveProfile(profiles, sunday9am.toMillis(ZoneOffset.UTC), utc), "active profile is null").isNull()
   }
 }

--- a/app/src/test/java/org/thoughtcrime/securesms/profiles/manage/UsernameEditStateMachineTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/profiles/manage/UsernameEditStateMachineTest.kt
@@ -1,7 +1,8 @@
 package org.thoughtcrime.securesms.profiles.manage
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import org.junit.Test
-import org.thoughtcrime.securesms.assertIs
 
 class UsernameEditStateMachineTest {
   @Test
@@ -10,7 +11,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.NoUserEntry(nickname = "", discriminator = "07", stateModifier = UsernameEditStateMachine.StateModifier.USER)
     val actual = given.onUserChangedNickname("")
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -21,7 +22,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredNickname(nickname = nickname, discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.USER)
     val actual = given.onUserChangedNickname(nickname)
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -32,7 +33,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.NoUserEntry(nickname = nickname, discriminator = "", stateModifier = UsernameEditStateMachine.StateModifier.USER)
     val actual = given.onUserChangedDiscriminator("")
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -43,7 +44,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredDiscriminator(nickname = nickname, discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.USER)
     val actual = given.onUserChangedDiscriminator(discriminator)
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -54,7 +55,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.NoUserEntry(nickname = "", discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.SYSTEM)
     val actual = given.onSystemChangedNickname("")
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -65,7 +66,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.NoUserEntry(nickname = nickname, discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.SYSTEM)
     val actual = given.onSystemChangedNickname(nickname)
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -76,7 +77,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.NoUserEntry(nickname = nickname, discriminator = "", stateModifier = UsernameEditStateMachine.StateModifier.SYSTEM)
     val actual = given.onSystemChangedDiscriminator("")
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -87,7 +88,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.NoUserEntry(nickname = nickname, discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.SYSTEM)
     val actual = given.onSystemChangedDiscriminator(discriminator)
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -96,7 +97,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.NoUserEntry(nickname = "", discriminator = "07", stateModifier = UsernameEditStateMachine.StateModifier.USER)
     val actual = given.onUserChangedNickname("")
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -107,7 +108,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredNickname(nickname = nickname, discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.USER)
     val actual = given.onUserChangedNickname(nickname)
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -118,7 +119,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredNickname(nickname = nickname, discriminator = "", stateModifier = UsernameEditStateMachine.StateModifier.USER)
     val actual = given.onUserChangedDiscriminator("")
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -129,7 +130,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredNicknameAndDiscriminator(nickname = nickname, discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.USER)
     val actual = given.onUserChangedDiscriminator(discriminator)
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -140,7 +141,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.NoUserEntry(nickname = "", discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.SYSTEM)
     val actual = given.onSystemChangedNickname("")
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -151,7 +152,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.NoUserEntry(nickname = nickname, discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.SYSTEM)
     val actual = given.onSystemChangedNickname(nickname)
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -162,7 +163,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredNickname(nickname = nickname, discriminator = "", stateModifier = UsernameEditStateMachine.StateModifier.SYSTEM)
     val actual = given.onSystemChangedDiscriminator("")
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -173,7 +174,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredNickname(nickname = nickname, discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.SYSTEM)
     val actual = given.onSystemChangedDiscriminator(discriminator)
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -184,7 +185,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredDiscriminator(nickname = "", discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.USER)
     val actual = given.onUserChangedNickname("")
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -195,7 +196,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredNicknameAndDiscriminator(nickname = nickname, discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.USER)
     val actual = given.onUserChangedNickname(nickname)
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -206,7 +207,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredNickname(nickname = nickname, discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.USER)
     val actual = given.onUserChangedNickname(nickname)
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -217,7 +218,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredDiscriminator(nickname = nickname, discriminator = "", stateModifier = UsernameEditStateMachine.StateModifier.USER)
     val actual = given.onUserChangedDiscriminator("")
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -228,7 +229,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredDiscriminator(nickname = nickname, discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.USER)
     val actual = given.onUserChangedDiscriminator(discriminator)
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -239,7 +240,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredDiscriminator(nickname = "", discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.SYSTEM)
     val actual = given.onSystemChangedNickname("")
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -250,7 +251,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredDiscriminator(nickname = nickname, discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.SYSTEM)
     val actual = given.onSystemChangedNickname(nickname)
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -261,7 +262,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.NoUserEntry(nickname = nickname, discriminator = "", stateModifier = UsernameEditStateMachine.StateModifier.SYSTEM)
     val actual = given.onSystemChangedDiscriminator("")
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -272,7 +273,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.NoUserEntry(nickname = nickname, discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.SYSTEM)
     val actual = given.onSystemChangedDiscriminator(discriminator)
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -283,7 +284,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredDiscriminator(nickname = "", discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.USER)
     val actual = given.onUserChangedNickname("")
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -294,7 +295,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredNicknameAndDiscriminator(nickname = nickname, discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.USER)
     val actual = given.onUserChangedNickname(nickname)
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -305,7 +306,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredNickname(nickname = nickname, discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.USER)
     val actual = given.onUserChangedNickname(nickname)
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -316,7 +317,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredNicknameAndDiscriminator(nickname = nickname, discriminator = "", stateModifier = UsernameEditStateMachine.StateModifier.USER)
     val actual = given.onUserChangedDiscriminator("")
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -327,7 +328,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredNicknameAndDiscriminator(nickname = nickname, discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.USER)
     val actual = given.onUserChangedDiscriminator(discriminator)
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -338,7 +339,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredDiscriminator(nickname = "", discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.SYSTEM)
     val actual = given.onSystemChangedNickname("")
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -349,7 +350,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredDiscriminator(nickname = nickname, discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.SYSTEM)
     val actual = given.onSystemChangedNickname(nickname)
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -360,7 +361,7 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredNickname(nickname = nickname, discriminator = "", stateModifier = UsernameEditStateMachine.StateModifier.SYSTEM)
     val actual = given.onSystemChangedDiscriminator("")
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -371,6 +372,6 @@ class UsernameEditStateMachineTest {
     val expected = UsernameEditStateMachine.UserEnteredNickname(nickname = nickname, discriminator = discriminator, stateModifier = UsernameEditStateMachine.StateModifier.SYSTEM)
     val actual = given.onSystemChangedDiscriminator(discriminator)
 
-    actual assertIs expected
+    assertThat(actual).isEqualTo(expected)
   }
 }

--- a/app/src/test/java/org/thoughtcrime/securesms/registration/fcm/PushChallengeRequestTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/registration/fcm/PushChallengeRequestTest.kt
@@ -6,21 +6,21 @@ package org.thoughtcrime.securesms.registration.fcm
 
 import android.app.Application
 import android.os.AsyncTask
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThanOrEqualTo
+import assertk.assertions.isLessThan
+import assertk.assertions.isPresent
 import io.mockk.called
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.greaterThanOrEqualTo
-import org.hamcrest.Matchers.lessThan
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import org.thoughtcrime.securesms.isAbsent
 import org.whispersystems.signalservice.api.SignalServiceAccountManager
 import java.io.IOException
 import java.util.Optional
@@ -34,7 +34,7 @@ class PushChallengeRequestTest {
 
     val challenge = PushChallengeRequest.getPushChallengeBlocking(signal, "session ID", Optional.of("token"), 50L)
 
-    assertFalse(challenge.isPresent)
+    assertThat(challenge).isAbsent()
   }
 
   @Test
@@ -45,7 +45,7 @@ class PushChallengeRequestTest {
     PushChallengeRequest.getPushChallengeBlocking(signal, "session ID", Optional.of("token"), 250L)
     val duration = System.currentTimeMillis() - startTime
 
-    assertThat(duration, greaterThanOrEqualTo(250L))
+    assertThat(duration).isGreaterThanOrEqualTo(250L)
   }
 
   @Test
@@ -62,12 +62,11 @@ class PushChallengeRequestTest {
     val challenge = PushChallengeRequest.getPushChallengeBlocking(signal, "session ID", Optional.of("token"), 500L)
     val duration = System.currentTimeMillis() - startTime
 
-    assertThat(duration, lessThan(500L))
+    assertThat(duration).isLessThan(500L)
     verify { signal.requestRegistrationPushChallenge("session ID", "token") }
     confirmVerified(signal)
 
-    assertTrue(challenge.isPresent)
-    assertEquals("CHALLENGE", challenge.get())
+    assertThat(challenge).isPresent().isEqualTo("CHALLENGE")
   }
 
   @Test
@@ -78,7 +77,7 @@ class PushChallengeRequestTest {
     PushChallengeRequest.getPushChallengeBlocking(signal, "session ID", Optional.empty(), 500L)
     val duration = System.currentTimeMillis() - startTime
 
-    assertThat(duration, lessThan(500L))
+    assertThat(duration).isLessThan(500L)
   }
 
   @Test
@@ -88,7 +87,7 @@ class PushChallengeRequestTest {
     val challenge = PushChallengeRequest.getPushChallengeBlocking(signal, "session ID", Optional.empty(), 500L)
 
     verify { signal wasNot called }
-    assertFalse(challenge.isPresent)
+    assertThat(challenge).isAbsent()
   }
 
   @Test
@@ -99,6 +98,6 @@ class PushChallengeRequestTest {
 
     val challenge = PushChallengeRequest.getPushChallengeBlocking(signal, "session ID", Optional.of("token"), 500L)
 
-    assertFalse(challenge.isPresent)
+    assertThat(challenge).isAbsent()
   }
 }

--- a/app/src/test/java/org/thoughtcrime/securesms/registration/secondary/DeviceNameCipherTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/registration/secondary/DeviceNameCipherTest.kt
@@ -1,14 +1,13 @@
 package org.thoughtcrime.securesms.registration.secondary
 
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.`is`
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import org.junit.Test
 import org.thoughtcrime.securesms.crypto.IdentityKeyUtil
 import org.thoughtcrime.securesms.devicelist.protos.DeviceName
 import java.nio.charset.Charset
 
 class DeviceNameCipherTest {
-
   @Test
   fun encryptDeviceName() {
     val deviceName = "xXxCoolDeviceNamexXx"
@@ -18,6 +17,6 @@ class DeviceNameCipherTest {
 
     val plaintext = DeviceNameCipher.decryptDeviceName(DeviceName.ADAPTER.decode(encryptedDeviceName), identityKeyPair)!!
 
-    assertThat(String(plaintext, Charset.forName("UTF-8")), `is`(deviceName))
+    assertThat(String(plaintext, Charset.forName("UTF-8"))).isEqualTo(deviceName)
   }
 }

--- a/app/src/test/java/org/thoughtcrime/securesms/registration/util/RegistrationUtilTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/registration/util/RegistrationUtilTest.kt
@@ -6,6 +6,12 @@
 package org.thoughtcrime.securesms.registration.util
 
 import android.app.Application
+import assertk.assertThat
+import assertk.assertions.each
+import assertk.assertions.extracting
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -20,7 +26,6 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.signal.core.util.logging.Log.initialize
-import org.thoughtcrime.securesms.assertIs
 import org.thoughtcrime.securesms.keyvalue.PhoneNumberPrivacyValues
 import org.thoughtcrime.securesms.profiles.ProfileName
 import org.thoughtcrime.securesms.recipients.Recipient
@@ -32,7 +37,6 @@ import org.thoughtcrime.securesms.util.RemoteConfig
 @RunWith(RobolectricTestRunner::class)
 @Config(application = Application::class, manifest = Config.NONE)
 class RegistrationUtilTest {
-
   @get:Rule
   val signalStore = MockSignalStoreRule(relaxed = setOf(PhoneNumberPrivacyValues::class))
 
@@ -125,8 +129,10 @@ class RegistrationUtilTest {
     verify(exactly = 0) { signalStore.registration.markRegistrationComplete() }
 
     val regUtilLogs = logRecorder.information.filter { it.tag == "RegistrationUtil" }
-    regUtilLogs.size assertIs 4
-    regUtilLogs.all { it.message == "Registration is not yet complete." } assertIs true
+    assertThat(regUtilLogs).hasSize(4)
+    assertThat(regUtilLogs)
+      .extracting { it.message }
+      .each { it.isEqualTo("Registration is not yet complete.") }
   }
 
   @Test
@@ -138,6 +144,6 @@ class RegistrationUtilTest {
     verify(exactly = 0) { signalStore.registration.markRegistrationComplete() }
 
     val regUtilLogs = logRecorder.information.filter { it.tag == "RegistrationUtil" }
-    regUtilLogs.size assertIs 0
+    assertThat(regUtilLogs).isEmpty()
   }
 }

--- a/app/src/test/java/org/thoughtcrime/securesms/s3/S3Test_getS3Url.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/s3/S3Test_getS3Url.kt
@@ -5,18 +5,18 @@
 
 package org.thoughtcrime.securesms.s3
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import okio.IOException
 import org.junit.Test
-import org.thoughtcrime.securesms.assertIs
 
 @Suppress("ClassName")
 class S3Test_getS3Url {
-
   @Test
   fun validS3Urls() {
-    S3.s3Url("/static/heart.png").toString() assertIs "https://updates2.signal.org/static/heart.png"
-    S3.s3Url("/static/heart.png?weee=1").toString() assertIs "https://updates2.signal.org/static/heart.png%3Fweee=1"
-    S3.s3Url("/@signal.org").toString() assertIs "https://updates2.signal.org/@signal.org"
+    assertThat(S3.s3Url("/static/heart.png").toString()).isEqualTo("https://updates2.signal.org/static/heart.png")
+    assertThat(S3.s3Url("/static/heart.png?weee=1").toString()).isEqualTo("https://updates2.signal.org/static/heart.png%3Fweee=1")
+    assertThat(S3.s3Url("/@signal.org").toString()).isEqualTo("https://updates2.signal.org/@signal.org")
   }
 
   @Test(expected = IOException::class)

--- a/app/src/test/java/org/thoughtcrime/securesms/util/LocaleRemoteConfig_isEnabled.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/util/LocaleRemoteConfig_isEnabled.kt
@@ -5,18 +5,19 @@
 
 package org.thoughtcrime.securesms.util
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
-import org.thoughtcrime.securesms.assertIs
 
+@Suppress("ClassName")
 @RunWith(Parameterized::class)
 class LocaleRemoteConfig_isEnabled(private val serializedList: String, private val e164: List<String>, private val output: Boolean) {
-
   @Test
   fun isLegal() {
     e164.forEach {
-      LocaleRemoteConfig.isEnabledE164Start(serializedList, it) assertIs output
+      assertThat(LocaleRemoteConfig.isEnabledE164Start(serializedList, it)).isEqualTo(output)
     }
   }
 

--- a/app/src/test/java/org/thoughtcrime/securesms/util/UsernameUtilTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/util/UsernameUtilTest.kt
@@ -1,83 +1,85 @@
 package org.thoughtcrime.securesms.util
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
 import org.junit.Test
-import org.thoughtcrime.securesms.assertIs
-import org.thoughtcrime.securesms.assertIsNull
 import org.thoughtcrime.securesms.util.UsernameUtil.checkDiscriminator
 import org.thoughtcrime.securesms.util.UsernameUtil.checkNickname
 
 class UsernameUtilTest {
   @Test
   fun checkUsername_tooShort() {
-    checkNickname(null) assertIs UsernameUtil.InvalidReason.TOO_SHORT
-    checkNickname("") assertIs UsernameUtil.InvalidReason.TOO_SHORT
-    checkNickname("ab") assertIs UsernameUtil.InvalidReason.TOO_SHORT
+    assertThat(checkNickname(null)).isEqualTo(UsernameUtil.InvalidReason.TOO_SHORT)
+    assertThat(checkNickname("")).isEqualTo(UsernameUtil.InvalidReason.TOO_SHORT)
+    assertThat(checkNickname("ab")).isEqualTo(UsernameUtil.InvalidReason.TOO_SHORT)
   }
 
   @Test
   fun checkUsername_tooLong() {
-    checkNickname("abcdefghijklmnopqrstuvwxyz1234567") assertIs UsernameUtil.InvalidReason.TOO_LONG
+    assertThat(checkNickname("abcdefghijklmnopqrstuvwxyz1234567")).isEqualTo(UsernameUtil.InvalidReason.TOO_LONG)
   }
 
   @Test
   fun checkUsername_startsWithNumber() {
-    checkNickname("0abcdefg") assertIs UsernameUtil.InvalidReason.STARTS_WITH_NUMBER
-    checkNickname("9abcdefg") assertIs UsernameUtil.InvalidReason.STARTS_WITH_NUMBER
-    checkNickname("8675309") assertIs UsernameUtil.InvalidReason.STARTS_WITH_NUMBER
+    assertThat(checkNickname("0abcdefg")).isEqualTo(UsernameUtil.InvalidReason.STARTS_WITH_NUMBER)
+    assertThat(checkNickname("9abcdefg")).isEqualTo(UsernameUtil.InvalidReason.STARTS_WITH_NUMBER)
+    assertThat(checkNickname("8675309")).isEqualTo(UsernameUtil.InvalidReason.STARTS_WITH_NUMBER)
   }
 
   @Test
   fun checkUsername_invalidCharacters() {
-    checkNickname("\$abcd") assertIs UsernameUtil.InvalidReason.INVALID_CHARACTERS
-    checkNickname(" abcd") assertIs UsernameUtil.InvalidReason.INVALID_CHARACTERS
-    checkNickname("ab cde") assertIs UsernameUtil.InvalidReason.INVALID_CHARACTERS
-    checkNickname("%%%%%") assertIs UsernameUtil.InvalidReason.INVALID_CHARACTERS
-    checkNickname("-----") assertIs UsernameUtil.InvalidReason.INVALID_CHARACTERS
-    checkNickname("asĸ_me") assertIs UsernameUtil.InvalidReason.INVALID_CHARACTERS
-    checkNickname("+18675309") assertIs UsernameUtil.InvalidReason.INVALID_CHARACTERS
+    assertThat(checkNickname("\$abcd")).isEqualTo(UsernameUtil.InvalidReason.INVALID_CHARACTERS)
+    assertThat(checkNickname(" abcd")).isEqualTo(UsernameUtil.InvalidReason.INVALID_CHARACTERS)
+    assertThat(checkNickname("ab cde")).isEqualTo(UsernameUtil.InvalidReason.INVALID_CHARACTERS)
+    assertThat(checkNickname("%%%%%")).isEqualTo(UsernameUtil.InvalidReason.INVALID_CHARACTERS)
+    assertThat(checkNickname("-----")).isEqualTo(UsernameUtil.InvalidReason.INVALID_CHARACTERS)
+    assertThat(checkNickname("asĸ_me")).isEqualTo(UsernameUtil.InvalidReason.INVALID_CHARACTERS)
+    assertThat(checkNickname("+18675309")).isEqualTo(UsernameUtil.InvalidReason.INVALID_CHARACTERS)
   }
 
   @Test
   fun checkUsername_validUsernames() {
-    checkNickname("abcd").assertIsNull()
-    checkNickname("abcdefghijklmnopqrstuvwxyz").assertIsNull()
-    checkNickname("ABCDEFGHIJKLMNOPQRSTUVWXYZ").assertIsNull()
-    checkNickname("web_head").assertIsNull()
-    checkNickname("Spider_Fan_1991").assertIsNull()
+    assertThat(checkNickname("abcd")).isNull()
+    assertThat(checkNickname("abcdefghijklmnopqrstuvwxyz")).isNull()
+    assertThat(checkNickname("ABCDEFGHIJKLMNOPQRSTUVWXYZ")).isNull()
+    assertThat(checkNickname("web_head")).isNull()
+    assertThat(checkNickname("Spider_Fan_1991")).isNull()
   }
 
   @Test
   fun checkDiscriminator_valid() {
-    checkDiscriminator(null).assertIsNull()
-    checkDiscriminator("01").assertIsNull()
-    checkDiscriminator("111111111").assertIsNull()
+    assertThat(checkDiscriminator(null)).isNull()
+    assertThat(checkDiscriminator("01")).isNull()
+    assertThat(checkDiscriminator("111111111")).isNull()
   }
 
   @Test
   fun checkDiscriminator_tooShort() {
-    checkDiscriminator("0") assertIs UsernameUtil.InvalidReason.TOO_SHORT
-    checkDiscriminator("") assertIs UsernameUtil.InvalidReason.TOO_SHORT
+    assertThat(checkDiscriminator("0")).isEqualTo(UsernameUtil.InvalidReason.TOO_SHORT)
+    assertThat(checkDiscriminator("")).isEqualTo(UsernameUtil.InvalidReason.TOO_SHORT)
   }
 
   @Test
   fun checkDiscriminator_tooLong() {
-    checkDiscriminator("1111111111") assertIs UsernameUtil.InvalidReason.TOO_LONG
+    assertThat(checkDiscriminator("1111111111")).isEqualTo(UsernameUtil.InvalidReason.TOO_LONG)
   }
 
   @Test
   fun checkDiscriminator_00() {
-    checkDiscriminator("00") assertIs UsernameUtil.InvalidReason.INVALID_NUMBER_00
+    assertThat(checkDiscriminator("00")).isEqualTo(UsernameUtil.InvalidReason.INVALID_NUMBER_00)
   }
 
   @Test
   fun checkDiscriminator_prefixZero() {
-    checkDiscriminator("001") assertIs UsernameUtil.InvalidReason.INVALID_NUMBER_PREFIX_0
-    checkDiscriminator("0001") assertIs UsernameUtil.InvalidReason.INVALID_NUMBER_PREFIX_0
-    checkDiscriminator("011") assertIs UsernameUtil.InvalidReason.INVALID_NUMBER_PREFIX_0
+    assertThat(checkDiscriminator("001")).isEqualTo(UsernameUtil.InvalidReason.INVALID_NUMBER_PREFIX_0)
+    assertThat(checkDiscriminator("0001")).isEqualTo(UsernameUtil.InvalidReason.INVALID_NUMBER_PREFIX_0)
+    assertThat(checkDiscriminator("011")).isEqualTo(UsernameUtil.InvalidReason.INVALID_NUMBER_PREFIX_0)
   }
 
+  @Test
   fun checkDiscriminator_invalidChars() {
-    checkDiscriminator("a1") assertIs UsernameUtil.InvalidReason.INVALID_CHARACTERS
-    checkDiscriminator("1x") assertIs UsernameUtil.InvalidReason.INVALID_CHARACTERS
+    assertThat(checkDiscriminator("a1")).isEqualTo(UsernameUtil.InvalidReason.INVALID_CHARACTERS)
+    assertThat(checkDiscriminator("1x")).isEqualTo(UsernameUtil.InvalidReason.INVALID_CHARACTERS)
   }
 }

--- a/app/src/testShared/org/thoughtcrime/securesms/KotlinAssertsUtil.kt
+++ b/app/src/testShared/org/thoughtcrime/securesms/KotlinAssertsUtil.kt
@@ -5,8 +5,12 @@
 
 package org.thoughtcrime.securesms
 
+import assertk.Assert
+import assertk.assertions.isTrue
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
+import org.signal.core.util.isAbsent
+import java.util.Optional
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
@@ -36,4 +40,8 @@ infix fun <T : Any?> T.assertIsNot(expected: T) {
 
 infix fun <E, T : Collection<E>> T.assertIsSize(expected: Int) {
   MatcherAssert.assertThat(this, Matchers.hasSize(expected))
+}
+
+fun <T> Assert<Optional<T>>.isAbsent() {
+  transform { it.isAbsent() }.isTrue()
 }

--- a/app/src/testShared/org/thoughtcrime/securesms/KotlinAssertsUtil.kt
+++ b/app/src/testShared/org/thoughtcrime/securesms/KotlinAssertsUtil.kt
@@ -6,42 +6,9 @@
 package org.thoughtcrime.securesms
 
 import assertk.Assert
-import assertk.assertions.isTrue
-import org.hamcrest.MatcherAssert
-import org.hamcrest.Matchers
-import org.signal.core.util.isAbsent
+import assertk.assertions.isFalse
 import java.util.Optional
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.contract
-
-@OptIn(ExperimentalContracts::class)
-fun <T : Any?> T.assertIsNull() {
-  contract {
-    returns() implies (this@assertIsNull == null)
-  }
-  MatcherAssert.assertThat(this, Matchers.nullValue())
-}
-
-@OptIn(ExperimentalContracts::class)
-fun <T : Any?> T.assertIsNotNull() {
-  contract {
-    returns() implies (this@assertIsNotNull != null)
-  }
-  MatcherAssert.assertThat(this, Matchers.notNullValue())
-}
-
-infix fun <T : Any?> T.assertIs(expected: T) {
-  MatcherAssert.assertThat(this, Matchers.`is`(expected))
-}
-
-infix fun <T : Any?> T.assertIsNot(expected: T) {
-  MatcherAssert.assertThat(this, Matchers.not(Matchers.`is`(expected)))
-}
-
-infix fun <E, T : Collection<E>> T.assertIsSize(expected: Int) {
-  MatcherAssert.assertThat(this, Matchers.hasSize(expected))
-}
 
 fun <T> Assert<Optional<T>>.isAbsent() {
-  transform { it.isAbsent() }.isTrue()
+  transform { it.isPresent }.isFalse()
 }

--- a/libsignal-service/src/test/java/org/whispersystems/signalservice/internal/crypto/PaddingInputStreamTest.kt
+++ b/libsignal-service/src/test/java/org/whispersystems/signalservice/internal/crypto/PaddingInputStreamTest.kt
@@ -4,15 +4,14 @@
  */
 package org.whispersystems.signalservice.internal.crypto
 
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.core.Is.`is`
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import org.junit.Test
 import org.signal.core.util.StreamUtil
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 
 class PaddingInputStreamTest {
-
   /**
    * Small stress test to confirm padding input only returns the source stream data
    * followed strictly by zeros.
@@ -31,9 +30,9 @@ class PaddingInputStreamTest {
 
       paddedData.forEachIndexed { index, byte ->
         if (index < length) {
-          assertThat(byte, `is`(source[index]))
+          assertThat(byte).isEqualTo(source[index])
         } else {
-          assertThat(byte, `is`(0x00))
+          assertThat(byte).isEqualTo(0x00)
         }
       }
     }

--- a/libsignal-service/src/test/java/org/whispersystems/signalservice/internal/crypto/SecondaryProvisioningCipherTest.kt
+++ b/libsignal-service/src/test/java/org/whispersystems/signalservice/internal/crypto/SecondaryProvisioningCipherTest.kt
@@ -5,10 +5,10 @@
 
 package org.whispersystems.signalservice.internal.crypto
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
 import okio.ByteString
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.instanceOf
-import org.hamcrest.Matchers.`is`
 import org.junit.Test
 import org.signal.libsignal.protocol.IdentityKey
 import org.signal.libsignal.protocol.IdentityKeyPair
@@ -21,7 +21,6 @@ import java.util.UUID
 import kotlin.random.Random
 
 class SecondaryProvisioningCipherTest {
-
   @Test
   fun decrypt() {
     val provisioningCipher = SecondaryProvisioningCipher.generate(generateIdentityKeyPair())
@@ -44,18 +43,18 @@ class SecondaryProvisioningCipherTest {
     val provisionMessage = ProvisionEnvelope.ADAPTER.decode(primaryProvisioningCipher.encrypt(message))
 
     val result = provisioningCipher.decrypt(provisionMessage)
-    assertThat(result, instanceOf(SecondaryProvisioningCipher.ProvisionDecryptResult.Success::class.java))
+    assertThat(result).isInstanceOf<SecondaryProvisioningCipher.ProvisionDecryptResult.Success>()
 
     val success = result as SecondaryProvisioningCipher.ProvisionDecryptResult.Success
 
-    assertThat(success.uuid.toString(), `is`(message.aci))
-    assertThat(success.e164, `is`(message.number))
-    assertThat(success.identityKeyPair.serialize(), `is`(primaryIdentityKeyPair.serialize()))
-    assertThat(success.profileKey.serialize(), `is`(primaryProfileKey.serialize()))
-    assertThat(success.areReadReceiptsEnabled, `is`(message.readReceipts))
-    assertThat(success.primaryUserAgent, `is`(message.userAgent))
-    assertThat(success.provisioningCode, `is`(message.provisioningCode))
-    assertThat(success.provisioningVersion, `is`(message.provisioningVersion))
+    assertThat(message.aci).isEqualTo(success.uuid.toString())
+    assertThat(message.number).isEqualTo(success.e164)
+    assertThat(primaryIdentityKeyPair.serialize()).isEqualTo(success.identityKeyPair.serialize())
+    assertThat(primaryProfileKey.serialize()).isEqualTo(success.profileKey.serialize())
+    assertThat(message.readReceipts).isEqualTo(success.areReadReceiptsEnabled)
+    assertThat(message.userAgent).isEqualTo(success.primaryUserAgent)
+    assertThat(message.provisioningCode).isEqualTo(success.provisioningCode)
+    assertThat(message.provisioningVersion).isEqualTo(success.provisioningVersion)
   }
 
   companion object {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * MacBook (unit tests)
 * Pixel 8 API 34 emulator (connected tests)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

In https://github.com/signalapp/Signal-Android/pull/13884, I am migrating the remaining Java/Hamcrest tests to Kotlin/AssertK.

In this PR, I am migrating the remaining Kotlin/Hamcrest tests to Kotlin/Assert. There are uses of Hamcrest in both the unit and connected device tests. A good number of these are under-the-hood via helper functions in `KotlinAssertsUtil.kt` and `TestUtils.kt`.

To find the remaining Kotlin files that still use Hamcrest, I used:
```console
 rg hamcrest $(git ls-files "app*.kt") $(git ls-files "*lib*kt")
```

And replaced every call site with the equivalent AssertK expression. (Frequently using a find/replace regex and then cleaning up by hand.)


### Testing
```console
./gradlew qa
[...snip...]
BUILD SUCCESSFUL in 3m 15s
```

```console
./gradlew :Signal-Android:connectedPlayProdInstrumentationAndroidTest
[...snip...]
```

^ `FixInAppCurrencyIfAbleTest` fails; but it does without these changes, too. So, the results of the suite are unchanged, and the failure is not related to this set of changes.

