### PR TITLE
Fix view-once messages allowing screenshots

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/revealable/ViewOnceMessageActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/revealable/ViewOnceMessageActivity.java
@@ -27,6 +27,7 @@ import org.thoughtcrime.securesms.mms.VideoSlide;
 import org.thoughtcrime.securesms.providers.BlobProvider;
 import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.video.VideoPlayer;
+import org.thoughtcrime.securesms.components.TemporaryScreenshotSecurity;
 
 import java.util.concurrent.TimeUnit;
 
@@ -71,6 +72,8 @@ public class ViewOnceMessageActivity extends PassphraseRequiredActivity implemen
   protected void onCreate(Bundle savedInstanceState, boolean ready) {
     super.onCreate(savedInstanceState, ready);
     setContentView(R.layout.view_once_message_activity);
+
+    TemporaryScreenshotSecurity.bind(this);
 
     this.image       = findViewById(R.id.view_once_image);
     this.video       = findViewById(R.id.view_once_video);


### PR DESCRIPTION
Fixes #14346

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Pixel 6a, Android 16, kernel 6.1.124 
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Do not let the user screenshot the screen while viewing view-once media. 

Reference: [Android Developer, Secure sensitive activities](https://developer.android.com/security/fraud-prevention/activities)

If you do take a screenshot, you get a black image. eg (screenshot of the screenshot).


<img width="629" height="1398" alt="image" src="https://github.com/user-attachments/assets/813c3383-2e0d-4b85-9cdf-c0579b3a78d6" />