### PR TITLE
#14437 Fix DeviceTransferSetupFragment to ensure proper flow

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/devicetransfer/DeviceTransferSetupFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/devicetransfer/DeviceTransferSetupFragment.java
@@ -97,6 +97,7 @@ public abstract class DeviceTransferSetupFragment extends LoggingFragment {
       switch (step) {
         case INITIAL:
           status.setText("");
+          break;
         case PERMISSIONS_CHECK:
           requestRequiredPermission();
           break;


### PR DESCRIPTION
### First time contributor checklist
- [ ✔️] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [ ✔️] I have signed the [Contributor License Agreement](https://signal.org/cla/)


### Description
Missing break statement causes fall-through execution

Impact: The INITIAL case at line 98 lacks a break statement, causing execution to fall through to the PERMISSIONS_CHECK case. This means when step is INITIAL, both the status text will be set to empty string AND requestRequiredPermission() will be called, which is likely unintended behavior.
