### PR TITLE
Fix textStoryToggle visibility when hasSelectedMedia

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/MediaSelectionActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/MediaSelectionActivity.kt
@@ -153,6 +153,14 @@ class MediaSelectionActivity :
       textViewModel.restoreFromInstanceState(savedInstanceState)
     }
 
+    viewModel.hasSelectedMedia.observe(this) { hasSelectedMedia->
+      if(hasSelectedMedia) {
+        textStoryToggle.visible = false
+      } else {
+        textStoryToggle.visible = canDisplayStorySwitch()
+      }
+    }
+
     (supportFragmentManager.findFragmentByTag(NAV_HOST_TAG) as NavHostFragment).navController.addOnDestinationChangedListener { _, d, _ ->
       when (d.id) {
         R.id.mediaCaptureFragment -> {
@@ -233,7 +241,6 @@ class MediaSelectionActivity :
   private fun canDisplayStorySwitch(): Boolean {
     return Stories.isFeatureEnabled() &&
       isCameraFirst() &&
-      !viewModel.hasSelectedMedia() &&
       (destination == MediaSelectionDestination.ChooseAfterMediaSelection || destination is MediaSelectionDestination.SingleStory)
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/MediaSelectionViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/MediaSelectionViewModel.kt
@@ -7,6 +7,8 @@ import android.os.Parcel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.distinctUntilChanged
+import androidx.lifecycle.map
 import com.google.common.io.ByteStreams
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Flowable
@@ -79,6 +81,8 @@ class MediaSelectionViewModel(
   val isContactSelectionRequired = destination == MediaSelectionDestination.ChooseAfterMediaSelection
 
   val state: LiveData<MediaSelectionState> = store.stateLiveData
+
+  val hasSelectedMedia: LiveData<Boolean> = store.stateLiveData.map { it.selectedMedia.isNotEmpty() }.distinctUntilChanged()
 
   private val internalHudCommands = PublishSubject.create<HudCommand>()
 
@@ -467,10 +471,6 @@ class MediaSelectionViewModel(
       val blobUri = BlobProvider.getInstance().forData(serializedEditorState).createForSingleUseInMemory()
       outState.putParcelable(STATE_EDITORS, blobUri)
     }
-  }
-
-  fun hasSelectedMedia(): Boolean {
-    return store.state.selectedMedia.isNotEmpty()
   }
 
   fun clearMediaErrors() {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Before:

https://github.com/user-attachments/assets/7c63adce-f2b2-43ae-abc9-0bdccdda49c5

After:
Observing to the latest state of selectedMedia count and updating the visibility 

