### PR TITLE
Enable key transparency checks for all users

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/advanced/AdvancedPrivacySettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/advanced/AdvancedPrivacySettingsFragment.kt
@@ -45,7 +45,6 @@ import org.signal.core.ui.compose.Texts
 import org.thoughtcrime.securesms.R
 import org.thoughtcrime.securesms.compose.rememberStatusBarColorNestedScrollModifier
 import org.thoughtcrime.securesms.util.CommunicationActions
-import org.thoughtcrime.securesms.util.RemoteConfig
 import org.thoughtcrime.securesms.util.viewModel
 
 /**
@@ -301,31 +300,29 @@ private fun AdvancedPrivacySettingsScreen(
         )
       }
 
-      if (RemoteConfig.internalUser) {
-        item {
-          Dividers.Default()
-        }
+      item {
+        Dividers.Default()
+      }
 
-        item {
-          val label = buildAnnotatedString {
-            append(stringResource(R.string.preferences_automatic_key_verification_body))
-            append(" ")
-            withLink(
-              LinkAnnotation.Clickable("learn-more", linkInteractionListener = {
-                callbacks.onAutomaticVerificationLearnMoreClick()
-              })
-            ) {
-              append(stringResource(R.string.LearnMoreTextView_learn_more))
-            }
+      item {
+        val label = buildAnnotatedString {
+          append(stringResource(R.string.preferences_automatic_key_verification_body))
+          append(" ")
+          withLink(
+            LinkAnnotation.Clickable("learn-more", linkInteractionListener = {
+              callbacks.onAutomaticVerificationLearnMoreClick()
+            })
+          ) {
+            append(stringResource(R.string.LearnMoreTextView_learn_more))
           }
-
-          Rows.ToggleRow(
-            checked = state.allowAutomaticKeyVerification,
-            text = AnnotatedString(stringResource(R.string.preferences_automatic_key_verification)),
-            label = label,
-            onCheckChanged = callbacks::onAllowAutomaticVerificationChanged
-          )
         }
+
+        Rows.ToggleRow(
+          checked = state.allowAutomaticKeyVerification,
+          text = AnnotatedString(stringResource(R.string.preferences_automatic_key_verification)),
+          label = label,
+          onCheckChanged = callbacks::onAllowAutomaticVerificationChanged
+        )
       }
     }
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/CheckKeyTransparencyJob.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/CheckKeyTransparencyJob.kt
@@ -17,7 +17,6 @@ import org.thoughtcrime.securesms.keyvalue.PhoneNumberPrivacyValues.PhoneNumberD
 import org.thoughtcrime.securesms.keyvalue.SignalStore
 import org.thoughtcrime.securesms.net.SignalNetwork
 import org.thoughtcrime.securesms.recipients.Recipient
-import org.thoughtcrime.securesms.util.RemoteConfig
 import org.thoughtcrime.securesms.util.TextSecurePreferences
 import org.whispersystems.signalservice.api.crypto.UnidentifiedAccess
 import kotlin.random.Random
@@ -87,10 +86,7 @@ class CheckKeyTransparencyJob private constructor(
     }
 
     private fun canRunJob(): Boolean {
-      return if (!RemoteConfig.internalUser) {
-        Log.i(TAG, "Remote config is not on. Exiting.")
-        false
-      } else if (!SignalStore.account.isRegistered) {
+      return if (!SignalStore.account.isRegistered) {
         Log.i(TAG, "Account not registered. Exiting.")
         false
       } else if (TextSecurePreferences.isUnauthorizedReceived(AppDependencies.application)) {

--- a/app/src/main/java/org/thoughtcrime/securesms/verify/VerifyDisplayScreenState.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/verify/VerifyDisplayScreenState.kt
@@ -7,12 +7,11 @@ package org.thoughtcrime.securesms.verify
 
 import org.thoughtcrime.securesms.keyvalue.SignalStore
 import org.thoughtcrime.securesms.recipients.Recipient
-import org.thoughtcrime.securesms.util.RemoteConfig
 
 data class VerifyDisplayScreenState(
   val isSafetyNumberVerified: Boolean,
-  val isAutomaticVerificationVisible: Boolean = RemoteConfig.internalUser && SignalStore.settings.automaticVerificationEnabled,
-  val shouldDisplayVerifyAutomaticallyEducationSheet: Boolean = RemoteConfig.internalUser && SignalStore.settings.automaticVerificationEnabled && !SignalStore.uiHints.hasSeenVerifyAutomaticallySheet(),
+  val isAutomaticVerificationVisible: Boolean = SignalStore.settings.automaticVerificationEnabled,
+  val shouldDisplayVerifyAutomaticallyEducationSheet: Boolean = SignalStore.settings.automaticVerificationEnabled && !SignalStore.uiHints.hasSeenVerifyAutomaticallySheet(),
   val recipient: Recipient? = null,
   val fingerprintHolder: FingerprintHolder = FingerprintHolder.Uninitialised,
   val automaticVerificationStatus: AutomaticVerificationStatus = AutomaticVerificationStatus.NONE,


### PR DESCRIPTION
## Summary
- Remove the internal-user gate from scheduled key transparency checks.
- Show automatic key verification controls whenever automatic verification is enabled.
- Keep the automatic verification education sheet tied to the feature setting instead of internal-user status.

## Testing
- `git diff --check`
- Searched for remaining automatic verification references gated by `RemoteConfig.internalUser`.
