### PR TITLE
Expand conversation list to full width when no chat is open on tablet.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/MainActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/MainActivity.kt
@@ -532,9 +532,21 @@ class MainActivity :
 
               is MainNavigationDetailLocation.Stories -> storiesNavHostController.navigateToDetailLocation(location)
             }
+
+            if (isSplitPane && paneExpansionState.currentAnchor != detailOnlyAnchor) {
+              val target = if (location is MainNavigationDetailLocation.Empty) listOnlyAnchor else detailAndListAnchor
+              if (paneExpansionState.currentAnchor != target) {
+                paneExpansionState.animateTo(target)
+              }
+            }
           }
 
-          mainNavigationViewModel.earlyNavigationDetailLocationRequested?.let { navigateToLocation(it) }
+          val earlyLocation = mainNavigationViewModel.earlyNavigationDetailLocationRequested
+          if (earlyLocation != null) {
+            navigateToLocation(earlyLocation)
+          } else if (isSplitPane && paneExpansionState.currentAnchor != detailOnlyAnchor) {
+            paneExpansionState.animateTo(listOnlyAnchor)
+          }
           mainNavigationViewModel.clearEarlyDetailLocation()
 
           mainNavigationViewModel.detailLocation.collect { navigateToLocation(it) }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Medium Tablet (Android Studio), Android 15.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

In split-pane mode, the pane defaulted to detailAndListAnchor even when the detail pane had no conversation, leaving the list constrained to half-screen width and truncating the last-message preview. Animate to listOnlyAnchor when the detail location is Empty, and back to detailAndListAnchor when a conversation opens, while preserving the user's choice if they have manually moved to detailOnlyAnchor.