### PR TITLE
Fix unexpected keyboard appearance on repeated back swipe (#14618)

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
@@ -4520,9 +4520,6 @@ class ConversationFragment :
       }
     }
 
-    override fun onFocusChange(v: View, hasFocus: Boolean) {
-    }
-
     override fun onCursorPositionChanged(start: Int, end: Int) {
       linkPreviewViewModel.onTextChanged(composeText.textTrimmed.toString(), start, end)
     }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:

Virtual device Pixel 9, Android OS 36
[x] My contribution is fully baked and ready to be merged as is
[x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
**Problem**
When navigating back from a conversation screen using Android's predictive back gesture, if the gesture was held briefly and then cancelled, the keyboard would unexpectedly appear on the subsequent back swipe attempt.

**Root Cause:**
Android's predictive back gesture cancellation internally restores focus to previously focused views (in this case, composeText). The onFocusChange listener was showing the IME whenever focus was gained, so this system-driven focus restoration was unintentionally triggering the keyboard to appear — even when the user had no intent to type.

**Solution**
Decouple IME visibility from focus changes entirely.

- onFocusChange — Removed the IME show call. Focus can be legitimately restored by the system (e.g., during predictive back cancellations) without the user intending to open the keyboard. The keyboard should only appear from explicit user or programmatic actions.
- Popup case — Replaced composeText.requestFocus() with container.showSoftkey(composeText) to explicitly show the keyboard where it is intentionally required, rather than relying on the focus change callback as a side effect.