### PR TITLE
Fix pasting an image into an edited message instead of sending a new copy

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
@@ -3786,7 +3786,7 @@ class ConversationFragment :
         body = result.body,
         mentions = result.mentions,
         bodyRanges = result.bodyRanges,
-        messageToEdit = null,
+        messageToEdit = inputPanel.editMessageId,
         quote = if (result.isViewOnce) null else inputPanel.quote.orNull(),
         scheduledDate = result.scheduledTime,
         slideDeck = null,


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 8, Android 15.
 
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

I think when the edit message feature was added, the ability to paste an image into the editing message was overlooked. Worth noting that this same bug also exists in the iOS application. 

For the fix, I've added the edit message ID into 'ConversationFragment.sendPreUploadMediaMessage(...)' for the messageToEdit parameter. This is how it's done in the regular text send. I tested it with several messages in a chat and it now edits the existing message instead of sending a fresh one. 
