### PR TITLE
Fixes #14067 - Prevent text overflow [Added Screenshot, First PR]

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/review/QualitySelectorBottomSheet.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/review/QualitySelectorBottomSheet.kt
@@ -77,7 +77,7 @@ private fun Content(quality: SentMediaQuality, onQualitySelected: (SentMediaQual
       val standardQuality = quality == SentMediaQuality.STANDARD
       Button(
         modifier = Modifier
-          .defaultMinSize(minWidth = 174.dp, minHeight = 60.dp)
+          .defaultMinSize(minHeight = 60.dp)
           .weight(1f),
         onClick = { onQualitySelected(SentMediaQuality.STANDARD) },
         shape = RoundedCornerShape(percent = 25),
@@ -89,7 +89,7 @@ private fun Content(quality: SentMediaQuality, onQualitySelected: (SentMediaQual
       }
       Button(
         modifier = Modifier
-          .defaultMinSize(minWidth = 174.dp, minHeight = 60.dp)
+          .defaultMinSize(minHeight = 60.dp)
           .weight(1f),
         onClick = { onQualitySelected(SentMediaQuality.HIGH) },
         shape = RoundedCornerShape(percent = 25),


### PR DESCRIPTION
Removed `minWidth` from `defaultMinSize` modifier to prevent text overflow in other locales.

### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 7A, Android 15
 * Virtual device, Android 15
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #14067` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Removed `minWidth` from `defaultMinSize` modifier to prevent text overflow in other locales.
Enforcing `minWidth` is not recommended in order to improve text adaptability in different languages.