### PR TITLE
Enforce no grouping in currency formatter, to be consistent with Mone…

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/subscription/boost/Boost.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/subscription/boost/Boost.kt
@@ -291,6 +291,7 @@ data class Boost(
         }
 
         formatter.maximumFractionDigits = currency.defaultFractionDigits
+        formatter.isGroupingUsed = false
 
         val value = s.toString().toDoubleOrNull()
 


### PR DESCRIPTION
…yFilter. Fixes #13922

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual device Medium Phone, Android 15.0
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
When pasting long numbers into the Custom Donation field, the grouping separator was being formatted in, causing further edits to the text to not work. The formatter needed to format the number without these separators (e.g. $1000 vs $1,000).

To verify the bug as en_US Locale, paste "12345" into the donate custom amount field. See it formatted as "$12,345". See that you cannot delete digits until you delete the comma. Also notice the NumberFormatException being caught for the withoutLeadingZeroes code.

After fix, it should format as "$12345", consistent with typing in the digits manually. NumberFormatException no longer being thrown.

Also tested with
Thoughtcrime
$12,345
12345
12,345
$12,345.00
12,345.00
12345.00
$0012345
$0012,345
532&12345
1,23
0012345
0012345.00
0012345.00$

Unexpected formats are disallowed from being pasted in, and leading zeroes are removed.