### PR TITLE
Improve handling of 12/24 hour timestamps on configuration change

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/computed/ConversationMessageComputeWorkers.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/computed/ConversationMessageComputeWorkers.kt
@@ -21,13 +21,14 @@ object ConversationMessageComputeWorkers {
 
   fun recomputeFormattedDate(
     context: Context,
-    items: List<ConversationMessageElement>
+    items: List<ConversationMessageElement>,
+    force: Boolean = false
   ): Single<Boolean> {
     return Single.fromCallable {
       var hasUpdatedProperties = false
       for (item in items) {
         val oldDate = item.conversationMessage.computedProperties.formattedDate
-        if (oldDate.isRelative) {
+        if (oldDate.isRelative || force) {
           val newDate = ConversationMessage.getFormattedDate(context, item.conversationMessage.messageRecord)
           item.conversationMessage.computedProperties.formattedDate = newDate
           hasUpdatedProperties = true

--- a/app/src/main/java/org/thoughtcrime/securesms/util/JavaTimeExtensions.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/JavaTimeExtensions.kt
@@ -1,7 +1,6 @@
 package org.thoughtcrime.securesms.util
 
 import android.content.Context
-import android.os.Build
 import android.text.format.DateFormat
 import java.time.DayOfWeek
 import java.time.Instant
@@ -13,7 +12,6 @@ import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
-import java.time.format.FormatStyle
 import java.time.temporal.WeekFields
 import java.util.Locale
 import java.util.concurrent.TimeUnit
@@ -91,15 +89,16 @@ fun Long.toLocalTime(zoneId: ZoneId = ZoneId.systemDefault()): LocalTime {
 }
 
 /**
- * Formats [LocalTime] as localized time. For example, "8:00 AM"
+ * Formats [LocalTime] as localized time. For example, "8:00 AM" or "13:45"
  */
 fun LocalTime.formatHours(context: Context): String {
-  return if (Build.VERSION.SDK_INT >= 26 || !DateFormat.is24HourFormat(context)) {
-    DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).format(this)
-  } else {
-    DateTimeFormatter.ofPattern("HH:mm", Locale.getDefault()).format(this)
-  }
+  // Note that the localized pattern of DateTimeFormatter.ofLocalizedTime() is looked up lazily,
+  // is immutable, and is not tied to the Android context. It does not change upon
+  // configuration change.
+  val pattern = if (DateFormat.is24HourFormat(context)) "HH:mm" else "h:mm a"
+  return DateTimeFormatter.ofPattern(pattern, Locale.getDefault()).format(this)
 }
+
 
 /**
  * Get the days of the week in order based on [Locale].


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Pixel 9, Android SDK 35
 * Virtual device "Pixel 4a", Android SDK 30
- [X] My contribution is fully baked and ready to be merged as is
- [X] N/A I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

This fixes an edge case seen on ConversationFragment, where if the device time format is switched between 12/24 hour format while the app is running, the old time format will still be displayed when the app is resumed.

This is due to a design flaw in `DateTimeFormatter.ofLocalizedTime`, where the time format is statically cached and not updated upon configuration change. The `LocalTime.formatHours()` extension method was updated to no longer rely on the misbehaving `ofLocalTime` method.

In addition, `ConversationMessaageComputeWorkers.recomputeFormattedDate` was designed to skip recomputing non-relative timestamps. This works in most cases but not this specific edge case. A `force: Boolean` flag was added to force all items to be updated. And the `force = true` flag was passed upon `onResume` of the fragment.

Note: this should actually be called in `onStart`, but it was added in `onResume` to match existing similar initializations.
