### PR TITLE
Skip confusing delete dialog body text in Note to Self

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/DeleteDialog.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/DeleteDialog.kt
@@ -38,12 +38,13 @@ object DeleteDialog {
     isAdmin: Boolean = false
   ): Single<Pair<Boolean, Boolean>> = Single.create { emitter ->
     val builder = MaterialAlertDialogBuilder(context)
+    val isNoteToSelfDelete = isNoteToSelfDelete(messageRecords)
 
     builder.setTitle(title)
-    builder.setMessage(message)
+    if (!isNoteToSelfDelete) {
+      builder.setMessage(message)
+    }
     builder.setCancelable(true)
-
-    val isNoteToSelfDelete = isNoteToSelfDelete(messageRecords)
 
     if (forceRemoteDelete) {
       builder.setPositiveButton(R.string.ConversationFragment_delete_for_everyone) { _, _ -> deleteForEveryone(messageRecords = messageRecords, emitter = emitter) }


### PR DESCRIPTION
## Summary

Fixes #14702

When deleting messages in Note to Self, the dialog shows "Who would you like to delete this message for?" which is confusing since there's no other party in the conversation. 

This change skips the body text for Note to Self, so the dialog just shows the title ("Delete selected message?") with Cancel and Delete buttons. The `isNoteToSelfDelete` check already existed in `DeleteDialog` for button text — this extends it to the body text as well.

## Before / After

**Before:** Dialog shows "Who would you like to delete this message for?" in Note to Self
**After:** Dialog shows just "Delete selected message?" — clean and clear

## Test plan

- [x] Open Note to Self, delete a single message — dialog shows "Delete selected message?" with no body text
- [x] Select multiple messages and delete — dialog shows "Delete selected messages?" with no body text
- [x] Delete in a regular 1:1 or group chat — dialog still shows "Who would you like to delete this message for?" as before