### PR TITLE
Use explicit Gradle property assignment in contacts modules

### DIFF
--- a/demo/contacts/build.gradle
+++ b/demo/contacts/build.gradle
@@ -4,10 +4,10 @@ plugins {
 }
 
 android {
-    namespace 'org.signal.contactstest'
+    namespace = 'org.signal.contactstest'
 
     defaultConfig {
-        applicationId "org.signal.contactstest"
+        applicationId = "org.signal.contactstest"
     }
 }
 

--- a/lib/contacts/build.gradle
+++ b/lib/contacts/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 android {
-    namespace 'org.signal.contacts'
+    namespace = 'org.signal.contacts'
 }
 
 dependencies {


### PR DESCRIPTION
Replaces deprecated Groovy DSL property assignment syntax in the contacts Gradle scripts with explicit assignment syntax. This keeps the module configuration behavior the same while avoiding Gradle 10 deprecation warnings.