### PR TITLE
Support Quote reply with Sticker/Contact/Docs

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
@@ -81,7 +81,6 @@ import org.thoughtcrime.securesms.attachments.DatabaseAttachment;
 import org.thoughtcrime.securesms.badges.BadgeImageView;
 import org.thoughtcrime.securesms.badges.gifts.GiftMessageView;
 import org.thoughtcrime.securesms.badges.gifts.OpenableGift;
-import org.thoughtcrime.securesms.billing.upgrade.UpgradeToStartMediaBackupSheet;
 import org.thoughtcrime.securesms.calls.links.CallLinks;
 import org.thoughtcrime.securesms.components.AlertView;
 import org.thoughtcrime.securesms.components.AudioView;
@@ -145,7 +144,6 @@ import org.thoughtcrime.securesms.util.MessageRecordUtil;
 import org.thoughtcrime.securesms.util.PlaceholderURLSpan;
 import org.thoughtcrime.securesms.util.Projection;
 import org.thoughtcrime.securesms.util.ProjectionList;
-import org.thoughtcrime.securesms.util.RemoteConfig;
 import org.thoughtcrime.securesms.util.SearchUtil;
 import org.thoughtcrime.securesms.util.ThemeUtil;
 import org.thoughtcrime.securesms.util.UrlClickHandler;
@@ -680,9 +678,15 @@ public final class ConversationItem extends RelativeLayout implements BindableCo
     int availableWidth;
     if (hasAudio(messageRecord)) {
       availableWidth = audioViewStub.get().getMeasuredWidth() + ViewUtil.getLeftMargin(audioViewStub.get()) + ViewUtil.getRightMargin(audioViewStub.get());
+    } else if((hasSticker(messageRecord) && isCaptionlessMms(messageRecord)) || isBorderless(messageRecord)) {
+      availableWidth = stickerStub.get().getMeasuredWidth() + ViewUtil.getLeftMargin(stickerStub.get()) + ViewUtil.getRightMargin(stickerStub.get());
+    } else if(hasSharedContact(messageRecord)) {
+      availableWidth = sharedContactStub.get().getMeasuredWidth() + ViewUtil.getLeftMargin(sharedContactStub.get()) + ViewUtil.getRightMargin(sharedContactStub.get());
+    } else if(hasDocument(messageRecord)) {
+      availableWidth = documentViewStub.get().getMeasuredWidth() + ViewUtil.getLeftMargin(documentViewStub.get()) + ViewUtil.getRightMargin(documentViewStub.get());
     } else if (!isViewOnceMessage(messageRecord) && (hasThumbnail(messageRecord) || hasBigImageLinkPreview(messageRecord))) {
       availableWidth = mediaThumbnailStub.require().getMeasuredWidth();
-    } else {
+    }  else {
       availableWidth = bodyBubble.getMeasuredWidth() - bodyBubble.getPaddingLeft() - bodyBubble.getPaddingRight();
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
@@ -804,8 +804,7 @@ class ConversationFragment :
 
   override fun onStickerSelected(sticker: StickerRecord) {
     sendSticker(
-      stickerRecord = sticker,
-      clearCompose = false
+      stickerRecord = sticker
     )
   }
 
@@ -1521,7 +1520,7 @@ class ConversationFragment :
 
     when (data) {
       is ShareOrDraftData.SendKeyboardImage -> sendMessageWithoutComposeInput(slide = data.slide, clearCompose = false)
-      is ShareOrDraftData.SendSticker -> sendMessageWithoutComposeInput(slide = data.slide, clearCompose = true)
+      is ShareOrDraftData.SendSticker -> sendMessageWithoutComposeInput(slide = data.slide)
       is ShareOrDraftData.SetText -> composeText.setDraftText(data.text)
       is ShareOrDraftData.SetLocation -> attachmentManager.setLocation(data.location, MediaConstraints.getPushMediaConstraints())
       is ShareOrDraftData.SetEditMessage -> {
@@ -1809,8 +1808,7 @@ class ConversationFragment :
   }
 
   private fun sendSticker(
-    stickerRecord: StickerRecord,
-    clearCompose: Boolean
+    stickerRecord: StickerRecord
   ) {
     val stickerLocator = StickerLocator(stickerRecord.packId, stickerRecord.packKey, stickerRecord.stickerId, stickerRecord.emoji)
     val slide = StickerSlide(
@@ -1821,7 +1819,7 @@ class ConversationFragment :
       stickerRecord.contentType
     )
 
-    sendMessageWithoutComposeInput(slide = slide, clearCompose = clearCompose)
+    sendMessageWithoutComposeInput(slide = slide)
 
     viewModel.updateStickerLastUsedTime(stickerRecord, System.currentTimeMillis().milliseconds)
   }
@@ -1829,7 +1827,6 @@ class ConversationFragment :
   private fun sendMessageWithoutComposeInput(
     slide: Slide? = null,
     contacts: List<Contact> = emptyList(),
-    quote: QuoteModel? = null,
     clearCompose: Boolean = true
   ) {
     sendMessage(
@@ -1840,7 +1837,6 @@ class ConversationFragment :
       mentions = emptyList(),
       bodyRanges = null,
       messageToEdit = null,
-      quote = quote,
       linkPreviews = emptyList(),
       bypassPreSendSafetyNumberCheck = true
     )
@@ -1889,12 +1885,12 @@ class ConversationFragment :
     if (slideDeck == null) {
       val voiceNote: DraftTable.Draft? = draftViewModel.voiceNoteDraft
       if (voiceNote != null) {
-        sendMessageWithoutComposeInput(slide = AudioSlide.createFromVoiceNoteDraft(voiceNote), clearCompose = true)
+        sendMessageWithoutComposeInput(slide = AudioSlide.createFromVoiceNoteDraft(voiceNote))
         return
       }
     }
 
-    if (body.isNullOrBlank() && slideDeck?.containsMediaSlide() != true && preUploadResults.isEmpty() && contacts.isEmpty()) {
+    if (body.isBlank() && slideDeck?.containsMediaSlide() != true && preUploadResults.isEmpty() && contacts.isEmpty()) {
       Log.i(TAG, "Unable to send due to empty message")
       toast(R.string.ConversationActivity_message_is_empty_exclamation)
       return
@@ -3677,8 +3673,7 @@ class ConversationFragment :
   private inner class ActivityResultCallbacks : ConversationActivityResultContracts.Callbacks {
     override fun onSendContacts(contacts: List<Contact>) {
       sendMessageWithoutComposeInput(
-        contacts = contacts,
-        clearCompose = false
+        contacts = contacts
       )
     }
 
@@ -4129,8 +4124,7 @@ class ConversationFragment :
 
     override fun onStickerSuggestionSelected(sticker: StickerRecord) {
       sendSticker(
-        stickerRecord = sticker,
-        clearCompose = true
+        stickerRecord = sticker
       )
     }
 
@@ -4414,8 +4408,7 @@ class ConversationFragment :
       val audioSlide = AudioSlide(draft.uri, draft.size, MediaUtil.AUDIO_AAC, true)
 
       sendMessageWithoutComposeInput(
-        slide = audioSlide,
-        quote = inputPanel.quote.orNull()
+        slide = audioSlide
       )
     }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
This changes include supporting following features/capabilities:
1. Quote reply to a message with a Sticker.
2. Quote reply to a message with sharing a contact.
3. Quote reply to a message by sharing a document.
4. Quote reply to a message with a sticker from your keyboard. 

Optionally: We can check if the message is a quoted reply then we can show the background for stickers too. Like in other apps.
Not covered: Clicking on the quoteView  won't show the ripple to the sticker message. This can be done by adding a background or any other approaches. I have not changed anything with it to keep the PR more specific.