### PR TITLE
Support Video Mode for CameraXFragment

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/CameraButtonView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/CameraButtonView.java
@@ -300,10 +300,4 @@ public class CameraButtonView extends View {
       videoCaptureListener.onZoomIncremented(percent);
     }
   }
-
-  interface VideoCaptureListener {
-    void onVideoCaptureStarted();
-    void onVideoCaptureComplete();
-    void onZoomIncremented(float percent);
-  }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/CameraFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/CameraFragment.java
@@ -55,6 +55,8 @@ public interface CameraFragment {
   void presentHud(int selectedMediaCount);
   void fadeOutControls(@NonNull Runnable onEndAction);
   void fadeInControls();
+  default void changeCameraToVideo() { }
+  default void changeVideoToCamera() { }
 
   interface Controller {
     void onCameraError();

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/CameraXVideoCaptureHelper.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/CameraXVideoCaptureHelper.java
@@ -39,8 +39,14 @@ import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
+interface VideoCaptureListener {
+  void onVideoCaptureStarted();
+  void onVideoCaptureComplete();
+  void onZoomIncremented(float percent);
+}
+
 @RequiresApi(26)
-class CameraXVideoCaptureHelper implements CameraButtonView.VideoCaptureListener {
+class CameraXVideoCaptureHelper implements VideoCaptureListener {
 
   private static final String TAG               = Log.tag(CameraXVideoCaptureHelper.class);
   private static final String VIDEO_DEBUG_LABEL = "video-capture";
@@ -86,7 +92,7 @@ class CameraXVideoCaptureHelper implements CameraButtonView.VideoCaptureListener
   };
 
   CameraXVideoCaptureHelper(@NonNull Fragment fragment,
-                            @NonNull CameraButtonView captureButton,
+                            @NonNull Consumer<Float> progressListener,
                             @NonNull CameraController cameraController,
                             @NonNull PreviewView previewView,
                             @NonNull MemoryFileDescriptor memoryFileDescriptor,
@@ -109,9 +115,7 @@ class CameraXVideoCaptureHelper implements CameraButtonView.VideoCaptureListener
     this.cameraXModePolicy      = cameraXModePolicy;
 
     updateProgressAnimator.setInterpolator(new LinearInterpolator());
-    updateProgressAnimator.addUpdateListener(anim -> {
-      captureButton.setProgress(anim.getAnimatedFraction());
-    });
+    updateProgressAnimator.addUpdateListener(anim -> progressListener.accept(anim.getAnimatedFraction()));
   }
 
   @Override

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/VideoCameraButtonView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/VideoCameraButtonView.java
@@ -1,0 +1,192 @@
+package org.thoughtcrime.securesms.mediasend;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.util.AttributeSet;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.signal.core.util.DimensionUnit;
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.util.Util;
+import org.thoughtcrime.securesms.util.ViewUtil;
+
+public class VideoCameraButtonView extends View {
+
+  private static final float CAPTURE_ARC_STROKE_WIDTH       = 3.5f;
+  private static final int   PROGRESS_ARC_STROKE_WIDTH      = 4;
+  private static final float CAPTURE_FILL_PROTECTION_IN_PX  = DimensionUnit.DP.toPixels(20);
+  private static final float STOP_ICON_CORNER_RADIUS        = 20f;
+
+  private final @NonNull Paint backgroundPaint  = backgroundPaint();
+  private final @NonNull Paint arcPaint         = arcPaint();
+  private final @NonNull Paint recordPaint      = recordPaint();
+  private final @NonNull Paint progressPaint    = progressPaint();
+  private final @NonNull Paint captureFillPaint = captureFillPaint();
+
+  private boolean isRecordingVideo = false;
+  private float   progressPercent  = 0f;
+
+  private @Nullable VideoCaptureListener videoCaptureListener;
+
+  private final float recordSize;
+  private final RectF progressRect = new RectF();
+  private final RectF stopIconRect = new RectF();
+
+  private final @NonNull OnClickListener startRecordingClickListener = v -> {
+    notifyVideoCaptureStarted();
+    setScaleX(1f);
+    setScaleY(1f);
+    isRecordingVideo = true;
+  };
+
+  private final @NonNull OnClickListener stopRecordingClickListener = v -> {
+    notifyVideoCaptureEnded();
+    setScaleX(1f);
+    setScaleY(1f);
+    isRecordingVideo = false;
+  };
+
+  public VideoCameraButtonView(@NonNull Context context) {
+    this(context, null);
+  }
+
+  public VideoCameraButtonView(@NonNull Context context, @Nullable AttributeSet attrs) {
+    this(context, attrs, 0);
+  }
+
+  public VideoCameraButtonView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+
+    TypedArray a = context.getTheme().obtainStyledAttributes(attrs, R.styleable.CameraButtonView, defStyleAttr, 0);
+
+    recordSize = a.getDimensionPixelSize(R.styleable.CameraButtonView_recordSize, -1);
+    a.recycle();
+  }
+
+  private static Paint recordPaint() {
+    Paint recordPaint = new Paint();
+    recordPaint.setColor(0xFFF44336);
+    recordPaint.setAntiAlias(true);
+    recordPaint.setStyle(Paint.Style.FILL);
+    return recordPaint;
+  }
+
+  private static Paint outlinePaint() {
+    Paint outlinePaint = new Paint();
+    outlinePaint.setColor(0x26000000);
+    outlinePaint.setAntiAlias(true);
+    outlinePaint.setStyle(Paint.Style.STROKE);
+    outlinePaint.setStrokeWidth(ViewUtil.dpToPx(4));
+    return outlinePaint;
+  }
+
+  private static Paint backgroundPaint() {
+    Paint backgroundPaint = new Paint();
+    backgroundPaint.setColor(0x4CFFFFFF);
+    backgroundPaint.setAntiAlias(true);
+    backgroundPaint.setStyle(Paint.Style.FILL);
+    return backgroundPaint;
+  }
+
+  private static Paint arcPaint() {
+    Paint arcPaint = new Paint();
+    arcPaint.setColor(0xFFFFFFFF);
+    arcPaint.setAntiAlias(true);
+    arcPaint.setStyle(Paint.Style.STROKE);
+    arcPaint.setStrokeWidth(DimensionUnit.DP.toPixels(CAPTURE_ARC_STROKE_WIDTH));
+    return arcPaint;
+  }
+
+  private static Paint progressPaint() {
+    Paint progressPaint = new Paint();
+    progressPaint.setColor(0xFFFFFFFF);
+    progressPaint.setAntiAlias(true);
+    progressPaint.setStyle(Paint.Style.STROKE);
+    progressPaint.setStrokeWidth(ViewUtil.dpToPx(PROGRESS_ARC_STROKE_WIDTH));
+    progressPaint.setShadowLayer(4, 0, 2, 0x40000000);
+    return progressPaint;
+  }
+
+  private static Paint captureFillPaint() {
+    Paint arcPaint = new Paint();
+    arcPaint.setColor(0xFFFFFFFF);
+    arcPaint.setAntiAlias(true);
+    arcPaint.setStyle(Paint.Style.FILL);
+    return arcPaint;
+  }
+
+  @Override
+  protected void onDraw(@NonNull Canvas canvas) {
+    super.onDraw(canvas);
+
+    drawForVideoCapture(canvas);
+  }
+
+  private void drawForVideoCapture(Canvas canvas) {
+    float centerX = getWidth() / 2f;
+    float centerY = getHeight() / 2f;
+
+    float radius = recordSize / 2f;
+    canvas.drawCircle(centerX, centerY, radius, backgroundPaint);
+    if (isRecordingVideo) {
+
+      stopIconRect.left   = centerX - CAPTURE_FILL_PROTECTION_IN_PX;
+      stopIconRect.top    = centerY - CAPTURE_FILL_PROTECTION_IN_PX;
+      stopIconRect.right  = centerX + CAPTURE_FILL_PROTECTION_IN_PX;
+      stopIconRect.bottom = centerY + CAPTURE_FILL_PROTECTION_IN_PX;
+
+      canvas.drawRoundRect(stopIconRect, STOP_ICON_CORNER_RADIUS, STOP_ICON_CORNER_RADIUS, recordPaint);
+    } else {
+      canvas.drawCircle(centerX, centerY, radius, arcPaint);
+      canvas.drawCircle(centerX, centerY, radius - CAPTURE_FILL_PROTECTION_IN_PX, captureFillPaint);
+    }
+
+    progressRect.left   = centerX - radius + (PROGRESS_ARC_STROKE_WIDTH);
+    progressRect.top    = centerY - radius + (PROGRESS_ARC_STROKE_WIDTH);
+    progressRect.right  = centerX + radius - (PROGRESS_ARC_STROKE_WIDTH);
+    progressRect.bottom = centerY + radius - (PROGRESS_ARC_STROKE_WIDTH);
+
+    canvas.drawArc(progressRect, 270f, 360f * progressPercent, false, progressPaint);
+  }
+
+  public void setVideoCaptureListener(@Nullable VideoCaptureListener videoCaptureListener) {
+    if (isRecordingVideo) throw new IllegalStateException("Cannot set video capture listener while recording");
+
+    if (videoCaptureListener != null) {
+      this.videoCaptureListener = videoCaptureListener;
+      setOnClickListener(startRecordingClickListener);
+    }
+  }
+
+  public void setProgress(float percentage) {
+    progressPercent = Util.clamp(percentage, 0f, 1f);
+    invalidate();
+  }
+
+  private void notifyVideoCaptureStarted() {
+    if (!isRecordingVideo && videoCaptureListener != null) {
+      videoCaptureListener.onVideoCaptureStarted();
+    }
+  }
+
+  private void notifyVideoCaptureEnded() {
+    if (isRecordingVideo && videoCaptureListener != null) {
+      videoCaptureListener.onVideoCaptureComplete();
+    }
+  }
+
+  @Override public boolean performClick() {
+    if (isRecordingVideo) {
+      setOnClickListener(stopRecordingClickListener);
+    } else {
+      setOnClickListener(startRecordingClickListener);
+    }
+    return super.performClick();
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/VideoCameraButtonView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/VideoCameraButtonView.java
@@ -38,18 +38,14 @@ public class VideoCameraButtonView extends View {
   private final RectF progressRect = new RectF();
   private final RectF stopIconRect = new RectF();
 
-  private final @NonNull OnClickListener startRecordingClickListener = v -> {
-    notifyVideoCaptureStarted();
-    setScaleX(1f);
-    setScaleY(1f);
-    isRecordingVideo = true;
-  };
-
-  private final @NonNull OnClickListener stopRecordingClickListener = v -> {
-    notifyVideoCaptureEnded();
-    setScaleX(1f);
-    setScaleY(1f);
-    isRecordingVideo = false;
+  private final @NonNull OnClickListener internalClickListener = v -> {
+    if(isRecordingVideo) {
+      notifyVideoCaptureStarted();
+      isRecordingVideo = true;
+    } else {
+      notifyVideoCaptureEnded();
+      isRecordingVideo = false;
+    }
   };
 
   public VideoCameraButtonView(@NonNull Context context) {
@@ -160,7 +156,7 @@ public class VideoCameraButtonView extends View {
 
     if (videoCaptureListener != null) {
       this.videoCaptureListener = videoCaptureListener;
-      setOnClickListener(startRecordingClickListener);
+      setOnClickListener(internalClickListener);
     }
   }
 
@@ -179,14 +175,5 @@ public class VideoCameraButtonView extends View {
     if (isRecordingVideo && videoCaptureListener != null) {
       videoCaptureListener.onVideoCaptureComplete();
     }
-  }
-
-  @Override public boolean performClick() {
-    if (isRecordingVideo) {
-      setOnClickListener(stopRecordingClickListener);
-    } else {
-      setOnClickListener(startRecordingClickListener);
-    }
-    return super.performClick();
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/HudCommand.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/HudCommand.kt
@@ -3,17 +3,18 @@ package org.thoughtcrime.securesms.mediasend.v2
 import android.view.KeyEvent
 
 sealed class HudCommand {
-  object StartDraw : HudCommand()
-  object StartCropAndRotate : HudCommand()
-  object SaveMedia : HudCommand()
+  data object StartDraw : HudCommand()
+  data object StartCropAndRotate : HudCommand()
+  data object SaveMedia : HudCommand()
 
-  object GoToText : HudCommand()
-  object GoToCapture : HudCommand()
+  data object GoToCamera : HudCommand()
+  data object GoToVideo : HudCommand()
+  data object GoToText : HudCommand()
 
-  object ResumeEntryTransition : HudCommand()
+  data object ResumeEntryTransition : HudCommand()
 
-  object OpenEmojiSearch : HudCommand()
-  object CloseEmojiSearch : HudCommand()
+  data object OpenEmojiSearch : HudCommand()
+  data object CloseEmojiSearch : HudCommand()
   data class EmojiInsert(val emoji: String?) : HudCommand()
   data class EmojiKeyEvent(val keyEvent: KeyEvent?) : HudCommand()
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/capture/MediaCaptureFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/capture/MediaCaptureFragment.kt
@@ -16,6 +16,7 @@ import org.thoughtcrime.securesms.components.settings.app.AppSettingsActivity
 import org.thoughtcrime.securesms.mediasend.CameraFragment
 import org.thoughtcrime.securesms.mediasend.Media
 import org.thoughtcrime.securesms.mediasend.v2.HudCommand
+import org.thoughtcrime.securesms.mediasend.v2.MediaSelectionActivity
 import org.thoughtcrime.securesms.mediasend.v2.MediaSelectionNavigator
 import org.thoughtcrime.securesms.mediasend.v2.MediaSelectionViewModel
 import org.thoughtcrime.securesms.mms.MediaConstraints
@@ -110,6 +111,14 @@ class MediaCaptureFragment : Fragment(R.layout.fragment_container), CameraFragme
 
     sharedViewModel.state.observe(viewLifecycleOwner) { state ->
       captureChildFragment.presentHud(state.selectedMedia.size)
+    }
+
+    sharedViewModel.mediaMode.observe(viewLifecycleOwner) { state->
+      if(state==MediaSelectionActivity.MediaMode.CAMERA) {
+        captureChildFragment.changeVideoToCamera()
+      } else if(state==MediaSelectionActivity.MediaMode.VIDEO) {
+        captureChildFragment.changeCameraToVideo()
+      }
     }
 
     lifecycleDisposable.bindTo(viewLifecycleOwner)

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/text/TextStoryPostCreationFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/text/TextStoryPostCreationFragment.kt
@@ -70,11 +70,6 @@ class TextStoryPostCreationFragment : Fragment(R.layout.stories_text_post_creati
     binding.storyTextPost.enableCreationMode()
 
     lifecycleDisposable.bindTo(viewLifecycleOwner)
-    lifecycleDisposable += sharedViewModel.hudCommands.subscribe {
-      if (it == HudCommand.GoToCapture) {
-        findNavController().popBackStack()
-      }
-    }
 
     lifecycleDisposable += viewModel.typeface.subscribeBy { typeface ->
       binding.storyTextPost.setTypeface(typeface)

--- a/app/src/main/res/layout/camera_controls_portrait.xml
+++ b/app/src/main/res/layout/camera_controls_portrait.xml
@@ -17,6 +17,17 @@
         app:layout_constraintStart_toStartOf="parent"
         app:recordSize="54dp" />
 
+    <org.thoughtcrime.securesms.mediasend.VideoCameraButtonView
+        android:id="@+id/video_capture_button"
+        android:layout_width="@dimen/camera_capture_button_size"
+        android:layout_height="@dimen/camera_capture_button_size"
+        android:contentDescription="@string/CameraXFragment_capture_description"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:recordSize="@dimen/camera_capture_image_button_size" />
+
     <org.thoughtcrime.securesms.mediasend.camerax.CameraXFlashToggleView
         android:id="@+id/camera_flash_button"
         android:layout_width="36dp"

--- a/app/src/main/res/layout/media_selection_activity.xml
+++ b/app/src/main/res/layout/media_selection_activity.xml
@@ -28,6 +28,24 @@
             app:layout_constraintTop_toTopOf="@id/camera_switch" />
 
         <TextView
+            android:id="@+id/video_switch"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:minHeight="36sp"
+            android:paddingHorizontal="18dp"
+            android:shadowColor="@color/black"
+            android:text="@string/MediaSelectionActivity__video"
+            android:textAppearance="@style/TextAppearance.Signal.Body2"
+            android:textColor="@color/story_pill_text_color"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/camera_switch"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintHorizontal_bias="1"
+            tools:background="@color/red_500" />
+
+        <TextView
             android:id="@+id/camera_switch"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/media_selection_activity_video_selected_constraints.xml
+++ b/app/src/main/res/layout/media_selection_activity_video_selected_constraints.xml
@@ -14,10 +14,10 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:background="@color/white"
-        app:layout_constraintBottom_toBottomOf="@id/text_switch"
-        app:layout_constraintEnd_toEndOf="@id/text_switch"
-        app:layout_constraintStart_toStartOf="@id/text_switch"
-        app:layout_constraintTop_toTopOf="@id/text_switch" />
+        app:layout_constraintBottom_toBottomOf="@id/video_switch"
+        app:layout_constraintEnd_toEndOf="@id/video_switch"
+        app:layout_constraintStart_toStartOf="@id/video_switch"
+        app:layout_constraintTop_toTopOf="@id/video_switch" />
 
     <TextView
         android:id="@+id/video_switch"
@@ -29,8 +29,7 @@
         android:textAppearance="@style/TextAppearance.Signal.Body2"
         android:textColor="@color/story_pill_text_color"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/camera_switch"
-        app:layout_constraintHorizontal_bias="1"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:background="@color/red_500" />
@@ -45,10 +44,10 @@
         android:textAppearance="@style/TextAppearance.Signal.Body2"
         android:textColor="@color/story_pill_text_color"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/text_switch"
-        app:layout_constraintHorizontal_bias="1"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintStart_toEndOf="@id/video_switch"
         tools:background="@color/red_500" />
 
     <TextView
@@ -61,9 +60,10 @@
         android:textAppearance="@style/TextAppearance.Signal.Body2"
         android:textColor="@color/story_pill_text_color"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintStart_toEndOf="@id/camera_switch"
         tools:background="@color/green_500" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6402,6 +6402,8 @@
     <string name="MediaSelectionActivity__text">Text</string>
     <!-- Camera label for media selection toggle -->
     <string name="MediaSelectionActivity__camera">Camera</string>
+    <!-- Video label for media selection toggle -->
+    <string name="MediaSelectionActivity__video">Video</string>
     <!-- Hint for entering a URL for a text post -->
     <string name="TextStoryPostLinkEntryFragment__type_or_paste_a_url">Type or paste a URL</string>
     <!-- Displayed prior to the user entering a URL for a text post -->


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
1. The new MediaMode (currently textStoryToggleMode) has 3 Mode { VIDEO, CAMERA, TEXT }.
2. The HugCommand has a new GoToVideo command.
3. To update the State properly, All GoToX HudCommands are handled in the MediaSelectionActivity.
4. A new VideoCameraButtonView is created to handle video button view independently

HELP:
1. For Camera1Fragment, I am not sure what is the recommended way to hide the video tab, simply put it in an if statement.

Problem/Bugs:
After testing, I have encountered further issues:
1. User can press on the gallery while recording.
2. User can change the MediaMode while recording.
3. User can press back while recording.
These issues are fixed in my last PR #13933
4. The CameraFragment is destroyed and recreated every time when we come back from TextStoryFragment, this can be prevented. (This already existed but is not introduced in this change).

Improvements:
1. VideoCameraButtonView can be improved, open for suggestions.