### PR TITLE
Double-tap quick react

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
@@ -2857,7 +2857,7 @@ class ConversationFragment :
     override fun onItemDoubleClick(item: MultiselectPart) {
       val edited = onDoubleTapToEdit(item.conversationMessage)
       if (!edited) {
-        onDoubleTapToQuickReact(item.conversationMessage);
+        onDoubleTapToQuickReact(item.conversationMessage)
       }
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
@@ -249,6 +249,7 @@ import org.thoughtcrime.securesms.keyboard.gif.GifKeyboardPageFragment
 import org.thoughtcrime.securesms.keyboard.sticker.StickerKeyboardPageFragment
 import org.thoughtcrime.securesms.keyboard.sticker.StickerSearchDialogFragment
 import org.thoughtcrime.securesms.keyvalue.SignalStore
+import org.thoughtcrime.securesms.keyvalue.SignalStore.Companion.emoji
 import org.thoughtcrime.securesms.linkpreview.LinkPreview
 import org.thoughtcrime.securesms.linkpreview.LinkPreviewViewModelV2
 import org.thoughtcrime.securesms.longmessage.LongMessageFragment
@@ -2854,21 +2855,28 @@ class ConversationFragment :
     }
 
     override fun onItemDoubleClick(item: MultiselectPart) {
-      Log.d(TAG, "onItemDoubleClick")
-      onDoubleTapToEdit(item.conversationMessage)
+      val edited = onDoubleTapToEdit(item.conversationMessage)
+      if (!edited) {
+        onDoubleTapToQuickReact(item.conversationMessage);
+      }
     }
 
-    private fun onDoubleTapToEdit(conversationMessage: ConversationMessage) {
+    private fun onDoubleTapToEdit(conversationMessage: ConversationMessage): Boolean {
       if (!isValidEditMessageSend(conversationMessage.getMessageRecord(), System.currentTimeMillis())) {
-        return
+        return false
       }
 
       if (SignalStore.uiHints.hasSeenDoubleTapEditEducationSheet) {
         onDoubleTapEditEducationSheetNext(conversationMessage)
-        return
+        return true
       }
 
       DoubleTapEditEducationSheet(conversationMessage).show(childFragmentManager, DoubleTapEditEducationSheet.KEY)
+      return true
+    }
+
+    private fun onDoubleTapToQuickReact(conversationMessage: ConversationMessage) {
+      disposables += viewModel.updateReaction(conversationMessage.messageRecord, emoji.reactions[0]).subscribe()
     }
 
     override fun onPaymentTombstoneClicked() {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Physical Samsung S21FE, Android 14
 * Virtual Pixel 5, Android 8.1
- [x] My contribution is fully baked and ready to be merged as is


----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Allows the user to quickly add a reaction by double-tapping a message, akin to Instagram and Facebook Messenger. The first of the user's list of reaction emojis is used, matching Instagram's behaviour. Double tapping again removes the reaction. If the user attempts to "quick-react" when they have already reacted with a different emoji, nothing will happen.  

This doesn't replace the holding down to react function. This only works for messages sent by other people; the user double-tapping their own message maintains the quick editing functionality.

This had been mentioned on the ideas forum a couple of times, and it seemed trivial to implement for a large UX gain.

I'm uncertain if the `disposables` / `.subscribe()` I used was correct, but it matches other behaviour for adding reactions.