### PR TITLE
Using theme primary color

### DIFF
--- a/app/src/main/res/layout/v2_media_add_message_dialog_fragment_content.xml
+++ b/app/src/main/res/layout/v2_media_add_message_dialog_fragment_content.xml
@@ -116,13 +116,12 @@
         android:layout_height="48dp"
         android:layout_marginEnd="8dp"
         android:layout_marginBottom="2dp"
-        android:contentDescription="@string/MediaReviewFragment__finish_adding_a_message_accessibility_label"
         android:padding="6dp"
+        android:contentDescription="@string/MediaReviewFragment__finish_adding_a_message_accessibility_label"
         app:layout_constraintBottom_toTopOf="@id/emoji_drawer_stub"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/input_barrier"
         app:srcCompat="@drawable/v2_media_add_a_message_check" />
-
 
     <ViewStub
         android:id="@+id/emoji_drawer_stub"


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] My contribution is fully baked and ready to be merged as is

----------

https://github.com/signalapp/Signal-Android/issues/14195

### Description

My pull request fixes the UI color change when someone adds an attachment and after clicking the add a message field, the color remains the default blue instead of the theme color chosen. I tested this with multiple themes and the color changed based on the theme set in the preview. 
