### PR TITLE
Fix the Edited label not always appearing

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/items/V2ConversationItemTextOnlyViewHolder.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/items/V2ConversationItemTextOnlyViewHolder.kt
@@ -718,8 +718,8 @@ open class V2ConversationItemTextOnlyViewHolder<Model : MappingModel<Model>>(
           dateLabel = getContext().getString(R.string.ConversationItem_edited_relative_timestamp_footer, dateLabel)
           dateLabelContentDesc = getContext().getString(R.string.ConversationItem_edited_relative_timestamp_footer, dateLabelContentDesc)
         } else {
-          getContext().getString(R.string.ConversationItem_edited_absolute_timestamp_footer, dateLabel)
-          dateLabelContentDesc = dateLabel
+          dateLabel = getContext().getString(R.string.ConversationItem_edited_absolute_timestamp_footer, dateLabel)
+          dateLabelContentDesc = getContext().getString(R.string.ConversationItem_edited_absolute_timestamp_footer, dateLabelContentDesc)
         }
 
         binding.footerDate.setOnClickListener {


### PR DESCRIPTION
### First time contributor checklist
- [ x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [ x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [ ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

The 'Edited' label next to a message does not always display; e.g. when it's been 1+ hour.  The code here is a little messy, and it looks like this is a bug, although I defer to your judgement.