### PR TITLE
Fix notification opening wrong conversation

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/v2/NotificationBuilder.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/v2/NotificationBuilder.kt
@@ -354,7 +354,7 @@ sealed class NotificationBuilder(protected val context: Context) {
 
       val intent: PendingIntent? = NotificationPendingIntentHelper.getActivity(
         context,
-        0,
+        conversation.notificationId,
         ConversationIntents.createBubbleIntent(context, conversation.recipient.id, conversation.thread.threadId),
         mutable()
       )

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/v2/NotificationConversation.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/v2/NotificationConversation.kt
@@ -136,11 +136,11 @@ data class NotificationConversation(
     return try {
       TaskStackBuilder.create(context)
         .addNextIntentWithParentStack(intent)
-        .getPendingIntent(0, PendingIntentFlags.updateCurrent())
+        .getPendingIntent(notificationId, PendingIntentFlags.updateCurrent())
     } catch (e: NullPointerException) {
       Log.w(NotificationFactory.TAG, "Vivo device quirk sometimes throws NPE", e)
       intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-      NotificationPendingIntentHelper.getActivity(context, 0, intent, PendingIntentFlags.updateCurrent())
+      NotificationPendingIntentHelper.getActivity(context, notificationId, intent, PendingIntentFlags.updateCurrent())
     } catch (e: SecurityException) {
       Log.w(NotificationFactory.TAG, "TaskStackBuilder too many pending intents device quirk: ${e.message}")
       null


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fixes #14610

### Problem
When multiple conversation notifications are present, tapping a notification can open the wrong chat.
This happens because conversation PendingIntents were created with the same requestCode (0), so Android can reuse the same PendingIntent and override extras.

### Solution
Use a unique requestCode per notification by switching to `notificationId`:
- `NotificationConversation.kt`: TaskStackBuilder and fallback PendingIntent paths
- `NotificationBuilder.kt`: bubble PendingIntent requestCode

### Testing
- Verified with two unread conversations: each notification opens the correct thread
- Verified bubble intent opens the correct conversation
