### PR TITLE
Fixes signalapp/Signal-Android#13789 - About Status Color

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/about/AboutSheet.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/about/AboutSheet.kt
@@ -208,9 +208,10 @@ private fun Content(
           Row {
             AndroidView(factory = ::EmojiTextView) {
               it.text = model.about
-              it.setTextColor(textColor.toArgb())
 
               TextViewCompat.setTextAppearance(it, R.style.Signal_Text_BodyLarge)
+
+              it.setTextColor(textColor.toArgb())
             }
           }
         },


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Android Studio IDE
 * LDPlayer Emulator (Android 9)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
I swapped two lines of code to preserve font color for the Status field in the About page for contacts. The sample text in the IDE preview pane was not visible on dark themes indicating font color data was being lost before my fix.
