### PR TITLE
Add Mi 9T Pro voice note sample rate special handling

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/audio/MediaRecorderWrapper.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/audio/MediaRecorderWrapper.java
@@ -74,9 +74,15 @@ public class MediaRecorderWrapper implements Recorder {
   }
 
   private static int getSampleRate() {
-    if ("Xiaomi".equals(Build.MANUFACTURER) && ("Mi 9T".equals(Build.MODEL) || "Mi 9T Pro".equals(Build.MODEL))) {
+    if ("Xiaomi".equals(Build.MANUFACTURER)) {
       // Recordings sound robotic with the standard sample rate.
-      return 44000;
+      switch(Build.MODEL) {
+        case "Mi 9T":
+          return 44000;
+        case "Mi 9T Pro":
+          return 32000;
+        default:
+      }
     }
     return SAMPLE_RATE;
   }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Xiaomi Mi 9T Pro
- [x] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixes #14452

After manual testing, I found that 32000 was the right value for the sample rate for Mi 9T Pro for correct voice message recording. I simply added this special case.
