### PR TITLE
Create enabledAndNotLoading state and don't set enabled in parameter

### DIFF
--- a/core-ui/src/main/java/org/signal/core/ui/Rows.kt
+++ b/core-ui/src/main/java/org/signal/core/ui/Rows.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
@@ -108,12 +109,16 @@ object Rows {
     label: String? = null,
     textColor: Color = MaterialTheme.colorScheme.onSurface,
     isLoading: Boolean = false,
-    enabled: Boolean = !isLoading
+    enabled: Boolean = true
   ) {
+    val enabledAndNotLoading by rememberSaveable(isLoading,enabled) {
+      mutableStateOf(!isLoading && enabled)
+    }
+
     Row(
       modifier = modifier
         .fillMaxWidth()
-        .clickable(enabled = enabled) { onCheckChanged(!checked) }
+        .clickable(enabled = enabledAndNotLoading) { onCheckChanged(!checked) }
         .padding(defaultPadding()),
       verticalAlignment = CenterVertically
     ) {
@@ -121,13 +126,13 @@ object Rows {
         text = text,
         label = label,
         textColor = textColor,
-        enabled = enabled,
+        enabled = enabledAndNotLoading,
         modifier = Modifier.padding(end = 16.dp)
       )
 
       val loadingContent by rememberDelayedState(isLoading)
-      val toggleState = remember(checked, loadingContent, enabled, onCheckChanged) {
-        ToggleState(checked, loadingContent, enabled, onCheckChanged)
+      val toggleState = remember(checked, loadingContent, enabledAndNotLoading, onCheckChanged) {
+        ToggleState(checked, loadingContent, enabledAndNotLoading, onCheckChanged)
       }
 
       AnimatedContent(


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device Realme GT NET 3T, Android 14
 * Device Infinix Hot 20 Pro, Android 14
 * Virtual device Pixel 8 Pro, Android 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe briefly how you tested that your fix actually works.
-->
An important thing to note here is,
NEVER set a param default value to another parameter(If they are interdependent).
This can lead to unexpected behavior from the call site.

For example in this case:
If the TabRow is also dependent on any other condition to enable the Toggle, and it is set to true at the call site. Then the default value of `enabled = !isLoading` will be overridden to always true, which leads to inconsistent enabled state behavior for all elements.

So, a better way is to keep the default values in params as it is, and then abstract out the logic for handling the "interdependent" states as I did here with `enabledAndNotLoading`. And now the component's developer is assured to have the states consistent.

Let's make sure other places are also following the same pattern.