### PR TITLE
Fix bubble desired height on high-density devices #14591

### DIFF
--- a/app/src/main/java/androidx/recyclerview/widget/ConversationLayoutManager.kt
+++ b/app/src/main/java/androidx/recyclerview/widget/ConversationLayoutManager.kt
@@ -4,6 +4,7 @@
  */
 
 package androidx.recyclerview.widget
+
 import android.content.Context
 import org.signal.core.util.logging.Log
 

--- a/app/src/main/java/org/thoughtcrime/securesms/components/InsetAwareConstraintLayout.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/InsetAwareConstraintLayout.kt
@@ -64,11 +64,6 @@ open class InsetAwareConstraintLayout @JvmOverloads constructor(
 
   private var insets: WindowInsetsCompat? = null
   private var windowTypes: Int = InsetAwareConstraintLayout.windowTypes
-
-  /**
-   * When set, this value is used for the navigation bar guideline instead of the system inset.
-   * Used in bubble mode to eliminate the bottom margin so more messages fit on screen.
-   */
   private var navigationBarInsetOverride: Int? = null
 
   private val windowInsetsListener = androidx.core.view.OnApplyWindowInsetsListener { _, insets ->
@@ -120,11 +115,6 @@ open class InsetAwareConstraintLayout @JvmOverloads constructor(
     }
   }
 
-
-  /**
-   * Override the navigation bar inset (e.g. use 0 in bubble mode to remove bottom margin).
-   * When non-null, this value is used instead of the system navigation bar inset.
-   */
   fun setNavigationBarInsetOverride(inset: Int?) {
     if (navigationBarInsetOverride == inset) return
     navigationBarInsetOverride = inset
@@ -162,8 +152,6 @@ open class InsetAwareConstraintLayout @JvmOverloads constructor(
     val isLtr = ViewUtil.isLtr(this)
 
     val statusBar = windowInsets.top
-    // In bubble mode we can override the navigation-bar inset entirely so the content
-    // extends to the bottom of the bubble instead of reserving space for system UI.
     val navigationBar = navigationBarInsetOverride ?: if (windowInsets.bottom == 0 && Build.VERSION.SDK_INT <= 29) {
       ViewUtil.getNavigationBarHeight(resources)
     } else {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/BubbleConversationActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/BubbleConversationActivity.kt
@@ -8,7 +8,7 @@ import org.thoughtcrime.securesms.util.ViewUtil
 
 /**
  * Activity which encapsulates a conversation for a Bubble window.
- *
+ *8
  * This activity exists so that we can override some of its manifest parameters
  * without clashing with [ConversationActivity] and provide an API-level
  * independent "is in bubble?" check.
@@ -16,8 +16,6 @@ import org.thoughtcrime.securesms.util.ViewUtil
 class BubbleConversationActivity : ConversationActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?, ready: Boolean) {
-    // Let our layout handle all insets so the bubble can use its full height and
-    // avoid leaving a large blank area above the launcher/navigation bar.
     WindowCompat.setDecorFitsSystemWindows(window, false)
     super.onCreate(savedInstanceState, ready)
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
@@ -634,18 +634,11 @@ class ConversationFragment :
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     binding.toolbar.isBackInvokedCallbackEnabled = false
-
-    // For full-screen conversations we respect system window insets; for bubbles we draw
-    // edge-to-edge inside the bubble window and manage insets ourselves.
     binding.root.setUseWindowTypes(args.conversationScreenType == ConversationScreenType.NORMAL && !resources.getWindowSizeClass().isSplitPane())
     if (args.conversationScreenType == ConversationScreenType.BUBBLE) {
-      // When shown as an Android bubble, force a zero navigation-bar inset so the
-      // message list and compose box can use the full bubble height.
       binding.root.setNavigationBarInsetOverride(0)
-      // Re-request insets and layout after a frame so we win over any system padding
-      // (e.g. on Android 15 / Pixel 9 where bubble insets can apply late).
       view.post {
-        androidx.core.view.ViewCompat.requestApplyInsets(binding.root)
+        ViewCompat.requestApplyInsets(binding.root)
         binding.root.requestLayout()
       }
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/v2/NotificationBuilder.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/v2/NotificationBuilder.kt
@@ -362,9 +362,6 @@ sealed class NotificationBuilder(protected val context: Context) {
       if (intent != null) {
         val bubbleMetadata = NotificationCompat.BubbleMetadata.Builder(intent, AvatarUtil.getIconCompat(context, conversation.recipient))
           .setAutoExpandBubble(bubbleState === BubbleUtil.BubbleState.SHOWN)
-          // Bubble desired height is in PX (not DP). Use a screen-based value so the expanded
-          // bubble isn't tiny on high-density devices (Android 15 / Pixel).
-          //.setDesiredHeight(600)
           .setDesiredHeight(BubbleUtil.getDesiredBubbleHeightPx(context))
           .setSuppressNotification(bubbleState === BubbleUtil.BubbleState.SHOWN)
           .build()
@@ -372,7 +369,6 @@ sealed class NotificationBuilder(protected val context: Context) {
         builder.bubbleMetadata = bubbleMetadata
       }
     }
-
     override fun setLights(@ColorInt color: Int, onTime: Int, offTime: Int) {
       if (NotificationChannels.supported()) {
         return

--- a/app/src/main/java/org/thoughtcrime/securesms/util/BubbleUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/BubbleUtil.java
@@ -16,6 +16,7 @@ import androidx.annotation.WorkerThread;
 
 import com.annimon.stream.Stream;
 
+import org.signal.core.util.DimensionUnit;
 import org.signal.core.util.concurrent.SignalExecutors;
 import org.signal.core.util.logging.Log;
 import org.thoughtcrime.securesms.dependencies.AppDependencies;
@@ -37,6 +38,8 @@ public final class BubbleUtil {
   private static final String TAG = Log.tag(BubbleUtil.class);
   private static String currentState = "";
 
+  private static final float MIN_BUBBLE_HEIGHT_DP = 600f;
+  private static final float BUBBLE_HEIGHT_SCREEN_FRACTION = 0.9f;
   private BubbleUtil() {
   }
 
@@ -137,21 +140,11 @@ public final class BubbleUtil {
     HIDDEN
   }
 
-  /**
-   * Desired expanded bubble height in pixels.
-   * <p>
-   * Note: {@code NotificationCompat.BubbleMetadata.Builder#setDesiredHeight(int)} expects PX, not DP.
-   * If we accidentally pass a "dp-looking" constant (e.g. 600), the bubble becomes very short on
-   * high-density devices which leaves a large empty area below the bubble.
-   */
   public static int getDesiredBubbleHeightPx(@NonNull Context context) {
-    final float density = context.getResources().getDisplayMetrics().density;
-    final int minHeightPx = (int) (600f * density + 0.5f); // 600dp min
-
+    int minHeightPx = (int) DimensionUnit.DP.toPixels(MIN_BUBBLE_HEIGHT_DP);
     int screenHeightPx = context.getResources().getDisplayMetrics().heightPixels;
 
-    // Prefer WindowMetrics when available (more reliable than DisplayMetrics)
-    if (android.os.Build.VERSION.SDK_INT >= 30) {
+    if (Build.VERSION.SDK_INT >= 30) {
       WindowManager wm = context.getSystemService(WindowManager.class);
       if (wm != null) {
         Rect bounds = wm.getCurrentWindowMetrics().getBounds();
@@ -159,12 +152,13 @@ public final class BubbleUtil {
       }
     }
 
-    if (screenHeightPx <= 0) return minHeightPx;
+    if (screenHeightPx <= 0) {
+      return minHeightPx;
+    }
 
-    final int targetPx = (int) (screenHeightPx * 0.9f);
-    final int desiredPx = Math.max(minHeightPx, targetPx);
+    int targetPx = (int) (screenHeightPx * BUBBLE_HEIGHT_SCREEN_FRACTION);
+    int desiredPx = Math.max(minHeightPx, targetPx);
 
-    // Never exceed screen height
     return Math.min(desiredPx, screenHeightPx);
   }
 }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ x ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [ x ] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ x ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ x  ] I have tested my contribution on these devices:
 * Device A, Android OPPO F15 , OS 11
 * Virtual device Pixel 5 , Pixel 7 , Pixel 9, Android OS 31, 33, 35
- [ ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #14591` 

----------

### Description
Fixes #14591

### Problem
Bubble metadata was using a hardcoded `setDesiredHeight(600)`, which is interpreted as pixels.  
On high-density devices and with increased display/font scaling, this resulted in a very short expanded bubble and a large unused area below the content.

### Solution
- Calculate desired bubble height in pixels using a screen-based value
- Enforce a minimum of 600dp (converted to px)
- Target ~90% of screen height via `BubbleUtil.getDesiredBubbleHeightPx(context)`
- Update `NotificationBuilder` to use the computed value

### Testing
- Android API 31, 33, and 35
- Default and increased Display/Font sizes
- Bubble height now matches expected behaviour and is consistent with other messaging apps

### Screenshots
**Before**  
<img width="276" height="630" alt="Before_changes" src="https://github.com/user-attachments/assets/45724be3-a8d3-4884-b0e2-3b6a54a222be" />

**After**  
<img width="253" height="576" alt="After_changes" src="https://github.com/user-attachments/assets/d6028d56-d698-4003-a29e-ed3cb800849d" />
