### PR TITLE
build: upgrade reproducible-builds base image from Ubuntu 22.04 to 24.04 LTS

### DIFF
--- a/reproducible-builds/Dockerfile
+++ b/reproducible-builds/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy-20230624@sha256:b060fffe8e1561c9c3e6dea6db487b900100fc26830b9ea2ec966c151ab4c020
+FROM ubuntu:noble-20260410@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
 
 COPY docker/ docker/
 COPY docker/apt.conf docker/sources.list /etc/apt/


### PR DESCRIPTION
### Contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices
- [x] My contribution is fully baked and ready to be merged as is

### Description

The `reproducible-builds/Dockerfile` currently pins to `ubuntu:jammy-20230624` (Ubuntu 22.04 LTS, from June 2023 -- nearly 3 years old). This PR updates the base image to `ubuntu:noble-20260410` (Ubuntu 24.04 LTS), which has been stable since April 2024 and is supported until 2029.

**Change:** 1 line in `Dockerfile`

```diff
-FROM ubuntu:jammy-20230624@sha256:b060fffe8e1561c9c3e6dea6db487b900100fc26830b9ea2ec966c151ab4c020
+FROM ubuntu:noble-20260410@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
```
