### PR TITLE
Hide schedules Media from ConversationSettings

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/DSLSettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/DSLSettingsFragment.kt
@@ -11,10 +11,10 @@ import androidx.annotation.MenuRes
 import androidx.annotation.StringRes
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
-import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import org.thoughtcrime.securesms.LoggingFragment
 import org.thoughtcrime.securesms.R
 import org.thoughtcrime.securesms.util.Material3OnScrollHelper
 import org.thoughtcrime.securesms.util.adapter.mapping.MappingAdapter
@@ -29,7 +29,7 @@ abstract class DSLSettingsFragment(
   @MenuRes private val menuId: Int = -1,
   @LayoutRes layoutId: Int = R.layout.dsl_settings_fragment,
   protected var layoutManagerProducer: (Context) -> RecyclerView.LayoutManager = { context -> LinearLayoutManager(context) }
-) : Fragment(layoutId) {
+) : LoggingFragment(layoutId) {
 
   protected var recyclerView: RecyclerView? = null
     private set

--- a/app/src/main/java/org/thoughtcrime/securesms/mediaoverview/MediaOverviewPageFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediaoverview/MediaOverviewPageFragment.java
@@ -32,6 +32,7 @@ import com.codewaves.stickyheadergrid.StickyHeaderGridLayoutManager;
 import org.signal.core.util.DimensionUnit;
 import org.signal.core.util.concurrent.LifecycleDisposable;
 import org.signal.core.util.logging.Log;
+import org.thoughtcrime.securesms.LoggingFragment;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.attachments.DatabaseAttachment;
 import org.thoughtcrime.securesms.components.DeleteSyncEducationDialog;
@@ -53,7 +54,7 @@ import org.thoughtcrime.securesms.util.ViewUtil;
 import java.util.Arrays;
 import java.util.Objects;
 
-public final class MediaOverviewPageFragment extends Fragment
+public final class MediaOverviewPageFragment extends LoggingFragment
   implements MediaGalleryAllAdapter.ItemClickListener,
              MediaGalleryAllAdapter.AudioItemListener,
              LoaderManager.LoaderCallbacks<GroupedThreadMediaLoader.GroupedThreadMedia>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Reasons for doing this:
1. Schedules messages are not logically "shared" in the thread.
2. We can go to the Media Preview Screen for Scheduled Image, which can allow us to delete a schedule message for everyone. So, possibility of a Deleted message is still scheduled.
3. A scheduled media message is present in the MediaOverview, from where we can select and delete it, this cause inconsistencies with the scheduled message flow.
4. Schedules Media message show the System.currentTimeMillis date for the media in MediaOverview screen but actually the media isn't sent yet!
![photo_6134124661139685546_y](https://github.com/user-attachments/assets/f2b02aea-07be-4e11-9493-69d12b98a5c1)


So, now showing the Scheduled media is probably the best choice which other Messengers like Telegram also follow.

https://github.com/user-attachments/assets/2ac1ce5b-2ddd-4803-81dd-ac09e39b5c31

