### PR TITLE
Support searching for emoji by emoji itself

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/EmojiSearchTable.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/EmojiSearchTable.kt
@@ -62,7 +62,7 @@ class EmojiSearchTable(context: Context, databaseHelper: SignalDatabase) : Datab
     readableDatabase
       .select(LABEL, EMOJI, RANK)
       .from(TABLE_NAME)
-      .where("$LABEL LIKE ?", "%$query%")
+      .where("$LABEL LIKE ? OR $EMOJI = ?", "%$query%", query)
       .orderBy("$RANK ASC")
       .limit(limit)
       .run()
@@ -123,7 +123,7 @@ class EmojiSearchTable(context: Context, databaseHelper: SignalDatabase) : Datab
   private fun similarityScore(searchTerm: String, entry: Entry, maxRank: Int): Float {
     val match: String = entry.label
 
-    if (searchTerm == match) {
+    if (searchTerm == entry.emoji || searchTerm == match) {
       return entry.scaledRank(maxRank)
     }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device sdk_gphone64_arm64, Android 15, API 35
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

I didn't find any open issues regarding this.

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Allow searching for emojis in the emoji picker using the emoji itself. e.g.

#### Before this change
<img width="248" alt="Screenshot 2025-01-26 at 9 19 36 PM" src="https://github.com/user-attachments/assets/bbcf29f5-9354-4ca0-a36a-9821b9b5ebb1" />

#### After this change
<img width="248" alt="Screenshot 2025-01-26 at 9 32 01 PM" src="https://github.com/user-attachments/assets/7c0cde39-21bb-4969-8c7e-236416a814b5" />

(The screenshots are from the emulated device listed above.)

This functionality has been available in [Signal-iOS for a while](https://github.com/signalapp/Signal-iOS/commit/61b3d1c9725693e70c8863737bf2dea54df55490).

