### PR TITLE
Fix NullPointerException in v2 backup creation for classic attachments

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/AttachmentTable.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/AttachmentTable.kt
@@ -625,7 +625,7 @@ class AttachmentTable(
         LocalArchivableAttachment(
           attachmentId = AttachmentId(it.requireLong(ID)),
           file = File(it.requireNonNullString(DATA_FILE)),
-          random = it.requireNonNullBlob(DATA_RANDOM),
+          random = it.requireBlob(DATA_RANDOM),
           size = it.requireLong(DATA_SIZE),
           localBackupKey = AttachmentMetadataTable.getMetadata(it)!!.localBackupKey!!,
           plaintextHash = Base64.decode(it.requireNonNullString(DATA_HASH_END)),
@@ -649,7 +649,7 @@ class AttachmentTable(
         LocalArchivableAttachment(
           attachmentId = AttachmentId(it.requireLong(ID)),
           file = File(it.requireNonNullString(DATA_FILE)),
-          random = it.requireNonNullBlob(DATA_RANDOM),
+          random = it.requireBlob(DATA_RANDOM),
           size = it.requireLong(DATA_SIZE),
           localBackupKey = AttachmentMetadataTable.getMetadata(it)!!.localBackupKey!!,
           plaintextHash = Base64.decode(it.requireNonNullString(DATA_HASH_END)),
@@ -2708,9 +2708,9 @@ class AttachmentTable(
   }
 
   @Throws(FileNotFoundException::class)
-  private fun getDataStream(file: File, random: ByteArray, offset: Long): InputStream? {
+  private fun getDataStream(file: File, random: ByteArray?, offset: Long): InputStream? {
     return try {
-      if (random.size == 32) {
+      if (random != null && random.size == 32) {
         ModernDecryptingPartInputStream.createFor(attachmentSecret, random, file, offset)
       } else {
         val stream = ClassicDecryptingPartInputStream.createFor(attachmentSecret, file)
@@ -2735,7 +2735,11 @@ class AttachmentTable(
     val thumbnailInfo = getThumbnailFileInfo(attachmentId) ?: return null
 
     return try {
-      ModernDecryptingPartInputStream.createFor(attachmentSecret, thumbnailInfo.random, thumbnailInfo.file, offset)
+      if (thumbnailInfo.random != null && thumbnailInfo.random.size == 32) {
+        ModernDecryptingPartInputStream.createFor(attachmentSecret, thumbnailInfo.random, thumbnailInfo.file, offset)
+      } else {
+        ClassicDecryptingPartInputStream.createFor(attachmentSecret, thumbnailInfo.file)
+      }
     } catch (e: FileNotFoundException) {
       Log.w(TAG, e)
       throw e
@@ -3527,7 +3531,7 @@ class AttachmentTable(
 
   private fun Cursor.readDataFileInfo(): DataFileInfo? {
     val filePath: String = this.requireString(DATA_FILE) ?: return null
-    val random: ByteArray = this.requireBlob(DATA_RANDOM) ?: return null
+    val random: ByteArray? = this.requireBlob(DATA_RANDOM)
 
     return DataFileInfo(
       id = AttachmentId(this.requireLong(ID)),
@@ -3551,7 +3555,7 @@ class AttachmentTable(
     return ThumbnailFileInfo(
       id = AttachmentId(this.requireLong(ID)),
       file = File(this.requireNonNullString(THUMBNAIL_FILE)),
-      random = this.requireNonNullBlob(THUMBNAIL_RANDOM)
+      random = this.requireBlob(THUMBNAIL_RANDOM)
     )
   }
 
@@ -3923,7 +3927,7 @@ class AttachmentTable(
     val id: AttachmentId,
     val file: File,
     val length: Long,
-    val random: ByteArray,
+    val random: ByteArray?,
     val hashStart: String?,
     val hashEnd: String?,
     val transformProperties: TransformProperties,
@@ -3940,7 +3944,7 @@ class AttachmentTable(
   class ThumbnailFileInfo(
     val id: AttachmentId,
     val file: File,
-    val random: ByteArray
+    val random: ByteArray?
   )
 
   enum class ThumbnailRestoreState(val value: Int) {
@@ -4013,7 +4017,7 @@ class AttachmentTable(
   class LocalArchivableAttachment(
     val attachmentId: AttachmentId,
     val file: File,
-    val random: ByteArray,
+    val random: ByteArray?,
     val size: Long,
     val plaintextHash: ByteArray,
     val localBackupKey: LocalBackupKey,

--- a/core/util/src/main/java/org/signal/core/util/CursorExtensions.kt
+++ b/core/util/src/main/java/org/signal/core/util/CursorExtensions.kt
@@ -155,7 +155,7 @@ inline fun <T> Cursor.readToList(predicate: (T) -> Boolean = { true }, mapper: (
     while (moveToNext()) {
       val record = mapper(this)
       if (predicate(record)) {
-        list += mapper(this)
+        list += record
       }
     }
   }
@@ -190,7 +190,7 @@ inline fun <T> Cursor.readToSet(predicate: (T) -> Boolean = { true }, mapper: (C
     while (moveToNext()) {
       val record = mapper(this)
       if (predicate(record)) {
-        set += mapper(this)
+        set += record
       }
     }
   }


### PR DESCRIPTION
This PR fixes a NullPointerException that occurred when users with older accounts attempted to create v2 backups.
Root Cause: Older attachments encrypted using the "Classic" scheme have a NULL value in the DATA_RANDOM column of the attachment table. The current implementation of getLocalArchivableAttachments used requireNonNullBlob(DATA_RANDOM), which triggered a crash when encountering these legacy records.
Changes:

1. Model Nullability: Updated LocalArchivableAttachment, DataFileInfo, and ThumbnailFileInfo in AttachmentTable.kt to allow a nullable random field.

2. Decryption Fallback: Updated getDataStream and getThumbnailStream to check for the presence and length of the random bytes. If random is null or not 32 bytes, the logic now correctly falls back to ClassicDecryptingPartInputStream.

3. CursorExtensions Fix: While investigating, I found that readToList and readToSet in CursorExtensions.kt were invoking the mapper function twice per row (once for the predicate and once for the list addition). This has been fixed to only invoke the mapper once.

Fixes: #14875