### PR TITLE
Support Opening the Scheduled Document files

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/DocumentView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/DocumentView.java
@@ -173,7 +173,7 @@ public class DocumentView extends FrameLayout {
 
     @Override
     public void onClick(View v) {
-      if (!slide.isPendingDownload() && !slide.isInProgress() && viewListener != null) {
+      if (slide.hasDocument() && slide.getUri()!=null && viewListener != null) {
         viewListener.onClick(v, slide);
       }
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
@@ -2597,7 +2597,7 @@ public final class ConversationItem extends RelativeLayout implements BindableCo
 
   private class ThumbnailClickListener implements SlideClickListener {
     public void onClick(final View v, final Slide slide) {
-      if (shouldInterceptClicks(messageRecord) || !batchSelected.isEmpty() || isCondensedMode()) {
+      if (shouldInterceptClicks(messageRecord) || !batchSelected.isEmpty() || (isCondensedMode() && !slide.hasDocument())) {
         performClick();
       } else if (!canPlayContent && mediaItem != null && eventListener != null) {
         eventListener.onPlayInlineContent(conversationMessage);


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
1. Support Opening documents for Scheduled messages as there is no preview available for Documents if they are scheduled.

Why Only Documents?
1. For Images/Video, there is a thumbnail present that indicates which item will be sent. I want to support opening these also, but Deleting the message from MediaPreview disturbs the scheduled messages. "Delete for Me"  removes the scheduled message. And "Delte for Everyone" will mark the scheduled message as delete and it will still be scheduled and will be sent". And, Scheduled Sheet won't be updated after any actions from MediaPreview Activity. More refactoring will be required for supporting these.
2. For Scheduled audio, I have already raised #13951 
3. For docs, there is no preview available when scheduled, so user might not know which file they have sent.