### PR TITLE
Fix jump-to-date being off by one day in non-UTC timezones

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
@@ -390,6 +390,7 @@ import org.thoughtcrime.securesms.wallpaper.ChatWallpaperDimLevelUtil
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.time.ZoneOffset
 import java.util.Locale
 import java.util.Optional
 import java.util.concurrent.ExecutionException
@@ -5247,7 +5248,7 @@ class ConversationFragment :
         datePicker.addOnPositiveButtonClickListener { selectedDate ->
           if (selectedDate != null) {
             val localMidnightTimestamp = Instant.ofEpochMilli(selectedDate)
-              .atZone(ZoneId.systemDefault())
+              .atZone(ZoneOffset.UTC)
               .toLocalDate()
               .atStartOfDay(ZoneId.systemDefault())
               .toInstant()

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/JumpToDateValidator.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/JumpToDateValidator.kt
@@ -16,6 +16,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.temporal.TemporalAdjusters
 import java.util.concurrent.Executor
 import kotlin.time.Duration.Companion.days
@@ -105,7 +106,7 @@ class JumpToDateValidator private constructor(
 
   private fun normalizeToLocalMidnight(timestamp: Long): Long {
     return Instant.ofEpochMilli(timestamp)
-      .atZone(zoneId)
+      .atZone(ZoneOffset.UTC)
       .toLocalDate()
       .atStartOfDay(zoneId)
       .toInstant()

--- a/app/src/test/java/org/thoughtcrime/securesms/conversation/v2/JumpToDateValidatorTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/conversation/v2/JumpToDateValidatorTest.kt
@@ -187,4 +187,27 @@ class JumpToDateValidatorTest {
 
     assertThat(validator.isValid(june15Utc)).isTrue()
   }
+
+  @Test
+  fun `picker date maps to the same calendar day in a negative-offset zone`() {
+    val newYorkZone = ZoneId.of("America/New_York")
+
+    // Days are keyed by local midnight in the database.
+    val june15NewYorkMidnight = LocalDate.of(2024, 6, 15)
+      .atStartOfDay(newYorkZone)
+      .toInstant()
+      .toEpochMilli()
+
+    val lookup = { dates: Collection<Long> ->
+      dates.associateWith { it == june15NewYorkMidnight }
+    }
+    val validator = createValidator(lookup, zone = newYorkZone)
+
+    // The picker reports June 15 as UTC midnight; it must map to June 15 locally, not June 14.
+    val june15PickerUtc = timestampForDate(2024, 6, 15)
+
+    validator.isValid(june15PickerUtc)
+
+    assertThat(validator.isValid(june15PickerUtc)).isTrue()
+  }
 }


### PR DESCRIPTION
Resolves #14342.

### Problem

In the conversation search "jump to date" picker, the selectable dates are one day ahead of the day they actually refer to (e.g. a message sent on 2025-06-20 only becomes selectable under 2025-06-21).

`MaterialDatePicker` works entirely in **UTC**: the selection, the calendar constraints, and the `DateValidator` callbacks are all UTC-midnight timestamps for the displayed calendar day. The picker is *set up* correctly (`LocalDateTime.now().atMidnight().atUTC()`), but both places that **read a value back** reinterpret that UTC-midnight instant in the local zone:

```kotlin
Instant.ofEpochMilli(timestamp).atZone(ZoneId.systemDefault()).toLocalDate()
```

- `JumpToDateValidator.normalizeToLocalMidnight()` — decides which calendar cells are selectable
- the date pickers positive-button handler in `ConversationFragment` — computes where to jump

For any **negative** UTC offset, UTC midnight of calendar day `D` falls on the previous evening locally, so `toLocalDate()` returns `D-1`. The validator therefore enables day `D` for messages that actually live on local day `D-1` (the "one day ahead" symptom), and the jump target is shifted by a day too.

The database keys message days by **local** midnight (`MessageTable.messageExistsOnDays`: `DATE_SENT >= startOfDay AND DATE_SENT < startOfDay + 86400000`), so the correct mapping is: read the calendar day from the picker **in UTC**, then re-anchor that day to **local** midnight.

### Fix

Use `ZoneOffset.UTC` when extracting the `LocalDate` from the picker timestamp in both read-back paths, keeping `atStartOfDay(zoneId)` to anchor at local midnight. Both sites must change together so the selectable day and the jump target stay consistent.

### Testing

Added a regression test to `JumpToDateValidatorTest` for a negative-offset zone (`America/New_York`): a picker selection of June 15 (UTC midnight) must map to New Yorks June 15, not June 14.

Verified locally against the pinned toolchain (`:Signal-Android:testPlayProdDebugUnitTest --tests "*JumpToDateValidatorTest"`):

- **Before** the fix: `10 tests completed, 1 failed` (the new test fails — `expected to be true`).
- **After** the fix: `tests="10" skipped="0" failures="0" errors="0"`.