### PR TITLE
Fix #14112 - Refreshing contacts doesn't search again

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/RecipientPicker.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/RecipientPicker.kt
@@ -200,6 +200,8 @@ private fun RecipientSearchResultsList(
     currentFragment?.isRefreshing = isRefreshing
     if (wasRefreshing && !isRefreshing) {
       currentFragment?.onDataRefreshed()
+      currentFragment?.setQueryFilter("")
+      currentFragment?.setQueryFilter(searchQuery)
     }
     wasRefreshing = isRefreshing
   }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Pixel 3a, Android 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fix #14112  - Refreshing contacts doesn't search again
Fix #14496 - [Old bug] After deleting any contact in Signal app, this contact continues to be displayed there.
Fix #14051 - Refreshing contacts clears search terms

This is somewhat a hack for the sake of simplification. Of course, a more proper solution would require more substantial work around the refresh trigger for LiveData and/or StateFlow. Nevertheless, this simple fix solves the problem and preserves the simplicity of the code.
