### PR TITLE
Two trivial parameter renaming fixes

### DIFF
--- a/core/models-jvm/src/main/java/org/signal/core/models/MasterKey.kt
+++ b/core/models-jvm/src/main/java/org/signal/core/models/MasterKey.kt
@@ -52,10 +52,10 @@ class MasterKey(masterKey: ByteArray) {
     return masterKey.clone()
   }
 
-  override fun equals(o: Any?): Boolean {
-    if (o == null || o.javaClass != javaClass) return false
+  override fun equals(other: Any?): Boolean {
+    if (other == null || other.javaClass != javaClass) return false
 
-    return (o as MasterKey).masterKey.contentEquals(masterKey)
+    return (other as MasterKey).masterKey.contentEquals(masterKey)
   }
 
   override fun hashCode(): Int {

--- a/lintchecks/src/main/java/org/signal/lint/StartForegroundServiceDetector.kt
+++ b/lintchecks/src/main/java/org/signal/lint/StartForegroundServiceDetector.kt
@@ -15,7 +15,7 @@ class StartForegroundServiceDetector : Detector(), Detector.UastScanner {
     return listOf("startForegroundService")
   }
 
-  override fun visitMethodCall(context: JavaContext, call: UCallExpression, method: PsiMethod) {
+  override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
     val evaluator = context.evaluator
 
     val classes = context.uastFile?.classes.orEmpty()
@@ -27,15 +27,15 @@ class StartForegroundServiceDetector : Detector(), Detector.UastScanner {
     if (evaluator.isMemberInClass(method, "androidx.core.content.ContextCompat")) {
       context.report(
         issue = START_FOREGROUND_SERVICE_ISSUE,
-        scope = call,
-        location = context.getLocation(call),
+        scope = node,
+        location = context.getLocation(node),
         message = "Using 'ContextCompat.startForegroundService' instead of a ForegroundServiceUtil"
       )
     } else if (evaluator.isMemberInClass(method, "android.content.Context")) {
       context.report(
         issue = START_FOREGROUND_SERVICE_ISSUE,
-        scope = call,
-        location = context.getLocation(call),
+        scope = node,
+        location = context.getLocation(node),
         message = "Using 'Context.startForegroundService' instead of a ForegroundServiceUtil"
       )
     }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
- [x] My contribution is fully baked and ready to be merged as is

----------

### Description
Fix two trivial PARAMETER_NAME_CHANGED_ON_OVERRIDE warnings by appropriately renaming the parameters.

Merged in https://github.com/signalapp/Signal-Android/commit/a00978d96e733ac1e1d3c2bc9c9d4168112a0655