### PR TITLE
Fix type and type annotations issues in reproducible script

### DIFF
--- a/reproducible-builds/apkdiff/apkdiff.py
+++ b/reproducible-builds/apkdiff/apkdiff.py
@@ -134,11 +134,11 @@ def compare_android_xml(bytes1: bytes, bytes2: bytes) -> bool:
     bad_differences = []
 
     for diff in all_differences:
-        is_split_attr = diff.diff_type == "attribute" and diff.path in ["manifest", "manifest/application"] and "split" in diff.attribute_name.lower()
+        is_split_attr = diff.diff_type == "attribute" and diff.path in ["manifest", "manifest/application"] and diff.attribute_name is not None and "split" in diff.attribute_name.lower()
         is_meta_attr = diff.diff_type == "attribute" and diff.path == "manifest/application/meta-data"
         is_meta_child_count = diff.diff_type == "child_count" and diff.child_tag == "meta-data"
 
-        if not is_split_attr and not is_meta_attr and not is_meta_child_count and not is_meta_attr:
+        if not is_split_attr and not is_meta_attr and not is_meta_child_count:
             bad_differences.append(diff)
 
     if bad_differences:
@@ -286,7 +286,7 @@ def compare_xml(bytes1: bytes, bytes2: bytes) -> list[XmlDifference]:
     entry_text_2 = printer.get_xml().decode("utf-8")
 
     if entry_text_1 == entry_text_2:
-        return True
+        return []
 
     root1 = ET.fromstring(entry_text_1)
     root2 = ET.fromstring(entry_text_2)
@@ -329,11 +329,11 @@ def compare_xml_elements(elem1: Element, elem2: Element, path: str = "") -> list
     children2 = list(elem2)
 
     # Try to match children by tag name for comparison
-    children1_by_tag = {}
+    children1_by_tag: dict[str, list[Element]] = {}
     for child in children1:
         children1_by_tag.setdefault(child.tag, []).append(child)
 
-    children2_by_tag = {}
+    children2_by_tag: dict[str, list[Element]] = {}
     for child in children2:
         children2_by_tag.setdefault(child.tag, []).append(child)
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Desktop, Linux (fedora 42)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

> "split" in diff.attribute_name.lower()

`diff.attribute_name` is `str | None`, we should avoid failure by checking if not None before

> and not is_meta_attr

It is a duplicate (already checked in this condition), can be safely removed

> return True

This function does not return `bool`, but `list[XmlDifference]`. If there is no difference, just return an empty list `[]`

> children1_by_tag: dict[str, list[Element]] = {}

Just add some type annotation where it couldn't be infered.