### PR TITLE
Contacts sharing logic improvements

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/contactshare/Contact.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/contactshare/Contact.java
@@ -43,7 +43,7 @@ public class Contact implements Parcelable {
   @JsonProperty
   private final Avatar              avatar;
 
-  public Contact(@JsonProperty("name")            @NonNull  Name                name,
+  public Contact(@JsonProperty("name")            @Nullable  Name                name,
                  @JsonProperty("organization")    @Nullable String              organization,
                  @JsonProperty("phoneNumbers")    @NonNull  List<Phone>         phoneNumbers,
                  @JsonProperty("emails")          @NonNull  List<Email>         emails,
@@ -77,7 +77,7 @@ public class Contact implements Parcelable {
   }
 
   public @NonNull Name getName() {
-    return name;
+    return name == null ? Name.EMPTY_NAME : name;
   }
 
   public @Nullable String getOrganization() {
@@ -227,6 +227,8 @@ public class Contact implements Parcelable {
       dest.writeString(middleName);
       dest.writeString(nickname);
     }
+
+    public static Name EMPTY_NAME = new Name("","","","","","");
 
     public static final Creator<Name> CREATOR = new Creator<Name>() {
       @Override

--- a/app/src/main/java/org/thoughtcrime/securesms/contactshare/ContactShareEditViewModel.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/contactshare/ContactShareEditViewModel.java
@@ -65,7 +65,6 @@ class ContactShareEditViewModel extends ViewModel {
 
   void updateContactName(int contactPosition, @NonNull Name name) {
     if (name.isEmpty()) {
-      events.postValue(Event.BAD_CONTACT);
       return;
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/contactshare/ContactUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/contactshare/ContactUtil.java
@@ -70,7 +70,7 @@ public final class ContactUtil {
       return contact.getName().getNickname();
     }
 
-    if (!TextUtils.isEmpty(contact.getName().getGivenName())) {
+    if (!TextUtils.isEmpty(contact.getName().getGivenName()) || !TextUtils.isEmpty(contact.getName().getFamilyName())) {
       return ProfileName.fromParts(contact.getName().getGivenName(), contact.getName().getFamilyName()).toString();
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/contactshare/SharedContactRepository.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/contactshare/SharedContactRepository.java
@@ -9,11 +9,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 
-import org.signal.core.util.logging.Log;
-import org.thoughtcrime.securesms.contacts.avatars.ContactPhoto;
 import org.signal.contacts.SystemContactsRepository;
 import org.signal.contacts.SystemContactsRepository.NameDetails;
 import org.signal.contacts.SystemContactsRepository.PhoneDetails;
+import org.signal.core.util.logging.Log;
+import org.thoughtcrime.securesms.contacts.avatars.ContactPhoto;
 import org.thoughtcrime.securesms.contactshare.Contact.Email;
 import org.thoughtcrime.securesms.contactshare.Contact.Name;
 import org.thoughtcrime.securesms.contactshare.Contact.Phone;
@@ -72,17 +72,16 @@ public class SharedContactRepository {
 
   @WorkerThread
   private @Nullable Contact getContactFromSystemContacts(long contactId) {
-    Name name = getName(contactId);
-    if (name == null) {
-      Log.w(TAG, "Couldn't find a name associated with the provided contact ID.");
+    List<Phone> phoneNumbers = getPhoneNumbers(contactId);
+    List<Email> emails       = getEmails(contactId);
+    if (phoneNumbers.isEmpty() && emails.isEmpty()) {
+      Log.w(TAG, "Couldn't find a phone number or email address associated with the provided contact ID.");
       return null;
     }
-
-    List<Phone> phoneNumbers = getPhoneNumbers(contactId);
-    AvatarInfo  avatarInfo   = getAvatarInfo(contactId, phoneNumbers);
-    Avatar      avatar       = avatarInfo != null ? new Avatar(avatarInfo.uri, avatarInfo.isProfile) : null;
-
-    return new Contact(name, null, phoneNumbers, getEmails(contactId), getPostalAddresses(contactId), avatar);
+    Name       name       = getName(contactId);
+    AvatarInfo avatarInfo = getAvatarInfo(contactId, phoneNumbers);
+    Avatar     avatar     = avatarInfo != null ? new Avatar(avatarInfo.uri, avatarInfo.isProfile) : null;
+    return new Contact(name, null, phoneNumbers, emails, getPostalAddresses(contactId), avatar);
   }
 
   @WorkerThread
@@ -223,7 +222,7 @@ public class SharedContactRepository {
     private final boolean isProfile;
 
     private AvatarInfo(Uri uri, boolean isProfile) {
-      this.uri = uri;
+      this.uri       = uri;
       this.isProfile = isProfile;
     }
 

--- a/app/src/main/res/layout/activity_contact_name_edit.xml
+++ b/app/src/main/res/layout/activity_contact_name_edit.xml
@@ -13,7 +13,7 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/signal_m3_toolbar_height"
         android:minHeight="@dimen/signal_m3_toolbar_height"
-        app:navigationIcon="@drawable/ic_x_tinted"
+        app:navigationIcon="@drawable/ic_check_28_tinted"
         app:title="@string/ContactShareEditActivity__edit_name"
         app:titleTextAppearance="@style/Signal.Text.TitleLarge" />
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device Realme GT Neo 3t, Android 14
 * Device Infinix Hot 20 Pro, Android 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
A contact can be saved in the device contacts without the name, without the number, and email. A contact is considered valid if we can reach them out by any means whether it is phone or email. 

This PR includes two improvements:
1. With the current implementation, we can share a contact as a valid contact even if it does not have a phone and an email. This PR fixes that.
2. A contact without a name should be considered valid, for cases where *the name might not be present* or the user may not want to share their saved weird names.

### Screenshots:

Currently present invalid shared contact:

![photo_6071122296975769469_y](https://github.com/user-attachments/assets/c0023550-9edf-4dc8-8929-6f2846e26af7)

After improvements, a contact with no name and only number:
The saved contact didn't have any name but just the contact number

![photo_6071122296975769470_y](https://github.com/user-attachments/assets/d09b12b8-7616-4eca-bc07-4674116ded50)
