### PR TITLE
Remove impossible to hit warning log

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/messages/MessageDecryptor.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/messages/MessageDecryptor.kt
@@ -223,8 +223,6 @@ object MessageDecryptor {
         } else {
           Log.w(TAG, "${logPrefix(envelope)} Ignoring PNI signature because the sourceServiceId isn't an ACI!")
         }
-      } else if (cipherResult.content.pniSignatureMessage != null) {
-        Log.w(TAG, "${logPrefix(envelope)} Ignoring PNI signature because the feature flag is disabled!")
       }
 
       // TODO We can move this to the "message processing" stage once we give it access to the envelope. But for now it'll stay here.


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have not tested my contribution, but I think it is safe by inspection.
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This warning log should have been removed in https://github.com/signalapp/Signal-Android/commit/ca3187d0b8605846103d25b6ee1d8d017f52c6ff#diff-aa184222c581239f8a6a007f4e8986b45e181aa7b46403df41753e35f2718237L161 which removed the feature flag check, but it was overlooked.