### PR TITLE
Deprecate MessageState with a new PushProcessMessageErrorJob

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/JobManagerFactories.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/JobManagerFactories.java
@@ -247,6 +247,7 @@ public final class JobManagerFactories {
       put(PostRegistrationBackupRedemptionJob.KEY,     new PostRegistrationBackupRedemptionJob.Factory());
       put(PushProcessEarlyMessagesJob.KEY,             new PushProcessEarlyMessagesJob.Factory());
       put(PushProcessMessageErrorJob.KEY,              new PushProcessMessageErrorJob.Factory());
+      put(PushProcessMessageErrorV3Job.KEY,            new PushProcessMessageErrorV3Job.Factory());
       put(PushProcessMessageJob.KEY,                   new PushProcessMessageJob.Factory());
       put(QuoteThumbnailBackfillJob.KEY,               new QuoteThumbnailBackfillJob.Factory());
       put(QuoteThumbnailReconstructionJob.KEY,         new QuoteThumbnailReconstructionJob.Factory());

--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/PushProcessMessageErrorV3Job.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/PushProcessMessageErrorV3Job.kt
@@ -11,27 +11,27 @@ import org.thoughtcrime.securesms.groups.GroupId
 import org.thoughtcrime.securesms.jobmanager.Job
 import org.thoughtcrime.securesms.jobmanager.JsonJobData
 import org.thoughtcrime.securesms.jobmanager.impl.ChangeNumberConstraint
+import org.thoughtcrime.securesms.jobs.PushProcessMessageJob.Companion.getQueueName
 import org.thoughtcrime.securesms.messages.ExceptionMetadata
 import org.thoughtcrime.securesms.messages.MessageContentProcessor
-import org.thoughtcrime.securesms.messages.MessageState
+import org.thoughtcrime.securesms.messages.MessageDecryptor
 import org.thoughtcrime.securesms.recipients.Recipient
 
 /**
  * Process messages that did not decrypt/validate successfully.
  */
-@Deprecated("In favor of PushProcessMessageErrorV3Job, that doesn't use MessageState")
-class PushProcessMessageErrorJob private constructor(
+class PushProcessMessageErrorV3Job private constructor(
   parameters: Parameters,
-  private val messageState: MessageState,
+  private val resultClass: String?,
   private val exceptionMetadata: ExceptionMetadata,
   private val timestamp: Long
 ) : BaseJob(parameters) {
 
-  constructor(messageState: MessageState, exceptionMetadata: ExceptionMetadata, timestamp: Long) : this(
-    parameters = createParameters(exceptionMetadata),
-    messageState = messageState,
-    exceptionMetadata = exceptionMetadata,
-    timestamp = timestamp
+  constructor(result: MessageDecryptor.Result.Error) : this(
+    createParameters(result.errorMetadata.toExceptionMetadata()),
+    result::class.qualifiedName,
+    result.errorMetadata.toExceptionMetadata(),
+    result.envelope.clientTimestamp!!
   )
 
   override fun getFactoryKey(): String = KEY
@@ -40,7 +40,7 @@ class PushProcessMessageErrorJob private constructor(
 
   override fun serialize(): ByteArray? {
     return JsonJobData.Builder()
-      .putInt(KEY_MESSAGE_STATE, messageState.ordinal)
+      .putString(KEY_RESULT_CLASS, resultClass)
       .putLong(KEY_TIMESTAMP, timestamp)
       .putString(KEY_EXCEPTION_SENDER, exceptionMetadata.sender)
       .putInt(KEY_EXCEPTION_DEVICE, exceptionMetadata.senderDevice)
@@ -49,24 +49,18 @@ class PushProcessMessageErrorJob private constructor(
   }
 
   override fun onRun() {
-    if (messageState == MessageState.DECRYPTED_OK || messageState == MessageState.NOOP) {
-      Log.w(TAG, "Error job queued for valid or no-op decryption, generally this shouldn't happen. Bailing on state: $messageState")
-      return
-    }
-
-    MessageContentProcessor.create(context).processException(messageState, exceptionMetadata, timestamp)
+    MessageContentProcessor.create(context).processExceptionV2(resultClass, exceptionMetadata, timestamp)
   }
 
   override fun onShouldRetry(e: Exception): Boolean = false
 
   override fun onFailure() = Unit
 
-  class Factory : Job.Factory<PushProcessMessageErrorJob?> {
-    override fun create(parameters: Parameters, serializedData: ByteArray?): PushProcessMessageErrorJob {
+  class Factory : Job.Factory<PushProcessMessageErrorV3Job?> {
+    override fun create(parameters: Parameters, serializedData: ByteArray?): PushProcessMessageErrorV3Job {
       val data = JsonJobData.deserialize(serializedData)
 
-      val state = MessageState.entries[data.getInt(KEY_MESSAGE_STATE)]
-      check(state != MessageState.DECRYPTED_OK && state != MessageState.NOOP)
+      val resultClass = data.getString(KEY_RESULT_CLASS)
 
       val exceptionMetadata = ExceptionMetadata(
         sender = data.getString(KEY_EXCEPTION_SENDER),
@@ -74,16 +68,16 @@ class PushProcessMessageErrorJob private constructor(
         groupId = GroupId.parseNullableOrThrow(data.getStringOrDefault(KEY_EXCEPTION_GROUP_ID, null))
       )
 
-      return PushProcessMessageErrorJob(parameters, state, exceptionMetadata, data.getLong(KEY_TIMESTAMP))
+      return PushProcessMessageErrorV3Job(parameters, resultClass, exceptionMetadata, data.getLong(KEY_TIMESTAMP))
     }
   }
 
   companion object {
-    const val KEY = "PushProcessMessageErrorV2Job"
+    const val KEY = "PushProcessMessageErrorV3Job"
 
-    val TAG = Log.tag(PushProcessMessageErrorJob::class.java)
+    val TAG = Log.tag(PushProcessMessageErrorV3Job::class.java)
 
-    private const val KEY_MESSAGE_STATE = "message_state"
+    private const val KEY_RESULT_CLASS = "result_class"
     private const val KEY_TIMESTAMP = "timestamp"
     private const val KEY_EXCEPTION_SENDER = "exception_sender"
     private const val KEY_EXCEPTION_DEVICE = "exception_device"
@@ -100,7 +94,7 @@ class PushProcessMessageErrorJob private constructor(
       return Parameters.Builder()
         .setMaxAttempts(Parameters.UNLIMITED)
         .addConstraint(ChangeNumberConstraint.KEY)
-        .setQueue(recipient?.let { PushProcessMessageJob.getQueueName(it.id) })
+        .setQueue(recipient?.let { getQueueName(it.id) })
         .build()
     }
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/messages/IncomingMessageObserver.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/messages/IncomingMessageObserver.kt
@@ -25,7 +25,7 @@ import org.thoughtcrime.securesms.jobmanager.impl.BackoffUtil
 import org.thoughtcrime.securesms.jobmanager.impl.NetworkConstraint
 import org.thoughtcrime.securesms.jobs.ForegroundServiceUtil
 import org.thoughtcrime.securesms.jobs.ForegroundServiceUtil.startWhenCapable
-import org.thoughtcrime.securesms.jobs.PushProcessMessageErrorJob
+import org.thoughtcrime.securesms.jobs.PushProcessMessageErrorV3Job
 import org.thoughtcrime.securesms.jobs.PushProcessMessageJob
 import org.thoughtcrime.securesms.jobs.RequestGroupV2InfoJob
 import org.thoughtcrime.securesms.jobs.UnableToStartException
@@ -343,11 +343,7 @@ class IncomingMessageObserver(
             }
           }
 
-          jobs += PushProcessMessageErrorJob(
-            result.toMessageState(),
-            result.errorMetadata.toExceptionMetadata(),
-            result.envelope.clientTimestamp!!
-          )
+          jobs += PushProcessMessageErrorV3Job(result)
 
           AppDependencies.jobManager.startChain(jobs)
         }
@@ -375,25 +371,6 @@ class IncomingMessageObserver(
     Log.i(TAG, "Received server receipt. Sender: $senderId, Device: ${envelope.sourceDeviceId}, Timestamp: ${envelope.clientTimestamp}")
     SignalDatabase.messages.incrementDeliveryReceiptCount(envelope.clientTimestamp!!, senderId, System.currentTimeMillis())
     SignalDatabase.messageLog.deleteEntryForRecipient(envelope.clientTimestamp!!, senderId, envelope.sourceDeviceId!!)
-  }
-
-  private fun MessageDecryptor.Result.toMessageState(): MessageState {
-    return when (this) {
-      is MessageDecryptor.Result.DecryptionError -> MessageState.DECRYPTION_ERROR
-      is MessageDecryptor.Result.Ignore -> MessageState.NOOP
-      is MessageDecryptor.Result.InvalidVersion -> MessageState.INVALID_VERSION
-      is MessageDecryptor.Result.LegacyMessage -> MessageState.LEGACY_MESSAGE
-      is MessageDecryptor.Result.Success -> MessageState.DECRYPTED_OK
-      is MessageDecryptor.Result.UnsupportedDataMessage -> MessageState.UNSUPPORTED_DATA_MESSAGE
-    }
-  }
-
-  private fun MessageDecryptor.ErrorMetadata.toExceptionMetadata(): ExceptionMetadata {
-    return ExceptionMetadata(
-      this.sender,
-      this.senderDevice,
-      this.groupId
-    )
   }
 
   private inner class MessageRetrievalThread : Thread("MessageRetrievalService"), Thread.UncaughtExceptionHandler {

--- a/app/src/main/java/org/thoughtcrime/securesms/messages/MessageContentProcessor.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/messages/MessageContentProcessor.kt
@@ -362,6 +362,7 @@ open class MessageContentProcessor(private val context: Context) {
     }
   }
 
+  @Deprecated("In favor of processExceptionV2")
   fun processException(messageState: MessageState, exceptionMetadata: ExceptionMetadata, timestamp: Long) {
     val sender = Recipient.external(exceptionMetadata.sender)
 
@@ -427,6 +428,66 @@ open class MessageContentProcessor(private val context: Context) {
       MessageState.DUPLICATE_MESSAGE -> warn(timestamp, "Duplicate message. Dropping.")
 
       else -> throw AssertionError("Not handled $messageState. ($timestamp)")
+    }
+  }
+
+  fun processExceptionV2(resultClass: String?, exceptionMetadata: ExceptionMetadata, timestamp: Long) {
+    val sender = Recipient.external(exceptionMetadata.sender)
+
+    if (sender == null) {
+      warn("Failed to create Recipient for identifier: $resultClass")
+      return
+    }
+
+    if (sender.isBlocked) {
+      warn("Ignoring exception content from blocked sender, message state: $resultClass")
+      return
+    }
+
+    when (resultClass) {
+      MessageDecryptor.Result.DecryptionError::class.qualifiedName -> {
+        warn(timestamp, "Handling encryption error.")
+
+        val threadRecipient = if (exceptionMetadata.groupId != null) Recipient.externalPossiblyMigratedGroup(exceptionMetadata.groupId) else sender
+        val threadId: Long? = SignalDatabase.threads.getThreadIdFor(threadRecipient.id)
+
+        if (threadId != null) {
+          SignalDatabase
+            .messages
+            .insertBadDecryptMessage(
+              recipientId = sender.id,
+              senderDevice = exceptionMetadata.senderDevice,
+              sentTimestamp = timestamp,
+              receivedTimestamp = System.currentTimeMillis(),
+              threadId = threadId
+            )
+        } else {
+          warn(timestamp, "Could not find a thread for the target recipient. Skipping.")
+        }
+      }
+
+      MessageDecryptor.Result.InvalidVersion::class.qualifiedName -> {
+        warn(timestamp, "Handling invalid version.")
+        insertErrorMessage(context, sender, timestamp, exceptionMetadata.groupId.toOptional()) { messageId ->
+          SignalDatabase.messages.markAsInvalidVersionKeyExchange(messageId)
+        }
+      }
+
+      MessageDecryptor.Result.LegacyMessage::class.qualifiedName -> {
+        warn(timestamp, "Handling legacy message.")
+        insertErrorMessage(context, sender, timestamp, exceptionMetadata.groupId.toOptional()) { messageId ->
+          SignalDatabase.messages.markAsLegacyVersion(messageId)
+        }
+      }
+
+      MessageDecryptor.Result.UnsupportedDataMessage::class.qualifiedName -> {
+        warn(timestamp, "Handling unsupported data message.")
+        insertErrorMessage(context, sender, timestamp, exceptionMetadata.groupId.toOptional()) { messageId ->
+          SignalDatabase.messages.markAsUnsupportedProtocolVersion(messageId)
+        }
+      }
+
+      else -> throw AssertionError("Not handled $resultClass. ($timestamp)")
     }
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/messages/MessageDecryptor.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/messages/MessageDecryptor.kt
@@ -600,7 +600,7 @@ object MessageDecryptor {
       override val serverDeliveredTimestamp: Long,
       override val errorMetadata: ErrorMetadata,
       override val followUpOperations: List<FollowUpOperation>
-    ) : Result, Error
+    ) : Error
 
     /** The envelope used an invalid version of the Signal protocol. */
     class InvalidVersion(
@@ -608,7 +608,7 @@ object MessageDecryptor {
       override val serverDeliveredTimestamp: Long,
       override val errorMetadata: ErrorMetadata,
       override val followUpOperations: List<FollowUpOperation>
-    ) : Result, Error
+    ) : Error
 
     /** The envelope used an old format that hasn't been used since 2015. This shouldn't be happening. */
     class LegacyMessage(
@@ -616,7 +616,7 @@ object MessageDecryptor {
       override val serverDeliveredTimestamp: Long,
       override val errorMetadata: ErrorMetadata,
       override val followUpOperations: List<FollowUpOperation>
-    ) : Result, Error
+    ) : Error
 
     /**
      * Indicates the that the [org.whispersystems.signalservice.internal.push.SignalServiceProtos.DataMessage.getRequiredProtocolVersion]
@@ -627,7 +627,7 @@ object MessageDecryptor {
       override val serverDeliveredTimestamp: Long,
       override val errorMetadata: ErrorMetadata,
       override val followUpOperations: List<FollowUpOperation>
-    ) : Result, Error
+    ) : Error
 
     /** There are no further results from this envelope that need to be processed. There may still be [followUpOperations]. */
     class Ignore(
@@ -636,7 +636,7 @@ object MessageDecryptor {
       override val followUpOperations: List<FollowUpOperation>
     ) : Result
 
-    interface Error {
+    interface Error : Result {
       val errorMetadata: ErrorMetadata
     }
   }
@@ -647,6 +647,14 @@ object MessageDecryptor {
     val groupMasterKey: GroupMasterKey?
   ) {
     val groupId: GroupId.V2? by lazy { groupMasterKey?.let { GroupId.v2(it) } }
+
+    fun toExceptionMetadata(): ExceptionMetadata {
+      return ExceptionMetadata(
+        this.sender,
+        this.senderDevice,
+        this.groupId
+      )
+    }
   }
 
   data class DecryptionErrorCount(

--- a/app/src/main/java/org/thoughtcrime/securesms/messages/MessageState.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/messages/MessageState.java
@@ -7,6 +7,7 @@ package org.thoughtcrime.securesms.messages;
 
 /**
  * Message processing state/result
+ * @deprecated as it is only used by a deprecated job
  */
 public enum MessageState {
   DECRYPTED_OK,


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [ ] My contribution is fully baked and ready to be merged as is

----------

### Description
I noticed that the MessageState enum had obsolete entries, and is only used for error cases. This cleans that up, using the underlying class names instead. The existing job is retained, and can be cleaned up in the next version, once there are no more existing jobs using it.

I am not sure this is worth doing, and I haven't tested it yet, but I wanted to put it up for consideration.