### PR TITLE
Fixes #14034 - Accessibility label for MediaPreview and Emojis

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiPageViewGridAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiPageViewGridAdapter.java
@@ -141,6 +141,7 @@ public class EmojiPageViewGridAdapter extends MappingAdapter implements PopupWin
     public void bind(@NonNull EmojiModel model) {
       final Drawable drawable = EmojiProvider.getEmojiDrawable(imageView.getContext(), model.emoji.getValue());
 
+      imageView.setContentDescription(model.emoji.getValue());
       if (drawable != null) {
         imageView.setVisibility(View.VISIBLE);
         imageView.setImageDrawable(drawable);

--- a/app/src/main/java/org/thoughtcrime/securesms/keyboard/KeyboardPageCategoryIconViewHolder.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyboard/KeyboardPageCategoryIconViewHolder.kt
@@ -27,6 +27,7 @@ class KeyboardPageCategoryIconViewHolder<T : KeyboardPageCategoryIconMappingMode
     }
 
     iconView.setImageDrawable(model.getIcon(context))
+    iconView.contentDescription = model.key
     iconView.isSelected = model.selected
     iconSelected.isSelected = model.selected
   }

--- a/app/src/main/res/layout/camera_controls_portrait.xml
+++ b/app/src/main/res/layout/camera_controls_portrait.xml
@@ -24,6 +24,7 @@
         android:layout_marginTop="14dp"
         android:layout_marginEnd="16dp"
         android:background="@drawable/circle_transparent_black_40"
+        android:contentDescription="@string/CameraControls_toggle_flash_mode_accessibility_label"
         android:padding="6dp"
         android:scaleType="fitCenter"
         android:src="@drawable/camerax_flash_toggle"

--- a/app/src/main/res/layout/v2_media_add_message_dialog_fragment_content.xml
+++ b/app/src/main/res/layout/v2_media_add_message_dialog_fragment_content.xml
@@ -76,6 +76,7 @@
         android:animateFirstView="false"
         android:inAnimation="@anim/fade_in"
         android:outAnimation="@anim/fade_out"
+        android:contentDescription="@string/MediaReviewFragment__view_once_toggle_accessibility_label"
         app:layout_constraintBottom_toBottomOf="@id/add_a_message_input"
         app:layout_constraintEnd_toStartOf="@id/confirm_button">
 
@@ -117,6 +118,7 @@
         android:layout_marginEnd="8dp"
         android:layout_marginBottom="2dp"
         android:padding="6dp"
+        android:contentDescription="@string/MediaReviewFragment__finish_adding_a_message_accessibility_label"
         app:layout_constraintBottom_toTopOf="@id/emoji_drawer_stub"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/input_barrier"

--- a/app/src/main/res/layout/v2_media_review_fragment.xml
+++ b/app/src/main/res/layout/v2_media_review_fragment.xml
@@ -87,6 +87,7 @@
             android:layout_marginBottom="15dp"
             android:alpha="0"
             android:background="@drawable/media_gallery_button_background"
+            android:contentDescription="@string/MediaReviewFragment__add_media_accessibility_label"
             android:padding="4dp"
             android:scaleType="centerInside"
             android:visibility="gone"
@@ -126,12 +127,13 @@
             android:layout_height="48dp"
             android:alpha="0"
             android:animateFirstView="false"
+            android:contentDescription="@string/MediaReviewFragment__view_once_toggle_accessibility_label"
             android:inAnimation="@anim/fade_in"
             android:outAnimation="@anim/fade_out"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="@id/add_a_message"
-            app:layout_constraintTop_toTopOf="@id/add_a_message"
             app:layout_constraintEnd_toEndOf="@id/add_a_message"
+            app:layout_constraintTop_toTopOf="@id/add_a_message"
             tools:alpha="1"
             tools:visibility="visible">
 
@@ -159,6 +161,7 @@
             android:layout_height="48dp"
             android:layout_gravity="center"
             android:background="@color/transparent"
+            android:contentDescription="@string/MediaReviewFragment__emoji_toggle_accessibility_label"
             android:scaleType="centerInside"
             android:src="@drawable/symbol_emoji_24"
             android:visibility="gone"
@@ -188,8 +191,8 @@
             app:thumbHintTextSize="14sp"
             app:thumbTouchRadius="24dp"
             app:thumbWidth="6dp"
-            tools:visibility="visible"
-            tools:targetApi="23" />
+            tools:targetApi="23"
+            tools:visibility="visible" />
 
         <TextView
             android:id="@+id/video_size_hint"
@@ -217,6 +220,7 @@
             android:layout_marginBottom="16dp"
             android:alpha="0"
             android:background="@drawable/media_gallery_button_background"
+            android:contentDescription="@string/MediaReviewFragment__brush_pen_accessibility_label"
             android:padding="6dp"
             android:scaleType="centerInside"
             android:visibility="gone"
@@ -236,6 +240,7 @@
             android:layout_marginBottom="16dp"
             android:alpha="0"
             android:background="@drawable/media_gallery_button_background"
+            android:contentDescription="@string/MediaReviewFragment__crop_rotate_accessibility_label"
             android:padding="4dp"
             android:scaleType="centerInside"
             android:visibility="gone"
@@ -256,6 +261,7 @@
             android:layout_marginBottom="16dp"
             android:alpha="0"
             android:background="@drawable/media_gallery_button_background"
+            android:contentDescription="@string/MediaReviewFragment__change_media_quality_accessibility_label"
             android:padding="4dp"
             android:scaleType="centerInside"
             android:visibility="gone"
@@ -275,6 +281,7 @@
             android:layout_marginStart="12dp"
             android:layout_marginBottom="16dp"
             android:background="@drawable/media_gallery_button_background"
+            android:contentDescription="@string/MediaReviewFragment__save_media_accessibility_label"
             android:padding="4dp"
             android:scaleType="centerInside"
             android:visibility="gone"
@@ -294,6 +301,7 @@
             android:layout_marginEnd="10dp"
             android:layout_marginBottom="16dp"
             android:background="@color/signal_light_colorPrimary"
+            android:contentDescription="@string/MediaReviewFragment__send_media_accessibility_label"
             android:padding="4dp"
             android:scaleType="centerInside"
             android:visibility="gone"
@@ -305,7 +313,7 @@
             app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.Signal.Circle"
             app:srcCompat="@drawable/symbol_send_fill_24"
             app:tint="@color/signal_colorOnSurface"
-            tools:visibility="visible"/>
+            tools:visibility="visible" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5787,6 +5787,24 @@
     <string name="MediaReviewFragment__photo_set_to_high_quality">Photo set to high quality</string>
     <!-- Small notification presented to the user when they set their still image to be sent in standard (lower than high) visual quality. -->
     <string name="MediaReviewFragment__photo_set_to_standard_quality">Photo set to standard quality</string>
+    <!-- Accessibility label describing the add media button on the Media review screen -->
+    <string name="MediaReviewFragment__add_media_accessibility_label">Add a Media</string>
+    <!-- Accessibility label describing the brush and pen button on the Media review screen -->
+    <string name="MediaReviewFragment__brush_pen_accessibility_label">Brush and Pen</string>
+    <!-- Accessibility label describing the crop and rotate button on the Media review screen -->
+    <string name="MediaReviewFragment__crop_rotate_accessibility_label">Crop and Rotate</string>
+    <!-- Accessibility label describing the change media quality button on the Media review screen -->
+    <string name="MediaReviewFragment__change_media_quality_accessibility_label">Change Media Quality</string>
+    <!-- Accessibility label describing the save media button on the Media review screen -->
+    <string name="MediaReviewFragment__save_media_accessibility_label">Save Media</string>
+    <!-- Accessibility label describing the toggle emoji keyboard button on the Media review screen -->
+    <string name="MediaReviewFragment__emoji_toggle_accessibility_label">Toggle emoji keyboard</string>
+    <!-- Accessibility label describing the toggle view once button on the Media review screen -->
+    <string name="MediaReviewFragment__view_once_toggle_accessibility_label">Toggle View Once</string>
+    <!-- Accessibility label describing the send media button on the Media review screen -->
+    <string name="MediaReviewFragment__send_media_accessibility_label">Send Media</string>
+    <!-- Accessibility label describing the finish adding a message button on the Media review screen dialog -->
+    <string name="MediaReviewFragment__finish_adding_a_message_accessibility_label">Finish adding a Message</string>
     <!-- Small notification presented to the user when they set multiple media items to be sent in high visual quality. -->
     <plurals name="MediaReviewFragment__items_set_to_high_quality">
         <item quantity="one">%1$d item set to high quality</item>
@@ -7318,6 +7336,8 @@
     <string name="CameraControls_capture_button_accessibility_label">Capture Button</string>
     <!-- Accessibility label describing the continue button on the camera screen -->
     <string name="CameraControls_continue_button_accessibility_label">Continue Button</string>
+    <!-- Accessibility label describing the flash Mode toggle button on the camera screen -->
+    <string name="CameraControls_toggle_flash_mode_accessibility_label">Toggle Flash Mode</string>
 
     <!-- CallPreference -->
     <!-- Generic group call in call info -->


### PR DESCRIPTION
Closes #14034 
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Apart from fixing the mentioned ticket, I also found that the Emojis in the sheet also do not have the accessibility labels. Adding them will give a huge value to the targetted audience.