### PR TITLE
Block untrusted media controllers from driving voice note sessions

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/voice/VoiceNoteControllerAccess.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/voice/VoiceNoteControllerAccess.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+@file:OptIn(androidx.media3.common.util.UnstableApi::class)
+
+package org.thoughtcrime.securesms.components.voice
+
+import android.content.Context
+import androidx.media3.session.MediaSession
+
+internal enum class VoiceNoteControllerAccessLevel {
+  INTERNAL,
+  TRUSTED_EXTERNAL,
+  REJECTED
+}
+
+internal object VoiceNoteControllerAccess {
+
+  /**
+   * The app itself needs full control to enqueue and resolve voice notes. Everyone else is limited
+   * to MediaSession's trusted controller model, which preserves system integrations but blocks
+   * arbitrary third-party apps from driving private playlist construction.
+   */
+  @JvmStatic
+  fun levelFor(context: Context, controller: MediaSession.ControllerInfo): VoiceNoteControllerAccessLevel {
+    return when {
+      controller.packageName == context.packageName -> VoiceNoteControllerAccessLevel.INTERNAL
+      controller.isTrusted -> VoiceNoteControllerAccessLevel.TRUSTED_EXTERNAL
+      else -> VoiceNoteControllerAccessLevel.REJECTED
+    }
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/components/voice/VoiceNotePlaybackService.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/voice/VoiceNotePlaybackService.java
@@ -133,6 +133,11 @@ public class VoiceNotePlaybackService extends MediaSessionService {
   @Nullable
   @Override
   public MediaSession onGetSession(@NonNull MediaSession.ControllerInfo controllerInfo) {
+    if (VoiceNoteControllerAccess.levelFor(this, controllerInfo) == VoiceNoteControllerAccessLevel.REJECTED) {
+      Log.w(TAG, "Denying media session access to untrusted controller: " + controllerInfo.getPackageName());
+      return null;
+    }
+
     return mediaSession;
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/components/voice/VoiceNotePlayerCallback.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/voice/VoiceNotePlayerCallback.kt
@@ -46,7 +46,7 @@ import kotlin.math.max
 @OptIn(UnstableApi::class)
 class VoiceNotePlayerCallback(val context: Context, val player: VoiceNotePlayer) : MediaSession.Callback {
   companion object {
-    private val SUPPORTED_ACTIONS = Player.Commands.Builder()
+    private val INTERNAL_PLAYER_COMMANDS = Player.Commands.Builder()
       .addAll(
         Player.COMMAND_PLAY_PAUSE,
         Player.COMMAND_PREPARE,
@@ -75,10 +75,31 @@ class VoiceNotePlayerCallback(val context: Context, val player: VoiceNotePlayer)
       )
       .build()
 
-    private val CUSTOM_COMMANDS = SessionCommands.Builder()
+    private val EXTERNAL_PLAYER_COMMANDS = Player.Commands.Builder()
+      .addAll(
+        Player.COMMAND_PLAY_PAUSE,
+        Player.COMMAND_PREPARE,
+        Player.COMMAND_STOP,
+        Player.COMMAND_SEEK_TO_DEFAULT_POSITION,
+        Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM,
+        Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM,
+        Player.COMMAND_SEEK_TO_PREVIOUS,
+        Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM,
+        Player.COMMAND_SEEK_TO_NEXT,
+        Player.COMMAND_SEEK_BACK,
+        Player.COMMAND_SEEK_FORWARD,
+        Player.COMMAND_GET_CURRENT_MEDIA_ITEM,
+        Player.COMMAND_GET_TIMELINE,
+        Player.COMMAND_GET_METADATA,
+        Player.COMMAND_GET_AUDIO_ATTRIBUTES
+      )
+      .build()
+
+    private val INTERNAL_SESSION_COMMANDS = SessionCommands.Builder()
       .add(SessionCommand(VoiceNotePlaybackService.ACTION_NEXT_PLAYBACK_SPEED, Bundle.EMPTY))
       .add(SessionCommand(VoiceNotePlaybackService.ACTION_SET_AUDIO_STREAM, Bundle.EMPTY))
       .build()
+    private val EXTERNAL_SESSION_COMMANDS = SessionCommands.Builder().build()
     private const val DEFAULT_PLAYBACK_SPEED = 1f
     private const val LIMIT: Long = 5
   }
@@ -93,16 +114,28 @@ class VoiceNotePlayerCallback(val context: Context, val player: VoiceNotePlayer)
   private var latestUri = Uri.EMPTY
 
   override fun onConnect(session: MediaSession, controller: MediaSession.ControllerInfo): MediaSession.ConnectionResult {
-    return MediaSession.ConnectionResult.accept(CUSTOM_COMMANDS, SUPPORTED_ACTIONS)
+    return when (controllerAccessLevel(controller)) {
+      VoiceNoteControllerAccessLevel.INTERNAL -> MediaSession.ConnectionResult.accept(INTERNAL_SESSION_COMMANDS, INTERNAL_PLAYER_COMMANDS)
+      VoiceNoteControllerAccessLevel.TRUSTED_EXTERNAL -> MediaSession.ConnectionResult.accept(EXTERNAL_SESSION_COMMANDS, EXTERNAL_PLAYER_COMMANDS)
+      VoiceNoteControllerAccessLevel.REJECTED -> {
+        Log.w(TAG, "Rejecting untrusted voice note controller. package=${controller.packageName}")
+        MediaSession.ConnectionResult.reject()
+      }
+    }
   }
 
   override fun onPostConnect(session: MediaSession, controller: MediaSession.ControllerInfo) {
-    if (customLayout.isNotEmpty() && controller.controllerVersion != 0) {
+    if (controllerAccessLevel(controller) == VoiceNoteControllerAccessLevel.INTERNAL && customLayout.isNotEmpty() && controller.controllerVersion != 0) {
       session.setCustomLayout(controller, customLayout)
     }
   }
 
   override fun onAddMediaItems(mediaSession: MediaSession, controller: MediaSession.ControllerInfo, mediaItems: MutableList<MediaItem>): ListenableFuture<MutableList<MediaItem>> {
+    if (controllerAccessLevel(controller) != VoiceNoteControllerAccessLevel.INTERNAL) {
+      Log.w(TAG, "Ignoring playlist mutation from non-internal controller. package=${controller.packageName}")
+      return Futures.immediateFuture(mutableListOf())
+    }
+
     mediaItems.forEach {
       val uri = it.localConfiguration?.uri
       if (uri != null) {
@@ -178,6 +211,11 @@ class VoiceNotePlayerCallback(val context: Context, val player: VoiceNotePlayer)
   }
 
   override fun onCustomCommand(session: MediaSession, controller: MediaSession.ControllerInfo, customCommand: SessionCommand, args: Bundle): ListenableFuture<SessionResult> {
+    if (controllerAccessLevel(controller) != VoiceNoteControllerAccessLevel.INTERNAL) {
+      Log.w(TAG, "Rejecting custom command from non-internal controller. package=${controller.packageName} action=${customCommand.customAction}")
+      return Futures.immediateFuture(SessionResult(SessionResult.RESULT_ERROR_PERMISSION_DENIED))
+    }
+
     return when (customCommand.customAction) {
       VoiceNotePlaybackService.ACTION_NEXT_PLAYBACK_SPEED -> incrementPlaybackSpeed(args)
       VoiceNotePlaybackService.ACTION_SET_AUDIO_STREAM -> setAudioStream(args)
@@ -277,5 +315,9 @@ class VoiceNotePlayerCallback(val context: Context, val player: VoiceNotePlayer)
 
   private fun List<MessageRecord>.messageRecordsToVoiceNoteMediaItems(): List<MediaItem> {
     return this.takeWhile { it.hasAudio() }.mapNotNull { VoiceNoteMediaItemFactory.buildMediaItem(context, it) }
+  }
+
+  private fun controllerAccessLevel(controller: MediaSession.ControllerInfo): VoiceNoteControllerAccessLevel {
+    return VoiceNoteControllerAccess.levelFor(context, controller)
   }
 }

--- a/app/src/test/java/org/thoughtcrime/securesms/components/voice/VoiceNotePlayerCallbackTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/components/voice/VoiceNotePlayerCallbackTest.kt
@@ -4,8 +4,13 @@ import android.app.Application
 import android.content.Context
 import android.media.AudioManager
 import android.os.Bundle
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import assertk.assertions.isEqualTo
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
+import androidx.media3.common.MediaItem
 import androidx.media3.session.MediaSession
 import androidx.media3.session.SessionCommand
 import androidx.test.core.app.ApplicationProvider
@@ -31,6 +36,7 @@ class VoiceNotePlayerCallbackTest {
   @Test
   fun `Given stream is media, When I onCommand for voice, then I expect the stream to switch to voice and continue playback`() {
     // GIVEN
+    every { controllerInfo.packageName } returns context.packageName
     every { player.audioAttributes } returns mediaAudioAttributes
 
     val command = SessionCommand(VoiceNotePlaybackService.ACTION_SET_AUDIO_STREAM, Bundle.EMPTY)
@@ -49,6 +55,7 @@ class VoiceNotePlayerCallbackTest {
   @Test
   fun `Given stream is voice, When I onCommand for media, then I expect the stream to switch to media and pause playback`() {
     // GIVEN
+    every { controllerInfo.packageName } returns context.packageName
     every { player.audioAttributes } returns callAudioAttributes
 
     val command = SessionCommand(VoiceNotePlaybackService.ACTION_SET_AUDIO_STREAM, Bundle.EMPTY)
@@ -67,6 +74,7 @@ class VoiceNotePlayerCallbackTest {
   @Test
   fun `Given stream is voice, When I onCommand for voice, then I expect no change`() {
     // GIVEN
+    every { controllerInfo.packageName } returns context.packageName
     every { player.audioAttributes } returns callAudioAttributes
 
     val command = SessionCommand(VoiceNotePlaybackService.ACTION_SET_AUDIO_STREAM, Bundle.EMPTY)
@@ -83,6 +91,7 @@ class VoiceNotePlayerCallbackTest {
   @Test
   fun `Given stream is media, When I onCommand for media, then I expect no change`() {
     // GIVEN
+    every { controllerInfo.packageName } returns context.packageName
     every { player.audioAttributes } returns mediaAudioAttributes
 
     val command = SessionCommand(VoiceNotePlaybackService.ACTION_SET_AUDIO_STREAM, Bundle.EMPTY)
@@ -94,5 +103,85 @@ class VoiceNotePlayerCallbackTest {
     // THEN
     verify(exactly = 0) { player.playWhenReady = any() }
     verify(exactly = 0) { player.setAudioAttributes(any(), any()) }
+  }
+
+  @Test
+  fun `Given internal controller, When onConnect, then I expect full playback and custom commands`() {
+    // GIVEN
+    every { controllerInfo.packageName } returns context.packageName
+
+    val customCommand = SessionCommand(VoiceNotePlaybackService.ACTION_SET_AUDIO_STREAM, Bundle.EMPTY)
+
+    // WHEN
+    val result = testSubject.onConnect(session, controllerInfo)
+
+    // THEN
+    assertThat(result.availablePlayerCommands.contains(androidx.media3.common.Player.COMMAND_SET_MEDIA_ITEM)).isTrue()
+    assertThat(result.availableSessionCommands.contains(customCommand)).isTrue()
+  }
+
+  @Test
+  fun `Given trusted external controller, When onConnect, then I expect playback controls without playlist mutation`() {
+    // GIVEN
+    every { controllerInfo.packageName } returns "com.android.systemui"
+    every { controllerInfo.isTrusted } returns true
+
+    val customCommand = SessionCommand(VoiceNotePlaybackService.ACTION_SET_AUDIO_STREAM, Bundle.EMPTY)
+
+    // WHEN
+    val result = testSubject.onConnect(session, controllerInfo)
+
+    // THEN
+    assertThat(result.availablePlayerCommands.contains(androidx.media3.common.Player.COMMAND_PLAY_PAUSE)).isTrue()
+    assertThat(result.availablePlayerCommands.contains(androidx.media3.common.Player.COMMAND_SET_MEDIA_ITEM)).isFalse()
+    assertThat(result.availablePlayerCommands.contains(androidx.media3.common.Player.COMMAND_CHANGE_MEDIA_ITEMS)).isFalse()
+    assertThat(result.availableSessionCommands.contains(customCommand)).isFalse()
+  }
+
+  @Test
+  fun `Given untrusted external controller, When onConnect, then I expect the connection to be rejected`() {
+    // GIVEN
+    every { controllerInfo.packageName } returns "com.bad.actor"
+    every { controllerInfo.isTrusted } returns false
+
+    // WHEN
+    val result = testSubject.onConnect(session, controllerInfo)
+
+    // THEN
+    assertThat(result.availablePlayerCommands.contains(androidx.media3.common.Player.COMMAND_PLAY_PAUSE)).isFalse()
+  }
+
+  @Test
+  fun `Given trusted external controller, When onCustomCommand, then I expect permission denied`() {
+    // GIVEN
+    every { controllerInfo.packageName } returns "com.android.systemui"
+    every { controllerInfo.isTrusted } returns true
+    every { player.audioAttributes } returns mediaAudioAttributes
+
+    val command = SessionCommand(VoiceNotePlaybackService.ACTION_SET_AUDIO_STREAM, Bundle.EMPTY)
+    val extras = Bundle().apply { putInt(VoiceNotePlaybackService.ACTION_SET_AUDIO_STREAM, AudioManager.STREAM_VOICE_CALL) }
+
+    // WHEN
+    val result = testSubject.onCustomCommand(session, controllerInfo, command, extras).get()
+
+    // THEN
+    assertThat(result.resultCode).isEqualTo(androidx.media3.session.SessionResult.RESULT_ERROR_PERMISSION_DENIED)
+    verify(exactly = 0) { player.setAudioAttributes(any(), any()) }
+  }
+
+  @Test
+  fun `Given trusted external controller, When onAddMediaItems, then I expect playlist mutation to be ignored`() {
+    // GIVEN
+    every { controllerInfo.packageName } returns "com.android.systemui"
+    every { controllerInfo.isTrusted } returns true
+
+    val mediaItem = MediaItem.Builder().setUri("content://org.signal.test/1").build()
+
+    // WHEN
+    val result = testSubject.onAddMediaItems(session, controllerInfo, mutableListOf(mediaItem)).get()
+
+    // THEN
+    assertThat(result.isEmpty()).isTrue()
+    verify(exactly = 0) { player.clearMediaItems() }
   }
 }


### PR DESCRIPTION
This fixes a trust-boundary problem around the voice note media session.

`VoiceNotePlaybackService` is exported so Signal can participate in normal Android media controls, but the session callback was effectively treating any connecting controller as trusted. That meant a third-party app on the same device could connect as a media controller, ask Signal to build a voice note queue from a caller-supplied `messageId`, and reach app-specific commands that were only intended for Signal's own UI.

That is more access than external media clients should ever have. Lock screen controls, headsets, Android Auto, and similar integrations only need standard transport controls.

What this change does:
- classifies controllers as internal, trusted external, or rejected
- rejects untrusted controllers before handing out the session
- keeps normal play/pause/seek style controls for trusted external clients
- blocks external clients from adding media items, mutating the playlist, or invoking Signal-only custom commands
- adds regression tests that cover all three controller classes and the denied mutation paths

