### PR TITLE
Fix memory usage in reproducible-build GitHub workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,21 +1,20 @@
-name: Reproducible Build Check
+name: Check reproducible-build Dockerfile
 
 on:
   schedule:
-    - cron: '0 5 * * *'
+    - cron: "0 5 * * *"
 
 permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Build image
-      run: cd reproducible-builds && docker build -t signal-android . && cd ..
-
-    - name: Test build
-      run: docker run --rm -v $(pwd):/project -w /project signal-android ./gradlew clean assemblePlayProdRelease
+      - uses: actions/checkout@v6
+      - name: Build image
+        run: |
+          cd reproducible-builds
+          docker build -t signal-android .
+      - name: Test build
+        run: docker run --memory=12g --rm -v "$(pwd)":/project -w /project signal-android ./gradlew --no-daemon --max-workers=1 -Dorg.gradle.jvmargs="-Xmx4g -XX:MaxMetaspaceSize=512m" -Dkotlin.compiler.execution.strategy=in-process bundlePlayProdRelease


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * github action runner, ubuntu-latest
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Fix reproducible-build github workflow.

1. Rename workflow

The current name, “Reproducible Build Check,” is misleading; people might think this workflow actually checks the reproducibility of the Signal APK.

2. Fix the Docker memory exhaustion issue

Actually, the Docker build is consuming too much RAM (as you can see [in all the last runs](https://github.com/signalapp/Signal-Android/actions/workflows/docker.yml)), which causes the GitHub Actions VM kernel to kill the Docker daemon (OOM killer).

This can be fixed with the following adjustments:

- `--memory=12g`: Limits the container's RAM usage to 12GB. Actual Github Action memory limit is 16GB (but only 14GB available).

- `--no-daemon`: Runs Gradle without a background daemon process.

- `--max-workers=1`: Limits parallel task workers to 1; runs tasks sequentially to reduce memory usage.

- `-Dorg.gradle.jvmargs="-Xmx4g -XX:MaxMetaspaceSize=512m"`: Sets JVM args for Gradle process: max heap 4GB, max metaspace 512 MB.

- `-Dkotlin.compiler.execution.strategy=in-process`: Runs Kotlin compiler in the same JVM process as Gradle (reduce memory usage).

You can see a successfull workflow here: https://github.com/BarbossHack/Signal-Android/actions/runs/21552219583

Note that this does not affect the reproduciblity, [all these successfull reproducible checks](https://github.com/BarbossHack/reproducible/blob/master/history/Signal-Android.md) were made with these settings.