### PR TITLE
Add GenericErrorFragment and navigation handling for error routes

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/AppSettingsActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/AppSettingsActivity.kt
@@ -48,8 +48,7 @@ class AppSettingsActivity : DSLSettingsActivity(), GooglePayComponent {
     val startingAction: NavDirections? = if (intent?.categories?.contains(NOTIFICATION_CATEGORY) == true) {
       AppSettingsFragmentDirections.actionDirectToNotificationsSettingsFragment()
     } else {
-      val appSettingsRoute: AppSettingsRoute? = intent?.getParcelableExtraCompat(START_ROUTE, AppSettingsRoute::class.java)
-      when (appSettingsRoute) {
+      when (val appSettingsRoute: AppSettingsRoute? = intent?.getParcelableExtraCompat(START_ROUTE, AppSettingsRoute::class.java)) {
         AppSettingsRoute.Empty -> null
         AppSettingsRoute.BackupsRoute.Local -> AppSettingsFragmentDirections.actionDirectToBackupsPreferenceFragment()
         is AppSettingsRoute.HelpRoute.Settings -> AppSettingsFragmentDirections.actionDirectToHelpFragment()
@@ -78,7 +77,7 @@ class AppSettingsActivity : DSLSettingsActivity(), GooglePayComponent {
         AppSettingsRoute.BackupsRoute.Backups -> AppSettingsFragmentDirections.actionDirectToBackupsSettingsFragment()
         AppSettingsRoute.Invite -> AppSettingsFragmentDirections.actionDirectToInviteFragment()
         AppSettingsRoute.DataAndStorageRoute.DataAndStorage -> AppSettingsFragmentDirections.actionDirectToStoragePreferenceFragment()
-        else -> error("Unsupported start location: ${appSettingsRoute?.javaClass?.name}")
+        else -> AppSettingsFragmentDirections.actionAppSettingsFragmentToGenericErrorFragment()
       }
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/AppSettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/AppSettingsFragment.kt
@@ -114,6 +114,7 @@ class AppSettingsFragment : ComposeFragment(), Callbacks {
             is AppSettingsRoute.InternalRoute.Internal -> findNavController().safeNavigate(R.id.action_appSettingsFragment_to_internalSettingsFragment)
             is AppSettingsRoute.AccountRoute.ManageProfile -> findNavController().safeNavigate(R.id.action_appSettingsFragment_to_manageProfileActivity)
             is AppSettingsRoute.UsernameLinkRoute.UsernameLink -> findNavController().safeNavigate(R.id.action_appSettingsFragment_to_usernameLinkSettingsFragment)
+            is AppSettingsRoute.ErrorRoute.ComposeError -> findNavController().navigate(R.id.action_appSettingsFragment_to_GenericErrorFragment)
             else -> error("Unsupported route: ${route.javaClass.name}")
           }
         }

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/GenericErrorFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/GenericErrorFragment.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.thoughtcrime.securesms.components.settings.app
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.Fragment
+import org.signal.core.ui.compose.theme.SignalTheme
+import org.thoughtcrime.securesms.R
+
+internal class GenericErrorFragment : Fragment() {
+  override fun onCreateView(
+    inflater: LayoutInflater,
+    container: ViewGroup?,
+    savedInstanceState: Bundle?
+  ): View {
+    return ComposeView(requireContext()).apply {
+      setContent {
+        SignalTheme {
+          ErrorScreen(onClose = { requireActivity().finish() })
+        }
+      }
+    }
+  }
+}
+
+@Composable
+internal fun ErrorScreen(onClose: () -> Unit) {
+  Surface(
+    modifier = Modifier.fillMaxSize(),
+    color = MaterialTheme.colorScheme.background
+  ) {
+    Column(
+      modifier = Modifier
+        .fillMaxSize()
+        .padding(32.dp),
+      verticalArrangement = Arrangement.Center,
+      horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+      Text(
+        text = stringResource(R.string.compose_error_message),
+        style = MaterialTheme.typography.titleLarge,
+        color = MaterialTheme.colorScheme.error,
+        textAlign = TextAlign.Center
+      )
+      Spacer(modifier = Modifier.height(24.dp))
+      Button(
+        onClick = onClose,
+        colors = androidx.compose.material3.ButtonDefaults.buttonColors(
+          containerColor = MaterialTheme.colorScheme.primary,
+          contentColor = MaterialTheme.colorScheme.onPrimary
+        )
+      ) {
+        Text(text = stringResource(R.string.compose_error_close), style = MaterialTheme.typography.labelLarge)
+      }
+    }
+  }
+}
+
+@Preview(name = "ErrorScreen Preview")
+@Composable
+private fun ErrorScreenPreview() {
+  MaterialTheme {
+    ErrorScreen(onClose = {})
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/routes/AppSettingsRoute.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/routes/AppSettingsRoute.kt
@@ -228,4 +228,9 @@ sealed interface AppSettingsRoute : Parcelable {
     data object AccountLocked : ChangeNumberRoute
     data object PinDiffers : ChangeNumberRoute
   }
+
+  @Parcelize
+  sealed interface ErrorRoute : AppSettingsRoute {
+    data object ComposeError : ErrorRoute
+  }
 }

--- a/app/src/main/res/navigation/app_settings_with_change_number.xml
+++ b/app/src/main/res/navigation/app_settings_with_change_number.xml
@@ -154,6 +154,13 @@
                 app:argType="integer"
                 app:nullable="false" />
         </action>
+        <action
+            android:id="@+id/action_appSettingsFragment_to_GenericErrorFragment"
+            app:destination="@id/GenericErrorFragment"
+            app:enterAnim="@anim/fragment_open_enter"
+            app:exitAnim="@anim/fragment_open_exit"
+            app:popEnterAnim="@anim/fragment_close_enter"
+            app:popExitAnim="@anim/fragment_close_exit" />
     </fragment>
 
     <activity
@@ -1175,4 +1182,8 @@
     <include app:graph="@navigation/username_link_settings" />
     <include app:graph="@navigation/story_privacy_settings" />
 
+    <fragment
+        android:id="@+id/GenericErrorFragment"
+        android:name="org.thoughtcrime.securesms.components.settings.app.GenericErrorFragment"
+        android:label="compose_error_fragment" />
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8976,5 +8976,9 @@
     <!-- Displayed as a snackbar after submitting feedback -->
     <string name="CallQualitySheet__thanks_for_your_feedback">Thanks for your feedback!</string>
 
+    <!-- GenericErrorFragment -->
+    <string name="compose_error_message">Something went wrong</string>
+    <string name="compose_error_close">Close</string>
+
     <!-- EOF -->
 </resources>


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 10, Android 16
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Quick workaround of the described [issue](https://github.com/signalapp/Signal-Android/issues/14404). Not sure this is the wanted behavior tho. If it is not, I suggest we review and eventually close the issue w/o a fix. 
To test, just run the adb command:
```
adb shell am start -n org.thoughtcrime.securesms/.components.settings.app.AppSettingsActivity
```
which is now having the AppSettingsActivity to fallback to a generic error screen in case of being unable to build an internal route.