### PR TITLE
Fixes #13850 - Fixes EnterPhoneNumber Screen Loading State Issue

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/registration/ui/RegistrationActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/ui/RegistrationActivity.kt
@@ -71,6 +71,7 @@ class RegistrationActivity : BaseActivity() {
     if (SignalStore.storageService.needsAccountRestore) {
       Log.i(TAG, "Performing pin restore.")
       startActivity(Intent(this, PinRestoreActivity::class.java))
+      sharedViewModel.setInProgress(false)
       finish()
     } else {
       val isProfileNameEmpty = Recipient.self().profileName.isEmpty
@@ -83,7 +84,6 @@ class RegistrationActivity : BaseActivity() {
       if (!needsProfile && !needsPin) {
         sharedViewModel.completeRegistration()
       }
-      sharedViewModel.setInProgress(false)
 
       val startIntent = MainActivity.clearTop(this).apply {
         if (needsPin) {
@@ -97,6 +97,7 @@ class RegistrationActivity : BaseActivity() {
 
       Log.d(TAG, "Launching ${startIntent.component}")
       startActivity(startIntent)
+      sharedViewModel.setInProgress(false)
       finish()
       ActivityNavigator.applyPopAnimationsToPendingTransition(this)
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/registration/ui/RegistrationViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/ui/RegistrationViewModel.kt
@@ -405,7 +405,6 @@ class RegistrationViewModel : ViewModel() {
             allowedToRequestCode = networkResult.body.allowedToRequestCode,
             challengesRequested = Challenge.parse(networkResult.body.requestedInformation),
             verified = networkResult.body.verified,
-            inProgress = false
           )
         }
       },
@@ -486,8 +485,7 @@ class RegistrationViewModel : ViewModel() {
             nextSmsTimestamp = sessionResult.nextSmsTimestamp,
             nextCallTimestamp = sessionResult.nextCallTimestamp,
             isAllowedToRequestCode = sessionResult.allowedToRequestCode,
-            challengesRequested = emptyList(),
-            inProgress = false
+            challengesRequested = emptyList()
           )
         }
         return true
@@ -499,7 +497,6 @@ class RegistrationViewModel : ViewModel() {
           it.copy(
             registrationCheckpoint = RegistrationCheckpoint.CHALLENGE_RECEIVED,
             challengesRequested = sessionResult.challenges,
-            inProgress = false
           )
         }
         return false
@@ -857,8 +854,7 @@ class RegistrationViewModel : ViewModel() {
 
     store.update {
       it.copy(
-        registrationCheckpoint = RegistrationCheckpoint.LOCAL_REGISTRATION_COMPLETE,
-        inProgress = false
+        registrationCheckpoint = RegistrationCheckpoint.LOCAL_REGISTRATION_COMPLETE
       )
     }
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/registration/ui/captcha/RegistrationCaptchaFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/ui/captcha/RegistrationCaptchaFragment.kt
@@ -21,6 +21,7 @@ class RegistrationCaptchaFragment : CaptchaFragment() {
   private val sharedViewModel by activityViewModels<RegistrationViewModel>()
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
+    sharedViewModel.setInProgress(false)
     sharedViewModel.addPresentedChallenge(Challenge.CAPTCHA)
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/registration/ui/entercode/EnterCodeFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/ui/entercode/EnterCodeFragment.kt
@@ -61,6 +61,7 @@ class EnterCodeFragment : LoggingFragment(R.layout.fragment_registration_enter_c
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
     setDebugLogSubmitMultiTapView(binding.verifyHeader)
+    sharedViewModel.setInProgress(false)
 
     phoneStateListener = SignalStrengthPhoneStateListener(this, PhoneStateCallback())
 

--- a/app/src/main/java/org/thoughtcrime/securesms/registration/ui/phonenumber/EnterPhoneNumberFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/ui/phonenumber/EnterPhoneNumberFragment.kt
@@ -592,12 +592,10 @@ class EnterPhoneNumberFragment : LoggingFragment(R.layout.fragment_registration_
 
   private fun moveToEnterPinScreen() {
     findNavController().safeNavigate(EnterPhoneNumberFragmentDirections.actionReRegisterWithPinFragment())
-    sharedViewModel.setInProgress(false)
   }
 
   private fun moveToVerificationEntryScreen() {
     findNavController().safeNavigate(EnterPhoneNumberFragmentDirections.actionEnterVerificationCode())
-    sharedViewModel.setInProgress(false)
   }
 
   private fun popBackStack() {

--- a/app/src/main/java/org/thoughtcrime/securesms/registration/ui/reregisterwithpin/ReRegisterWithPinFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/ui/reregisterwithpin/ReRegisterWithPinFragment.kt
@@ -43,6 +43,7 @@ class ReRegisterWithPinFragment : LoggingFragment(R.layout.fragment_registration
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
+    registrationViewModel.setInProgress(false)
 
     RegistrationViewDelegate.setDebugLogSubmitMultiTapView(binding.pinRestorePinTitle)
     binding.pinRestorePinDescription.setText(R.string.RegistrationLockFragment__enter_the_pin_you_created_for_your_account)


### PR DESCRIPTION
Closes #13850 

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device Realme GT Neo 3t, Android 14
 * Device Infinix Hot 20 Pro, Android 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

The issue reports that the EnterPhoneNumberFragment Loading state is set to false before the user is navigated to another screen which can give the user a sense of unresponsiveness and the user might click on the Next button multiple times(Unnecessary calls).
The PR fixes this by setting the progress bar to false only when the user is already navigated to another screen.

The same last PR was closed because I raised it the from main branch and force-pushed after removing the commit. Please consider only this PR as valid.

### Screenshots:

https://github.com/user-attachments/assets/af44072c-05c0-4bb7-ad59-e11500c1a9e6

