### PR TITLE
Add "None" label for empty selection in Rows

### DIFF
--- a/core/ui/src/main/java/org/signal/core/ui/compose/Rows.kt
+++ b/core/ui/src/main/java/org/signal/core/ui/compose/Rows.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
@@ -222,13 +223,18 @@ object Rows {
     onSelectionChanged: (Array<String>) -> Unit
   ) {
     var displayDialog by remember { mutableStateOf(false) }
+    val none = stringResource(R.string.core__none)
 
     TextRow(
       text = text,
-      label = selection.joinToString(", ") {
-        val index = values.indexOf(it)
-        if (index == -1) error("not found: $it in ${values.joinToString(", ")}")
-        labels[index]
+      label = if (selection.isEmpty()) {
+        none
+      } else {
+        selection.joinToString(", ") {
+          val index = values.indexOf(it)
+          if (index == -1) error("not found: $it in ${values.joinToString(", ")}")
+          labels[index]
+        }
       },
       onClick = {
         displayDialog = true

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -21,4 +21,8 @@
     <!-- StorageUtil -->
     <!-- Format string for displaying a storage path as volume/filename -->
     <string name="StorageUtil__s_s">%1$s/%2$s</string>
+
+    <!-- General -->
+    <!-- Label displayed when no option is selected or when a value is absent -->
+    <string name="core__none">None</string>
 </resources>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
* Virtual device Medium Phone API
* Samsung Galaxy a25 5G, Android 16
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Displays a localized "None" label when no option is selected in the selection row component, rather than showing an empty string. This improves UX by providing clear feedback when no selection has been made.