### PR TITLE
Fix ensure incoming call screen wakes device

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/webrtc/v2/WebRtcCallActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/webrtc/v2/WebRtcCallActivity.kt
@@ -135,6 +135,7 @@ class WebRtcCallActivity : BaseActivity(), SafetyNumberChangeDialog.Callback, Re
 
     if (Build.VERSION.SDK_INT >= 27) {
       setShowWhenLocked(true)
+      setTurnScreenOn(true)
     } else {
       window.addFlags(WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED)
     }


### PR DESCRIPTION

### First time contributor checklist
- [ x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [ x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
- [ x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x ] I have tested my contribution on these devices:
 * Samsung s23 ultra, One UI 7.0 Android version 15
 * Samsung s23, One UI 6.1 Android version 14
 * Samsung s25 ultra, One UI 7.0 Android version 15
- [x ] My contribution is fully baked and ready to be merged as is

----------

### Description

This PR fixes an issue where the incoming call screen was not displayed when the device screen was off on Android 15 (API 35). Although the ringtone, vibration, and notification were triggered correctly, the full-screen intent activity was not shown because the device screen remained off.
To resolve this, the setTurnScreenOn(true) flag was added to the incoming call activity. This ensures that the device wakes up and the call screen becomes visible even when the device is locked or the screen is off.

How I tested ?

I had multiple phones and tested them.
First, I downloaded the latest version of Signal on a phone and created a group. Then I locked the phone and turned off the screen. After that, I started a video call in that group. The screen of the Android 15 phone did not turn on; only the vibration and sound came through. The Android 14 phone vibrated, made a sound, and the screen turned on, and I saw webrtccallactivity. However, the same thing did not happen on the other phone. It used to happen before the operating system update, but it stopped happening after installing the Android 15 update.

