### PR TITLE
Fix black bars around circular notification avatars

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/v2/NotificationExtensions.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/v2/NotificationExtensions.kt
@@ -49,8 +49,8 @@ fun Recipient.getContactDrawable(context: Context): Drawable? {
         .diskCacheStrategy(DiskCacheStrategy.ALL)
         .transform(MultiTransformation(listOf(CircleCrop())))
         .submit(
-          context.resources.getDimensionPixelSize(android.R.dimen.notification_large_icon_width),
-          context.resources.getDimensionPixelSize(android.R.dimen.notification_large_icon_height)
+          context.resources.getDimensionPixelSize(R.dimen.contact_photo_target_size),
+          context.resources.getDimensionPixelSize(R.dimen.contact_photo_target_size)
         )
         .get(IMAGE_LOAD_TIMEOUT_SECONDS, TimeUnit.SECONDS)
     } catch (e: InterruptedException) {


### PR DESCRIPTION
Uses the app's own square contact_photo_target_size dimension for the Glide submit() call instead of the OEM-overridable system dimensions android.R.dimen.notification_large_icon_width/height. Those system dimensions aren't guaranteed to be square, so CircleCrop() could produce a rectangular bitmap with transparent letterbox padding, which some OEM skins render as black bars instead of transparency.

Fixes #14811

### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Realme 15 pro, Android 16
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
While I was investigating this, I stepped through the rendering of the notification avatar and noticed Recipient.getContactDrawable() (in NotificationExtensions.kt) issues a Glide request using the system dimensions of android.R.dimen.notificationlargeiconwidth and height. These are dimensions that OEM can override, and there’s nothing to say they are equal. Since CircleCrop() only inscribes a circle inside whatever box is provided, an imperfectly shaped box leaves transparency letterboxed around the circle. This bitmap is then almost entirely unchanged and handed off to setLargeIcon() (the resizing call in toLargeBitmap()/BitmapUtil.createFromDrawable() doesn’t happen for BitmapDrawable, so the padding carries through). On some OEM notification-shade skins, this transparent area seems to display as black, which is a plausible explanation for the black bars in the initial report.
The proposed fix uses the app’s own square contactphototarget_size value (which is already being used later in the notification icon pipeline) instead of the OEM-supplied system values. That way, the image is already square when it’s given to Glide, so CircleCrop() never produces any letterboxing.

Testing status

I’ve built and installed this code after applying the fix onto my Realme device (Android 16) and can see that notification icons are now displayed without the black bars. I don’t know whether the bug would have reproduced on this device prior to the fix though, so I cannot definitively confirm that this device was one affected by the issue – the report mentioned the bug as being on a Samsung Galaxy A34 on One UI. It would be useful if the original reporter or anyone with a Samsung/One UI device could check that this solves the issue for them as well.
