### PR TITLE
IDN link previews

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/LinkPreviewView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/LinkPreviewView.java
@@ -30,8 +30,10 @@ import org.thoughtcrime.securesms.linkpreview.LinkPreviewRepository;
 import org.thoughtcrime.securesms.mms.ImageSlide;
 import org.thoughtcrime.securesms.mms.SlidesClickedListener;
 import org.signal.core.util.Util;
+import org.thoughtcrime.securesms.util.LinkUtil;
 import org.thoughtcrime.securesms.util.ViewUtil;
 
+import java.net.IDN;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
@@ -199,6 +201,12 @@ public class LinkPreviewView extends FrameLayout {
       HttpUrl url = HttpUrl.parse(linkPreview.getUrl());
       if (url != null) {
         domain = url.topPrivateDomain();
+        if (domain != null) {
+          String unicodeDomain = IDN.toUnicode(domain);
+          if (LinkUtil.isLegalUrl(unicodeDomain)) {
+            domain = unicodeDomain;
+          }
+        }
       }
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/components/LinkPreviewView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/LinkPreviewView.java
@@ -29,8 +29,10 @@ import org.thoughtcrime.securesms.linkpreview.LinkPreviewRepository;
 import org.thoughtcrime.securesms.mms.ImageSlide;
 import org.thoughtcrime.securesms.mms.SlidesClickedListener;
 import org.signal.core.util.Util;
+import org.thoughtcrime.securesms.util.LinkUtil;
 import org.thoughtcrime.securesms.util.ViewUtil;
 
+import java.net.IDN;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
@@ -171,6 +173,12 @@ public class LinkPreviewView extends FrameLayout {
       HttpUrl url = HttpUrl.parse(linkPreview.getUrl());
       if (url != null) {
         domain = url.topPrivateDomain();
+        if (domain != null) {
+          String unicodeDomain = IDN.toUnicode(domain);
+          if (LinkUtil.isLegalUrl(unicodeDomain)) {
+            domain = unicodeDomain;
+          }
+        }
       }
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiEditText.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiEditText.java
@@ -9,6 +9,9 @@ import android.os.Build;
 import android.text.InputFilter;
 import android.text.TextUtils;
 import android.util.AttributeSet;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
+import android.view.inputmethod.InputConnectionWrapper;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -18,6 +21,7 @@ import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.emoji.EmojiProvider.EmojiDrawable;
 import org.thoughtcrime.securesms.keyvalue.SignalStore;
 import org.thoughtcrime.securesms.util.EditTextExtensionsKt;
+import org.thoughtcrime.securesms.util.LinkUtil;
 import org.thoughtcrime.securesms.util.ServiceUtil;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.signal.core.util.Util;
@@ -59,6 +63,27 @@ public class EmojiEditText extends AppCompatEditText {
     if (!isInEditMode()) {
       EditTextExtensionsKt.setIncognitoKeyboardEnabled(this, TextSecurePreferences.isIncognitoKeyboardEnabled(context));
     }
+  }
+
+  @Override
+  public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+    InputConnection base = super.onCreateInputConnection(outAttrs);
+    if (base == null) return null;
+    return new InputConnectionWrapper(base, true) {
+      @Override
+      public boolean commitText(CharSequence text, int newCursorPosition) {
+        if (text != null) {
+          String trimmed = text.toString().trim();
+          if (LinkUtil.isLegalUrl(trimmed)) {
+            String display = LinkUtil.toDisplayUrl(trimmed);
+            if (!display.equals(trimmed)) {
+              return super.commitText(display, newCursorPosition);
+            }
+          }
+        }
+        return super.commitText(text, newCursorPosition);
+      }
+    };
   }
 
   public void insertEmoji(String emoji) {
@@ -121,6 +146,17 @@ public class EmojiEditText extends AppCompatEditText {
         if (TextUtils.equals(Util.COPY_LABEL, label) && shouldPersistSignalStylingWhenPasting()) {
           return super.onTextContextMenuItem(id);
         } else {
+          CharSequence pasteText = getTextFromClipData(clipData);
+          if (pasteText != null) {
+            String trimmed = pasteText.toString().trim();
+            if (LinkUtil.isLegalUrl(trimmed)) {
+              String display = LinkUtil.toDisplayUrl(trimmed);
+              if (!display.equals(trimmed)) {
+                pasteUrlDisplay(display);
+                return true;
+              }
+            }
+          }
           return super.onTextContextMenuItem(android.R.id.pasteAsPlainText);
         }
       }
@@ -138,6 +174,15 @@ public class EmojiEditText extends AppCompatEditText {
     }
 
     return super.onTextContextMenuItem(id);
+  }
+
+  private void pasteUrlDisplay(@NonNull String display) {
+    if (getText() == null) return;
+    int start = Math.max(0, getSelectionStart());
+    int end   = Math.max(0, getSelectionEnd());
+    if (start > end) { int tmp = start; start = end; end = tmp; }
+    getText().replace(start, end, display);
+    setSelection(start + display.length());
   }
 
   private @Nullable CharSequence getTextFromClipData(@Nullable ClipData data) {

--- a/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiEditText.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiEditText.java
@@ -9,6 +9,9 @@ import android.os.Build;
 import android.text.InputFilter;
 import android.text.TextUtils;
 import android.util.AttributeSet;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
+import android.view.inputmethod.InputConnectionWrapper;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -19,6 +22,7 @@ import org.signal.emoji.EmojiProvider.EmojiDrawable;
 import org.thoughtcrime.securesms.keyvalue.SignalStore;
 import org.thoughtcrime.securesms.util.EditTextExtensionsKt;
 import org.signal.core.util.ServiceUtil;
+import org.thoughtcrime.securesms.util.LinkUtil;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.signal.core.util.Util;
 
@@ -60,6 +64,27 @@ public class EmojiEditText extends AppCompatEditText {
     if (!isInEditMode()) {
       EditTextExtensionsKt.setIncognitoKeyboardEnabled(this, TextSecurePreferences.isIncognitoKeyboardEnabled(context));
     }
+  }
+
+  @Override
+  public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+    InputConnection base = super.onCreateInputConnection(outAttrs);
+    if (base == null) return null;
+    return new InputConnectionWrapper(base, true) {
+      @Override
+      public boolean commitText(CharSequence text, int newCursorPosition) {
+        if (text != null) {
+          String trimmed = text.toString().trim();
+          if (LinkUtil.isLegalUrl(trimmed)) {
+            String display = LinkUtil.toDisplayUrl(trimmed);
+            if (!display.equals(trimmed)) {
+              return super.commitText(display, newCursorPosition);
+            }
+          }
+        }
+        return super.commitText(text, newCursorPosition);
+      }
+    };
   }
 
   public void insertEmoji(String emoji) {
@@ -122,6 +147,17 @@ public class EmojiEditText extends AppCompatEditText {
         if (TextUtils.equals(Util.COPY_LABEL, label) && shouldPersistSignalStylingWhenPasting()) {
           return super.onTextContextMenuItem(id);
         } else {
+          CharSequence pasteText = getTextFromClipData(clipData);
+          if (pasteText != null) {
+            String trimmed = pasteText.toString().trim();
+            if (LinkUtil.isLegalUrl(trimmed)) {
+              String display = LinkUtil.toDisplayUrl(trimmed);
+              if (!display.equals(trimmed)) {
+                pasteUrlDisplay(display);
+                return true;
+              }
+            }
+          }
           return super.onTextContextMenuItem(android.R.id.pasteAsPlainText);
         }
       }
@@ -139,6 +175,15 @@ public class EmojiEditText extends AppCompatEditText {
     }
 
     return super.onTextContextMenuItem(id);
+  }
+
+  private void pasteUrlDisplay(@NonNull String display) {
+    if (getText() == null) return;
+    int start = Math.max(0, getSelectionStart());
+    int end   = Math.max(0, getSelectionEnd());
+    if (start > end) { int tmp = start; start = end; end = tmp; }
+    getText().replace(start, end, display);
+    setSelection(start + display.length());
   }
 
   private @Nullable CharSequence getTextFromClipData(@Nullable ClipData data) {

--- a/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ShareRepository.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ShareRepository.kt
@@ -10,6 +10,7 @@ import io.reactivex.rxjava3.schedulers.Schedulers
 import org.signal.core.models.media.Media
 import org.signal.core.util.logging.Log
 import org.thoughtcrime.securesms.providers.BlobProvider
+import org.thoughtcrime.securesms.util.LinkUtil
 import org.thoughtcrime.securesms.util.MediaUtil
 import org.thoughtcrime.securesms.util.RemoteConfig
 import org.thoughtcrime.securesms.util.UriUtil
@@ -24,7 +25,7 @@ class ShareRepository(context: Context) {
     return when (unresolvedShareData) {
       is UnresolvedShareData.ExternalMultiShare -> Single.fromCallable { resolve(unresolvedShareData) }
       is UnresolvedShareData.ExternalSingleShare -> Single.fromCallable { resolve(unresolvedShareData) }
-      is UnresolvedShareData.ExternalPrimitiveShare -> Single.just(ResolvedShareData.Primitive(unresolvedShareData.text))
+      is UnresolvedShareData.ExternalPrimitiveShare -> Single.just(ResolvedShareData.Primitive(prettifyIfUrl(unresolvedShareData.text)))
     }.subscribeOn(Schedulers.io())
   }
 
@@ -129,6 +130,11 @@ class ShareRepository(context: Context) {
 
   companion object {
     private val TAG = Log.tag(ShareRepository::class.java)
+
+    private fun prettifyIfUrl(text: CharSequence): CharSequence {
+      val trimmed = text.toString().trim()
+      return if (LinkUtil.isLegalUrl(trimmed)) LinkUtil.toDisplayUrl(trimmed) else text
+    }
 
     private fun getMimeType(context: Context, uri: Uri, mimeType: String?, fileExtension: String? = null): String {
       var updatedMimeType = MediaUtil.getMimeType(context, uri, fileExtension)

--- a/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ShareRepository.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ShareRepository.kt
@@ -10,6 +10,7 @@ import io.reactivex.rxjava3.schedulers.Schedulers
 import org.signal.core.models.media.Media
 import org.signal.core.util.logging.Log
 import org.thoughtcrime.securesms.dependencies.AppDependencies
+import org.thoughtcrime.securesms.util.LinkUtil
 import org.thoughtcrime.securesms.util.MediaUtil
 import org.thoughtcrime.securesms.util.RemoteConfig
 import org.thoughtcrime.securesms.util.UriUtil
@@ -24,7 +25,7 @@ class ShareRepository(context: Context) {
     return when (unresolvedShareData) {
       is UnresolvedShareData.ExternalMultiShare -> Single.fromCallable { resolve(unresolvedShareData) }
       is UnresolvedShareData.ExternalSingleShare -> Single.fromCallable { resolve(unresolvedShareData) }
-      is UnresolvedShareData.ExternalPrimitiveShare -> Single.just(ResolvedShareData.Primitive(unresolvedShareData.text))
+      is UnresolvedShareData.ExternalPrimitiveShare -> Single.just(ResolvedShareData.Primitive(prettifyIfUrl(unresolvedShareData.text)))
     }.subscribeOn(Schedulers.io())
   }
 
@@ -129,6 +130,11 @@ class ShareRepository(context: Context) {
 
   companion object {
     private val TAG = Log.tag(ShareRepository::class.java)
+
+    private fun prettifyIfUrl(text: CharSequence): CharSequence {
+      val trimmed = text.toString().trim()
+      return if (LinkUtil.isLegalUrl(trimmed)) LinkUtil.toDisplayUrl(trimmed) else text
+    }
 
     private fun getMimeType(context: Context, uri: Uri, mimeType: String?, fileExtension: String? = null): String {
       var updatedMimeType = MediaUtil.getMimeType(context, uri, fileExtension)

--- a/app/src/main/java/org/thoughtcrime/securesms/util/LinkUtil.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/LinkUtil.kt
@@ -2,8 +2,13 @@ package org.thoughtcrime.securesms.util
 
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.thoughtcrime.securesms.stickers.StickerUrl
+import java.io.ByteArrayOutputStream
+import java.net.IDN
 import java.net.URI
 import java.net.URISyntaxException
+import java.nio.ByteBuffer
+import java.nio.charset.CharacterCodingException
+import java.nio.charset.CodingErrorAction
 import java.util.Objects
 import java.util.regex.Pattern
 
@@ -14,7 +19,6 @@ object LinkUtil {
   private val DOMAIN_PATTERN = Pattern.compile("^(https?://)?([^/]+).*$")
   private val ILLEGAL_CHARACTERS_PATTERN = Pattern.compile("[\u202C\u202D\u202E\u2500-\u25FF]")
   private val ILLEGAL_PERIODS_PATTERN = Pattern.compile("(\\.{2,}|…)")
-
   private val INVALID_DOMAINS = listOf("example", "example\\.com", "example\\.net", "example\\.org", "i2p", "invalid", "localhost", "onion", "test")
   private val INVALID_DOMAINS_REGEX: Regex = Regex("^(.+\\.)?(${INVALID_DOMAINS.joinToString("|")})\\.?\$")
 
@@ -113,6 +117,145 @@ object LinkUtil {
       i += Character.charCount(cp)
     }
     return false
+  }
+
+  /**
+   * Converts a URL to a human-readable display form:
+   * 1. ACE/punycode domain labels are decoded to Unicode when the decoded domain passes [isLegalUrl].
+   * 2. Percent-encoded path bytes are decoded when they represent ASCII letters, ASCII digits,
+   *    hyphens, or sequences of UTF-8 bytes that decode to Unicode letters or digits.
+   *    All other percent-encoded bytes (spaces, slashes, control chars, …) are left as-is.
+   */
+  @JvmStatic
+  fun toDisplayUrl(url: String): String {
+    return try {
+      val uri = URI(url)
+      val host = uri.host ?: return url
+
+      val unicodeHost = IDN.toUnicode(host)
+      val displayHost = if (isLegalUrl(unicodeHost)) unicodeHost else host
+      val niceRawPath = decodeUrlSafeChars(uri.rawPath ?: "")
+
+      buildString {
+        if (uri.scheme != null) append("${uri.scheme}://")
+        if (uri.rawUserInfo != null) append("${uri.rawUserInfo}@")
+        append(displayHost)
+        if (uri.port != -1) append(":${uri.port}")
+        append(niceRawPath)
+        if (uri.rawQuery != null) append("?${uri.rawQuery}")
+        if (uri.rawFragment != null) append("#${uri.rawFragment}")
+      }
+    } catch (e: Exception) {
+      url
+    }
+  }
+
+  /**
+   * Decodes percent-encoded byte sequences that represent ASCII letters, ASCII digits, hyphens,
+   * or multi-byte UTF-8 sequences whose decoded Unicode code point is a letter or digit.
+   * All other percent-encoded sequences are left unchanged.
+   *
+   * If fully decoding all percent-encoded bytes would not yield valid UTF-8, the string is
+   * returned unchanged — partial decoding would produce misleading output (e.g. a bare lead
+   * byte next to a decoded ASCII character that happened to share a code unit with a
+   * continuation byte).
+   */
+  private fun decodeUrlSafeChars(encoded: String): String {
+    if (!encoded.contains('%')) return encoded
+    if (!isFullyDecodedUtf8Valid(encoded)) return encoded
+    val sb = StringBuilder(encoded.length)
+    var i = 0
+    while (i < encoded.length) {
+      val c = encoded[i]
+      if (c != '%' || i + 2 >= encoded.length) {
+        sb.append(c)
+        i++
+        continue
+      }
+      val firstHex = encoded.substring(i + 1, i + 3).toIntOrNull(16)
+      if (firstHex == null) {
+        sb.append(c)
+        i++
+        continue
+      }
+      val firstByte = firstHex and 0xFF
+      val cpByteCount = when {
+        firstByte and 0x80 == 0    -> 1  // 0xxxxxxx  ASCII
+        firstByte and 0xE0 == 0xC0 -> 2  // 110xxxxx  2-byte UTF-8
+        firstByte and 0xF0 == 0xE0 -> 3  // 1110xxxx  3-byte UTF-8
+        firstByte and 0xF8 == 0xF0 -> 4  // 11110xxx  4-byte UTF-8
+        else                       -> 0  // continuation or invalid lead byte
+      }
+      if (cpByteCount <= 0) {
+        sb.append(encoded, i, i + 3)
+        i += 3
+        continue
+      }
+      // Collect cpByteCount consecutive %XX tokens.
+      val rawTokens = ArrayList<String>(cpByteCount)
+      val rawBytes  = ArrayList<Byte>(cpByteCount)
+      var j = i
+      var ok = true
+      for (k in 0 until cpByteCount) {
+        if (j + 2 >= encoded.length || encoded[j] != '%') { ok = false; break }
+        val hex  = encoded.substring(j + 1, j + 3)
+        val bInt = hex.toIntOrNull(16)
+        if (bInt == null) { ok = false; break }
+        if (k > 0 && (bInt and 0xC0 != 0x80)) { ok = false; break }  // must be continuation byte
+        rawTokens.add(encoded.substring(j, j + 3))
+        rawBytes.add(bInt.toByte())
+        j += 3
+      }
+      if (!ok || rawBytes.size != cpByteCount) {
+        // Could not assemble a complete code point — emit only the first %XX raw.
+        sb.append(encoded, i, i + 3)
+        i += 3
+        continue
+      }
+      val byteArray = rawBytes.toByteArray()
+      val decoded   = String(byteArray, Charsets.UTF_8)
+      val cp        = decoded.codePointAt(0)
+      if (cp != 0xFFFD && (Character.isLetter(cp) || Character.isDigit(cp) || cp == '-'.code)) {
+        sb.appendCodePoint(cp)
+      } else {
+        sb.append(rawTokens.joinToString(""))
+      }
+      i = j
+    }
+    return sb.toString()
+  }
+
+  /**
+   * Returns true if decoding every percent-encoded byte sequence in [encoded] would yield a
+   * byte stream that is valid UTF-8. Literal (non-encoded) characters are already valid Unicode
+   * and always contribute valid UTF-8 bytes. Percent sequences with invalid hex digits are
+   * treated as literal '%' characters.
+   */
+  private fun isFullyDecodedUtf8Valid(encoded: String): Boolean {
+    val buf = ByteArrayOutputStream(encoded.length)
+    var i = 0
+    while (i < encoded.length) {
+      if (encoded[i] == '%' && i + 2 < encoded.length) {
+        val hex = encoded.substring(i + 1, i + 3).toIntOrNull(16)
+        if (hex != null) {
+          buf.write(hex)
+          i += 3
+          continue
+        }
+      }
+      val cp = encoded.codePointAt(i)
+      buf.write(String(Character.toChars(cp)).toByteArray(Charsets.UTF_8))
+      i += Character.charCount(cp)
+    }
+    return try {
+      Charsets.UTF_8.newDecoder()
+        .onMalformedInput(CodingErrorAction.REPORT)
+        .onUnmappableCharacter(CodingErrorAction.REPORT)
+        .decode(ByteBuffer.wrap(buf.toByteArray()))
+      true
+    } catch (_: CharacterCodingException) {
+      false
+    }
   }
 
   @JvmStatic

--- a/app/src/main/java/org/thoughtcrime/securesms/util/LinkUtil.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/LinkUtil.kt
@@ -12,8 +12,6 @@ import java.util.regex.Pattern
  */
 object LinkUtil {
   private val DOMAIN_PATTERN = Pattern.compile("^(https?://)?([^/]+).*$")
-  private val ALL_ASCII_PATTERN = Pattern.compile("^[\\x00-\\x7F]*$")
-  private val ALL_NON_ASCII_PATTERN = Pattern.compile("^[^\\x00-\\x7F]*$")
   private val ILLEGAL_CHARACTERS_PATTERN = Pattern.compile("[\u202C\u202D\u202E\u2500-\u25FF]")
   private val ILLEGAL_PERIODS_PATTERN = Pattern.compile("(\\.{2,}|…)")
 
@@ -84,11 +82,37 @@ object LinkUtil {
       return LegalCharactersResult(false)
     }
 
-    val cleanedDomain = domain.replace("\\.".toRegex(), "")
     return LegalCharactersResult(
-      isLegal = ALL_ASCII_PATTERN.matcher(cleanedDomain).matches() || ALL_NON_ASCII_PATTERN.matcher(cleanedDomain).matches(),
+      isLegal = !mixesScripts(domain),
       domain = domain
     )
+  }
+
+  /**
+   * Returns true if [str] contains letters from more than one Unicode script,
+   * ignoring characters with script COMMON or INHERITED (digits, punctuation, etc.).
+   * Used to detect potential homograph attacks in domain names: a domain that mixes,
+   * say, Cyrillic and Latin letters is suspicious, while an IDN label like "grå"
+   * that uses only Latin letters (including extended Latin like å) is fine.
+   */
+  private fun mixesScripts(str: String): Boolean {
+    var firstScript: Character.UnicodeScript? = null
+    var i = 0
+    while (i < str.length) {
+      val cp = str.codePointAt(i)
+      if (Character.isLetter(cp)) {
+        val script = Character.UnicodeScript.of(cp)
+        if (script != Character.UnicodeScript.COMMON && script != Character.UnicodeScript.INHERITED) {
+          if (firstScript == null) {
+            firstScript = script
+          } else if (script != firstScript) {
+            return true
+          }
+        }
+      }
+      i += Character.charCount(cp)
+    }
+    return false
   }
 
   @JvmStatic

--- a/app/src/main/java/org/thoughtcrime/securesms/util/LinkUtil.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/LinkUtil.kt
@@ -3,8 +3,13 @@ package org.thoughtcrime.securesms.util
 import com.google.common.net.InetAddresses
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.thoughtcrime.securesms.stickers.StickerUrl
+import java.io.ByteArrayOutputStream
+import java.net.IDN
 import java.net.URI
 import java.net.URISyntaxException
+import java.nio.ByteBuffer
+import java.nio.charset.CharacterCodingException
+import java.nio.charset.CodingErrorAction
 import java.util.Objects
 import java.util.regex.Pattern
 
@@ -15,7 +20,6 @@ object LinkUtil {
   private val DOMAIN_PATTERN = Pattern.compile("^(https?://)?([^/]+).*$")
   private val ILLEGAL_CHARACTERS_PATTERN = Pattern.compile("[\u202C\u202D\u202E\u2500-\u25FF]")
   private val ILLEGAL_PERIODS_PATTERN = Pattern.compile("(\\.{2,}|…)")
-
   private val INVALID_DOMAINS = listOf("example", "example\\.com", "example\\.net", "example\\.org", "i2p", "invalid", "localhost", "onion", "test")
   private val INVALID_DOMAINS_REGEX: Regex = Regex("^(.+\\.)?(${INVALID_DOMAINS.joinToString("|")})\\.?\$")
 
@@ -130,6 +134,145 @@ object LinkUtil {
       i += Character.charCount(cp)
     }
     return false
+  }
+
+  /**
+   * Converts a URL to a human-readable display form:
+   * 1. ACE/punycode domain labels are decoded to Unicode when the decoded domain passes [isLegalUrl].
+   * 2. Percent-encoded path bytes are decoded when they represent ASCII letters, ASCII digits,
+   *    hyphens, or sequences of UTF-8 bytes that decode to Unicode letters or digits.
+   *    All other percent-encoded bytes (spaces, slashes, control chars, …) are left as-is.
+   */
+  @JvmStatic
+  fun toDisplayUrl(url: String): String {
+    return try {
+      val uri = URI(url)
+      val host = uri.host ?: return url
+
+      val unicodeHost = IDN.toUnicode(host)
+      val displayHost = if (isLegalUrl(unicodeHost)) unicodeHost else host
+      val niceRawPath = decodeUrlSafeChars(uri.rawPath ?: "")
+
+      buildString {
+        if (uri.scheme != null) append("${uri.scheme}://")
+        if (uri.rawUserInfo != null) append("${uri.rawUserInfo}@")
+        append(displayHost)
+        if (uri.port != -1) append(":${uri.port}")
+        append(niceRawPath)
+        if (uri.rawQuery != null) append("?${uri.rawQuery}")
+        if (uri.rawFragment != null) append("#${uri.rawFragment}")
+      }
+    } catch (e: Exception) {
+      url
+    }
+  }
+
+  /**
+   * Decodes percent-encoded byte sequences that represent ASCII letters, ASCII digits, hyphens,
+   * or multi-byte UTF-8 sequences whose decoded Unicode code point is a letter or digit.
+   * All other percent-encoded sequences are left unchanged.
+   *
+   * If fully decoding all percent-encoded bytes would not yield valid UTF-8, the string is
+   * returned unchanged — partial decoding would produce misleading output (e.g. a bare lead
+   * byte next to a decoded ASCII character that happened to share a code unit with a
+   * continuation byte).
+   */
+  private fun decodeUrlSafeChars(encoded: String): String {
+    if (!encoded.contains('%')) return encoded
+    if (!isFullyDecodedUtf8Valid(encoded)) return encoded
+    val sb = StringBuilder(encoded.length)
+    var i = 0
+    while (i < encoded.length) {
+      val c = encoded[i]
+      if (c != '%' || i + 2 >= encoded.length) {
+        sb.append(c)
+        i++
+        continue
+      }
+      val firstHex = encoded.substring(i + 1, i + 3).toIntOrNull(16)
+      if (firstHex == null) {
+        sb.append(c)
+        i++
+        continue
+      }
+      val firstByte = firstHex and 0xFF
+      val cpByteCount = when {
+        firstByte and 0x80 == 0    -> 1  // 0xxxxxxx  ASCII
+        firstByte and 0xE0 == 0xC0 -> 2  // 110xxxxx  2-byte UTF-8
+        firstByte and 0xF0 == 0xE0 -> 3  // 1110xxxx  3-byte UTF-8
+        firstByte and 0xF8 == 0xF0 -> 4  // 11110xxx  4-byte UTF-8
+        else                       -> 0  // continuation or invalid lead byte
+      }
+      if (cpByteCount <= 0) {
+        sb.append(encoded, i, i + 3)
+        i += 3
+        continue
+      }
+      // Collect cpByteCount consecutive %XX tokens.
+      val rawTokens = ArrayList<String>(cpByteCount)
+      val rawBytes  = ArrayList<Byte>(cpByteCount)
+      var j = i
+      var ok = true
+      for (k in 0 until cpByteCount) {
+        if (j + 2 >= encoded.length || encoded[j] != '%') { ok = false; break }
+        val hex  = encoded.substring(j + 1, j + 3)
+        val bInt = hex.toIntOrNull(16)
+        if (bInt == null) { ok = false; break }
+        if (k > 0 && (bInt and 0xC0 != 0x80)) { ok = false; break }  // must be continuation byte
+        rawTokens.add(encoded.substring(j, j + 3))
+        rawBytes.add(bInt.toByte())
+        j += 3
+      }
+      if (!ok || rawBytes.size != cpByteCount) {
+        // Could not assemble a complete code point — emit only the first %XX raw.
+        sb.append(encoded, i, i + 3)
+        i += 3
+        continue
+      }
+      val byteArray = rawBytes.toByteArray()
+      val decoded   = String(byteArray, Charsets.UTF_8)
+      val cp        = decoded.codePointAt(0)
+      if (cp != 0xFFFD && (Character.isLetter(cp) || Character.isDigit(cp) || cp == '-'.code)) {
+        sb.appendCodePoint(cp)
+      } else {
+        sb.append(rawTokens.joinToString(""))
+      }
+      i = j
+    }
+    return sb.toString()
+  }
+
+  /**
+   * Returns true if decoding every percent-encoded byte sequence in [encoded] would yield a
+   * byte stream that is valid UTF-8. Literal (non-encoded) characters are already valid Unicode
+   * and always contribute valid UTF-8 bytes. Percent sequences with invalid hex digits are
+   * treated as literal '%' characters.
+   */
+  private fun isFullyDecodedUtf8Valid(encoded: String): Boolean {
+    val buf = ByteArrayOutputStream(encoded.length)
+    var i = 0
+    while (i < encoded.length) {
+      if (encoded[i] == '%' && i + 2 < encoded.length) {
+        val hex = encoded.substring(i + 1, i + 3).toIntOrNull(16)
+        if (hex != null) {
+          buf.write(hex)
+          i += 3
+          continue
+        }
+      }
+      val cp = encoded.codePointAt(i)
+      buf.write(String(Character.toChars(cp)).toByteArray(Charsets.UTF_8))
+      i += Character.charCount(cp)
+    }
+    return try {
+      Charsets.UTF_8.newDecoder()
+        .onMalformedInput(CodingErrorAction.REPORT)
+        .onUnmappableCharacter(CodingErrorAction.REPORT)
+        .decode(ByteBuffer.wrap(buf.toByteArray()))
+      true
+    } catch (_: CharacterCodingException) {
+      false
+    }
   }
 
   @JvmStatic

--- a/app/src/main/java/org/thoughtcrime/securesms/util/LinkUtil.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/LinkUtil.kt
@@ -13,8 +13,6 @@ import java.util.regex.Pattern
  */
 object LinkUtil {
   private val DOMAIN_PATTERN = Pattern.compile("^(https?://)?([^/]+).*$")
-  private val ALL_ASCII_PATTERN = Pattern.compile("^[\\x00-\\x7F]*$")
-  private val ALL_NON_ASCII_PATTERN = Pattern.compile("^[^\\x00-\\x7F]*$")
   private val ILLEGAL_CHARACTERS_PATTERN = Pattern.compile("[\u202C\u202D\u202E\u2500-\u25FF]")
   private val ILLEGAL_PERIODS_PATTERN = Pattern.compile("(\\.{2,}|…)")
 
@@ -101,11 +99,37 @@ object LinkUtil {
       return LegalCharactersResult(false)
     }
 
-    val cleanedDomain = domain.replace("\\.".toRegex(), "")
     return LegalCharactersResult(
-      isLegal = ALL_ASCII_PATTERN.matcher(cleanedDomain).matches() || ALL_NON_ASCII_PATTERN.matcher(cleanedDomain).matches(),
+      isLegal = !mixesScripts(domain),
       domain = domain
     )
+  }
+
+  /**
+   * Returns true if [str] contains letters from more than one Unicode script,
+   * ignoring characters with script COMMON or INHERITED (digits, punctuation, etc.).
+   * Used to detect potential homograph attacks in domain names: a domain that mixes,
+   * say, Cyrillic and Latin letters is suspicious, while an IDN label like "grå"
+   * that uses only Latin letters (including extended Latin like å) is fine.
+   */
+  private fun mixesScripts(str: String): Boolean {
+    var firstScript: Character.UnicodeScript? = null
+    var i = 0
+    while (i < str.length) {
+      val cp = str.codePointAt(i)
+      if (Character.isLetter(cp)) {
+        val script = Character.UnicodeScript.of(cp)
+        if (script != Character.UnicodeScript.COMMON && script != Character.UnicodeScript.INHERITED) {
+          if (firstScript == null) {
+            firstScript = script
+          } else if (script != firstScript) {
+            return true
+          }
+        }
+      }
+      i += Character.charCount(cp)
+    }
+    return false
   }
 
   @JvmStatic

--- a/app/src/test/java/org/thoughtcrime/securesms/components/emoji/EmojiEditTextTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/components/emoji/EmojiEditTextTest.kt
@@ -1,0 +1,61 @@
+package org.thoughtcrime.securesms.components.emoji
+
+import android.app.Application
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.view.ContextThemeWrapper
+import androidx.test.core.app.ApplicationProvider
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+import org.thoughtcrime.securesms.R
+import org.thoughtcrime.securesms.keyvalue.SettingsValues
+import org.thoughtcrime.securesms.testutil.MockSignalStoreRule
+import org.thoughtcrime.securesms.util.TextSecurePreferences
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+@LooperMode(LooperMode.Mode.LEGACY)
+class EmojiEditTextTest {
+
+  @get:Rule
+  val signalStore = MockSignalStoreRule(relaxed = setOf(SettingsValues::class))
+
+  private lateinit var editText: EmojiEditText
+
+  @Before
+  fun setUp() {
+    mockkStatic(TextSecurePreferences::class)
+    every { TextSecurePreferences.isIncognitoKeyboardEnabled(any()) } returns false
+    every { signalStore.settings.isPreferSystemEmoji() } returns true
+
+    val context = ContextThemeWrapper(ApplicationProvider.getApplicationContext(), R.style.Signal_DayNight)
+    editText = EmojiEditText(context)
+  }
+
+  @After
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun `pasting a punycode URL converts it to unicode display form`() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    clipboard.setPrimaryClip(ClipData.newPlainText("url", "https://xn--gr-zia.org"))
+
+    editText.onTextContextMenuItem(android.R.id.paste)
+
+    assertEquals("https://grå.org", editText.text.toString())
+  }
+}

--- a/app/src/test/java/org/thoughtcrime/securesms/util/LinkUtilTest_isLegal.java
+++ b/app/src/test/java/org/thoughtcrime/securesms/util/LinkUtilTest_isLegal.java
@@ -29,7 +29,7 @@ public class LinkUtilTest_isLegal {
         { "https://abcdefg.i2p",                   true  },
         { "http://кц.com",                         false },
         { "кц.com",                                false },
-        { "http://asĸ.com",                        false },
+        { "http://asĸ.com",                        true  }, // ĸ (U+0138) is Unicode script LATIN
         { "http://foo.кц.рф",                      false },
         { "кц.рф\u202C",                           false },
         { "кц.рф\u202D",                           false },
@@ -47,6 +47,12 @@ public class LinkUtilTest_isLegal {
         { "localhost",                             true },
         { "https://localhost",                     true },
         { "cool.test",                             true },
+        { "grå.org",                               true }, // å is Latin script
+        { "münchen.de",                            true }, // ü is Latin script
+        { "慕田峪长城.网址",                         true }, // Great Wall site
+        // Мышкин is the idiot in Dostoyevsky's book.
+        { "Мышкин.рф",                             true }, // Cyrillic к U+043A
+        { "Мышκин.рф",                             false }, // Greek κ U+03BA
         { "https://github.com/signalapp/Signal-Android/compare/v6.23.2...v6.23.3", true }
     });
   }

--- a/app/src/test/java/org/thoughtcrime/securesms/util/LinkUtilTest_isValidPreviewUrl.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/util/LinkUtilTest_isValidPreviewUrl.kt
@@ -52,7 +52,10 @@ class LinkUtilTest_isValidPreviewUrl(private val input: String, private val outp
         arrayOf("https://cool.invalid.com", true),
         arrayOf("https://cool.localhost.signal.org", true),
         arrayOf("https://cool.test.blarg.gov", true),
-        arrayOf("https://github.com/signalapp/Signal-Android/compare/v6.23.2...v6.23.3", true)
+        arrayOf("https://github.com/signalapp/Signal-Android/compare/v6.23.2...v6.23.3", true),
+        arrayOf("https://grå.org", true),
+        arrayOf("https://grå.org/some/path", true),
+        arrayOf("http://grå.org", false)
       )
     }
   }

--- a/app/src/test/java/org/thoughtcrime/securesms/util/LinkUtilTest_isValidPreviewUrl.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/util/LinkUtilTest_isValidPreviewUrl.kt
@@ -72,7 +72,10 @@ class LinkUtilTest_isValidPreviewUrl(private val input: String, private val outp
         arrayOf("https://[fc00::1]/", false),
         arrayOf("https://[fd12:3456:789a::1]/", false),
         arrayOf("https://8.8.8.8", true),
-        arrayOf("https://[2001:4860:4860::8888]/", true)
+        arrayOf("https://[2001:4860:4860::8888]/", true),
+        arrayOf("https://grå.org", true),
+        arrayOf("https://grå.org/some/path", true),
+        arrayOf("http://grå.org", false)
       )
     }
   }

--- a/app/src/test/java/org/thoughtcrime/securesms/util/LinkUtilTest_toDisplayUrl.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/util/LinkUtilTest_toDisplayUrl.kt
@@ -1,0 +1,70 @@
+package org.thoughtcrime.securesms.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@Suppress("ClassName")
+@RunWith(Parameterized::class)
+class LinkUtilTest_toDisplayUrl(private val input: String, private val expected: String) {
+
+  @Test
+  fun toDisplayUrl() {
+    assertEquals(expected, LinkUtil.toDisplayUrl(input))
+  }
+
+  companion object {
+    @Parameterized.Parameters(name = "{0}")
+    @JvmStatic
+    fun data(): Collection<Array<Any>> {
+      return listOf(
+        // Punycode host → Unicode when the decoded domain is valid
+        arrayOf("https://xn--gr-zia.org",           "https://grå.org"),
+        arrayOf("https://xn--gr-zia.org/some/path", "https://grå.org/some/path"),
+
+        // Multi-byte UTF-8 path decoding: %C3%A5 is the UTF-8 encoding of å (U+00E5)
+        arrayOf("https://xn--gr-zia.org/gr%C3%A5.html", "https://grå.org/grå.html"),
+
+        // ASCII-range single-byte decoding
+        arrayOf("https://example.com/%61%62%63",        "https://example.com/abc"),   // letters
+        arrayOf("https://example.com/%31%32%33",        "https://example.com/123"),   // digits
+        arrayOf("https://example.com/Signal%2DAndroid", "https://example.com/Signal-Android"), // hyphen %2D
+
+        // Characters that must NOT be decoded
+        arrayOf("https://example.com/some%20path",  "https://example.com/some%20path"), // space
+        arrayOf("https://example.com/a%2Fb",        "https://example.com/a%2Fb"),       // slash
+        arrayOf("https://example.com/a%40b",        "https://example.com/a%40b"),       // @
+
+        // Plain ASCII host — unchanged
+        arrayOf("https://google.com",                          "https://google.com"),
+        arrayOf("https://google.com/path",                     "https://google.com/path"),
+
+        // Port is preserved
+        arrayOf("https://example.com:8080/path%2Dname", "https://example.com:8080/path-name"),
+
+        // No scheme — returned as-is (java.net.URI sees no host; fallback regex requires https?://)
+        arrayOf("xn--gr-zia.org", "xn--gr-zia.org"),
+
+        // Query and fragment are left untouched
+        arrayOf("https://example.com/path?q=%61", "https://example.com/path?q=%61"),
+        arrayOf("https://example.com/path%2Dname?q=1#sec%2D1",
+                 "https://example.com/path-name?q=1#sec%2D1"),
+
+        // Invalid UTF-8 when fully decoded — path left entirely unchanged
+        // %C3 is a 2-byte lead byte; %61 ('a') is not a continuation byte
+        arrayOf("https://example.com/%C3%61",    "https://example.com/%C3%61"),
+        // %80 is a continuation byte with no preceding lead byte
+        arrayOf("https://example.com/%80",       "https://example.com/%80"),
+        // %FF is never a valid UTF-8 byte
+        arrayOf("https://example.com/%FF",       "https://example.com/%FF"),
+        // valid å (%C3%A5) followed by a lone lead byte (%C3) with no continuation
+        arrayOf("https://example.com/%C3%A5%C3", "https://example.com/%C3%A5%C3"),
+
+        // Valid UTF-8 when fully decoded — selective decoding still applies
+        // å decoded as a letter, space (%20) stays encoded
+        arrayOf("https://example.com/%C3%A5%20path", "https://example.com/å%20path"),
+      )
+    }
+  }
+}


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy A54, Android 16 running my code
 * Pixel 8, Android 16 running my code
 * ... interoperating with production Signal on other devices
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/) — ie. I found none.

----------

### Description

At present, when you share a site such as https://grå.org from e.g. Chrome on Android via either cut-and-paste or the share sheet, Signal shows a lot of xn--, which is user-unfriendly and IMO a problem waiting to happen. I saw that there's some attempt to make it work, so I improved, tested and tested it:
1. I improved the existing code that tried to defend against homograph attacks, so that Münster and Orléans are no longer considered shady but IВM still is (that middle letter is a cyrillic V).
2. I changed all three flows from browser to Signal, so that grå.org is pasted/shared in the way we Norwegians expect it, while IВM.org is not rendered in the way a blackhat attacker might expect it.
3. I improved the link preview to use grå, as well.
4. Path segments were still rendered using a lot of %AB%CD, which can make an otherwise user-comprehensible URL opaque, so I fixed those similarly.
5. I added unit tests, enough that a unit test should fail if this code is accidentally broken.

After this change, the link preview uses a lot of the letters/digits people learn in school and many fewer hex blobs. Basically, I tried to make it so that the link you share is one you can read.

I had to wait a little with the CLA. I rebased my branch and made this PR once I could sign the CLA. So this is properly tested, but I've rebased since, and frankly I expect to rebase more often than I carry out four-device tests.

(FYI, I work with this. This kind of problem is my day job. "Bringing internet to people who can read and write, but aren't so great with A-Z" if you see what I mean. I'll be happy to look at any Signal issue or PR that concerns unicode URLs/domains/addresses or the use of non-ASCII scripts, whether Norwegian or Nepali.)