### PR TITLE
fix(ui): use theme-aware color for media review send button

### DIFF
--- a/app/src/main/res/layout/v2_media_review_fragment.xml
+++ b/app/src/main/res/layout/v2_media_review_fragment.xml
@@ -301,7 +301,7 @@
             android:layout_marginStart="12dp"
             android:layout_marginEnd="10dp"
             android:layout_marginBottom="16dp"
-            android:background="@color/signal_light_colorPrimary"
+            android:background="@color/signal_colorPrimary"
             android:contentDescription="@string/MediaReviewFragment__send_media_accessibility_label"
             android:padding="4dp"
             android:scaleType="centerInside"

--- a/app/src/main/res/layout/v2_media_review_selected_item.xml
+++ b/app/src/main/res/layout/v2_media_review_selected_item.xml
@@ -40,7 +40,7 @@
         android:visibility="gone"
         app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.Signal.MediaSelection.Selected"
         app:srcCompat="@drawable/ic_trash_24"
-        app:strokeColor="@color/signal_light_colorPrimary"
+        app:strokeColor="@color/signal_colorPrimary"
         app:strokeWidth="2dp"
         app:tint="@color/core_white"
         tools:visibility="visible" />


### PR DESCRIPTION
## Summary
Fixes the attachment message confirm button to use the user's selected theme color instead of always displaying blue.

## Changes
- Updated `v2_media_review_fragment.xml` to use `@color/signal_colorPrimary` for send button background
- Updated `v2_media_review_selected_item.xml` to use `@color/signal_colorPrimary` for stroke color

## Testing
1. Go to Settings → Appearance → Accent color → Select "Red"
2. Navigate to any conversation
3. Tap attachment (+) → Select image
4. Tap "Add a message" input field
5. ✅ Send button displays red background matching theme

## Issue Reference
Fixes #14195