### PR TITLE
Use theme primary color for attachment message confirm button

### DIFF
--- a/app/src/main/res/drawable/v2_media_add_a_message_check.xml
+++ b/app/src/main/res/drawable/v2_media_add_a_message_check.xml
@@ -5,7 +5,7 @@
             <size
                 android:width="32dp"
                 android:height="32dp" />
-            <solid android:color="@color/core_ultramarine" />
+            <solid android:color="@color/signal_light_colorPrimary" />
             <padding
                 android:bottom="4dp"
                 android:left="4dp"


### PR DESCRIPTION
Resolves #14195.

### Problem
When adding a message to an attachment, the confirm (check) button that appears next to the input field has a hardcoded ultramarine-blue circular background. It ignores the accent color used by the rest of the media send flow, so it visually clashes with the theme.

The background was set to `@color/core_ultramarine` (`#2c6bed`) in `v2_media_add_a_message_check.xml`, whereas the other accent surfaces in the same flow use `@color/signal_light_colorPrimary` (`#2C58C3`):

- the final send button — `v2_media_review_fragment.xml` (`@id/send`)
- the media selection count pill — `media_selection_pill.xml`

### Fix
Change the confirm button background to `@color/signal_light_colorPrimary` so it matches the send button and the rest of the media send UI. This keeps a solid dark accent behind the white check icon (preserving contrast) while removing the lone hardcoded-color outlier.

One-line change:

```diff
-            <solid android:color="@color/core_ultramarine" />
+            <solid android:color="@color/signal_light_colorPrimary" />
```

### Testing
- Open a chat → add an attachment (+) → tap the “Add a message” field → the confirm check button background now uses the same primary color as the send button.