### PR TITLE
Prevent entering oversized custom donation amounts

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/subscription/boost/Boost.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/subscription/boost/Boost.kt
@@ -244,6 +244,7 @@ data class Boost(
 
     val pattern: Pattern = "($digitsGroup)*([$separator]){0,$separatorCount}($digitsGroup){0,${currency.defaultFractionDigits}}".toPattern()
     val symbolPattern: Regex = """\s*${Regex.escape(symbol)}\s*""".toRegex()
+    private val maximumCustomDonationIntegralDigits = 10
     val leadingZeroesPattern: Regex = """^($zeros)*""".toRegex()
 
     override fun filter(
@@ -256,6 +257,12 @@ data class Boost(
     ): CharSequence? {
       val result = dest.subSequence(0, dstart).toString() + source.toString() + dest.subSequence(dend, dest.length)
       val resultWithoutCurrencyPrefix = BidiUtil.stripBidiIndicator(result.removePrefix(symbol).removeSuffix(symbol).trim())
+
+      val integralPart = resultWithoutCurrencyPrefix.substringBefore(separator)
+
+      if (integralPart.count { it.isDigit() } > maximumCustomDonationIntegralDigits) {
+        return dest.subSequence(dstart, dend)
+      }
 
       if (resultWithoutCurrencyPrefix.length == 1 && !resultWithoutCurrencyPrefix.isDigitsOnly() && resultWithoutCurrencyPrefix != separator.toString()) {
         return dest.subSequence(dstart, dend)


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist

- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist

- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
  - Google Pixel 8, Android 16 (Build: BP3A.251005.004.B2)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Fixes #14750

#### Summary

This change adds input-level validation to the custom one-time donation amount field.

Previously, users could continue entering arbitrarily large numeric values into the custom donation amount field. This change prevents additional digits from being entered once the configured input limit has been reached while preserving the existing currency formatting and validation behavior.

#### Testing

**Device**

- Google Pixel 8
- Android 16 (Build: BP3A.251005.004.B2)

**App**

- Signal Android 8.17.1 (versionCode 171101)

Verified that:

- Valid custom donation amounts can still be entered.
- Currency formatting continues to work correctly.
- Additional digits are rejected once the configured input limit is reached.
- Existing predefined donation options continue to function as expected.

#### Screenshots

##### Before

![Before](https://github.com/user-attachments/assets/17e25d39-a7ea-418f-9e11-96e95ad26e5e)

##### After

![After](https://github.com/user-attachments/assets/3825c587-6af6-4256-bde6-c65d9ec71153)