### PR TITLE
Allow adding new lines when enter key send is enabled

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/ComposeText.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/ComposeText.java
@@ -238,7 +238,6 @@ public class ComposeText extends EmojiEditText {
 
     if (SignalStore.settings().isEnterKeySends()) {
       editorInfo.imeOptions &= ~EditorInfo.IME_FLAG_NO_ENTER_ACTION;
-      editorInfo.inputType &= ~EditorInfo.TYPE_TEXT_FLAG_MULTI_LINE;
     }
 
     if (mediaListener == null) {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S25, Android 16.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

Fixes #14372, #14469

This PR fixes a regression happened in this commit https://github.com/signalapp/Signal-Android/commit/a0997e6a873226b3cd17cb06b8ae5090db0bc9c7. I wasn't able to find an issue which produced this code, however it doesn't make sense. When there are attachments in a draft, everything works fine without the newly introduced line.

Screenshots from testing on Samsung S25:

Send with enter enabled:
![photo_2026-01-07 16 37 57](https://github.com/user-attachments/assets/946f38d8-8b52-429b-8016-263eaf9a8165)

Send with enter disabled:
![photo_2026-01-07 16 37 55](https://github.com/user-attachments/assets/927b2c78-bf01-4d2d-a6d7-420db6e899ce)
