### PR TITLE
Fix incorrect member count during group creation and modification

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/ContactSelectionListFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ContactSelectionListFragment.java
@@ -483,7 +483,7 @@ public final class ContactSelectionListFragment extends LoggingFragment {
       return 0;
     }
 
-    return getSelectedContactsCount() + contactSearchMediator.getFixedContactsSize();
+    return getSelectedMembersSize() + contactSearchMediator.getFixedContactsSize();
   }
 
   private Set<RecipientId> getCurrentSelection() {

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/ui/creategroup/CreateGroupActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/ui/creategroup/CreateGroupActivity.java
@@ -158,12 +158,11 @@ public class CreateGroupActivity extends ContactSelectionActivity implements Con
 
   @Override
   public void onSelectionChanged() {
-    int selectedMembers = contactsFragment.getSelectedMembersSize();
     int selectedContactsCount = contactsFragment.getTotalMemberCount();
     if (selectedContactsCount == 0) {
       getToolbar().setTitle(getString(R.string.CreateGroupActivity__select_members));
     } else {
-      getToolbar().setTitle(getResources().getQuantityString(R.plurals.CreateGroupActivity__d_members, selectedMembers, selectedMembers));
+      getToolbar().setTitle(getResources().getQuantityString(R.plurals.CreateGroupActivity__d_members, selectedContactsCount, selectedContactsCount));
     }
   }
 


### PR DESCRIPTION
Resolves issue #13206 where the member count displayed was inaccurate when creating or modifying groups.  The member count now reflects the correct number of participants when selecting/deselecting.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Motorola Moto G Power 5G, API 34
 * Virtual Device Pixel 9 Pro, API 35
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #13206 ` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Previously, the displayed member count in the 'X members' message was incorrect when adding/removing members from both new and existing groups.  This PR ensures the correct count is shown at all times.