### PR TITLE
Fixes #14538, fixes typing: IMPORTANT this is not a translation change, this is an …

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4582,7 +4582,7 @@
     </plurals>
 
     <!-- conversation_group_options -->
-    <string name="convesation_group_options__recipients_list">Recipients list</string>
+    <string name="conversation_group_options__recipients_list">Recipients list</string>
     <string name="conversation_group_options__delivery">Delivery</string>
     <!-- Label for a menu item that appears after pressing the three-dot icon in a  -->
     <string name="conversation_group_options__conversation">Chat</string>


### PR DESCRIPTION
Fixes typing: IMPORTANT this is not a translation change, this is an internal change of the value field for the translations

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ x] My contribution is fully baked and ready to be merged as is
- [ x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Fixes typing: Important this is not a translation change, this is an internal change of the value field for the translations - another important thing to mention: This (probably) has to be changed in all language translation files as well and also in the general value context if it's wrong there as well and copied
