### PR TITLE
Minor usability improvement: Add a few 'buffer-days' in case of 1-Year 'KeepMessagesDuration'

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/keyvalue/KeepMessagesDuration.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyvalue/KeepMessagesDuration.java
@@ -9,7 +9,8 @@ import java.util.concurrent.TimeUnit;
 
 public enum KeepMessagesDuration {
   FOREVER(0, R.string.preferences_storage__forever, Long.MAX_VALUE),
-  ONE_YEAR(1, R.string.preferences_storage__one_year, TimeUnit.DAYS.toMillis(365)),
+  //Remark: Simply adding a few "buffer-days" to 365 increases the usability wrt annually messages (good wishes for birthday, New Year, etc), so that users are still able to cross-check, what exact wording they have written to a person 1 year before (e.g. to avoid writing always the same)
+  ONE_YEAR(1, R.string.preferences_storage__one_year, TimeUnit.DAYS.toMillis(365+3)),
   SIX_MONTHS(2, R.string.preferences_storage__six_months, TimeUnit.DAYS.toMillis(183)),
   THIRTY_DAYS(3, R.string.preferences_storage__thirty_days, TimeUnit.DAYS.toMillis(30));
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Oppo A94
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Usability improvement of KeepMessagesDuration (1-YEAR): Simply adding a few buffer-days to 365 increases the usability wrt annually messages (e.g. good wishes for birthday, New Year, etc). In this way, users are still able to cross-check, what exact wording they have written to a person 1 year before (e.g. to avoid writing always the same). Currently, without this fix, messages of last year are always already vanished exactly on the annual day.