### PR TITLE
#14084 fix: preserve trailing hyphen in URLs when followed by space or newline

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/items/V2ConversationItemUtils.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/items/V2ConversationItemUtils.kt
@@ -41,8 +41,20 @@ object V2ConversationItemUtils {
 
     messageBody.getSpans(0, messageBody.length, URLSpan::class.java).forEach { urlSpan ->
       val start = messageBody.getSpanStart(urlSpan)
-      val end = messageBody.getSpanEnd(urlSpan)
-      val span = InterceptableLongClickCopyLinkSpan(urlSpan.url, urlClickHandler)
+      var end = messageBody.getSpanEnd(urlSpan)
+      var url = urlSpan.url
+
+      while (end < messageBody.length && messageBody[end] == '-') {
+        val nextCharIndex = end + 1
+        if (nextCharIndex >= messageBody.length || messageBody[nextCharIndex] == ' ' || messageBody[nextCharIndex] == '\n') {
+          url += '-'
+          end++
+        } else {
+          break
+        }
+      }
+
+      val span = InterceptableLongClickCopyLinkSpan(url, urlClickHandler)
 
       messageBody.setSpan(span, start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
       messageBody.removeSpan(urlSpan)

--- a/app/src/test/java/org/thoughtcrime/securesms/conversation/ConversationItemTest_linkifyUrlLinks.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/conversation/ConversationItemTest_linkifyUrlLinks.kt
@@ -39,6 +39,8 @@ class ConversationItemTest_linkifyUrlLinks(private val input: String, private va
       arrayOf("https://www.google.com%d332", "https://www.google.com"),
 //      arrayOf("https://www.instagram.com/tv/CfImYdngccQ/?igshid=YmMyMTA2M2Y= ", "https://www.instagram.com/tv/CfImYdngccQ/?igshid=YmMyMTA2M2Y="),
       arrayOf("https://www.instagram.com/tv/CfImYdngccQ/?igshid=YmMyMTA2M2Y=\n", "https://www.instagram.com/tv/CfImYdngccQ/?igshid=YmMyMTA2M2Y="),
+      arrayOf("https://example.com/link- word", "https://example.com/link-"),
+      arrayOf("https://example.com/link-\nword.", "https://example.com/link-"),
 //      arrayOf("https://fr.ulule.com/sapins-barbus-la-bd-/ ", "https://fr.ulule.com/sapins-barbus-la-bd-/"),
       arrayOf("https://fr.ulule.com/sapins-barbus-la-bd-/\n", "https://fr.ulule.com/sapins-barbus-la-bd-/"),
       arrayOf("https://de.m.wikipedia.org/wiki/Red_Dawn_(2012)", "https://de.m.wikipedia.org/wiki/Red_Dawn_(2012)")


### PR DESCRIPTION

### First time contributor checklist

- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist

- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Galaxy 26, Android 16
 
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the [Fixes #14084](https://github.com/signalapp/Signal-Android/issues/14084)

----------

### Description

Fixes a bug where URLs ending with a hyphen (-) lost the trailing hyphen when followed by a space, newline, or word. Now, the trailing hyphen is preserved in the link if it is followed by whitespace, a newline, or end of string.
<img width="384" height="150" alt="image" src="https://github.com/user-attachments/assets/a3b53364-3cf1-4304-9528-a5d4526f6add" />
