### PR TITLE
Opt out of location data in CellServiceConstraintObserver

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/jobmanager/impl/CellServiceConstraintObserver.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobmanager/impl/CellServiceConstraintObserver.java
@@ -43,7 +43,9 @@ public class CellServiceConstraintObserver implements ConstraintObserver {
     TelephonyManager           telephonyManager     = ServiceUtil.getTelephonyManager(application);
     LegacyServiceStateListener serviceStateListener = new LegacyServiceStateListener();
 
-    if (Build.VERSION.SDK_INT >= 31) {
+    if (Build.VERSION.SDK_INT >= 33) {
+      telephonyManager.registerTelephonyCallback(TelephonyManager.INCLUDE_LOCATION_DATA_NONE, SignalExecutors.BOUNDED, new ServiceStateListenerApi31());
+    } else if (Build.VERSION.SDK_INT >= 31) {
       telephonyManager.registerTelephonyCallback(SignalExecutors.BOUNDED, new ServiceStateListenerApi31());
     } else {
       HandlerThread handlerThread = SignalExecutors.getAndStartHandlerThread("CellServiceConstraintObserver", Thread.NORM_PRIORITY);


### PR DESCRIPTION
  Register the TelephonyCallback with INCLUDE_LOCATION_DATA_NONE on API 33+
  to prevent TelephonyRegistry from resulting in spurious FINE_LOCATION AppOps
  entries on every service-state update. 

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel Pro 10, Android 16
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/) 

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

If Signal has permission to access location, the system (privacy dashboard/appops log) reports that it accesses location whenever the app is running. Our tests found evidence that these accesses are not triggered directly within the app itself, but rather through callbacks registered by CellServiceConstraintObserver. Currently, this registration uses registerTelephonyCallback without opting out of location data. On API 33+, this causes TelephonyRegistry to include location-sensitive fields in the callback based on whatever location permission Signal has been granted and to write location AppOps entries linked to the Signal UID on every service-state update. CellServiceConstraintObserver does not seem to need the location-sensitive fields that trigger this check.

The proposed fix uses the option to request callbacks without location data introduced in API 33. With our patched build, we no longer observe Signal location requests.

This PR might be related to issues #13105 and #14761.