### PR TITLE
Fixes #13992 - Adjust size of the unidentified delivery icon

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/advanced/AdvancedPrivacySettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/advanced/AdvancedPrivacySettingsFragment.kt
@@ -52,7 +52,7 @@ class AdvancedPrivacySettingsFragment : DSLSettingsFragment(R.string.preferences
         R.drawable.ic_unidentified_delivery
       )
     )
-    unidentifiedDeliveryIcon.setBounds(0, 0, ViewUtil.dpToPx(18), ViewUtil.dpToPx(13))
+    unidentifiedDeliveryIcon.setBounds(0, 0, ViewUtil.dpToPx(20), ViewUtil.dpToPx(15))
     val iconTint = ContextCompat.getColor(requireContext(), R.color.signal_text_primary_dialog)
     unidentifiedDeliveryIcon.colorFilter = PorterDuffColorFilter(iconTint, PorterDuff.Mode.SRC_IN)
 

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/advanced/AdvancedPrivacySettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/advanced/AdvancedPrivacySettingsFragment.kt
@@ -52,7 +52,7 @@ class AdvancedPrivacySettingsFragment : DSLSettingsFragment(R.string.preferences
         R.drawable.ic_unidentified_delivery
       )
     )
-    unidentifiedDeliveryIcon.setBounds(0, 0, ViewUtil.dpToPx(20), ViewUtil.dpToPx(20))
+    unidentifiedDeliveryIcon.setBounds(0, 0, ViewUtil.dpToPx(18), ViewUtil.dpToPx(13))
     val iconTint = ContextCompat.getColor(requireContext(), R.color.signal_text_primary_dialog)
     unidentifiedDeliveryIcon.colorFilter = PorterDuffColorFilter(iconTint, PorterDuff.Mode.SRC_IN)
 


### PR DESCRIPTION


<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

In the advanced privacy settings screen set the sealed sender icon to its original width and height to maintain its aspect ratio without stretching it.

Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/4e7b14e7-1114-430e-91e9-e1459bbdce8d" width="300" /> | <img src="https://github.com/user-attachments/assets/42fd0f54-704d-472d-a5b4-d8a4ae58ac2c" width="300" />


