### PR TITLE
Fix TopBar visibility reset after onResume in MultiSelect

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/main/MainActivityListHostFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/main/MainActivityListHostFragment.kt
@@ -176,6 +176,10 @@ class MainActivityListHostFragment : Fragment(R.layout.main_activity_list_host_f
       .findViewById<View>(R.id.fragment_container)
       .findNavController()
       .addOnDestinationChangedListener(destinationChangedListener)
+
+    if(conversationListTabsViewModel.isMultiSelectOpen()) {
+      presentToolbarForMultiselect()
+    }
   }
 
   override fun onPause() {

--- a/app/src/main/java/org/thoughtcrime/securesms/stories/tabs/ConversationListTabsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/stories/tabs/ConversationListTabsViewModel.kt
@@ -74,6 +74,10 @@ class ConversationListTabsViewModel(startingTab: ConversationListTab, repository
     performStoreUpdate { it.copy(visibilityState = it.visibilityState.copy(isMultiSelectOpen = true)) }
   }
 
+  fun isMultiSelectOpen(): Boolean {
+    return store.state.visibilityState.isMultiSelectOpen
+  }
+
   fun onMultiSelectFinished() {
     performStoreUpdate { it.copy(visibilityState = it.visibilityState.copy(isMultiSelectOpen = false)) }
   }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device Realme GT Neo 3t, Android 14
 * Device Infinix Hot 20 Pro, Android 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
This issue was found for the Calls Log Screen but later I saw the same problem with the Chats List screen too, so a better place is the `MainActivityListHostFragment` to handle this issue. It has been found that 
```
// onResume - MainActivityListHostFragment
    requireView()
      .findViewById<View>(R.id.fragment_container)
      .findNavController()
      .addOnDestinationChangedListener(destinationChangedListener)
```
is causing the toolbar state to reset. But adding a condition on this important operation is not a good idea hence the best solution is to hide the toolbar again after onResume.
### Screenshots:

Before:

https://github.com/user-attachments/assets/73775f37-2cc9-4ab4-bb9e-2ae529f50a82

After:

https://github.com/user-attachments/assets/c98f9435-689f-4127-a3b3-db19ba86c93c





