### PR TITLE
NotificationProfile Icon visibility updates from all tabs

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
@@ -1023,7 +1023,6 @@ public class ConversationListFragment extends MainFragment implements ActionMode
     lifecycleDisposable.add(viewModel.getMegaphoneState().subscribe(this::onMegaphoneChanged));
     lifecycleDisposable.add(viewModel.getConversationsState().subscribe(this::onConversationListChanged));
     lifecycleDisposable.add(viewModel.getHasNoConversations().subscribe(this::updateEmptyState));
-    lifecycleDisposable.add(viewModel.getNotificationProfiles().subscribe(profiles -> requireCallback().updateNotificationProfileStatus(profiles)));
     lifecycleDisposable.add(viewModel.getWebSocketState().subscribe(pipeState -> requireCallback().updateProxyStatus(pipeState)));
     lifecycleDisposable.add(viewModel.getChatFolderState().subscribe(this::onChatFoldersChanged));
 
@@ -2034,8 +2033,6 @@ public class ConversationListFragment extends MainFragment implements ActionMode
     @NonNull View getUnreadPaymentsDot();
 
     @NonNull Stub<Toolbar> getBasicToolbar();
-
-    void updateNotificationProfileStatus(@NonNull List<NotificationProfile> notificationProfiles);
 
     void updateProxyStatus(@NonNull WebSocketConnectionState state);
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListViewModel.kt
@@ -17,7 +17,6 @@ import org.signal.paging.PagingConfig
 import org.signal.paging.ProxyPagingController
 import org.thoughtcrime.securesms.components.settings.app.chats.folders.ChatFolderRecord
 import org.thoughtcrime.securesms.components.settings.app.chats.folders.ChatFoldersRepository
-import org.thoughtcrime.securesms.components.settings.app.notifications.profiles.NotificationProfilesRepository
 import org.thoughtcrime.securesms.conversationlist.chatfilter.ConversationFilterRequest
 import org.thoughtcrime.securesms.conversationlist.chatfilter.ConversationFilterSource
 import org.thoughtcrime.securesms.conversationlist.model.Conversation
@@ -31,7 +30,6 @@ import org.thoughtcrime.securesms.megaphone.Megaphone
 import org.thoughtcrime.securesms.megaphone.MegaphoneRepository
 import org.thoughtcrime.securesms.megaphone.Megaphones
 import org.thoughtcrime.securesms.notifications.MarkReadReceiver
-import org.thoughtcrime.securesms.notifications.profiles.NotificationProfile
 import org.thoughtcrime.securesms.recipients.Recipient
 import org.thoughtcrime.securesms.recipients.RecipientId
 import org.thoughtcrime.securesms.util.rx.RxStore
@@ -40,8 +38,7 @@ import java.util.concurrent.TimeUnit
 
 class ConversationListViewModel(
   private val isArchived: Boolean,
-  private val megaphoneRepository: MegaphoneRepository = AppDependencies.megaphoneRepository,
-  private val notificationProfilesRepository: NotificationProfilesRepository = NotificationProfilesRepository()
+  private val megaphoneRepository: MegaphoneRepository = AppDependencies.megaphoneRepository
 ) : ViewModel() {
 
   companion object {
@@ -239,11 +236,6 @@ class ConversationListViewModel(
         )
       }
     }
-  }
-
-  fun getNotificationProfiles(): Flowable<List<NotificationProfile>> {
-    return notificationProfilesRepository.getProfiles()
-      .observeOn(AndroidSchedulers.mainThread())
   }
 
   private fun setSelection(newSelection: Collection<Conversation>) {

--- a/app/src/main/java/org/thoughtcrime/securesms/main/MainActivityListHostFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/main/MainActivityListHostFragment.kt
@@ -108,6 +108,10 @@ class MainActivityListHostFragment : Fragment(R.layout.main_activity_list_host_f
         R.id.callLogFragment -> goToStateFromCalling(state, controller)
       }
     }
+
+    disposables += conversationListTabsViewModel.getNotificationProfiles().subscribeBy { profiles ->
+      updateNotificationProfileStatus(profiles)
+    }
   }
 
   private fun goToStateFromConversationList(state: ConversationListTabsState, navController: NavController) {
@@ -314,7 +318,7 @@ class MainActivityListHostFragment : Fragment(R.layout.main_activity_list_host_f
     }
   }
 
-  override fun updateNotificationProfileStatus(notificationProfiles: List<NotificationProfile>) {
+  private fun updateNotificationProfileStatus(notificationProfiles: List<NotificationProfile>) {
     val activeProfile = NotificationProfiles.getActiveProfile(notificationProfiles)
     if (activeProfile != null) {
       if (activeProfile.id != SignalStore.notificationProfile.lastProfilePopup) {

--- a/app/src/main/java/org/thoughtcrime/securesms/stories/tabs/ConversationListTabsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/stories/tabs/ConversationListTabsViewModel.kt
@@ -10,10 +10,15 @@ import io.reactivex.rxjava3.disposables.Disposable
 import io.reactivex.rxjava3.kotlin.plusAssign
 import io.reactivex.rxjava3.subjects.PublishSubject
 import io.reactivex.rxjava3.subjects.Subject
+import org.thoughtcrime.securesms.components.settings.app.notifications.profiles.NotificationProfilesRepository
+import org.thoughtcrime.securesms.notifications.profiles.NotificationProfile
 import org.thoughtcrime.securesms.stories.Stories
 import org.thoughtcrime.securesms.util.rx.RxStore
 
 class ConversationListTabsViewModel(startingTab: ConversationListTab, repository: ConversationListTabRepository) : ViewModel() {
+
+  private val notificationProfilesRepository: NotificationProfilesRepository = NotificationProfilesRepository()
+
   private val store = RxStore(ConversationListTabsState(tab = startingTab))
 
   val stateSnapshot: ConversationListTabsState
@@ -45,6 +50,11 @@ class ConversationListTabsViewModel(startingTab: ConversationListTab, repository
 
   override fun onCleared() {
     disposables.clear()
+  }
+
+  fun getNotificationProfiles(): Flowable<List<NotificationProfile>> {
+    return notificationProfilesRepository.getProfiles()
+      .observeOn(AndroidSchedulers.mainThread())
   }
 
   fun onChatsSelected() {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
1. Create and enable a Notifiation profile to see the sleep icon in the topbar.
2. Clicking on it opens the bottom sheet and disabling the notification profile removes the icon from topbar.
3. This behavior is only observed from the ConversationListFragment, means call and status screen can't update sleep icon visibility state.

I moved the logic to MainActivityListHostFragment.


Before:

https://github.com/user-attachments/assets/caf994fe-57fa-4ec5-88c4-3370d616e8be

After:

https://github.com/user-attachments/assets/95d50f93-f390-44b2-8d47-b5e79c86d9b2



