### PR TITLE
Use local time for local-backup snapshot folder names

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/backup/v2/local/ArchiveFileSystem.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/v2/local/ArchiveFileSystem.kt
@@ -38,7 +38,6 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
-import java.util.TimeZone
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -255,7 +254,7 @@ class ArchiveFileSystem private constructor(private val context: Context, root: 
    * Attempt to create a [SnapshotFileSystem] to represent a single backup snapshot.
    */
   fun createSnapshot(): SnapshotFileSystem? {
-    val timestamp = SimpleDateFormat("yyyy-MM-dd-HH-mm-ss", Locale.US).apply { timeZone = TimeZone.getTimeZone("UTC") }.format(Date())
+    val timestamp = SimpleDateFormat("yyyy-MM-dd-HH-mm-ss", Locale.US).format(Date())
     val snapshotDirectoryName = "${BACKUP_DIRECTORY_PREFIX}-$timestamp"
 
     if (signalBackups.hasFile(snapshotDirectoryName)) {
@@ -281,6 +280,11 @@ class ArchiveFileSystem private constructor(private val context: Context, root: 
 
   /**
    * List all snapshots found in this directory sorted by creation timestamp, newest first.
+   *
+   * The timestamp comes from the directory's last-modified time rather than its name. Names are only a fallback for providers that don't report a modified
+   * time, because a directory may have been named by a version that stamped names in UTC rather than local time, and parsing such a name with a single rule
+   * yields a time that is off by the local UTC offset. That matters here: this ordering drives both [deleteOldBackups] retention and the dates shown when
+   * choosing a backup to restore.
    */
   fun listSnapshots(): List<SnapshotInfo> {
     return signalBackups
@@ -290,7 +294,7 @@ class ArchiveFileSystem private constructor(private val context: Context, root: 
       .mapNotNull { f -> f.name?.let { it to f } }
       .filter { (name, _) -> name.startsWith(BACKUP_DIRECTORY_PREFIX) }
       .map { (name, file) ->
-        val timestamp = name.replace(BACKUP_DIRECTORY_PREFIX, "").toMilliseconds()
+        val timestamp = file.lastModified().takeIf { it > 0 } ?: name.replace(BACKUP_DIRECTORY_PREFIX, "").toMilliseconds()
         SnapshotInfo(timestamp, name, file)
       }
       .sortedByDescending { it.timestamp }
@@ -507,12 +511,19 @@ class FilesFileSystem(private val context: Context, private val root: DocumentFi
   }
 }
 
+/**
+ * Parses a snapshot directory name suffix (e.g. "-2026-01-02-03-04-05") into epoch milliseconds, interpreting the timestamp in the device's default time zone
+ * to match [ArchiveFileSystem.createSnapshot].
+ *
+ * Only a fallback for [ArchiveFileSystem.listSnapshots] when a directory reports no modified time. Names written before snapshots were stamped in local time
+ * are in UTC, and nothing in the name distinguishes the two, so a parsed value can be off by the local UTC offset.
+ */
 private fun String.toMilliseconds(): Long {
   val parts: List<String> = split("-").dropLastWhile { it.isEmpty() }
 
   if (parts.size == 7) {
     try {
-      val calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"), Locale.US)
+      val calendar = Calendar.getInstance(Locale.US)
       calendar[Calendar.YEAR] = parts[1].toInt()
       calendar[Calendar.MONTH] = parts[2].toInt() - 1
       calendar[Calendar.DAY_OF_MONTH] = parts[3].toInt()

--- a/app/src/test/java/org/thoughtcrime/securesms/backup/v2/local/ArchiveFileSystemTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/backup/v2/local/ArchiveFileSystemTest.kt
@@ -10,6 +10,8 @@ import android.content.Context
 import androidx.documentfile.provider.DocumentFile
 import androidx.test.core.app.ApplicationProvider
 import assertk.assertThat
+import assertk.assertions.isBetween
+import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
@@ -20,6 +22,9 @@ import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import java.util.Calendar
+import java.util.Locale
+import java.util.TimeZone
 
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, application = Application::class)
@@ -126,6 +131,88 @@ class ArchiveFileSystemTest {
     val result = ArchiveFileSystem.openForRestore(context, DocumentFile.fromFile(renamed))
 
     assertThat(result).isNull()
+  }
+
+  @Test
+  fun `createSnapshot folder name round-trips through listSnapshots in a non-UTC time zone`() {
+    val defaultTimeZone = TimeZone.getDefault()
+    try {
+      TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"))
+
+      val parent = temporaryFolder.newFolder()
+      val fileSystem = ArchiveFileSystem.fromFile(context, parent)
+
+      val before = System.currentTimeMillis() / 1000 * 1000
+      val snapshot = fileSystem.createSnapshot()!!
+      snapshot.finalize()
+      val after = System.currentTimeMillis()
+
+      val info = fileSystem.listSnapshots().single()
+      assertThat(info.timestamp).isBetween(before, after)
+    } finally {
+      TimeZone.setDefault(defaultTimeZone)
+    }
+  }
+
+  @Test
+  fun `listSnapshots sorts a newer local-time snapshot ahead of an older UTC-named one`() {
+    val defaultTimeZone = TimeZone.getDefault()
+    try {
+      TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"))
+
+      val parent = temporaryFolder.newFolder()
+      val fileSystem = ArchiveFileSystem.fromFile(context, parent)
+      val signalBackups = parent.resolve(ArchiveFileSystem.MAIN_DIRECTORY_NAME)
+
+      // Written by a version that stamped names in UTC. Created first, but its name reads 7 hours ahead of local time.
+      val older = signalBackups.resolve("${ArchiveFileSystem.BACKUP_DIRECTORY_PREFIX}-2026-08-03-18-55-33").also { it.mkdir() }
+      // Written after the switch to local-time names, so its name reads lower despite being newer.
+      val newer = signalBackups.resolve("${ArchiveFileSystem.BACKUP_DIRECTORY_PREFIX}-2026-08-03-12-04-35").also { it.mkdir() }
+
+      older.setLastModified(1_785_783_333_000)
+      newer.setLastModified(1_785_783_875_000)
+
+      val snapshots = fileSystem.listSnapshots()
+
+      assertThat(snapshots.map { it.name }).isEqualTo(listOf(newer.name, older.name))
+    } finally {
+      TimeZone.setDefault(defaultTimeZone)
+    }
+  }
+
+  @Test
+  fun `listSnapshots falls back to the name when no modified time is reported`() {
+    val parent = temporaryFolder.newFolder()
+    val fileSystem = ArchiveFileSystem.fromFile(context, parent)
+    val signalBackups = parent.resolve(ArchiveFileSystem.MAIN_DIRECTORY_NAME)
+    val snapshot = signalBackups.resolve("${ArchiveFileSystem.BACKUP_DIRECTORY_PREFIX}-2026-01-02-03-04-05").also { it.mkdir() }
+    snapshot.setLastModified(0)
+
+    val info = fileSystem.listSnapshots().single()
+
+    val expected = Calendar.getInstance(Locale.US).apply {
+      set(2026, Calendar.JANUARY, 2, 3, 4, 5)
+      set(Calendar.MILLISECOND, 0)
+    }.timeInMillis
+    assertThat(info.timestamp).isEqualTo(expected)
+  }
+
+  @Test
+  fun `listSnapshots sorts newest first`() {
+    val parent = temporaryFolder.newFolder()
+    val fileSystem = ArchiveFileSystem.fromFile(context, parent)
+    val signalBackups = parent.resolve(ArchiveFileSystem.MAIN_DIRECTORY_NAME)
+    signalBackups.resolve("${ArchiveFileSystem.BACKUP_DIRECTORY_PREFIX}-2026-01-01-00-00-00").also { it.mkdir() }.setLastModified(1_767_225_600_000)
+    signalBackups.resolve("${ArchiveFileSystem.BACKUP_DIRECTORY_PREFIX}-2026-01-02-00-00-00").also { it.mkdir() }.setLastModified(1_767_312_000_000)
+
+    val snapshots = fileSystem.listSnapshots()
+
+    assertThat(snapshots.map { it.name }).isEqualTo(
+      listOf(
+        "${ArchiveFileSystem.BACKUP_DIRECTORY_PREFIX}-2026-01-02-00-00-00",
+        "${ArchiveFileSystem.BACKUP_DIRECTORY_PREFIX}-2026-01-01-00-00-00"
+      )
+    )
   }
 
   /**


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 10 Pro, Android 17 (`playStagingSpinner`) — on-device backup run against this branch and against `main`
 * Robolectric: `ArchiveFileSystemTest`, 14/14
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` syntax

----------

### Description

Fixes #14866.

Snapshot directories for on-device backups are stamped in UTC, so a backup taken at 11:55 local shows up as `signal-backup-2026-08-03-18-55-33`. The reporter noticed this is a change from the v1 `.backup` files, which used local time.

This appears to be the only place in the app that stamps a filename in UTC. Android's v1 backups both write and parse in device-local time (`LocalBackupJob` / `LocalBackupJobApi29`, and `BackupUtil.getBackupTimestamp`, none of which set an explicit zone), and iOS's local backups do the same — `LocalFileBackupManager.Constants.dateFormatter` sets no `timeZone`, so it uses `TimeZone.current`. That's what led me to read v2's UTC as unintentional. **If it was deliberate, I'm happy to close this and instead look at displaying local time wherever these names surface to users — just say the word.**

Two changes:

- `createSnapshot()` names new snapshots in the device's local time zone.
- `listSnapshots()` no longer derives ordering from names. Directories written before this change carry UTC names, and nothing in a name distinguishes the two generations, so parsing a mixed directory with one rule orders an older snapshot ahead of a newer one by the local UTC offset. That ordering drives `deleteOldBackups()` retention, and `RestoreLocalBackupViewModel` renders `SnapshotInfo.timestamp` as the date label when picking a backup to restore, so a legacy directory written at 8pm local would also display under the following day's date. It now uses the directory's last-modified time, falling back to the parsed name only when a provider reports no modified time.

Renaming in either direction has the mixed-generation problem, which is why ordering moves off names rather than trying to parse both formats.

### Testing

Built this branch and `main` onto a Pixel 10 Pro and ran an on-device backup with each, ~9 minutes apart in America/Los_Angeles:

```
signal-backup-2026-08-03-12-04-35   <- this branch, phone clock read 12:04 PDT
signal-backup-2026-08-03-18-55-33   <- main,        phone clock read 11:55 PDT
```

That pair is also what the new ordering test reconstructs: a mixed UTC/local directory asserting the newer snapshot sorts first, which fails without the `listSnapshots()` change. Also added a round-trip test pinned to a non-UTC zone (fails if either the write or parse side alone reverts to UTC) and a test for the name-parsing fallback. `ArchiveFileSystemTest` passes 14/14.

### Unrelated observation

iOS writes `signal-backups-<date>` (plural) while Android writes `signal-backup-<date>` (singular), and the iOS doc comment documents the singular form. Android's prefix filter matches both by accident. Not touching it here, but flagging it in case local backup directories are meant to be portable between platforms.
