### PR TITLE
support rotation snapping

### DIFF
--- a/feature/media-send/src/main/java/org/signal/mediasend/screens/edit/image/ImageEditor.kt
+++ b/feature/media-send/src/main/java/org/signal/mediasend/screens/edit/image/ImageEditor.kt
@@ -87,7 +87,9 @@ internal fun ImageEditor(
         .matchParentSize()
         .clipToBounds()
         .onSizeChanged { state.setCanvasSize(it.width.toFloat(), it.height.toFloat()) }
-        .imageEditorPointerInput(state, controller, scope)
+        .imageEditorPointerInput(state, controller, scope) {
+          hapticFeedback.performHapticFeedback(HapticFeedbackType.SegmentTick)
+        }
     ) {
       state.revision
 
@@ -151,9 +153,9 @@ private fun HiddenTextInput(controller: ImageController) {
 /** How far a finger travels before a touch on an element counts as a drag. */
 private const val MAX_MOVE_SQUARED_BEFORE_DRAG = 10f
 
-private fun Modifier.imageEditorPointerInput(state: ImageEditorState, controller: ImageController, scope: CoroutineScope): Modifier {
+private fun Modifier.imageEditorPointerInput(state: ImageEditorState, controller: ImageController, scope: CoroutineScope, onRotationSnap: () -> Unit): Modifier {
   return this.pointerInput(controller, controller.textEditingElement) {
-    val touchHandler = ImageEditorTouchHandler()
+    val touchHandler = ImageEditorTouchHandler(onRotationSnap)
 
     // The tap that a second one has to land on, and beat the timeout from, to count as a double tap.
     var lastTapElement: EditorElement? = null

--- a/lib/image-editor/src/main/java/org/signal/imageeditor/core/ElementDragEditSession.java
+++ b/lib/image-editor/src/main/java/org/signal/imageeditor/core/ElementDragEditSession.java
@@ -9,14 +9,17 @@ import org.signal.imageeditor.core.model.EditorElement;
 
 final class ElementDragEditSession extends ElementEditSession {
 
-  private ElementDragEditSession(@NonNull EditorElement selected, @NonNull Matrix inverseMatrix) {
+  private final RotationSnapListener rotationSnapListener;
+
+  private ElementDragEditSession(@NonNull EditorElement selected, @NonNull Matrix inverseMatrix, RotationSnapListener rotationSnapListener) {
     super(selected, inverseMatrix);
+    this.rotationSnapListener = rotationSnapListener;
   }
 
-  static ElementDragEditSession startDrag(@NonNull EditorElement selected, @NonNull Matrix inverseViewModelMatrix, @NonNull PointF point) {
+  static ElementDragEditSession startDrag(@NonNull EditorElement selected, @NonNull Matrix inverseViewModelMatrix, @NonNull PointF point, @NonNull RotationSnapListener rotationSnapListener) {
     if (!selected.getFlags().isEditable()) return null;
 
-    ElementDragEditSession elementDragEditSession = new ElementDragEditSession(selected, inverseViewModelMatrix);
+    ElementDragEditSession elementDragEditSession = new ElementDragEditSession(selected, inverseViewModelMatrix, rotationSnapListener);
     elementDragEditSession.setScreenStartPoint(0, point);
     elementDragEditSession.setScreenEndPoint(0, point);
 
@@ -33,7 +36,7 @@ final class ElementDragEditSession extends ElementEditSession {
 
   @Override
   public EditSession newPoint(@NonNull Matrix newInverse, @NonNull PointF point, int p) {
-    return ElementScaleEditSession.startScale(this, newInverse, point, p);
+    return ElementScaleEditSession.startScale(this, newInverse, point, p, rotationSnapListener);
   }
 
   @Override

--- a/lib/image-editor/src/main/java/org/signal/imageeditor/core/ElementDragEditSession.java
+++ b/lib/image-editor/src/main/java/org/signal/imageeditor/core/ElementDragEditSession.java
@@ -11,7 +11,7 @@ final class ElementDragEditSession extends ElementEditSession {
 
   private final RotationSnapListener rotationSnapListener;
 
-  private ElementDragEditSession(@NonNull EditorElement selected, @NonNull Matrix inverseMatrix, RotationSnapListener rotationSnapListener) {
+  private ElementDragEditSession(@NonNull EditorElement selected, @NonNull Matrix inverseMatrix, @NonNull RotationSnapListener rotationSnapListener) {
     super(selected, inverseMatrix);
     this.rotationSnapListener = rotationSnapListener;
   }

--- a/lib/image-editor/src/main/java/org/signal/imageeditor/core/ElementScaleEditSession.java
+++ b/lib/image-editor/src/main/java/org/signal/imageeditor/core/ElementScaleEditSession.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 package org.signal.imageeditor.core;
 
 import android.graphics.Matrix;
@@ -9,13 +14,16 @@ import org.signal.imageeditor.core.model.EditorElement;
 
 final class ElementScaleEditSession extends ElementEditSession {
 
-  private ElementScaleEditSession(@NonNull EditorElement selected, @NonNull Matrix inverseMatrix) {
+  private final float initialRotationRadians;
+
+  private ElementScaleEditSession(@NonNull EditorElement selected, @NonNull Matrix inverseMatrix, float initialRotationRadians) {
     super(selected, inverseMatrix);
+    this.initialRotationRadians = initialRotationRadians;
   }
 
   static ElementScaleEditSession startScale(@NonNull ElementDragEditSession session, @NonNull Matrix inverseMatrix, @NonNull PointF point, int p) {
     session.commit();
-    ElementScaleEditSession newSession = new ElementScaleEditSession(session.selected, inverseMatrix);
+    ElementScaleEditSession newSession = new ElementScaleEditSession(session.selected, inverseMatrix, session.selected.getLocalRotationAngle());
     newSession.setScreenStartPoint(1 - p, session.endPointScreen[0]);
     newSession.setScreenEndPoint(1 - p, session.endPointScreen[0]);
     newSession.setScreenStartPoint(p, point);
@@ -38,6 +46,7 @@ final class ElementScaleEditSession extends ElementEditSession {
       editorMatrix.postScale(scale, scale);
 
       double angle = angle(endPointElement[0], endPointElement[1]) - angle(startPointElement[0], startPointElement[1]);
+      angle = RotationSnap.snapToAngle(initialRotationRadians, angle);
 
       if (!selected.getFlags().isRotateLocked()) {
         editorMatrix.postRotate((float) Math.toDegrees(angle));

--- a/lib/image-editor/src/main/java/org/signal/imageeditor/core/ElementScaleEditSession.java
+++ b/lib/image-editor/src/main/java/org/signal/imageeditor/core/ElementScaleEditSession.java
@@ -16,7 +16,7 @@ final class ElementScaleEditSession extends ElementEditSession {
 
   private final RotationSnapListener rotationSnapListener;
   private final float                initialRotationRadians;
-  private       boolean              wasRotationSnapped;
+  private       boolean              wasRotationSnapped = true; // skip triggering listener on start of session
 
   private ElementScaleEditSession(@NonNull EditorElement selected, @NonNull Matrix inverseMatrix, @NonNull RotationSnapListener rotationSnapListener, float initialRotationRadians) {
     super(selected, inverseMatrix);

--- a/lib/image-editor/src/main/java/org/signal/imageeditor/core/ElementScaleEditSession.java
+++ b/lib/image-editor/src/main/java/org/signal/imageeditor/core/ElementScaleEditSession.java
@@ -15,8 +15,8 @@ import org.signal.imageeditor.core.model.EditorElement;
 final class ElementScaleEditSession extends ElementEditSession {
 
   private final RotationSnapListener rotationSnapListener;
-  private final float initialRotationRadians;
-  private boolean wasRotationSnapped;
+  private final float                initialRotationRadians;
+  private       boolean              wasRotationSnapped;
 
   private ElementScaleEditSession(@NonNull EditorElement selected, @NonNull Matrix inverseMatrix, @NonNull RotationSnapListener rotationSnapListener, float initialRotationRadians) {
     super(selected, inverseMatrix);

--- a/lib/image-editor/src/main/java/org/signal/imageeditor/core/ElementScaleEditSession.java
+++ b/lib/image-editor/src/main/java/org/signal/imageeditor/core/ElementScaleEditSession.java
@@ -14,16 +14,19 @@ import org.signal.imageeditor.core.model.EditorElement;
 
 final class ElementScaleEditSession extends ElementEditSession {
 
+  private final RotationSnapListener rotationSnapListener;
   private final float initialRotationRadians;
+  private boolean wasRotationSnapped;
 
-  private ElementScaleEditSession(@NonNull EditorElement selected, @NonNull Matrix inverseMatrix, float initialRotationRadians) {
+  private ElementScaleEditSession(@NonNull EditorElement selected, @NonNull Matrix inverseMatrix, @NonNull RotationSnapListener rotationSnapListener, float initialRotationRadians) {
     super(selected, inverseMatrix);
+    this.rotationSnapListener   = rotationSnapListener;
     this.initialRotationRadians = initialRotationRadians;
   }
 
-  static ElementScaleEditSession startScale(@NonNull ElementDragEditSession session, @NonNull Matrix inverseMatrix, @NonNull PointF point, int p) {
+  static ElementScaleEditSession startScale(@NonNull ElementDragEditSession session, @NonNull Matrix inverseMatrix, @NonNull PointF point, int p, @NonNull RotationSnapListener rotationSnapListener) {
     session.commit();
-    ElementScaleEditSession newSession = new ElementScaleEditSession(session.selected, inverseMatrix, session.selected.getLocalRotationAngle());
+    ElementScaleEditSession newSession = new ElementScaleEditSession(session.selected, inverseMatrix, rotationSnapListener, session.selected.getLocalRotationAngle());
     newSession.setScreenStartPoint(1 - p, session.endPointScreen[0]);
     newSession.setScreenEndPoint(1 - p, session.endPointScreen[0]);
     newSession.setScreenStartPoint(p, point);
@@ -46,10 +49,15 @@ final class ElementScaleEditSession extends ElementEditSession {
       editorMatrix.postScale(scale, scale);
 
       double angle = angle(endPointElement[0], endPointElement[1]) - angle(startPointElement[0], startPointElement[1]);
-      angle = RotationSnap.snapToAngle(initialRotationRadians, angle);
+      RotationSnapResult rotationSnapResult = RotationSnap.snapToAngle(initialRotationRadians, angle);
+      angle = rotationSnapResult.getAngleRadians();
 
       if (!selected.getFlags().isRotateLocked()) {
         editorMatrix.postRotate((float) Math.toDegrees(angle));
+        if (rotationSnapResult.getSnapped() && !wasRotationSnapped) {
+          rotationSnapListener.onRotationSnap();
+        }
+        wasRotationSnapped = rotationSnapResult.getSnapped();
       }
 
       editorMatrix.postTranslate(endPointElement[0].x, endPointElement[0].y);
@@ -80,7 +88,7 @@ final class ElementScaleEditSession extends ElementEditSession {
   }
 
   private ElementDragEditSession convertToDrag(int p, @NonNull Matrix inverse) {
-    return ElementDragEditSession.startDrag(selected, inverse, endPointScreen[1 - p]);
+    return ElementDragEditSession.startDrag(selected, inverse, endPointScreen[1 - p], rotationSnapListener);
   }
 
   /**

--- a/lib/image-editor/src/main/java/org/signal/imageeditor/core/ImageEditorTouchHandler.kt
+++ b/lib/image-editor/src/main/java/org/signal/imageeditor/core/ImageEditorTouchHandler.kt
@@ -24,7 +24,9 @@ import org.signal.imageeditor.core.renderers.TrashRenderer
  * Usage: call the on* methods in order as pointer events arrive. The handler manages
  * edit session state internally.
  */
-class ImageEditorTouchHandler {
+class ImageEditorTouchHandler(
+  private val rotationSnapListener: RotationSnapListener
+) {
 
   private var drawing: Boolean = false
   private var blur: Boolean = false
@@ -159,7 +161,7 @@ class ImageEditorTouchHandler {
     point: PointF,
     selected: EditorElement?
   ): EditSession? {
-    val session = startMoveAndResizeSession(model, viewMatrix, inverse, point, selected)
+    val session = startMoveAndResizeSession(model, viewMatrix, inverse, point, selected, rotationSnapListener)
     if (session == null && drawing) {
       drawingSession = true
       return startDrawingSession(model, viewMatrix, point)
@@ -191,7 +193,8 @@ class ImageEditorTouchHandler {
       viewMatrix: Matrix,
       inverse: Matrix,
       point: PointF,
-      selected: EditorElement?
+      selected: EditorElement?,
+      rotationSnapListener: RotationSnapListener
     ): EditSession? {
       if (selected == null) return null
 
@@ -209,14 +212,15 @@ class ImageEditorTouchHandler {
             elementInverseMatrix,
             thumbContainerRelativeMatrix,
             thumb.controlPoint,
-            point
+            point,
+            rotationSnapListener
           )
         } else {
           null
         }
       }
 
-      return ElementDragEditSession.startDrag(selected, inverse, point)
+      return ElementDragEditSession.startDrag(selected, inverse, point, rotationSnapListener)
     }
   }
 }

--- a/lib/image-editor/src/main/java/org/signal/imageeditor/core/ImageEditorView.java
+++ b/lib/image-editor/src/main/java/org/signal/imageeditor/core/ImageEditorView.java
@@ -473,13 +473,13 @@ public final class ImageEditorView extends FrameLayout {
 
       elementInverseMatrix = model.findElementInverseMatrix(selected, viewMatrix);
       if (elementInverseMatrix != null) {
-        return ThumbDragEditSession.startDrag(selected, elementInverseMatrix, thumbContainerRelativeMatrix, thumb.getControlPoint(), point);
+        return ThumbDragEditSession.startDrag(selected, elementInverseMatrix, thumbContainerRelativeMatrix, thumb.getControlPoint(), point, () -> {});
       } else {
         return null;
       }
     }
 
-    return ElementDragEditSession.startDrag(selected, inverse, point);
+    return ElementDragEditSession.startDrag(selected, inverse, point, () -> {});
   }
 
   @NonNull

--- a/lib/image-editor/src/main/java/org/signal/imageeditor/core/RotationSnap.java
+++ b/lib/image-editor/src/main/java/org/signal/imageeditor/core/RotationSnap.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.signal.imageeditor.core;
+
+final class RotationSnap {
+
+  private static final double SNAP_ANGLE_RADIANS     = Math.PI / 2d; // 90 degrees in radians
+  private static final double SNAP_THRESHOLD_RADIANS = Math.toRadians(5d);
+
+  private RotationSnap() {}
+
+  private static double snapToAngle(double angleRadians) {
+    double snappedAngle = Math.rint(angleRadians / SNAP_ANGLE_RADIANS) * SNAP_ANGLE_RADIANS;
+
+    if (Math.abs(angleRadians - snappedAngle) <= SNAP_THRESHOLD_RADIANS) {
+      return snappedAngle;
+    }
+
+    return angleRadians;
+  }
+
+  static double snapToAngle(double baseAngleRadians, double relativeAngleRadians) {
+    double absoluteAngle        = baseAngleRadians + relativeAngleRadians;
+    double snappedAbsoluteAngle = snapToAngle(absoluteAngle);
+    return snappedAbsoluteAngle - baseAngleRadians;
+  }
+}

--- a/lib/image-editor/src/main/java/org/signal/imageeditor/core/RotationSnap.kt
+++ b/lib/image-editor/src/main/java/org/signal/imageeditor/core/RotationSnap.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package org.signal.imageeditor.core
+
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.round
+
+internal object RotationSnap {
+  private const val SNAP_ANGLE_RADIANS = PI / 2.0 // 90 degrees in radians
+  private val SNAP_THRESHOLD_RADIANS = Math.toRadians(5.0)
+
+  private fun snapToAngle(angleRadians: Double): Double {
+    val snappedAngle: Double = round(angleRadians / SNAP_ANGLE_RADIANS) * SNAP_ANGLE_RADIANS
+
+    if (abs(angleRadians - snappedAngle) <= SNAP_THRESHOLD_RADIANS) {
+      return snappedAngle
+    }
+
+    return angleRadians
+  }
+
+  @JvmStatic
+  fun snapToAngle(baseAngleRadians: Double, relativeAngleRadians: Double): Double {
+    val absoluteAngle = baseAngleRadians + relativeAngleRadians
+    val snappedAbsoluteAngle = snapToAngle(absoluteAngle)
+    return snappedAbsoluteAngle - baseAngleRadians
+  }
+}

--- a/lib/image-editor/src/main/java/org/signal/imageeditor/core/RotationSnap.kt
+++ b/lib/image-editor/src/main/java/org/signal/imageeditor/core/RotationSnap.kt
@@ -8,24 +8,33 @@ import kotlin.math.PI
 import kotlin.math.abs
 import kotlin.math.round
 
+internal data class RotationSnapResult(
+  val angleRadians: Double,
+  val snapped: Boolean
+)
+
 internal object RotationSnap {
   private const val SNAP_ANGLE_RADIANS = PI / 2.0 // 90 degrees in radians
   private val SNAP_THRESHOLD_RADIANS = Math.toRadians(5.0)
 
-  private fun snapToAngle(angleRadians: Double): Double {
+  private fun snapToAngle(angleRadians: Double): RotationSnapResult {
     val snappedAngle: Double = round(angleRadians / SNAP_ANGLE_RADIANS) * SNAP_ANGLE_RADIANS
 
-    if (abs(angleRadians - snappedAngle) <= SNAP_THRESHOLD_RADIANS) {
-      return snappedAngle
+    return if (isCloseEnoughToSnap(angleRadians, snappedAngle)) {
+      RotationSnapResult(snappedAngle, true)
+    } else {
+      RotationSnapResult(angleRadians, false)
     }
+  }
 
-    return angleRadians
+  private fun isCloseEnoughToSnap(angleRadians: Double, snappedAngle: Double): Boolean {
+    return abs(angleRadians - snappedAngle) <= SNAP_THRESHOLD_RADIANS
   }
 
   @JvmStatic
-  fun snapToAngle(baseAngleRadians: Double, relativeAngleRadians: Double): Double {
+  fun snapToAngle(baseAngleRadians: Double, relativeAngleRadians: Double): RotationSnapResult {
     val absoluteAngle = baseAngleRadians + relativeAngleRadians
     val snappedAbsoluteAngle = snapToAngle(absoluteAngle)
-    return snappedAbsoluteAngle - baseAngleRadians
+    return RotationSnapResult(snappedAbsoluteAngle.angleRadians - baseAngleRadians, snappedAbsoluteAngle.snapped)
   }
 }

--- a/lib/image-editor/src/main/java/org/signal/imageeditor/core/RotationSnapListener.kt
+++ b/lib/image-editor/src/main/java/org/signal/imageeditor/core/RotationSnapListener.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2026 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package org.signal.imageeditor.core
+
+fun interface RotationSnapListener {
+  fun onRotationSnap()
+}

--- a/lib/image-editor/src/main/java/org/signal/imageeditor/core/ThumbDragEditSession.java
+++ b/lib/image-editor/src/main/java/org/signal/imageeditor/core/ThumbDragEditSession.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 package org.signal.imageeditor.core;
 
 import android.graphics.Matrix;
@@ -13,6 +18,7 @@ class ThumbDragEditSession extends ElementEditSession {
   private final PointF  oppositeControlPoint                = new PointF();
   private final float[] oppositeControlPointOnControlParent = new float[2];
   private final float[] oppositeControlPointOnElement       = new float[2];
+  private final float   initialRotationRadians;
 
   @NonNull
   private final          ThumbRenderer.ControlPoint controlPoint;
@@ -21,11 +27,13 @@ class ThumbDragEditSession extends ElementEditSession {
   private ThumbDragEditSession(@NonNull EditorElement selected,
                                @NonNull ThumbRenderer.ControlPoint controlPoint,
                                @NonNull Matrix inverseMatrix,
-                               @NonNull Matrix thumbContainerRelativeMatrix)
+                               @NonNull Matrix thumbContainerRelativeMatrix,
+                               float initialRotationRadians)
   {
     super(selected, inverseMatrix);
     this.controlPoint                 = controlPoint;
     this.thumbContainerRelativeMatrix = thumbContainerRelativeMatrix;
+    this.initialRotationRadians       = initialRotationRadians;
   }
 
   static EditSession startDrag(@NonNull EditorElement selected,
@@ -36,7 +44,7 @@ class ThumbDragEditSession extends ElementEditSession {
   {
     if (!selected.getFlags().isEditable()) return null;
 
-    ElementEditSession elementDragEditSession = new ThumbDragEditSession(selected, controlPoint, inverseViewModelMatrix, thumbContainerRelativeMatrix);
+    ElementEditSession elementDragEditSession = new ThumbDragEditSession(selected, controlPoint, inverseViewModelMatrix, thumbContainerRelativeMatrix, selected.getLocalRotationAngle());
     elementDragEditSession.setScreenStartPoint(0, point);
     elementDragEditSession.setScreenEndPoint(0, point);
     return elementDragEditSession;
@@ -72,6 +80,7 @@ class ThumbDragEditSession extends ElementEditSession {
       editorMatrix.postTranslate(-oppositeControlPoint.x, -oppositeControlPoint.y);
       editorMatrix.postScale(scale, scale);
       double angle = angle(endPointElement[0], oppositeControlPoint) - angle(startPointElement[0], oppositeControlPoint);
+      angle = RotationSnap.snapToAngle(initialRotationRadians, angle);
       rotate(editorMatrix, angle);
       editorMatrix.postTranslate(oppositeControlPoint.x, oppositeControlPoint.y);
     } else {

--- a/lib/image-editor/src/main/java/org/signal/imageeditor/core/ThumbDragEditSession.java
+++ b/lib/image-editor/src/main/java/org/signal/imageeditor/core/ThumbDragEditSession.java
@@ -21,7 +21,7 @@ class ThumbDragEditSession extends ElementEditSession {
 
   private final RotationSnapListener rotationSnapListener;
   private final float                initialRotationRadians;
-  private       boolean              wasRotationSnapped;
+  private       boolean              wasRotationSnapped = true; // skip triggering listener on start of session
 
   @NonNull
   private final          ThumbRenderer.ControlPoint controlPoint;

--- a/lib/image-editor/src/main/java/org/signal/imageeditor/core/ThumbDragEditSession.java
+++ b/lib/image-editor/src/main/java/org/signal/imageeditor/core/ThumbDragEditSession.java
@@ -18,7 +18,9 @@ class ThumbDragEditSession extends ElementEditSession {
   private final PointF  oppositeControlPoint                = new PointF();
   private final float[] oppositeControlPointOnControlParent = new float[2];
   private final float[] oppositeControlPointOnElement       = new float[2];
+  private final RotationSnapListener rotationSnapListener;
   private final float   initialRotationRadians;
+  private boolean wasRotationSnapped;
 
   @NonNull
   private final          ThumbRenderer.ControlPoint controlPoint;
@@ -28,11 +30,13 @@ class ThumbDragEditSession extends ElementEditSession {
                                @NonNull ThumbRenderer.ControlPoint controlPoint,
                                @NonNull Matrix inverseMatrix,
                                @NonNull Matrix thumbContainerRelativeMatrix,
+                               @NonNull RotationSnapListener rotationSnapListener,
                                float initialRotationRadians)
   {
     super(selected, inverseMatrix);
     this.controlPoint                 = controlPoint;
     this.thumbContainerRelativeMatrix = thumbContainerRelativeMatrix;
+    this.rotationSnapListener         = rotationSnapListener;
     this.initialRotationRadians       = initialRotationRadians;
   }
 
@@ -40,11 +44,12 @@ class ThumbDragEditSession extends ElementEditSession {
                                @NonNull Matrix inverseViewModelMatrix,
                                @NonNull Matrix thumbContainerRelativeMatrix,
                                @NonNull ThumbRenderer.ControlPoint controlPoint,
-                               @NonNull PointF point)
+                               @NonNull PointF point,
+                               @NonNull RotationSnapListener rotationSnapListener)
   {
     if (!selected.getFlags().isEditable()) return null;
 
-    ElementEditSession elementDragEditSession = new ThumbDragEditSession(selected, controlPoint, inverseViewModelMatrix, thumbContainerRelativeMatrix, selected.getLocalRotationAngle());
+    ElementEditSession elementDragEditSession = new ThumbDragEditSession(selected, controlPoint, inverseViewModelMatrix, thumbContainerRelativeMatrix, rotationSnapListener, selected.getLocalRotationAngle());
     elementDragEditSession.setScreenStartPoint(0, point);
     elementDragEditSession.setScreenEndPoint(0, point);
     return elementDragEditSession;
@@ -80,8 +85,15 @@ class ThumbDragEditSession extends ElementEditSession {
       editorMatrix.postTranslate(-oppositeControlPoint.x, -oppositeControlPoint.y);
       editorMatrix.postScale(scale, scale);
       double angle = angle(endPointElement[0], oppositeControlPoint) - angle(startPointElement[0], oppositeControlPoint);
-      angle = RotationSnap.snapToAngle(initialRotationRadians, angle);
+
+      RotationSnapResult rotationSnapResult = RotationSnap.snapToAngle(initialRotationRadians, angle);
+      angle = rotationSnapResult.getAngleRadians();
       rotate(editorMatrix, angle);
+      if (rotationSnapResult.getSnapped() && !wasRotationSnapped) {
+        rotationSnapListener.onRotationSnap();
+      }
+      wasRotationSnapped = rotationSnapResult.getSnapped();
+
       editorMatrix.postTranslate(oppositeControlPoint.x, oppositeControlPoint.y);
     } else {
       // 8 point controls, where edges scale in just one dimension and corners scale in both, optionally fixed aspect ratio

--- a/lib/image-editor/src/main/java/org/signal/imageeditor/core/ThumbDragEditSession.java
+++ b/lib/image-editor/src/main/java/org/signal/imageeditor/core/ThumbDragEditSession.java
@@ -18,9 +18,10 @@ class ThumbDragEditSession extends ElementEditSession {
   private final PointF  oppositeControlPoint                = new PointF();
   private final float[] oppositeControlPointOnControlParent = new float[2];
   private final float[] oppositeControlPointOnElement       = new float[2];
+
   private final RotationSnapListener rotationSnapListener;
-  private final float   initialRotationRadians;
-  private boolean wasRotationSnapped;
+  private final float                initialRotationRadians;
+  private       boolean              wasRotationSnapped;
 
   @NonNull
   private final          ThumbRenderer.ControlPoint controlPoint;


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Android 7 low-res screen emulator
 * Android 15 Physical tablet
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

This PR implements feature request https://community.signalusers.org/t/74780. As it is a rather trivial feature and doesn't need synchronization between different platforms and differs already today (e.g., in signal desktop you can perform resize and rotate operations independently), I thought it might be a suitable feature for an external contribution.

When merged, rotation angles less than 5° get automatically snapped to the next 90° rotation step. Based on some testing on my side, 5° seemed like the sweet spot between usability for snapping and keeping as much freedom as possible to allow other creative angles.

This is important for all the perfectionists out there, who feel real physical pain if they can't align things properly, so please consider this :)

https://github.com/user-attachments/assets/1c4684f3-ba04-4d5e-a321-40b628c784f2

