### PR TITLE
Discontinue use of deprecated HKDFv3

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupId.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupId.java
@@ -5,7 +5,7 @@ import androidx.annotation.Nullable;
 
 import org.signal.core.util.DatabaseId;
 import org.signal.core.util.Hex;
-import org.signal.libsignal.protocol.kdf.HKDFv3;
+import org.signal.libsignal.protocol.kdf.HKDF;
 import org.signal.libsignal.zkgroup.InvalidInputException;
 import org.signal.libsignal.zkgroup.groups.GroupIdentifier;
 import org.signal.libsignal.zkgroup.groups.GroupMasterKey;
@@ -299,7 +299,7 @@ public abstract class GroupId implements DatabaseId {
 
     public GroupMasterKey deriveV2MigrationMasterKey() {
       try {
-        return new GroupMasterKey(new HKDFv3().deriveSecrets(getDecodedId(), "GV2 Migration".getBytes(), GroupMasterKey.SIZE));
+        return new GroupMasterKey(HKDF.deriveSecrets(getDecodedId(), "GV2 Migration".getBytes(), GroupMasterKey.SIZE));
       } catch (InvalidInputException e) {
         throw new AssertionError(e);
       }

--- a/libsignal-service/src/main/java/org/whispersystems/signalservice/internal/contacts/crypto/RemoteAttestationKeys.java
+++ b/libsignal-service/src/main/java/org/whispersystems/signalservice/internal/contacts/crypto/RemoteAttestationKeys.java
@@ -5,7 +5,7 @@ import org.signal.libsignal.protocol.InvalidKeyException;
 import org.signal.libsignal.protocol.ecc.Curve;
 import org.signal.libsignal.protocol.ecc.ECKeyPair;
 import org.signal.libsignal.protocol.ecc.ECPublicKey;
-import org.signal.libsignal.protocol.kdf.HKDFv3;
+import org.signal.libsignal.protocol.kdf.HKDF;
 import org.signal.libsignal.protocol.util.ByteUtil;
 
 public class RemoteAttestationKeys {
@@ -19,9 +19,7 @@ public class RemoteAttestationKeys {
 
     byte[] masterSecret = ByteUtil.combine(ephemeralToEphemeral, ephemeralToStatic                          );
     byte[] publicKeys   = ByteUtil.combine(keyPair.getPublicKey().getPublicKeyBytes(), serverPublicEphemeral, serverPublicStatic);
-
-    HKDFv3 generator = new HKDFv3();
-    byte[] keys      = generator.deriveSecrets(masterSecret, publicKeys, new byte[0], clientKey.length + serverKey.length);
+    byte[] keys      = HKDF.deriveSecrets(masterSecret, publicKeys, new byte[0], clientKey.length + serverKey.length);
 
     System.arraycopy(keys, 0, clientKey, 0, clientKey.length);
     System.arraycopy(keys, clientKey.length, serverKey, 0, serverKey.length);

--- a/libsignal-service/src/test/java/org/whispersystems/signalservice/api/crypto/AttachmentCipherTest.java
+++ b/libsignal-service/src/test/java/org/whispersystems/signalservice/api/crypto/AttachmentCipherTest.java
@@ -6,7 +6,7 @@ import org.signal.core.util.StreamUtil;
 import org.signal.libsignal.protocol.InvalidMessageException;
 import org.signal.libsignal.protocol.incrementalmac.ChunkSizeChoice;
 import org.signal.libsignal.protocol.incrementalmac.InvalidMacException;
-import org.signal.libsignal.protocol.kdf.HKDFv3;
+import org.signal.libsignal.protocol.kdf.HKDF;
 import org.whispersystems.signalservice.api.backup.MediaRootBackupKey;
 import org.whispersystems.signalservice.internal.crypto.PaddingInputStream;
 import org.whispersystems.signalservice.internal.push.http.AttachmentCipherOutputStreamFactory;
@@ -516,7 +516,7 @@ public final class AttachmentCipherTest {
   }
 
   private static byte[] expandPackKey(byte[] shortKey) {
-    return new HKDFv3().deriveSecrets(shortKey, "Sticker Pack".getBytes(), 64);
+    return HKDF.deriveSecrets(shortKey, "Sticker Pack".getBytes(), 64);
   }
 
   private static class EncryptResult {


### PR DESCRIPTION

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

`HKDFv3` says:
```kotlin
/**
 * @deprecated Use the static methods of {@link HKDF} instead.
 */
@Deprecated
public class HKDFv3 extends HKDF {}
```

I followed the usages of this class and replaced them with `HKDF` static calls.

`./gradlew qa` passes:
