### PR TITLE
Exclude duplicate files from the sourcesJar task

### DIFF
--- a/lib/libsignal-service/build.gradle.kts
+++ b/lib/libsignal-service/build.gradle.kts
@@ -35,6 +35,9 @@ tasks.withType<KotlinCompile>().configureEach {
   }
 }
 
+tasks.named<Jar>("sourcesJar") {
+  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
 val sourceSets = extensions.getByName("sourceSets") as SourceSetContainer
 sourceSets.named("main") {
   output.dir(


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- N/A I have tested my contribution on these devices:
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
The `sourcesJar` Gradle task was failing due to the `proto-sources` directory being included twice, both from the wire plugin and the Kotlin compilation.

This is tested by running the Gradle task, and it not failing. :-)