### PR TITLE
Publish Kotlin class outputs as Gradle SourceSet outputs so that VSCode (jdt.ls) resolves Java -> Kotlin imports

### DIFF
--- a/core-util-jvm/build.gradle.kts
+++ b/core-util-jvm/build.gradle.kts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import org.gradle.api.tasks.SourceSetContainer
+
 val signalJavaVersion: JavaVersion by rootProject.extra
 val signalKotlinJvmTarget: String by rootProject.extra
 
@@ -47,6 +49,16 @@ wire {
 
 tasks.runKtlintCheckOverMainSourceSet {
   dependsOn(":core-util-jvm:generateMainProtos")
+}
+
+val sourceSets = extensions.getByName("sourceSets") as SourceSetContainer
+sourceSets.named("main") {
+  output.dir(mapOf("builtBy" to tasks.named("compileKotlin")),
+    "$buildDir/classes/kotlin/main")
+}
+sourceSets.named("test") {
+  output.dir(mapOf("builtBy" to tasks.named("compileTestKotlin")),
+    "$buildDir/classes/kotlin/test")
 }
 
 dependencies {

--- a/libsignal-service/build.gradle.kts
+++ b/libsignal-service/build.gradle.kts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import org.gradle.api.tasks.SourceSetContainer
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -39,6 +40,16 @@ tasks.withType<KotlinCompile>().configureEach {
       suppressWarnings = true
     }
   }
+}
+
+val sourceSets = extensions.getByName("sourceSets") as SourceSetContainer
+sourceSets.named("main") {
+  output.dir(mapOf("builtBy" to tasks.named("compileKotlin")),
+    "$buildDir/classes/kotlin/main")
+}
+sourceSets.named("test") {
+  output.dir(mapOf("builtBy" to tasks.named("compileTestKotlin")),
+    "$buildDir/classes/kotlin/test")
 }
 
 afterEvaluate {


### PR DESCRIPTION
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device sdk_gphone64_amd64, Android 12.
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
 * I was not able to find any issues related to this

----------

# VSCode + Gradle + jdt.ls: Publish Kotlin class outputs for IntelliSense analysis

**Summary**

This patch teaches Gradle to publish Kotlin class output directories as part of each source set’s outputs.
That enables the Eclipse Buildship model, consumed by VSCode’s Java Language Server (jdt.ls),
to include `build/classes/kotlin/{main,test}` on the Java classpath.

As a result, **Java files can resolve symbols defined in Kotlin files** within the same module when working in VSCode.
This is a build‑metadata change only; it does **not** affect runtime behavior, packaging, or Android build artifacts.

## Background

When building Signal-Android with VSCode or derivatives, IntelliSense does not find the compiled
Kotlin classes, resulting in thousands of IntelliSense error messages, while the Gradle builds compile just fine.

The reason for this is that VSCode Java uses **jdt.ls** with **Buildship** to import Gradle projects. The imported classpath is derived from **Gradle source set outputs**. By default, these outputs include the Java classes dir (e.g., `build/classes/java/main`) but **not** the Kotlin classes dir (`build/classes/kotlin/main`). When Kotlin outputs aren’t surfaced, jdt.ls can’t type‑check Java references to Kotlin, leading to false IntelliSense errors and broken navigation. Publishing the Kotlin outputs via `SourceSetOutput.output.dir(...)` fixes this at the model level and works across cleans.

## What this patch does

In each affected JVM module (`libsignal-service` and `core-util-jvm`), we declare the Kotlin class directories as **additional outputs** of the `main` and `test` source sets, and mark them `builtBy` the corresponding Kotlin compile tasks:

```kotlin
import org.gradle.api.tasks.SourceSetContainer

val sourceSets = extensions.getByName("sourceSets") as SourceSetContainer

sourceSets.named("main") {
  output.dir(mapOf("builtBy" to tasks.named("compileKotlin")),     "$buildDir/classes/kotlin/main")
}
sourceSets.named("test") {
  output.dir(mapOf("builtBy" to tasks.named("compileTestKotlin")), "$buildDir/classes/kotlin/test")
}
```

**Scope & impact**

- Build‑time metadata only; no change to app behavior, artifacts, or packaging.
- IDE‑agnostic (doesn’t commit Eclipse/VSCode files); improves the Gradle Tooling API model
  so any importer that respects source set outputs benefits.
- Android Studio/IntelliJ remain unaffected.

---

## VSCode setup

**Extensions**
- Extension Pack for Java (includes Language Support for Java by Red Hat and Gradle for Java)
- Kotlin extension (language server)

**Workspace settings** (typical)
```json
{
  "java.import.gradle.enabled": true,
  "java.import.gradle.wrapper.enabled": true,
  "java.import.gradle.offline.enabled": false,
  "java.import.gradle.buildTasks": ["compileKotlin", "classes"],
  "java.configuration.updateBuildConfiguration": "automatic",
  "java.compile.nullAnalysis.mode": "disabled"
}
```

**Repro/verification steps**
1. `./gradlew :libsignal-service:clean :libsignal-service:compileKotlin`.
2. In VSCode: *Java: Clean Java Language Server Workspace* → reload; let Gradle import complete.
3. Open a Java file that references a Kotlin type in the same module. With this patch, the thousands of false errors reported by IntelliSense disappear, leaving some 60 warnings and notes, at least many of which appear factual.

## Note

This patch was created with the help of ChatGPT-5.  I have carefully reviewed all the generated code and documentation and do understand the function and purpose of everything in this patch. However, I am not a Gradle expert myself. Hence, I would have never been able to find this solution by myself and cannot determine if this is the most desirable way to do this. There may be better ways to approach this issue.

## References

- Long‑standing VSCode Java issue about unresolved Kotlin types from Java: 
      https://github.com/redhat-developer/vscode-java/issues/531
- Gradle `SourceSetOutput` (publish additional output dirs): 
      https://docs.gradle.org/current/dsl/org.gradle.api.tasks.SourceSetOutput.html
- Eclipse newsletter (Buildship & source set/classpath modeling): 
     https://www.eclipse.org/community/eclipse_newsletter/2018/february/buildship.php
