### PR TITLE
Add more accessibility support.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/AppSettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/AppSettingsFragment.kt
@@ -613,7 +613,8 @@ private fun BioRow(
         size = 36.dp,
         colors = IconButtons.iconButtonColors(
           containerColor = SignalTheme.colors.colorSurface4
-        )
+        ),
+        contentDescription = stringResource(R.string.ManageProfileFragment_link_setting_text)
       ) {
         Icon(
           painter = painterResource(R.drawable.symbol_qrcode_24),

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/usernamelinks/main/UsernameLinkShareScreen.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/usernamelinks/main/UsernameLinkShareScreen.kt
@@ -146,17 +146,20 @@ private fun ButtonBar(
       enabled = linkState is UsernameLinkState.Present,
       onClick = onLinkClicked,
       iconResId = R.drawable.symbol_link_24,
-      labelResId = R.string.UsernameLinkSettings_link_button_label
+      labelResId = R.string.UsernameLinkSettings_link_button_label,
+      contentDescriptionId = R.string.UsernameLinkSettings_link_button_label
     )
     Buttons.ActionButton(
       onClick = onShareClicked,
       iconResId = R.drawable.symbol_share_android_24,
-      labelResId = R.string.UsernameLinkSettings_share_button_label
+      labelResId = R.string.UsernameLinkSettings_share_button_label,
+      contentDescriptionId = R.string.UsernameLinkSettings_share_button_label
     )
     Buttons.ActionButton(
       onClick = onColorClicked,
       iconResId = R.drawable.symbol_color_24,
-      labelResId = R.string.UsernameLinkSettings_color_button_label
+      labelResId = R.string.UsernameLinkSettings_color_button_label,
+      contentDescriptionId = R.string.UsernameLinkSettings_color_button_label
     )
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/stories/landing/StoriesLandingItem.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/stories/landing/StoriesLandingItem.kt
@@ -159,6 +159,7 @@ object StoriesLandingItem {
         avatarView.displayProfileAvatar(model.data.storyRecipient)
         badgeView.setBadgeFromRecipient(model.data.storyRecipient)
       }
+      badgeView.isClickable = false
 
       val record = model.data.primaryStory.messageRecord as MmsMessageRecord
 

--- a/app/src/main/res/layout/edit_profile_fragment.xml
+++ b/app/src/main/res/layout/edit_profile_fragment.xml
@@ -23,6 +23,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 app:navigationIcon="@drawable/ic_arrow_left_24"
+                app:navigationContentDescription="@string/DSLSettingsToolbar__navigate_up"
                 app:title="@string/CreateProfileActivity__profile"
                 app:titleTextAppearance="@style/Signal.Text.TitleLarge" />
 

--- a/core-ui/src/main/java/org/signal/core/ui/compose/Buttons.kt
+++ b/core-ui/src/main/java/org/signal/core/ui/compose/Buttons.kt
@@ -183,6 +183,7 @@ object Buttons {
     @DrawableRes iconResId: Int,
     @StringRes labelResId: Int,
     modifier: Modifier = Modifier,
+    @StringRes contentDescriptionId: Int? = null,
     enabled: Boolean = true
   ) {
     ActionButton(
@@ -193,7 +194,9 @@ object Buttons {
     ) {
       Image(
         painter = painterResource(iconResId),
-        contentDescription = null,
+        contentDescription = contentDescriptionId?.let {
+          stringResource(it)
+        },
         modifier = Modifier.padding(16.dp),
         colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onSecondaryContainer)
       )

--- a/core-ui/src/main/java/org/signal/core/ui/compose/IconButtons.kt
+++ b/core-ui/src/main/java/org/signal/core/ui/compose/IconButtons.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.signal.core.ui.compose.copied.androidx.compose.material3.IconButtonColors
@@ -74,6 +76,7 @@ object IconButtons {
     shape: Shape = CircleShape,
     enabled: Boolean = true,
     colors: IconButtonColors = iconButtonColors(),
+    contentDescription: String?= null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     content: @Composable () -> Unit
   ) {
@@ -83,6 +86,11 @@ object IconButtons {
         .size(size)
         .clip(shape)
         .background(color = colors.containerColor(enabled).value)
+        .semantics {
+          contentDescription?.let {
+            this.contentDescription = it
+          }
+        }
         .clickable(
           onClick = onClick,
           enabled = enabled,


### PR DESCRIPTION
`badgeView.isClickable = false` because the badge was selectable and clickable, but no click listener was there.