### PR TITLE
Fix scheduled Note To Self messages delivering without notifications …

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/MessageTable.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/MessageTable.kt
@@ -2341,6 +2341,14 @@ open class MessageTable(context: Context?, databaseHelper: SignalDatabase) : Dat
     AppDependencies.databaseObserver.notifyConversationListListeners()
   }
 
+  fun markAsUnread(messageId: Long) {
+    writableDatabase
+      .update(TABLE_NAME)
+      .values(READ to 0)
+      .where("$ID = ?", messageId)
+      .run()
+  }
+
   fun markAsRemoteDelete(targetMessage: MessageRecord, deletedBy: RecipientId) {
     writableDatabase.withinTransaction { db ->
       val hasRevision = (targetMessage as? MmsMessageRecord)?.latestRevisionId?.id != null

--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/IndividualSendJob.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/IndividualSendJob.kt
@@ -22,6 +22,7 @@ import org.thoughtcrime.securesms.jobs.RetrieveProfileJob.Companion.enqueue
 import org.thoughtcrime.securesms.keyvalue.SignalStore
 import org.thoughtcrime.securesms.mms.MmsException
 import org.thoughtcrime.securesms.mms.OutgoingMessage
+import org.thoughtcrime.securesms.notifications.v2.ConversationId
 import org.thoughtcrime.securesms.ratelimit.ProofRequiredExceptionHandler
 import org.thoughtcrime.securesms.recipients.Recipient
 import org.thoughtcrime.securesms.recipients.RecipientUtil
@@ -169,13 +170,13 @@ class IndividualSendJob private constructor(parameters: Parameters, private val 
       markAttachmentsUploaded(messageId, message)
       SignalDatabase.messages.markUnidentified(messageId, unidentified)
 
-      // For scheduled messages, which may not have updated the thread with its snippet yet
-      SignalDatabase.threads.updateSilently(threadId, false)
+      SignalDatabase.threads.update(threadId, false)
 
       if (recipient.isSelf) {
         SignalDatabase.messages.incrementDeliveryReceiptCount(message.sentTimeMillis, recipient.id, System.currentTimeMillis())
         SignalDatabase.messages.incrementReadReceiptCount(message.sentTimeMillis, recipient.id, System.currentTimeMillis())
         SignalDatabase.messages.incrementViewedReceiptCount(message.sentTimeMillis, recipient.id, System.currentTimeMillis())
+        AppDependencies.messageNotifier.updateNotification(context, ConversationId.forConversation(threadId))
       }
 
       if (unidentified && accessMode == SealedSenderAccessMode.UNKNOWN && profileKey == null) {

--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/IndividualSendJobV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/IndividualSendJobV2.kt
@@ -32,6 +32,7 @@ import org.thoughtcrime.securesms.jobmanager.impl.NetworkConstraint
 import org.thoughtcrime.securesms.jobmanager.impl.SealedSenderConstraint
 import org.thoughtcrime.securesms.jobs.protos.IndividualSendJobV2Data
 import org.thoughtcrime.securesms.keyvalue.SignalStore
+import org.thoughtcrime.securesms.notifications.v2.ConversationId
 import org.thoughtcrime.securesms.ratelimit.ProofRequiredExceptionHandler
 import org.thoughtcrime.securesms.recipients.Recipient
 import org.thoughtcrime.securesms.recipients.RecipientUtil
@@ -219,12 +220,13 @@ class IndividualSendJobV2 private constructor(parameters: Parameters, private va
         SignalDatabase.messages.markAsSent(messageId, success.sentUnidentified)
         PushSendJob.markAttachmentsUploaded(messageId, message)
 
-        SignalDatabase.threads.updateSilently(threadId, false)
+        SignalDatabase.threads.update(threadId, false)
 
         if (recipient.isSelf) {
           SignalDatabase.messages.incrementDeliveryReceiptCount(message.sentTimeMillis, recipient.id, System.currentTimeMillis())
           SignalDatabase.messages.incrementReadReceiptCount(message.sentTimeMillis, recipient.id, System.currentTimeMillis())
           SignalDatabase.messages.incrementViewedReceiptCount(message.sentTimeMillis, recipient.id, System.currentTimeMillis())
+          AppDependencies.messageNotifier.updateNotification(context, ConversationId.forConversation(threadId))
         }
 
         val accessMode = recipient.sealedSenderAccessMode

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/v2/NotificationFactory.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/v2/NotificationFactory.kt
@@ -214,7 +214,8 @@ object NotificationFactory {
     }
     val canAlertBasedOnTime: Boolean = lastNotificationTimestamp < System.currentTimeMillis() - throttle.inWholeMilliseconds || lastNotificationTimestamp > System.currentTimeMillis()
 
-    return ((conversation.hasNewNotifications() && canAlertBasedOnTime) || alertOverride) && !conversation.mostRecentNotification.authorRecipient.isSelf
+    return ((conversation.hasNewNotifications() && canAlertBasedOnTime) || alertOverride) &&
+      (!conversation.mostRecentNotification.authorRecipient.isSelf || conversation.recipient.isSelf)
   }
 
   @WorkerThread

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/v2/NotificationStateProvider.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/v2/NotificationStateProvider.kt
@@ -161,6 +161,7 @@ object NotificationStateProvider {
   ) {
     private val isGroupStoryReply: Boolean = thread.groupStoryId != null
     private val isUnreadIncoming: Boolean = isUnreadMessage && !messageRecord.isOutgoing && !isGroupStoryReply
+    private val isNoteToSelfScheduled: Boolean = isUnreadMessage && messageRecord.isOutgoing && threadRecipient.isSelf
     private val isIncomingMissedCall: Boolean = !messageRecord.isOutgoing && (messageRecord.isMissedAudioCall || messageRecord.isMissedVideoCall)
 
     private val isNotifiableGroupStoryMessage: Boolean =
@@ -170,7 +171,7 @@ object NotificationStateProvider {
         (isParentStorySentBySelf || messageRecord.hasGroupQuoteOrSelfMention() || (hasSelfRepliedToStory && !messageRecord.isStoryReaction()))
 
     fun includeMessage(notificationProfile: NotificationProfile?): MessageInclusion {
-      return if (isUnreadIncoming || stickyThread || isNotifiableGroupStoryMessage || isIncomingMissedCall) {
+      return if (isUnreadIncoming || stickyThread || isNotifiableGroupStoryMessage || isIncomingMissedCall || isNoteToSelfScheduled) {
         if (threadRecipient.isMuted && !breaksThroughMute()) {
           MessageInclusion.MUTE_FILTERED
         } else if (notificationProfile != null && !notificationProfile.isRecipientAllowed(threadRecipient.id) && !(notificationProfile.allowAllMentions && messageRecord.hasGroupQuoteOrSelfMention())) {

--- a/app/src/main/java/org/thoughtcrime/securesms/service/ScheduledMessageManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/ScheduledMessageManager.kt
@@ -56,6 +56,9 @@ class ScheduledMessageManager(
     for (record in scheduledMessagesToSend) {
       val expiresIn = SignalDatabase.recipients.getExpiresInSeconds(record.toRecipient.id)
       if (messagesTable.clearScheduledStatus(record.threadId, record.id, expiresIn.seconds.inWholeMilliseconds)) {
+        if (record.toRecipient.isSelf) {
+          messagesTable.markAsUnread(record.id)
+        }
         if (record.toRecipient.isPushGroup) {
           PushGroupSendJob.enqueue(application, AppDependencies.jobManager, record.id, record.toRecipient.id, emptySet(), true)
         } else {


### PR DESCRIPTION
…or preview update

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S25 Ultra (SM-S938U), Android 16 (One UI 8.5)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixes #13352

Fix 1: Conversation list preview not updated
IndividualSendJob and IndividualSendJobV2 called ThreadTable.updateSilently() after marking a scheduled message as sent. updateSilently skips notifyConversationListListeners(), so the UI never refreshes. Fixed by switching to ThreadTable.update().

Fix 2: No notification
Three layers of filtering combined to suppress the notification:
1. getMessagesForNotificationState only fetches messages with READ = 0. Outgoing messages (including Note To Self sends) are stored with READ = 1, so they are never queried.
2. NotificationMessage.isUnreadIncoming excludes all outgoing messages, so even if fetched they would be dropped from notification state.
3. NotificationFactory.shouldAlert() suppressed all notifications where authorRecipient.isSelf.

Fix: when ScheduledMessageManager fires a scheduled Note To Self message, it sets READ = 0 on that message via a new MessageTable.markAsUnread() helper. A new isNoteToSelfScheduled flag in NotificationStateProvider includes outgoing unread messages in Note To Self threads. shouldAlert() is updated to allow alerts for Note To Self conversations specifically (group conversations where you are the last sender remain unaffected). Finally, IndividualSendJob and IndividualSendJobV2 call MessageNotifier.updateNotification() after completing a Note To Self send to trigger the notification at the right moment.

Testing
1. Scheduled a message in Note To Self with the app in the background - notification fired correctly.
2. Scheduled a message and remained in the app in conversations list - conversation list preview updated immediately with an unread badge (no popup notification, which is expected foreground behavior).
3. Sent a regular (non-scheduled) Note To Self message - no notifications.