### PR TITLE
feat: add mute/unmute video feature before sending

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ kls_database.db
 .kotlin
 lefthook-local.yml
 sample-videos/
+*.apk
+app/githubProd/
+app/nightly/
+app/benchmark/

--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/AttachmentCompressionJob.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/AttachmentCompressionJob.java
@@ -258,7 +258,9 @@ public final class AttachmentCompressionJob extends BaseJob {
           }
         }
 
-        StreamingTranscoder transcoder = new StreamingTranscoder(dataSource, options, constraints.getVideoTranscodingSettings(), constraints.getCompressedVideoMaxSize(context), RemoteConfig.allowAudioRemuxing());
+        boolean removeAudio = transformProperties != null && transformProperties.videoMuted;
+
+        StreamingTranscoder transcoder = new StreamingTranscoder(dataSource, options, constraints.getVideoTranscodingSettings(), constraints.getCompressedVideoMaxSize(context), RemoteConfig.allowAudioRemuxing(), removeAudio);
 
         if (transcoder.isTranscodeRequired()) {
           Log.i(TAG, "Compressing with streaming muxer");

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/VideoEditorFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/VideoEditorFragment.kt
@@ -76,6 +76,7 @@ class VideoEditorFragment : Fragment(), PositionDragListener, MediaSendPageFragm
 
     player = view.findViewById(R.id.video_player)
     hud = view.findViewById(R.id.video_editor_hud)
+    val muteButton: android.widget.ImageButton = view.findViewById(R.id.mute_video_button)
 
     uri = requireArguments().getParcelable(KEY_URI)!!
     isVideoGif = requireArguments().getBoolean(KEY_IS_VIDEO_GIF)
@@ -87,8 +88,28 @@ class VideoEditorFragment : Fragment(), PositionDragListener, MediaSendPageFragm
 
     hud.visible = !slide.isVideoGif
 
+    // Setup mute button with proper state management
+    muteButton.setOnClickListener {
+      try {
+        if (player.isMuted()) {
+          player.unmute()
+        } else {
+          player.mute()
+        }
+        updateMuteButtonIcon(muteButton)
+        updateMuteState(player.isMuted())
+      } catch (e: Exception) {
+        Log.e(TAG, "Error toggling mute", e)
+      }
+    }
+
     if (slide.isVideoGif) {
       player.setPlayerCallback(object : PlayerCallback {
+        override fun onReady() {
+          muteButton.visibility = if (player.hasAudioTrack()) View.VISIBLE else View.GONE
+          updateMuteButtonIcon(muteButton)
+        }
+
         override fun onPlaying() {
           controller.onPlayerReady()
         }
@@ -115,6 +136,8 @@ class VideoEditorFragment : Fragment(), PositionDragListener, MediaSendPageFragm
 
       player.setPlayerCallback(object : PlayerCallback {
         override fun onReady() {
+          muteButton.visibility = if (player.hasAudioTrack()) View.VISIBLE else View.GONE
+          updateMuteButtonIcon(muteButton)
           controller.onPlayerReady()
         }
 
@@ -293,6 +316,20 @@ class VideoEditorFragment : Fragment(), PositionDragListener, MediaSendPageFragm
       val milliseconds = position.microseconds.inWholeMilliseconds
       player.playbackPosition = milliseconds
     }
+  }
+
+  private fun updateMuteButtonIcon(button: android.widget.ImageButton) {
+    if (player.isMuted()) {
+      button.setImageResource(R.drawable.symbol_speaker_slash_24)
+    } else {
+      button.setImageResource(R.drawable.symbol_speaker_24)
+    }
+  }
+
+  private fun updateMuteState(isMuted: Boolean) {
+    val currentData = (sharedViewModel.getEditorState(uri) as? VideoTrimData) ?: VideoTrimData()
+    val updatedData = currentData.copy(isMuted = isMuted)
+    sharedViewModel.setEditorState(uri, updatedData)
   }
 
   interface Controller {

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/VideoTrimTransform.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/VideoTrimTransform.kt
@@ -22,7 +22,7 @@ class VideoTrimTransform(private val data: VideoTrimData) : MediaTransform {
       isVideoGif = media.isVideoGif,
       bucketId = media.bucketId,
       caption = media.caption,
-      transformProperties = TransformProperties(false, data.isDurationEdited, data.startTimeUs, data.endTimeUs, SentMediaQuality.STANDARD.code, false),
+      transformProperties = TransformProperties(false, data.isDurationEdited, data.startTimeUs, data.endTimeUs, SentMediaQuality.STANDARD.code, false, data.isMuted),
       fileName = media.fileName
     )
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/MediaSelectionRepository.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/MediaSelectionRepository.kt
@@ -264,7 +264,7 @@ class MediaSelectionRepository(context: Context) {
         }
       }
 
-      if (state is VideoTrimData && state.isDurationEdited) {
+      if (state is VideoTrimData && (state.isDurationEdited || state.isMuted)) {
         modelsToRender[it] = VideoTrimTransform(state)
       }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/videos/VideoTrimData.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/v2/videos/VideoTrimData.kt
@@ -16,7 +16,8 @@ data class VideoTrimData(
   val isDurationEdited: Boolean = false,
   val totalInputDurationUs: Long = 0,
   val startTimeUs: Long = 0,
-  val endTimeUs: Long = 0
+  val endTimeUs: Long = 0,
+  val isMuted: Boolean = false
 ) {
 
   fun getDuration(): Duration = (endTimeUs - startTimeUs).microseconds
@@ -27,6 +28,7 @@ data class VideoTrimData(
       putLong(KEY_TOTAL, totalInputDurationUs)
       putLong(KEY_START, startTimeUs)
       putLong(KEY_END, endTimeUs)
+      putByte(KEY_MUTED, (if (isMuted) 1 else 0).toByte())
     }
   }
 
@@ -35,13 +37,15 @@ data class VideoTrimData(
     private const val KEY_TOTAL = "TOTAL"
     private const val KEY_START = "START"
     private const val KEY_END = "END"
+    private const val KEY_MUTED = "MUTED"
 
     fun fromBundle(bundle: Bundle): VideoTrimData {
       return VideoTrimData(
         isDurationEdited = bundle.getByte(KEY_EDITED) == 1.toByte(),
         totalInputDurationUs = bundle.getLong(KEY_TOTAL),
         startTimeUs = bundle.getLong(KEY_START),
-        endTimeUs = bundle.getLong(KEY_END)
+        endTimeUs = bundle.getLong(KEY_END),
+        isMuted = bundle.getByte(KEY_MUTED) == 1.toByte()
       )
     }
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/video/VideoPlayer.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/video/VideoPlayer.java
@@ -271,6 +271,10 @@ public class VideoPlayer extends FrameLayout {
     }
   }
 
+  public boolean isMuted() {
+    return this.muted;
+  }
+
   public boolean hasAudioTrack() {
     if (exoPlayer != null) {
       Tracks tracks = exoPlayer.getCurrentTracks();

--- a/app/src/main/res/layout/mediasend_video_fragment.xml
+++ b/app/src/main/res/layout/mediasend_video_fragment.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:viewBindingIgnore="true"
     android:layout_width="match_parent"
@@ -15,5 +16,22 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:visibility="gone" />
+
+    <ImageButton
+        android:id="@+id/mute_video_button"
+        android:layout_width="46dp"
+        android:layout_height="46dp"
+        android:layout_gravity="top|end"
+        android:layout_marginTop="59dp"
+        android:layout_marginEnd="16dp"
+        android:background="@drawable/circle_tintable"
+        android:backgroundTint="#99000000"
+        android:contentDescription="@string/media_preview__mute_video_title"
+        android:scaleType="centerInside"
+        android:padding="12dp"
+        app:srcCompat="@drawable/symbol_speaker_slash_24"
+        android:tint="@color/core_white"
+        android:elevation="4dp"
+        tools:visibility="visible" />
 
 </FrameLayout>

--- a/app/src/main/res/menu/media_preview.xml
+++ b/app/src/main/res/menu/media_preview.xml
@@ -13,4 +13,8 @@
           android:title="@string/delete"
           android:icon="@drawable/ic_trash_24"
           app:showAsAction="never"/>
+    <item android:id="@+id/mute_video"
+          android:title="@string/media_preview__mute_video_title"
+          android:icon="@drawable/symbol_speaker_slash_24"
+          app:showAsAction="always"/>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4778,6 +4778,7 @@
     <!-- media_preview -->
     <string name="media_preview__save_title">Save</string>
     <string name="media_preview__edit_title">Edit</string>
+    <string name="media_preview__mute_video_title">Mute Video</string>
 
 
     <!-- media_preview_activity -->

--- a/core/models/src/main/java/org/signal/core/models/media/TransformProperties.kt
+++ b/core/models/src/main/java/org/signal/core/models/media/TransformProperties.kt
@@ -55,7 +55,13 @@ data class TransformProperties(
   @JsonProperty("mp4Faststart")
   @SerialName("mp4Faststart")
   @JvmField
-  val mp4FastStart: Boolean = false
+  val mp4FastStart: Boolean = false,
+
+  @EncodeDefault(EncodeDefault.Mode.ALWAYS)
+  @JsonProperty("videoMuted")
+  @SerialName("videoMuted")
+  @JvmField
+  val videoMuted: Boolean = false
 ) : Parcelable {
   fun shouldSkipTransform(): Boolean {
     return skipTransform
@@ -89,7 +95,8 @@ data class TransformProperties(
         videoTrimStartTimeUs = 0,
         videoTrimEndTimeUs = 0,
         sentMediaQuality = DEFAULT_MEDIA_QUALITY,
-        mp4FastStart = false
+        mp4FastStart = false,
+        videoMuted = false
       )
     }
 
@@ -100,7 +107,8 @@ data class TransformProperties(
         videoTrimStartTimeUs = 0,
         videoTrimEndTimeUs = 0,
         sentMediaQuality = DEFAULT_MEDIA_QUALITY,
-        mp4FastStart = false
+        mp4FastStart = false,
+        videoMuted = false
       )
     }
 
@@ -111,7 +119,8 @@ data class TransformProperties(
         videoTrimStartTimeUs = videoTrimStartTimeUs,
         videoTrimEndTimeUs = videoTrimEndTimeUs,
         sentMediaQuality = DEFAULT_MEDIA_QUALITY,
-        mp4FastStart = false
+        mp4FastStart = false,
+        videoMuted = false
       )
     }
 

--- a/lib/video/src/main/java/org/thoughtcrime/securesms/video/StreamingTranscoder.java
+++ b/lib/video/src/main/java/org/thoughtcrime/securesms/video/StreamingTranscoder.java
@@ -42,6 +42,7 @@ public final class StreamingTranscoder {
   private final           long               fileSizeEstimate;
   private final @Nullable TranscoderOptions  options;
   private final           boolean            allowAudioRemux;
+  private final           boolean            removeAudio;
 
   /**
    * @param upperSizeLimit A upper size to transcode to. The actual output size can be up to 10% smaller.
@@ -50,12 +51,14 @@ public final class StreamingTranscoder {
                              @Nullable TranscoderOptions options,
                              @NonNull TranscodingPreset preset,
                              long upperSizeLimit,
-                             boolean allowAudioRemux)
+                             boolean allowAudioRemux,
+                             boolean removeAudio)
       throws IOException, VideoSourceException
   {
     this.dataSource = dataSource;
     this.options    = options;
     this.allowAudioRemux = allowAudioRemux;
+    this.removeAudio = removeAudio;
 
     final MediaMetadataRetriever mediaMetadataRetriever = new MediaMetadataRetriever();
     try {
@@ -84,6 +87,20 @@ public final class StreamingTranscoder {
     this.fileSizeEstimate   = targetQuality.getByteCountEstimate();
   }
 
+  /**
+   * Convenience overload without removeAudio parameter (defaults to false).
+   * @param upperSizeLimit A upper size to transcode to. The actual output size can be up to 10% smaller.
+   */
+  public StreamingTranscoder(@NonNull MediaDataSource dataSource,
+                             @Nullable TranscoderOptions options,
+                             @NonNull TranscodingPreset preset,
+                             long upperSizeLimit,
+                             boolean allowAudioRemux)
+      throws IOException, VideoSourceException
+  {
+    this(dataSource, options, preset, upperSizeLimit, allowAudioRemux, false);
+  }
+
   private StreamingTranscoder(@NonNull MediaDataSource dataSource,
                              @Nullable TranscoderOptions options,
                              String codec,
@@ -96,6 +113,7 @@ public final class StreamingTranscoder {
     this.dataSource      = dataSource;
     this.options         = options;
     this.allowAudioRemux = allowAudioRemux;
+    this.removeAudio = false;
 
     final MediaMetadataRetriever mediaMetadataRetriever = new MediaMetadataRetriever();
     try {
@@ -183,6 +201,7 @@ public final class StreamingTranscoder {
     converter.setVideoBitrate(targetQuality.getTargetVideoBitRate());
     converter.setAudioBitrate(targetQuality.getTargetAudioBitRate());
     converter.setAllowAudioRemux(allowAudioRemux);
+    converter.setSkipAudio(removeAudio);
 
     if (options != null) {
       if (options.endTimeUs > 0) {

--- a/lib/video/src/main/java/org/thoughtcrime/securesms/video/videoconverter/MediaConverter.java
+++ b/lib/video/src/main/java/org/thoughtcrime/securesms/video/videoconverter/MediaConverter.java
@@ -72,6 +72,7 @@ public final class MediaConverter {
     private @VideoCodec String mVideoCodec = VIDEO_CODEC_H264;
     private int mAudioBitrate = 128000; // 128Kbps
     private boolean mAllowAudioRemux = false;
+    private boolean mSkipAudio = false;
 
     private Listener mListener;
     private boolean mCancelled;
@@ -144,6 +145,10 @@ public final class MediaConverter {
         mAllowAudioRemux = allow;
     }
 
+    public void setSkipAudio(boolean skipAudio) {
+        mSkipAudio = skipAudio;
+    }
+
     /**
      * @return The total content size of the MP4 mdat box.
      */
@@ -213,7 +218,7 @@ public final class MediaConverter {
             muxer = mOutput.createMuxer();
 
             videoTrackConverter = VideoTrackConverter.create(mInput, mTimeFrom, mTimeTo, mVideoResolution, mVideoBitrate, mVideoCodec, excludedDecoders);
-            audioTrackConverter = AudioTrackConverter.create(mInput, mTimeFrom, mTimeTo, mAudioBitrate, mAllowAudioRemux && muxer.supportsAudioRemux());
+            audioTrackConverter = mSkipAudio ? null : AudioTrackConverter.create(mInput, mTimeFrom, mTimeTo, mAudioBitrate, mAllowAudioRemux && muxer.supportsAudioRemux());
 
             if (videoTrackConverter == null && audioTrackConverter == null) {
                 throw new EncodingException("No video and audio tracks");


### PR DESCRIPTION
This change introduces support for removing the audio track from a video before sending it.

Functional Flow
	1.	A mute toggle is introduced in the video preview editor (VideoEditorFragment).
	2.	The toggle is visible only when the selected video contains an audio track.
	3.	When the toggle is enabled, the editor stores the mute state in the media editing state object.

State Propagation
The mute state is propagated through the media editing pipeline:
	•	VideoTrimData
	•	Added isMuted field to track the mute state during editing.
	•	Added serialization support using bundle storage.
	•	TransformProperties
	•	Added videoMuted property to propagate the mute state to the media transformation layer.

Media Processing Integration
- The mute state is passed through the existing video processing pipeline.

MediaSelectionRepository
	•	Updated logic so that a transform is triggered when either trimming or mute is enabled.

VideoTrimTransform
	•	Includes videoMuted when generating transform properties.

AttachmentCompressionJob
	•	Reads transformProperties.videoMuted.
	•	Determines whether audio should be removed during transcoding.
	•	Passes the removeAudio flag to the transcoder.

StreamingTranscoder
	•	Added a removeAudio parameter.
	•	When enabled, the transcoder signals the conversion layer to skip audio processing.

MediaConverter
	•	Added setSkipAudio(boolean) method.
	•	When skipAudio is enabled, the audio track converter is not initialized.
	•	The resulting MP4 contains only the video track.

UI Behavior

VideoEditorFragment
	•	Added mute toggle button overlay in the video preview layout.
	•	Toggle updates editor state and playback preview.
	•	Button visibility is determined by player.hasAudioTrack().

Layout
	•	Added mute_video_button to mediasend_video_fragment.xml.
	•	Positioned as a top-right overlay on the preview surface.

Resulting Processing Pipeline

User interaction → VideoEditorFragment → VideoTrimData.isMuted
→ TransformProperties.videoMuted
→ AttachmentCompressionJob
→ StreamingTranscoder(removeAudio)
→ MediaConverter.setSkipAudio(true)
→ Output Video without audio track

Behavior
	•	If mute is enabled, the audio track is removed during video processing.
	•	If mute is disabled, the video is processed and sent unchanged.b x 
	•	Existing video editing, compression, and encryption workflows remain unchanged.
	
<img width="864" height="1920" alt="Screenshot_20260405-131235" src="https://github.com/user-attachments/assets/e4318ffb-e362-47c0-a986-47c6e7847f92" />
