### PR TITLE
Fix type comparison in reproducible script

### DIFF
--- a/reproducible-builds/apkdiff/apkdiff.py
+++ b/reproducible-builds/apkdiff/apkdiff.py
@@ -204,7 +204,7 @@ def compare_resources_arsc(first_entry_bytes: bytes, second_entry_bytes: bytes) 
             pkg1 = packages1[i]
             pkg2 = packages2[i]
 
-            if type(pkg1) != type(pkg2):
+            if type(pkg1) is not type(pkg2):
                 print(f"Element type mismatch at index {i}: {type(pkg1).__name__} vs {type(pkg2).__name__}")
                 success = False
                 continue


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Desktop, Linux (feodra 42)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Enforce strict type comparison.

Example of a bad type comparison with '==':

```python
class Meta(type):
    def __eq__(cls, other):
        return True
class A(metaclass=Meta):
    pass
class B(metaclass=Meta):
    pass

a = A()
b = B()
print(type(a) == type(b))  # True  - because Meta.__eq__ returns True
print(type(a) is type(b))  # False - type check is correct
```