### PR TITLE
Fixes #14051: Preserve search term when refreshing contacts

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/ContactSelectionActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ContactSelectionActivity.java
@@ -170,7 +170,6 @@ public abstract class ContactSelectionActivity extends PassphraseRequiredActivit
       ContactSelectionActivity activity = this.activity.get();
 
       if (activity != null && !activity.isFinishing()) {
-        activity.contactFilterView.clear();
         activity.contactsFragment.resetQueryFilter();
       }
     }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
The fix is straightforward - I've removed the line in `RefreshDirectoryTask.onPostExecute()` that was explicitly clearing the search field `activity.contactFilterView.clear()`, while maintaining the call to reset the query filter. This allows the contacts to refresh properly while preserving the user's search term.

I tested the fix by:
-starting a new chat
-Searching for the contact by name (not found initially)
-Clicking "refresh contacts"
-Verifying the search term remained in the search field
-Confirming the newly added contact appears in the filtered results after refresh

The fix was tested on a Pixel 7 Pro running Android 15 with Signal version 7.38.5
