### PR TITLE
Collapse messages with excessive newlines regardless of character count

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
@@ -1221,7 +1221,7 @@ public final class ConversationItem extends RelativeLayout implements BindableCo
       if (hasExtraText(messageRecord)) {
         bodyText.setOverflowText(getLongMessageSpan(messageRecord));
         int trimmedLength = TextUtils.getTrimmedLength(styledText);
-        int maxLength     = Math.min(MessageRecordUtil.MAX_BODY_DISPLAY_LENGTH, trimmedLength - 2);
+        int maxLength     = Math.min(MessageRecordUtil.getMaxBodyDisplayLength(messageRecord), trimmedLength - 2);
         bodyText.setMaxLength(maxLength);
       }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/items/V2ConversationItemTextOnlyViewHolder.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/items/V2ConversationItemTextOnlyViewHolder.kt
@@ -49,7 +49,6 @@ import org.thoughtcrime.securesms.recipients.Recipient
 import org.thoughtcrime.securesms.recipients.RecipientId
 import org.thoughtcrime.securesms.util.InterceptableLongClickCopyLinkSpan
 import org.thoughtcrime.securesms.util.LongClickMovementMethod
-import org.thoughtcrime.securesms.util.MAX_BODY_DISPLAY_LENGTH
 import org.thoughtcrime.securesms.util.PlaceholderURLSpan
 import org.thoughtcrime.securesms.util.Projection
 import org.thoughtcrime.securesms.util.ProjectionList
@@ -58,6 +57,7 @@ import org.thoughtcrime.securesms.util.SignalLocalMetrics
 import org.thoughtcrime.securesms.util.VibrateUtil
 import org.thoughtcrime.securesms.util.ViewUtil
 import org.thoughtcrime.securesms.util.adapter.mapping.MappingModel
+import org.thoughtcrime.securesms.util.getMaxBodyDisplayLength
 import org.thoughtcrime.securesms.util.hasExtraText
 import org.thoughtcrime.securesms.util.hasNoBubble
 import org.thoughtcrime.securesms.util.isScheduled
@@ -422,7 +422,7 @@ open class V2ConversationItemTextOnlyViewHolder<Model : MappingModel<Model>>(
     if (record.hasExtraText()) {
       binding.body.setOverflowText(getLongMessageSpan())
       val trimmedLength = StringUtil.trim(styledText).length
-      binding.body.setMaxLength(minOf(MAX_BODY_DISPLAY_LENGTH, trimmedLength - 2))
+      binding.body.setMaxLength(minOf(record.getMaxBodyDisplayLength(), trimmedLength - 2))
     } else {
       binding.body.setOverflowText(null)
       binding.body.setMaxLength(-1)

--- a/app/src/main/java/org/thoughtcrime/securesms/util/MessageRecordUtil.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/MessageRecordUtil.kt
@@ -16,6 +16,7 @@ import org.thoughtcrime.securesms.polls.PollRecord
 import org.thoughtcrime.securesms.stickers.StickerUrl
 
 const val MAX_BODY_DISPLAY_LENGTH = 1000
+const val MAX_BODY_DISPLAY_LINES = 16
 
 fun MessageRecord.isMediaMessage(): Boolean {
   return isMms &&
@@ -66,9 +67,26 @@ fun MessageRecord.isViewOnceMessage(): Boolean = isMms && (this as MmsMessageRec
 
 fun MessageRecord.hasExtraText(): Boolean {
   val hasTextSlide = isMms && (this as MmsMessageRecord).slideDeck.textSlide != null
-  val hasOverflowText: Boolean = body.length > MAX_BODY_DISPLAY_LENGTH
+  val hasOverflowText: Boolean = body.length > MAX_BODY_DISPLAY_LENGTH || body.count { it == '\n' } >= MAX_BODY_DISPLAY_LINES
 
   return hasTextSlide || hasOverflowText
+}
+
+/**
+ * Returns the maximum number of characters that should be displayed for a message body.
+ * This takes into account both [MAX_BODY_DISPLAY_LENGTH] and [MAX_BODY_DISPLAY_LINES].
+ */
+fun MessageRecord.getMaxBodyDisplayLength(): Int {
+  var lineCount = 0
+  for (i in body.indices) {
+    if (body[i] == '\n') {
+      lineCount++
+      if (lineCount == MAX_BODY_DISPLAY_LINES) {
+        return minOf(MAX_BODY_DISPLAY_LENGTH, i)
+      }
+    }
+  }
+  return MAX_BODY_DISPLAY_LENGTH
 }
 
 fun MessageRecord.hasQuote(): Boolean = isMms && (this as MmsMessageRecord).quote != null


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
  * Virtual device (emulator), Android 15
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` syntax

----------

### Description

Previously, whether a message needed a "Read more" overflow was decided purely by character count (`MAX_BODY_DISPLAY_LENGTH`). Messages with very few characters but a large number of newlines were never flagged as overflowing, causing them to render at full height and degrade scroll performance (see #14861).

This adds a line-count check (`MAX_BODY_DISPLAY_LINES`) alongside the existing character-count check in `hasExtraText()`, and introduces `getMaxBodyDisplayLength()` to compute the correct truncation point based on whichever limit (characters or lines) is hit first.

**How I tested it:**
- Built the project and ran it on a virtual device (Android 15).
- Sent a message consisting of a short string with a large number of newlines (e.g. a single character, followed by many blank lines, followed by another character) and confirmed it now correctly collapses with a "Read more" option, and that scrolling near it is smooth.
- Verified that existing behavior for normal long text messages (1000+ characters, few/no newlines) still collapses correctly as before, confirming no regression.

Fixes #14861