### PR TITLE
Enable verified subtitle on group chat. Fixes #13873

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
@@ -1236,9 +1236,7 @@ class ConversationFragment :
   }
 
   private fun presentIdentityRecordsState(identityRecordsState: IdentityRecordsState) {
-    if (!identityRecordsState.isGroup) {
-      binding.conversationTitleView.root.setVerified(identityRecordsState.isVerified)
-    }
+    binding.conversationTitleView.root.setVerified(identityRecordsState.isVerified)
 
     if (identityRecordsState.isUnverified) {
       binding.conversationBanner.showUnverifiedBanner(identityRecordsState.identityRecords)


### PR DESCRIPTION
The verified subtitle doesn't appear when all group members have verified status, unlike iOS/Desktop apps. Currently existing code looks capable of this feature, but was being explicitly skipped. I'm not seeing an obvious reason why that check was in place. Removing the isGroup check allows the verified badge to display on group chats.

Fixes #13873 