### PR TITLE
Fix country code filtering by removing "+" prefix handling.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/findby/FindByViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/findby/FindByViewModel.kt
@@ -99,7 +99,7 @@ class FindByViewModel(
         query = filterBy,
         filteredCountries = state.value.supportedCountries.filter { country: Country ->
           country.name.contains(filterBy, ignoreCase = true) ||
-            country.countryCode.toString().contains(filterBy) ||
+            country.countryCode.toString().contains(filterBy.removePrefix("+")) ||
             (filterBy.equals("usa", ignoreCase = true) && country.name.equals("United States", ignoreCase = true))
         }
       )


### PR DESCRIPTION
The search query for "+1" won't show anything. So, removing the + prefix. I'll probably add testcases for these classes too.