### PR TITLE
Fix typo in comment referencing a class name

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/contacts/paged/ContactSearchConfiguration.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/contacts/paged/ContactSearchConfiguration.kt
@@ -200,7 +200,7 @@ class ContactSearchConfiguration private constructor(
     /**
      * Chat types that are displayed when creating a chat folder.
      *
-     * Key: [ContactSearchKey.ChatType]
+     * Key: [ContactSearchKey.ChatTypeSearchKey]
      * Data: [ContactSearchData.ChatTypeRow]
      * Model: [ContactSearchAdapter.ChatTypeModel]
      */


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- N/A I have tested my contribution on these devices:
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message
----------

### Description
Fix a very small typo -- the name of the class was wrong in the comment, so it didn't link.

Fixed in https://github.com/signalapp/Signal-Android/commit/905a6f1a6b27db869ad215c3fbf9d38e881c695e