### PR TITLE
Added "Mute" option while sending videos

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/VideoEditorFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/VideoEditorFragment.kt
@@ -89,6 +89,14 @@ class VideoEditorFragment : Fragment(), PositionDragListener, MediaSendPageFragm
 
     hud.visible = !slide.isVideoGif
 
+    sharedViewModel.state.observe(viewLifecycleOwner) { state->
+      if(state.mutedVideosMap[state.focusedMedia?.uri] == true) {
+        player.mute()
+      } else {
+        player.unmute()
+      }
+    }
+
     if (slide.isVideoGif) {
       player.setPlayerCallback(object : PlayerCallback {
         override fun onPlaying() {

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/MediaSelectionState.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/MediaSelectionState.kt
@@ -20,6 +20,7 @@ data class MediaSelectionState(
   val focusedMedia: Media? = null,
   val recipient: Recipient? = null,
   val quality: SentMediaQuality = SignalStore.settings.sentMediaQuality,
+  val mutedVideosMap: Map<Uri, Boolean> = mapOf(),
   val message: CharSequence? = null,
   val viewOnceToggleState: ViewOnceToggleState = ViewOnceToggleState.default,
   val isTouchEnabled: Boolean = true,

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/MediaSelectionViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/MediaSelectionViewModel.kt
@@ -345,6 +345,16 @@ class MediaSelectionViewModel(
     store.update { it.copy(viewOnceToggleState = it.viewOnceToggleState.next()) }
   }
 
+  fun changeIsMuteState() {
+    store.update {
+      val uri = it.focusedMedia?.uri ?: return@update it
+      val isMuted = it.mutedVideosMap[uri] ?: false
+      it.copy(
+        mutedVideosMap = it.mutedVideosMap + (uri to !isMuted)
+      )
+    }
+  }
+
   fun onEditVideoDuration(totalDurationUs: Long, startTimeUs: Long, endTimeUs: Long, touchEnabled: Boolean) {
     store.update {
       val uri = it.focusedMedia?.uri ?: return@update it
@@ -404,6 +414,7 @@ class MediaSelectionViewModel(
     return UntrustedRecords.checkForBadIdentityRecords(selectedContacts.toSet(), identityChangesSince).andThen(
       repository.send(
         selectedMedia = store.state.selectedMedia,
+        mutedVideosMap = store.state.mutedVideosMap,
         stateMap = store.state.editorStateMap,
         quality = store.state.quality,
         message = store.state.message,

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/VideoMuteTransform.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/VideoMuteTransform.kt
@@ -1,0 +1,117 @@
+package org.thoughtcrime.securesms.mediasend.v2
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.media.MediaCodec
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import android.media.MediaMuxer
+import android.net.Uri
+import androidx.annotation.WorkerThread
+import org.thoughtcrime.securesms.mediasend.Media
+import org.thoughtcrime.securesms.mediasend.MediaTransform
+import org.thoughtcrime.securesms.providers.BlobProvider
+import org.thoughtcrime.securesms.util.MediaUtil
+import java.io.FileInputStream
+import java.nio.ByteBuffer
+
+class VideoMuteTransform : MediaTransform {
+
+  @WorkerThread
+  override fun transform(context: Context, media: Media): Media {
+    try {
+      val oldUri = media.uri
+      val mutedVideoInputStream = getMutedVideoStream(context,oldUri) ?: return media
+
+      val mutedVideoUri = BlobProvider.getInstance()
+        .forData(mutedVideoInputStream, mutedVideoInputStream.channel.size())
+        .withMimeType(MediaUtil.VIDEO_MP4)
+        .createForSingleSessionOnDisk(context)
+      return Media(
+        mutedVideoUri,
+        media.contentType,
+        media.date,
+        media.width,
+        media.height,
+        media.size,
+        media.duration,
+        media.isBorderless,
+        media.isVideoGif,
+        media.bucketId,
+        media.caption,
+        media.transformProperties,
+        media.fileName
+      )
+    } catch (e: Exception) {
+      e.printStackTrace()
+      return media
+    }
+  }
+
+  @SuppressLint("WrongConstant")
+  private fun getMutedVideoStream(context: Context, oldUri: Uri): FileInputStream? {
+    try {
+      val resolver = context.contentResolver
+      val inputDescriptor = resolver.openFileDescriptor(oldUri, "r") ?: return null
+
+      val extractor = MediaExtractor()
+      extractor.setDataSource(inputDescriptor.fileDescriptor)
+
+      val tempFile = BlobProvider().forNonAutoEncryptingSingleSessionOnDisk(context)
+      val muxer = MediaMuxer(tempFile.absolutePath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
+
+      var videoTrackIndex = -1
+      var rotationDegrees = 0
+
+      for (i in 0 until extractor.trackCount) {
+        val format = extractor.getTrackFormat(i)
+        val mime = format.getString(MediaFormat.KEY_MIME) ?: continue
+
+        if (mime.startsWith("video/")) {
+          extractor.selectTrack(i)
+          videoTrackIndex = muxer.addTrack(format)
+
+          if (format.containsKey("rotation-degrees")) {
+            rotationDegrees = format.getInteger("rotation-degrees")
+          }
+        }
+      }
+
+      if (videoTrackIndex == -1) {
+        extractor.release()
+        muxer.release()
+        return null
+      }
+
+      muxer.setOrientationHint(rotationDegrees)
+      muxer.start()
+
+      val buffer = ByteBuffer.allocate(1024 * 1024)
+      val bufferInfo = MediaCodec.BufferInfo()
+
+      while (true) {
+        bufferInfo.offset = 0
+        bufferInfo.size = extractor.readSampleData(buffer, 0)
+
+        if (bufferInfo.size < 0) {
+          bufferInfo.size = 0
+          break
+        }
+
+        bufferInfo.presentationTimeUs = extractor.sampleTime
+        bufferInfo.flags = extractor.sampleFlags
+        muxer.writeSampleData(videoTrackIndex, buffer, bufferInfo)
+        extractor.advance()
+      }
+
+      muxer.stop()
+      muxer.release()
+      extractor.release()
+
+      return FileInputStream(tempFile)
+    } catch (e: Exception) {
+      e.printStackTrace()
+      return null
+    }
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/util/MediaUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/MediaUtil.java
@@ -356,6 +356,9 @@ public class MediaUtil {
   }
 
   public static boolean isNonGifVideo(Media media) {
+    if(media == null) {
+      return false;
+    }
     return isVideo(media.getContentType()) && !media.isVideoGif();
   }
 

--- a/app/src/main/res/layout/v2_media_review_fragment.xml
+++ b/app/src/main/res/layout/v2_media_review_fragment.xml
@@ -269,6 +269,26 @@
             tools:visibility="visible" />
 
         <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/mute_selector"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_marginStart="12dp"
+            android:layout_marginBottom="16dp"
+            android:alpha="0"
+            android:background="@drawable/media_gallery_button_background"
+            android:padding="4dp"
+            android:scaleType="centerInside"
+            android:visibility="gone"
+            app:layout_constraintBottom_toTopOf="@id/add_a_message"
+            app:layout_constraintStart_toEndOf="@id/quality_selector"
+            app:layout_goneMarginStart="10dp"
+            app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.Signal.Circle"
+            app:srcCompat="@drawable/symbol_speaker_24"
+            app:tint="@color/signal_dark_colorOnSurface"
+            tools:alpha="1"
+            tools:visibility="visible" />
+
+        <com.google.android.material.imageview.ShapeableImageView
             android:id="@+id/save_to_media"
             android:layout_width="48dp"
             android:layout_height="48dp"
@@ -279,7 +299,7 @@
             android:scaleType="centerInside"
             android:visibility="gone"
             app:layout_constraintBottom_toTopOf="@id/add_a_message"
-            app:layout_constraintStart_toEndOf="@id/quality_selector"
+            app:layout_constraintStart_toEndOf="@id/mute_selector"
             app:layout_goneMarginStart="10dp"
             app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.Signal.Circle"
             app:srcCompat="@drawable/symbol_save_android_24"


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device Realme GT Neo 3t, Android 14
 * Device Infinix Hot 20 Pro, Android 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
I have tried to follow all patterns that are already used in these flows. 
Optimization scope:
1. The logic for `getMutedVideoStream` can be improved, I know first I am creating a file(for a single session) and then using it to get a `FileInputStream` to pass in to `BlobProvider` which will internally create the same file for a single session. I would love to get some feedback on this implementation and what the pros and cons could be.
2. Creating separate live data for observing muted state only? Pros and cons or just overkill?
3. I think merging `mutedVideosMap` into `editorStateMap` can create unnecessary complexity to the overall flow of this mute functionality. Opinions?
4. I can also add toggle message like we are showing for the quality toggle, but it's not required imo.

Output:

https://github.com/user-attachments/assets/b57616ce-0226-4b8c-8fcc-b569b8568035

