### PR TITLE
Fixes broken resumePlayback for Message LongPress

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/voice/VoiceNoteMediaController.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/voice/VoiceNoteMediaController.kt
@@ -314,7 +314,7 @@ class VoiceNoteMediaController(val activity: FragmentActivity, private var postp
   inner class PlaybackStateListener : Player.Listener {
     override fun onEvents(player: Player, events: Player.Events) {
       super.onEvents(player, events)
-      if (events.contains(Player.EVENT_PLAYBACK_STATE_CHANGED)) {
+      if (events.contains(Player.EVENT_PLAYBACK_STATE_CHANGED) || events.contains(Player.EVENT_IS_PLAYING_CHANGED)) {
         if (!isActivityResumed()) {
           return
         }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
@@ -3237,7 +3237,7 @@ class ConversationFragment :
 
                 binding.conversationItemRecycler.suppressLayout(false)
                 if (selectedConversationModel.audioUri != null) {
-                  getVoiceNoteMediaController().resumePlayback(selectedConversationModel.audioUri, messageRecord.getId())
+                  getVoiceNoteMediaController().resumePlayback(selectedConversationModel.audioUri, messageRecord.id)
                 }
 
                 WindowUtil.setLightStatusBarFromTheme(requireActivity())
@@ -3307,12 +3307,12 @@ class ConversationFragment :
     }
 
     private fun MessageRecord.getAudioUriForLongClick(): Uri? {
-      val playbackState = getVoiceNoteMediaController().voiceNotePlaybackState.value
-      if (playbackState == null || !playbackState.isPlaying) {
+      if (!hasAudio()) {
         return null
       }
 
-      if (hasAudio() || !isMms) {
+      val playbackState = getVoiceNoteMediaController().voiceNotePlaybackState.value
+      if (playbackState == null || !playbackState.isPlaying) {
         return null
       }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device Realme GT Neo 3t, Android 14
 * Device Infinix Hot 20 Pro, Android 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
It took me some time to find the actual issue of why/what is causing the issue to NOT trigger the playback update handler, but the exploration was worth it. I was able to understand the pattern being used in this entire flow.

### Screenshots:

### Before: The controller resumes but playbackstate didn't

https://github.com/user-attachments/assets/c3c447d9-b065-4988-ae89-b138751cf15e

### After:vAfter controller resumes, triggers the handler to update playbackstate

https://github.com/user-attachments/assets/4858d07c-bf38-4590-a79a-e69d252ab6ce



