### PR TITLE
Fixes #13870 - Showing SwipeProgressBar on Remove/Block contact

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/ContactSelectionListFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ContactSelectionListFragment.java
@@ -570,6 +570,10 @@ public final class ContactSelectionListFragment extends LoggingFragment {
     swipeRefresh.setRefreshing(refreshing);
   }
 
+  public boolean isRefreshing() {
+    return swipeRefresh.isRefreshing();
+  }
+
   public void reset() {
     contactSearchMediator.clearSelection();
     fastScroller.setVisibility(View.GONE);

--- a/app/src/main/java/org/thoughtcrime/securesms/NewConversationActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/NewConversationActivity.java
@@ -356,6 +356,7 @@ public class NewConversationActivity extends ContactSelectionActivity
                                               recipient,
                                               () -> {
                                                 disposables.add(viewModel.blockContact(recipient).subscribe(() -> {
+                                                  handleManualRefresh();
                                                   displaySnackbar(R.string.NewConversationActivity__s_has_been_blocked, recipient.getDisplayName(this));
                                                   contactsFragment.reset();
                                                 }));
@@ -381,8 +382,9 @@ public class NewConversationActivity extends ContactSelectionActivity
         .setPositiveButton(R.string.NewConversationActivity__remove,
                            (dialog, which) -> {
                              disposables.add(viewModel.hideContact(recipient).subscribe(() -> {
-                               onRefresh();
+                               handleManualRefresh();
                                displaySnackbar(R.string.NewConversationActivity__s_has_been_removed, recipient.getDisplayName(this));
+                               contactsFragment.reset();
                              }));
                            }
         )


### PR DESCRIPTION
Closes #13870 

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device Realme GT NET 3T, Android 14
 * Device Infinix Hot 20 Pro, Android 14
 * Virtual device Pixel 8 Pro, Android 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe briefly how you tested that your fix actually works.
-->
Call `handleManualRefresh` to show the progress bar. An Important check is added `isRecipientPresent`, so that when the user might have the dialog opened when contact is being removed or blocked, then the operation can not be performed again after progress is completed. This will prevent any unwanted exceptions or DB calls.

This `isRefreshing` function is already present in #13874 