### PR TITLE
Fix audio dropping issues in Jetpack Telecom integration

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/TelecomCallController.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/TelecomCallController.kt
@@ -7,6 +7,7 @@ import android.telecom.DisconnectCause
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.telecom.CallAttributesCompat
+import androidx.core.telecom.CallControlResult
 import androidx.core.telecom.CallEndpointCompat
 import androidx.core.telecom.CallsManager
 import kotlinx.coroutines.channels.Channel
@@ -21,6 +22,7 @@ import org.thoughtcrime.securesms.keyvalue.SignalStore
 import org.thoughtcrime.securesms.recipients.Recipient
 import org.thoughtcrime.securesms.recipients.RecipientId
 import org.thoughtcrime.securesms.webrtc.CallNotificationBuilder
+import org.thoughtcrime.securesms.webrtc.audio.AudioManagerCommand
 import org.thoughtcrime.securesms.webrtc.audio.SignalAudioManager
 
 sealed class TelecomCommand {
@@ -179,8 +181,17 @@ class TelecomCallController(
         for (command in commandChannel) {
           when (command) {
             is TelecomCommand.Activate -> {
-              val result = setActive()
-              Log.i(TAG, "setActive result: $result")
+              val result = if (isOutgoing) {
+                setActive()
+              } else {
+                val callType = if (isVideoCall) CallAttributesCompat.CALL_TYPE_VIDEO_CALL else CallAttributesCompat.CALL_TYPE_AUDIO_CALL
+                answer(callType)
+              }
+              Log.i(TAG, "activate result: $result")
+              if (result is CallControlResult.Success) {
+                ActiveCallManager.sendAudioManagerCommand(context, AudioManagerCommand.Start())
+                Log.i(TAG, "AudioManagerCommand.Start fired for callId=$callId recipientId=$recipientId")
+              }
               needToResetAudioRoute = false
             }
             is TelecomCommand.Disconnect -> {


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 10 & Pixel Watch 3, Android 17 (CP2A.260705.006)
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
- Replaced `setActive()` with `answer(callType)` for incoming calls in `TelecomCallController`'s `Activate` command block, as Jetpack Telecom requires incoming calls to be explicitly answered.
- Enforced waiting for a successful `CallControlResult.Success` before dispatching `AudioManagerCommand.Start` to the `ActiveCallManager`, ensuring that the WebRTC audio engine does not begin recording or playing before Telecom has actually initialized the active media route.
