### PR TITLE
Fixes #14119 - Adjust bottom margin of bottomActionBar…

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/SignalBottomActionBarController.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/SignalBottomActionBarController.kt
@@ -27,6 +27,7 @@ class SignalBottomActionBarController(
     }
 
     if (isVisible) {
+      bottomActionBar.adjustBottomMarginForNavBar()
       ViewUtil.animateIn(bottomActionBar, bottomActionBar.enterAnimation)
       callback.onBottomActionBarVisibilityChanged(View.VISIBLE)
 
@@ -36,6 +37,12 @@ class SignalBottomActionBarController(
         .animateOut(bottomActionBar, bottomActionBar.exitAnimation)
         .addListener(BecomingGoneAnimationListener())
     }
+  }
+
+  private fun View.adjustBottomMarginForNavBar(extraPaddingDp: Int = 8) {
+    val navBarHeightPx = ViewUtil.getNavigationBarHeight(this)
+    val paddingPx = ViewUtil.dpToPx(extraPaddingDp)
+    ViewUtil.setBottomMargin(this, navBarHeightPx + paddingPx)
   }
 
   private inner class BecomingVisiblePreDrawListener : ViewTreeObserver.OnPreDrawListener {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
@@ -1143,8 +1143,15 @@ public class ConversationListFragment extends MainFragment implements Conversati
   }
 
   private void startActionMode() {
+    adjustBottomMarginForNavBar(bottomActionBar, 8);
     ViewUtil.animateIn(bottomActionBar, bottomActionBar.getEnterAnimation());
     requireCallback().onMultiSelectStarted();
+  }
+
+  private void adjustBottomMarginForNavBar(View v, int extraPaddingDp) {
+    int navBarHeightPx = ViewUtil.getNavigationBarHeight(v);
+    int paddingPx = ViewUtil.dpToPx(extraPaddingDp);
+    ViewUtil.setBottomMargin(v, navBarHeightPx + paddingPx);
   }
 
   public void endActionModeIfActive() {


### PR DESCRIPTION
… in ConversationListFragment, CallLogFragment to accomodate nav bar

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Pixel 9, Android SDK 35
 * Virtual device "Pixel 4a", Android SDK 30
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

This adds a bottom margin to the `bottomActionBar` inside `ConversationListFragment` and `CallLogFragment` (via `SignalBottomActionBarController`) to accomodate Navigation Bars. 
* I was a bit concerned that the `SignalBottomActionBarController` change would affect other bottom actionbars but I confirmed that it's used only inside the `CallLogFragment`. 
* I tested on SDK 30 using both gesture navigation and 3 button navigation to make sure the nav bar height calculation was correct (even though `ViewUtil.getNavigationBarHeight` already existed). 
* I used my judgement to determine an extra padding of 8dp between the nav bar and action bar looked the best. 16dp seemed too big.
* I considered moving `adjustBottomMarginForNavBar` to `ViewUtil` (especially since it just calls 3 `ViewUtil` methods anyway) but it seemed too specific to this use case. I could be convinced to move it there. LMK