### PR TITLE
Fixes #13936 - Finish StoryActivity if Story was already deleted

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/stories/viewer/StoryViewerState.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/stories/viewer/StoryViewerState.kt
@@ -22,7 +22,7 @@ data class StoryViewerState(
   }
 
   sealed class CrossfadeTarget {
-    object None : CrossfadeTarget()
+    data object None : CrossfadeTarget()
     data class Record(val messageRecord: MmsMessageRecord) : CrossfadeTarget()
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/stories/viewer/StoryViewerViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/stories/viewer/StoryViewerViewModel.kt
@@ -136,13 +136,22 @@ class StoryViewerViewModel(
 
   fun refresh() {
     disposables.clear()
-    disposables += repository.getFirstStory(storyViewerArgs.recipientId, storyViewerArgs.storyId).subscribe { record ->
-      store.update {
-        it.copy(
-          crossfadeTarget = StoryViewerState.CrossfadeTarget.Record(record)
-        )
+    disposables += repository.getFirstStory(storyViewerArgs.recipientId, storyViewerArgs.storyId)
+      .doOnSuccess { record ->
+        store.update {
+          it.copy(
+            crossfadeTarget = StoryViewerState.CrossfadeTarget.Record(record)
+          )
+        }
       }
-    }
+      .onErrorComplete {
+        store.update {
+          it.copy(
+            crossfadeTarget = StoryViewerState.CrossfadeTarget.None
+          )
+        }
+        true
+      }.subscribe()
     disposables += getStories().subscribe { recipientIds ->
       store.update {
         val page: Int = if (it.pages.isNotEmpty()) {


### PR DESCRIPTION
Closes #13936 

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixes:
Closes the StoryActivty if onQuoteClick has a deleted message's ID.

Improvements:
1. Start this StoryActivity for result, and if the result from StoryViewerFragment says that the story message is deleted, then after receiving that result in ChaFragment, update that paticular message's state.
Should I use onActivityResult? or launcher?
Is it fine to update the message state from this callback?

1. Add a callback listening to deletion of story.