### PR TITLE
Fixes #13904 - ExoPlayer can't start a new audio from a seek point

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/voice/VoiceNotePlayer.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/voice/VoiceNotePlayer.kt
@@ -42,7 +42,7 @@ class VoiceNotePlayer @JvmOverloads constructor(
     val isSeekingToStart = positionMs == C.TIME_UNSET
 
     return if (isQueueToneIndex && isSeekingToStart) {
-      val nextVoiceNoteWindowIndex = if (currentWindowIndex < windowIndex) windowIndex + 1 else windowIndex - 1
+      val nextVoiceNoteWindowIndex = if (currentMediaItemIndex < windowIndex) windowIndex + 1 else windowIndex - 1
       if (mediaItemCount <= nextVoiceNoteWindowIndex) {
         super.seekTo(windowIndex, positionMs)
       } else {

--- a/app/src/main/java/org/thoughtcrime/securesms/components/voice/VoiceNotePlayerCallback.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/voice/VoiceNotePlayerCallback.kt
@@ -155,6 +155,17 @@ class VoiceNotePlayerCallback(val context: Context, val player: VoiceNotePlayer)
             }
           }
         })
+        player.addListener(
+          object : Player.Listener {
+            override fun onPlaybackStateChanged(playbackState: Int) {
+              super.onPlaybackStateChanged(playbackState)
+              if(playbackState == Player.STATE_READY) {
+                player.seekTo(window, (player.duration * progress).toLong())
+                player.removeListener(this)
+              }
+            }
+          }
+        )
         player.prepare()
         canLoadMore = !singlePlayback
       } else if (latestUri == uri) {

--- a/app/src/main/java/org/thoughtcrime/securesms/components/voice/VoiceNotePlayerCallback.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/voice/VoiceNotePlayerCallback.kt
@@ -228,7 +228,7 @@ class VoiceNotePlayerCallback(val context: Context, val player: VoiceNotePlayer)
 
   private fun indexOfPlayerMediaItemByUri(uri: Uri): Int {
     for (i in 0 until player.mediaItemCount) {
-      val playbackProperties: LocalConfiguration? = player.getMediaItemAt(i).playbackProperties
+      val playbackProperties: LocalConfiguration? = player.getMediaItemAt(i).localConfiguration
       if (playbackProperties?.uri == uri) {
         return i
       }

--- a/app/src/main/java/org/thoughtcrime/securesms/video/exo/SignalMediaSourceFactory.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/video/exo/SignalMediaSourceFactory.java
@@ -9,8 +9,6 @@ import androidx.media3.common.C;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.datasource.DataSource;
-import androidx.media3.datasource.DataSpec;
-import androidx.media3.datasource.TransferListener;
 import androidx.media3.exoplayer.drm.DrmSessionManagerProvider;
 import androidx.media3.exoplayer.source.MediaSource;
 import androidx.media3.exoplayer.source.ProgressiveMediaSource;


### PR DESCRIPTION


<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device Realme GT Neo 3t, Android 14
 * Device Infinix Hot 20 Pro, Android 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
After doing some research I have found that exoplayer can not seek to a position if it does not have the required information for the file, and it can only get the information once it is ready, so we need to first call the `play.prepare()`, but this does not guarantee that after this line the player will be ready and got the required information, so need to add a callback that will seek to the required position for the first audio file.

Screenshot after fixing:

https://github.com/user-attachments/assets/41b0e17d-5dbd-477f-a456-6680baec2b73



### NOTE:
This solution is only applicable if we are playing one audio and won't work for consecutive audio plays, as we only have the progress/seek position information for the first audio file when consecutive call is made. 

Possible solution:
We might need to pass or store the progress information of all the consecutive audio files we are about to play. This can require a larger refactoring of the Controller file, so I have not touched it yet. 

