### PR TITLE
Fix integer division in failed-service-start notification heuristic

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/SlowNotificationHeuristics.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/SlowNotificationHeuristics.kt
@@ -164,7 +164,7 @@ object SlowNotificationHeuristics {
       return false
     }
 
-    if (failures.size / (failures.size + successes.size) >= failurePercentage) {
+    if (failures.size.toFloat() / (failures.size + successes.size) >= failurePercentage) {
       Log.w(TAG, "User often unable start FCM service. ${failures.size} failed : ${successes.size} successful")
       return true
     }


### PR DESCRIPTION
### Problem

`SlowNotificationHeuristics.hasRepeatedFailedServiceStarts()` decides whether a user is failing to start the FCM service too often by comparing the failure ratio against `serviceStartFailurePercentage` (a `Float`, default `0.5`). However, the ratio is computed with integer division:

```kotlin
if (failures.size / (failures.size + successes.size) >= failurePercentage) {
```

Both `failures.size` and `successes.size` are `Int`, so `failures.size / (failures.size + successes.size)` is integer division. Because `failures.size` is always `<=` the total, this evaluates to:

- `0` whenever there is at least one success (i.e. any mixed ratio), and
- `1` only when there are **zero** successes (100% failures).

Comparing that integer result against `0.5f` means the branch only ever passes at a **100% failure rate**, never at the configured 50% (or any other fractional threshold). In practice the failed-service-start signal of the delayed-notifications heuristic is dead for the realistic case of a user who fails, say, 50–99% of service starts.

The sibling heuristics (`isFailingToDrainQueue`, `hasLongMessageLatency`) compare raw counts/latencies, so they are unaffected — this is the only place a fractional rate is computed.

### Fix

Promote the numerator to `Float` so the comparison uses the intended fractional failure rate:

```diff
-    if (failures.size / (failures.size + successes.size) >= failurePercentage) {
+    if (failures.size.toFloat() / (failures.size + successes.size) >= failurePercentage) {
```

Division by zero is not a concern here: an earlier guard returns when `(successes.size + failures.size) < minimumEventCount` (default `10`).

### Notes

One-line change, no behavior change for the 100%-failure case; it now also correctly triggers for the intended fractional thresholds.