### PR TITLE
Fix doze banner dismissal

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/banner/banners/DozeBanner.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/banner/banners/DozeBanner.kt
@@ -6,12 +6,16 @@
 package org.thoughtcrime.securesms.banner.banners
 
 import android.content.Context
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import org.signal.core.ui.compose.DayNightPreviews
 import org.signal.core.ui.compose.Previews
 import org.signal.core.util.ServiceUtil
@@ -23,7 +27,7 @@ import org.thoughtcrime.securesms.keyvalue.SignalStore
 import org.thoughtcrime.securesms.util.PowerManagerCompat
 import org.thoughtcrime.securesms.util.TextSecurePreferences
 
-class DozeBanner(private val context: Context, private val onDismissListener: () -> Unit) : Banner<Unit>() {
+class DozeBanner(private val context: Context) : Banner<Unit>() {
 
   override val enabled: Boolean
     get() = !SignalStore.account.fcmEnabled && !TextSecurePreferences.hasPromptedOptimizeDoze(context) && !ServiceUtil.getPowerManager(context).isIgnoringBatteryOptimizations(context.packageName)
@@ -31,19 +35,35 @@ class DozeBanner(private val context: Context, private val onDismissListener: ()
   override val dataFlow: Flow<Unit>
     get() = flowOf(Unit)
 
+  private val enabledState = MutableStateFlow(enabled)
+
+  override val stateUpdates: Flow<Unit>
+    get() = enabledState.map { }
+
   @Composable
   override fun DisplayBanner(model: Unit, contentPadding: PaddingValues) {
+    val batteryOptLauncher = rememberLauncherForActivityResult(
+      contract = ActivityResultContracts.StartActivityForResult()
+    ) { _ ->
+      markAsPrompted()
+    }
+
     Banner(
       contentPadding = contentPadding,
       onDismissListener = {
-        TextSecurePreferences.setPromptedOptimizeDoze(context, true)
-        onDismissListener.invoke()
+        markAsPrompted()
       },
       onOkListener = {
-        TextSecurePreferences.setPromptedOptimizeDoze(context, true)
-        PowerManagerCompat.requestIgnoreBatteryOptimizations(context)
+        batteryOptLauncher.launch(
+          PowerManagerCompat.buildRequestIgnoreBatteryOptimizationsIntent(context)
+        )
       }
     )
+  }
+
+  private fun markAsPrompted() {
+    TextSecurePreferences.setPromptedOptimizeDoze(context, true)
+    enabledState.value = false
   }
 }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
@@ -836,10 +836,7 @@ public class ConversationListFragment extends MainFragment implements Conversati
         new UnauthorizedBanner(requireContext()),
         new ServiceOutageBanner(requireContext()),
         new OutdatedBuildBanner(),
-        new DozeBanner(requireContext(), () -> {
-          bannerManager.updateContent(bannerView.get());
-          return Unit.INSTANCE;
-        }),
+        new DozeBanner(requireContext()),
         new CdsTemporaryErrorBanner(getChildFragmentManager()),
         new CdsPermanentErrorBanner(getChildFragmentManager()),
         new UsernameOutOfSyncBanner((usernameSyncState) -> {

--- a/app/src/main/java/org/thoughtcrime/securesms/util/PowerManagerCompat.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/PowerManagerCompat.java
@@ -20,8 +20,12 @@ public class PowerManagerCompat {
   }
 
   public static void requestIgnoreBatteryOptimizations(@NonNull Context context) {
-    Intent intent = new Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
-                               Uri.parse("package:" + context.getPackageName()));
-    context.startActivity(intent);
+    context.startActivity(buildRequestIgnoreBatteryOptimizationsIntent(context));
+  }
+
+  @NonNull
+  public static Intent buildRequestIgnoreBatteryOptimizationsIntent(@NonNull Context context) {
+    return new Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+                      Uri.parse("package:" + context.getPackageName()));
   }
 }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel, Android 14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

The doze banner ("Optimize for Missing Play Services") was not hiding after the user either dismisses the banner or completes the battery optimization prompt (denying or allowing the permission).

This PR fixes this issue, and now the banner dismisses itself via `Banner.stateUpdates` flow.

<img width="270" height="540" alt="Screenshot_20260714_160051" src="https://github.com/user-attachments/assets/85dd932d-aa19-4fb1-9e8e-8d34c778e73f" />
