### PR TITLE
Always use software AEC for known-issue ROMs

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/RingRtcDynamicConfiguration.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/RingRtcDynamicConfiguration.kt
@@ -21,7 +21,7 @@ object RingRtcDynamicConfiguration {
 
     return if (shouldUseOboeAdm()) {
       when {
-        shouldUseSoftwareAecForOboe() -> AudioProcessingMethod.ForceSoftwareAec3
+        shouldUseSoftwareAecForOboe() || isKnownFaultyHardwareImplementation() -> AudioProcessingMethod.ForceSoftwareAec3
         else -> AudioProcessingMethod.ForceHardware
       }
     } else {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Moto G7 Power (Ocean), LineageOS 21 (Android 14); also tested on LineageOS 20
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Older logic as introduced in 3e001dd was to always use software AEC for known-issue ROMs (LineageOS, CalyxOS). That logic was recently modified with introduction of Oboe ADM in 643f64e. For known-issue ROMs, Oboe ADM is now employed (which is good), but software AEC is not enforced anymore in that code path, resulting in echo for the call recipient. This commit applies the previous logic also to the Oboe case, enforcing software AEC for known-issue ROMs to avoid echo.