### PR TITLE
Fixes #14372

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/HudCommand.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/HudCommand.kt
@@ -16,4 +16,7 @@ sealed class HudCommand {
   object CloseEmojiSearch : HudCommand()
   data class EmojiInsert(val emoji: String?) : HudCommand()
   data class EmojiKeyEvent(val keyEvent: KeyEvent?) : HudCommand()
+
+  // Request that the hosting MediaReviewFragment perform a send (same logic as the send button).
+  object PerformSend : HudCommand()
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/review/MediaReviewFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/review/MediaReviewFragment.kt
@@ -151,6 +151,16 @@ class MediaReviewFragment : Fragment(R.layout.v2_media_review_fragment), Schedul
     disposables += sharedViewModel.hudCommands.subscribe {
       when (it) {
         HudCommand.ResumeEntryTransition -> startPostponedEnterTransition()
+        HudCommand.PerformSend -> {
+          if (!readyToSend) {
+            Log.d(TAG, "Attachment send button not currently enabled. Ignoring PerformSend command.")
+            return@subscribe
+          }
+
+          Log.d(TAG, "Performing send from PerformSend HUD command.")
+          readyToSend = false
+          performSend()
+        }
         else -> Unit
       }
     }


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 10, Android 16
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This pull request improves the user experience when sending messages with media attachments by allowing users to send their message using the keyboard's "Send" action or the Enter key, in addition to tapping the send button. The changes ensure that keyboard-based sending respects user preferences and that the send action is only performed when allowed.

### "Enter" to send
[Screen_recording_20251115_144951.webm](https://github.com/user-attachments/assets/84355378-71ae-4c91-81b3-f22640505bc2)
 
### "Enter" to new line

[Screen_recording_20251115_144913.webm](https://github.com/user-attachments/assets/765bb7e6-896e-4e1b-816e-da794af7cb04)


