### PR TITLE
Fix duplicate clipboard popup

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/LongClickCopySpan.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/LongClickCopySpan.java
@@ -2,6 +2,7 @@ package org.thoughtcrime.securesms.util;
 
 import android.content.Context;
 import android.graphics.Color;
+import android.os.Build;
 import android.text.TextPaint;
 import android.text.style.URLSpan;
 import android.view.View;
@@ -38,7 +39,9 @@ public class LongClickCopySpan extends URLSpan {
     Context context = widget.getContext();
     String preparedUrl = prepareUrl(getURL());
     copyUrl(context, preparedUrl);
-    Toast.makeText(context, context.getString(R.string.ConversationItem_copied_text, preparedUrl), Toast.LENGTH_SHORT).show();
+    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+      Toast.makeText(context, context.getString(R.string.ConversationItem_copied_text, preparedUrl), Toast.LENGTH_SHORT).show();
+    }
   }
 
   @Override


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Virtual device: Pixel 10 Pro XL, Android 17.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

When copying an URI from a message using a long press on Android 13 and higher, Android as well as Signal show a popup/toast. Signal's toast is displayed on top of the Android system popup, making it unreadable and confusing.
Related forum post: https://community.signalusers.org/t/dont-show-toast-when-uri-is-copied/72147
This behavior is explicitly discouraged by the Android Developer Docs: https://developer.android.com/develop/ui/views/touch-and-input/copy-paste#duplicate-notifications
This PRs applies the fix suggested by the Android Developer Docs by conditionally displaying the toast when the Android version is below 13.

<img height="512" alt="image" src="https://github.com/user-attachments/assets/df2e3d23-dcfa-46b5-8eef-0a97dba6ba24" />