### PR TITLE
Update R8 configuration for deterministic and reproducible builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,12 @@
 # R8 in AGP 9.x is non-deterministic, producing intermittent dex differences between
 # otherwise-identical builds. Two flags work together to stabilize it:
-#   - -Dcom.android.tools.r8.threadCount=1 removes thread-scheduling-dependent ordering.
+#   - -Dcom.android.tools.r8.deterministicdebugging=true run R8 compilation in a 
+#     single thread and without randomly shuffling the input.
 #   - -XX:hashCode=3 (deterministic incrementing Object.identityHashCode) removes
 #     IdentityHashMap iteration-order non-determinism inside R8 (e.g. in
 #     KotlinClassMetadataReader, which decides whether to keep the Signature attribute
 #     on Kotlin generic lambda subclasses).
-org.gradle.jvmargs=-Xmx12g -Xms256m -XX:MaxMetaspaceSize=1g -Dcom.android.tools.r8.threadCount=1 -XX:+UnlockExperimentalVMOptions -XX:hashCode=3
+org.gradle.jvmargs=-Xmx12g -Xms256m -XX:MaxMetaspaceSize=1g -Dcom.android.tools.r8.deterministicdebugging=true -XX:+UnlockExperimentalVMOptions -XX:hashCode=3
 
 # Without this, the Kotlin compile daemon inherits -Xmx12g from org.gradle.jvmargs.
 kotlin.daemon.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Fedora 44
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

#### Context

Currently, Signal-Android tries to enforce deterministic R8 compilation by setting threadCount=1 in gradle.properties, as you can see in this commit: https://github.com/signalapp/Signal-Android/commit/09822d3ae9879565f78fd8a62e4393599df929e9

#### Problem

The option `com.android.tools.r8.threadCount=1` does not exist in [R8 source code](https://r8.googlesource.com/r8/+/refs/heads/main) and therefore has no effect.

### Changes introduced by this MR

Remove the `com.android.tools.r8.threadCount=1` option and add `com.android.tools.r8.deterministicdebugging=true` instead.

As you can see in the R8 source code:
https://r8.googlesource.com/r8/+/refs/heads/main/src/main/java/com/android/tools/r8/utils/InternalOptions.java#164
```java
  // Set to true to run compilation in a single thread and without randomly shuffling the input.
  // This makes life easier when running R8 in a debugger.
  public static final boolean DETERMINISTIC_DEBUGGING =
      System.getProperty("com.android.tools.r8.deterministicdebugging") != null;
```

You can also see here that this is the correct option to set threadCount to 1:
https://r8.googlesource.com/r8/+/refs/heads/main/src/main/java/com/android/tools/r8/utils/InternalOptions.java#555
```java
  // Number of threads to use while processing the dex files.
  public int threadCount = DETERMINISTIC_DEBUGGING ? 1 : ThreadUtils.NOT_SPECIFIED;
``` 


### Credits

@valldrac (from Molly) was the one who noticed that the `com.android.tools.r8.threadCount` option did not exists on R8. He ran compilation tests to confirm that `threadCount` had no effect, and that `deterministicdebugging` really fixed the issue (see https://github.com/mollyim/mollyim-android/pull/795#issuecomment-5044622052)

> In the end, enabling com.android.tools.r8.deterministicdebugging resolved the issue. I also confirmed this by taking heap dumps during the minify task and inspecting R8's configuration. The correct approach is indeed to enable deterministicdebugging.