### PR TITLE
Linkify geo: URIs in message bodies

### DIFF
--- a/core/util-jvm/src/main/java/org/signal/core/util/Linkifier.kt
+++ b/core/util-jvm/src/main/java/org/signal/core/util/Linkifier.kt
@@ -68,7 +68,18 @@ object Linkifier {
   )
 
   /**
-   * Finds all web URLs in [text], in left-to-right order.
+   * Matches a `geo:` URI per RFC 5870 plus Google's `?q=`/`?z=` query extension. Coordinate shape
+   * is permissive here — lat/lon ranges are validated separately by [hasValidGeoCoordinates].
+   */
+  private val GEO_URI_PATTERN: Pattern = Pattern.compile(
+    "(?i)geo:" +
+      "-?\\d{1,3}(?:\\.\\d+)?,-?\\d{1,3}(?:\\.\\d+)?" +
+      "(?:,-?\\d+(?:\\.\\d+)?)?" +
+      "(?:[;?]" + URL_CHAR + "*)?"
+  )
+
+  /**
+   * Finds all web URLs and `geo:` URIs in [text], in left-to-right order.
    */
   @JvmStatic
   fun findLinks(text: CharSequence): List<DetectedLink> {
@@ -76,11 +87,12 @@ object Linkifier {
       return emptyList()
     }
 
-    val matcher = WEB_URL_PATTERN.matcher(text)
     val out = ArrayList<DetectedLink>()
-    while (matcher.find()) {
-      val start = matcher.start()
-      val rawEnd = matcher.end()
+
+    val webMatcher = WEB_URL_PATTERN.matcher(text)
+    while (webMatcher.find()) {
+      val start = webMatcher.start()
+      val rawEnd = webMatcher.end()
 
       if (!isAtLeadingBoundary(text, start)) {
         continue
@@ -104,6 +116,36 @@ object Linkifier {
 
       val normalized = if (raw.contains("://")) raw else "http://$raw"
       out.add(DetectedLink(start, end, normalized))
+    }
+
+    val geoMatcher = GEO_URI_PATTERN.matcher(text)
+    while (geoMatcher.find()) {
+      val start = geoMatcher.start()
+      val rawEnd = geoMatcher.end()
+
+      if (!isAtLeadingBoundary(text, start)) {
+        continue
+      }
+
+      val end = trimTrailingNonUrlChars(text, start, rawEnd)
+      if (end <= start) {
+        continue
+      }
+
+      if (end < text.length && isFormatOrZeroWidth(text[end])) {
+        continue
+      }
+
+      val raw = text.subSequence(start, end).toString()
+      if (!hasValidGeoCoordinates(raw)) {
+        continue
+      }
+
+      out.add(DetectedLink(start, end, raw))
+    }
+
+    if (out.size > 1) {
+      out.sortBy { it.start }
     }
     return out
   }
@@ -208,6 +250,20 @@ object Linkifier {
       return false
     }
     return tld.lowercase() in TOP_LEVEL_DOMAINS
+  }
+
+  /**
+   * Checks that the lat/lon embedded in a geo URI fall within valid Earth ranges. The regex is
+   * permissive so out-of-range coordinates (e.g. lat 91) still need to be rejected here.
+   */
+  private fun hasValidGeoCoordinates(geoUri: String): Boolean {
+    val body = geoUri.substring("geo:".length)
+    val coordEnd = body.indexOfAny(charArrayOf(';', '?')).let { if (it < 0) body.length else it }
+    val parts = body.substring(0, coordEnd).split(',')
+    if (parts.size < 2 || parts.size > 3) return false
+    val lat = parts[0].toDoubleOrNull() ?: return false
+    val lon = parts[1].toDoubleOrNull() ?: return false
+    return lat in -90.0..90.0 && lon in -180.0..180.0
   }
 
   /** Returns a set containing every entry in [unicode] plus its punycode form (where applicable). */

--- a/core/util-jvm/src/test/java/org/signal/core/util/LinkifierTest.kt
+++ b/core/util-jvm/src/test/java/org/signal/core/util/LinkifierTest.kt
@@ -66,6 +66,7 @@ class LinkifierTest(private val case: Case) {
   companion object {
 
     private fun web(spanText: String, url: String = spanText) = Expected(spanText, url)
+    private fun geo(spanText: String) = Expected(spanText, url = spanText)
 
     @Parameterized.Parameters(name = "{0}")
     @JvmStatic
@@ -177,7 +178,40 @@ class LinkifierTest(private val case: Case) {
       Case("leading bidi override rejects url", "‬moc.diordna.com next", emptyList()),
       Case("trailing bidi override rejects url", "moc.diordna.com‭ next", emptyList()),
       Case("internal bidi override rejects both halves", "moc.diordna.com‮moc.diordna.com", emptyList()),
-      Case("zero-width space adjacent to url rejects it", "see signal.org​ next", emptyList())
+      Case("zero-width space adjacent to url rejects it", "see signal.org​ next", emptyList()),
+
+      // ----- geo URIs -----
+      Case("geo uri with basic coords", "geo:48.2010,16.3695", listOf(geo("geo:48.2010,16.3695"))),
+      Case("geo uri with altitude", "geo:48.2010,16.3695,123", listOf(geo("geo:48.2010,16.3695,123"))),
+      Case("geo uri with uncertainty param", "geo:48.2010,16.3695;u=40", listOf(geo("geo:48.2010,16.3695;u=40"))),
+      Case("geo uri with google query and label", "geo:0,0?q=37.786971,-122.399677(Treasure%20Island)", listOf(geo("geo:0,0?q=37.786971,-122.399677(Treasure%20Island)"))),
+      Case("geo uri with google search query", "geo:0,0?q=Eiffel+Tower", listOf(geo("geo:0,0?q=Eiffel+Tower"))),
+      Case("geo uri with negative coords", "geo:-33.86,151.21", listOf(geo("geo:-33.86,151.21"))),
+      Case("geo uri at origin", "geo:0,0", listOf(geo("geo:0,0"))),
+      Case("geo uri scheme is case insensitive", "GEO:48.2,16.3", listOf(geo("GEO:48.2,16.3"))),
+
+      // ----- geo URI in sentence context -----
+      Case("geo uri followed by sentence period", "Meet at geo:48.2,16.3.", listOf(geo("geo:48.2,16.3"))),
+      Case("geo uri followed by sentence comma", "From geo:48.2,16.3, walk north", listOf(geo("geo:48.2,16.3"))),
+      Case("geo uri inside parens is detected without them", "(geo:48.2,16.3)", listOf(geo("geo:48.2,16.3"))),
+      Case("balanced parens inside geo query are preserved", "place geo:0,0?q=37.78,-122.4(Treasure%20Island) end", listOf(geo("geo:0,0?q=37.78,-122.4(Treasure%20Island)"))),
+      Case("unmatched close paren after geo query is trimmed", "(see geo:0,0?q=foo)", listOf(geo("geo:0,0?q=foo"))),
+      Case("non-numeric altitude falls back to coord-only match", "geo:48,16,foo", listOf(geo("geo:48,16"))),
+
+      // ----- geo URI false-positive guards -----
+      Case("geo with lat over 90 is rejected", "geo:91.0,0", emptyList()),
+      Case("geo with lon over 180 is rejected", "geo:0,181.0", emptyList()),
+      Case("geo with lat below -90 is rejected", "geo:-91,0", emptyList()),
+      Case("geo with non-numeric coords is not matched", "geo:foo,bar", emptyList()),
+      Case("geo glued to a leading letter is rejected", "xgeo:48.2,16.3", emptyList()),
+      Case("geo missing lon is not matched", "geo:48.2", emptyList()),
+      Case("bare geo scheme is not matched", "geo:", emptyList()),
+      Case("whitespace between geo coords breaks the uri", "geo:48.2, 16.3", emptyList()),
+
+      // ----- geo + web mixed -----
+      Case("geo uri then web url ordered left-to-right", "see geo:48.2,16.3 and https://signal.org", listOf(geo("geo:48.2,16.3"), web("https://signal.org"))),
+      Case("web url then geo uri ordered left-to-right", "https://signal.org then geo:48.2,16.3", listOf(web("https://signal.org"), geo("geo:48.2,16.3"))),
+      Case("two geo uris in the same string", "from geo:48.2,16.3 to geo:51.5,-0.1", listOf(geo("geo:48.2,16.3"), geo("geo:51.5,-0.1")))
     ).map { arrayOf<Any>(it) }
   }
 }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device `system-images/android-36/google_apis_playstore/arm64-v8a`, Android 16.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

geo: URIs (RFC 5870) were not linkified, and worse, the stock phone
number linkifier matched the coordinates, so "geo:52.5,13.4" rendered
as a tappable phone number.

This PR adds support for geo: to the new Linkifier added in Commit [5655fcf](https://github.com/uzantome/Signal-Android/commit/5655fcf9733e1594c5e9abe2b144520aa3356823).

geo: is a platform-neutral scheme and leaves the choice of map app to the user.
It can be opened locally without disclosing the location to any web service.
It is also supported by Google Maps.
This PR doesn't change what Signal's own location-sharing sends (Google Maps links); it only makes received
geo: URIs behave.

This addresses
- #4206
- #9189
- https://community.signalusers.org/t/support-geo-links/68132/10
- https://community.signalusers.org/t/display-location-as-textual-coordinates/12851

### Tested
- added some unit tests
- tested it in the emulator (see screenshots) with `useNewLinkifier` set to `true`

geo URIs get linkified:
<img width="1080" height="2400" alt="linkified_geo-uris" src="https://github.com/user-attachments/assets/9e00919e-e57b-4246-b2d2-91539324e947" />

tapping a detected geo URI shows the maps-app chooser:
<img width="1080" height="2400" alt="clicking_geo-URI_lets_user_choose_map-app" src="https://github.com/user-attachments/assets/b17ca968-7525-46cf-9fb8-52119cc2527d" />

long-press copies the URI:
<img width="1080" height="2400" alt="long-press_copies" src="https://github.com/user-attachments/assets/cd49d460-51cb-43a1-b4d2-cfd23346ad7e" />


`geo:0,0?q=Eiffel+Tower` opens in Google Maps with the query:

<img width="1080" height="2400" alt="opens-in-googleMaps-with-query-only" src="https://github.com/user-attachments/assets/9ec5b541-0cd7-472c-a3da-780a5523bccc" />

geo URI opened with CoMaps:
<img width="1080" height="2400" alt="geo-URI_opened_in_comaps" src="https://github.com/user-attachments/assets/7e99c6b4-dd86-41bb-ac49-14d268d64c7e" />

