### PR TITLE
fix(outdated-build): allow dismissing outdated build banner

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/banner/banners/OutdatedBuildBanner.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/banner/banners/OutdatedBuildBanner.kt
@@ -7,6 +7,10 @@ package org.thoughtcrime.securesms.banner.banners
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -46,24 +50,25 @@ class OutdatedBuildBanner : Banner<Int>() {
   @Composable
   override fun DisplayBanner(model: Int, contentPadding: PaddingValues) {
     val context = LocalContext.current
+    var dismissed by remember { mutableStateOf(false) }
+
+    if (dismissed) return
 
     Banner(
       contentPadding = contentPadding,
       daysUntilExpiry = model,
       onUpdateClicked = {
         PlayStoreUtil.openPlayStoreOrOurApkDownloadPage(context)
+      },
+      onDismissClicked = {
+        dismissed = true
       }
     )
   }
-
-  data class Model(
-    val daysUntilExpiry: Int,
-    val isClientDeprecated: Boolean
-  )
 }
 
 @Composable
-private fun Banner(contentPadding: PaddingValues, daysUntilExpiry: Int, onUpdateClicked: () -> Unit = {}) {
+private fun Banner(contentPadding: PaddingValues, daysUntilExpiry: Int, onUpdateClicked: () -> Unit = {},onDismissClicked: () -> Unit = {}) {
   val bodyText = if (daysUntilExpiry == 0) {
     stringResource(id = R.string.OutdatedBuildReminder_your_version_of_signal_will_expire_today)
   } else {
@@ -81,6 +86,9 @@ private fun Banner(contentPadding: PaddingValues, daysUntilExpiry: Int, onUpdate
     actions = listOf(
       Action(R.string.ExpiredBuildReminder_update_now) {
         onUpdateClicked()
+      },
+      Action(R.string.SetUpYourUsername__dismiss) {
+        onDismissClicked()
       }
     ),
     paddingValues = contentPadding


### PR DESCRIPTION
Fixes #14424

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ x ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [ x ] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ x ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ x ] I have tested my contribution on these devices:
 * Device A, Android 16 - Oneplus nord 5
 * Device B, Android 13 - Moto G32
- [ x ] My contribution is fully baked and ready to be merged as is
- [ x ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

This PR adds a dismiss action to the outdated build banner, allowing users to temporarily hide the banner during the current app session.

Previously, the banner could only be resolved by updating the app, which meant it would remain visible even when users were already aware of the warning or unable to update immediately. This change introduces a lightweight dismissal mechanism using local Compose state, without altering any existing expiry logic or update behavior.

The banner will reappear on the next app restart if the build is still outdated, ensuring that users continue to receive the reminder while avoiding unnecessary friction within a single session.

**Testing**

* Verified that the outdated build banner is shown as before when the build is nearing expiry.
* Confirmed that tapping **Dismiss** hides the banner immediately.
* Confirmed that tapping **Update** still opens the Play Store or APK download page.
* Verified that the banner reappears after app restart when the build is still outdated.

This change addresses the UX concern described in #14424 while keeping the warning behavior intact.

