### PR TITLE
Fix local backup crash on classic-encrypted attachments

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/backup/v2/local/LocalArchiver.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/v2/local/LocalArchiver.kt
@@ -96,24 +96,26 @@ object LocalArchiver {
             filesFileSystem.delete(mediaName)
           }
 
-          source()?.use { sourceStream ->
-            val destination: OutputStream? = filesFileSystem.fileOutputStream(mediaName)
+          try {
+            source()?.use { sourceStream ->
+              val destination: OutputStream? = filesFileSystem.fileOutputStream(mediaName)
 
-            if (destination == null) {
-              Log.w(TAG, "Unable to create output file for ${attachment.attachmentId}")
-              createFailures.add(attachment.attachmentId)
-            } else {
-              try {
+              if (destination == null) {
+                Log.w(TAG, "Unable to create output file for ${attachment.attachmentId}")
+                createFailures.add(attachment.attachmentId)
+              } else {
                 PaddingInputStream(sourceStream, attachment.size).use { input ->
                   AttachmentCipherOutputStream(attachment.localBackupKey.key, null, destination).use { output ->
                     StreamUtil.copy(input, output, false, false)
                   }
                 }
-              } catch (e: IOException) {
-                Log.w(TAG, "Unable to save ${attachment.attachmentId}", e)
-                readWriteFailures.add(attachment.attachmentId)
               }
             }
+          } catch (e: Exception) {
+            // Opening the source is as failure-prone as copying it: the file may be missing, or undecryptable with the secrets this install has. Neither should
+            // take down the whole backup, and not every such failure arrives as an IOException, so this records the attachment and moves on.
+            Log.w(TAG, "Unable to save ${attachment.attachmentId}", e)
+            readWriteFailures.add(attachment.attachmentId)
           }
         }
       }

--- a/app/src/main/java/org/thoughtcrime/securesms/database/AttachmentTable.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/AttachmentTable.kt
@@ -625,7 +625,7 @@ class AttachmentTable(
         LocalArchivableAttachment(
           attachmentId = AttachmentId(it.requireLong(ID)),
           file = File(it.requireNonNullString(DATA_FILE)),
-          random = it.requireNonNullBlob(DATA_RANDOM),
+          random = it.requireBlob(DATA_RANDOM),
           size = it.requireLong(DATA_SIZE),
           localBackupKey = AttachmentMetadataTable.getMetadata(it)!!.localBackupKey!!,
           plaintextHash = Base64.decode(it.requireNonNullString(DATA_HASH_END)),
@@ -649,7 +649,7 @@ class AttachmentTable(
         LocalArchivableAttachment(
           attachmentId = AttachmentId(it.requireLong(ID)),
           file = File(it.requireNonNullString(DATA_FILE)),
-          random = it.requireNonNullBlob(DATA_RANDOM),
+          random = it.requireBlob(DATA_RANDOM),
           size = it.requireLong(DATA_SIZE),
           localBackupKey = AttachmentMetadataTable.getMetadata(it)!!.localBackupKey!!,
           plaintextHash = Base64.decode(it.requireNonNullString(DATA_HASH_END)),
@@ -2716,9 +2716,9 @@ class AttachmentTable(
   }
 
   @Throws(FileNotFoundException::class)
-  private fun getDataStream(file: File, random: ByteArray, offset: Long): InputStream? {
+  private fun getDataStream(file: File, random: ByteArray?, offset: Long): InputStream? {
     return try {
-      if (random.size == 32) {
+      if (random != null && random.size == 32) {
         ModernDecryptingPartInputStream.createFor(attachmentSecret, random, file, offset)
       } else {
         val stream = ClassicDecryptingPartInputStream.createFor(attachmentSecret, file)
@@ -4021,7 +4021,8 @@ class AttachmentTable(
   class LocalArchivableAttachment(
     val attachmentId: AttachmentId,
     val file: File,
-    val random: ByteArray,
+    /** Null (or non-32-byte) for very old attachments encrypted with the classic scheme — see [getDataStream]. */
+    val random: ByteArray?,
     val size: Long,
     val plaintextHash: ByteArray,
     val localBackupKey: LocalBackupKey,

--- a/app/src/test/java/org/thoughtcrime/securesms/database/AttachmentTableTest_getLocalArchivableAttachments.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/database/AttachmentTableTest_getLocalArchivableAttachments.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.thoughtcrime.securesms.database
+
+import android.app.Application
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import org.junit.BeforeClass
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.signal.core.models.database.AttachmentId
+import org.signal.core.util.Base64
+import org.signal.core.util.logging.Log
+import org.signal.core.util.update
+import org.thoughtcrime.securesms.attachments.ArchivedAttachment
+import org.thoughtcrime.securesms.attachments.Attachment
+import org.thoughtcrime.securesms.mms.IncomingMessage
+import org.thoughtcrime.securesms.recipients.Recipient
+import org.thoughtcrime.securesms.testutil.RecipientTestRule
+import org.thoughtcrime.securesms.testutil.SystemOutLogger
+import java.util.UUID
+import kotlin.random.Random
+
+/**
+ * JVM (Robolectric) coverage for [AttachmentTable.getLocalArchivableAttachments]. Verifies that attachments encrypted with the classic scheme (a NULL
+ * data_random, predating modern per-attachment randoms) are still listed for local archiving rather than crashing the whole backup export.
+ */
+@Suppress("ClassName")
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, application = Application::class)
+class AttachmentTableTest_getLocalArchivableAttachments {
+
+  @get:Rule val recipients = RecipientTestRule()
+
+  companion object {
+    @BeforeClass
+    @JvmStatic
+    fun setUpClass() {
+      Log.initialize(SystemOutLogger())
+    }
+  }
+
+  @Test
+  fun givenClassicAttachmentWithNullDataRandom_whenGetLocalArchivableAttachments_thenItIsReturnedWithNullRandom() {
+    val attachmentId = insertLocalArchivableAttachment(dataRandom = null)
+
+    val result = SignalDatabase.attachments.getLocalArchivableAttachments()
+
+    assertThat(result).hasSize(1)
+    assertThat(result.single().attachmentId).isEqualTo(attachmentId)
+    assertThat(result.single().random).isNull()
+  }
+
+  @Test
+  fun givenModernAttachment_whenGetLocalArchivableAttachments_thenItKeepsItsRandom() {
+    val random = Random.nextBytes(32)
+    insertLocalArchivableAttachment(dataRandom = random)
+
+    val result = SignalDatabase.attachments.getLocalArchivableAttachments()
+
+    assertThat(result).hasSize(1)
+    assertThat(result.single().random contentEquals random).isEqualTo(true)
+  }
+
+  @Test
+  fun givenMixOfClassicAndModernAttachments_whenGetLocalArchivableAttachments_thenBothAreReturned() {
+    insertLocalArchivableAttachment(dataRandom = null)
+    insertLocalArchivableAttachment(dataRandom = Random.nextBytes(32))
+
+    val result = SignalDatabase.attachments.getLocalArchivableAttachments()
+
+    assertThat(result).hasSize(2)
+  }
+
+  /**
+   * Inserts an attachment that satisfies the local-archivable criteria (non-null data_file, data_hash_end, and metadata local_backup_key),
+   * then forces data_random to [dataRandom] to simulate a classic-era (NULL) or modern (32-byte) row.
+   */
+  private fun insertLocalArchivableAttachment(dataRandom: ByteArray?): AttachmentId {
+    val from = recipients.createRecipient("Some Contact")
+    val threadId = SignalDatabase.threads.getOrCreateThreadIdFor(Recipient.resolved(from))
+
+    val message = IncomingMessage(
+      type = MessageType.NORMAL,
+      from = from,
+      body = null,
+      sentTimeMillis = 100L,
+      serverTimeMillis = 100L,
+      receivedTimeMillis = 200L,
+      attachments = listOf(createAttachment(localBackupKey = Random.nextBytes(32)))
+    )
+
+    val messageId = SignalDatabase.messages.insertMessageInbox(message, threadId).get().messageId
+    val attachmentId = SignalDatabase.attachments.getAttachmentsForMessage(messageId).first().attachmentId
+
+    SignalDatabase.attachments.writableDatabase
+      .update(AttachmentTable.TABLE_NAME)
+      .values(
+        AttachmentTable.DATA_FILE to "/data/parts/${attachmentId.id}.mms",
+        AttachmentTable.DATA_RANDOM to dataRandom,
+        AttachmentTable.DATA_HASH_END to Base64.encodeWithPadding(Random.nextBytes(32)),
+        AttachmentTable.DATA_SIZE to 1024L
+      )
+      .where("${AttachmentTable.ID} = ?", attachmentId.id)
+      .run()
+
+    return attachmentId
+  }
+
+  private fun createAttachment(localBackupKey: ByteArray?): Attachment {
+    return ArchivedAttachment(
+      contentType = "image/jpeg",
+      size = 1024,
+      cdn = 3,
+      uploadTimestamp = 0,
+      key = Random.nextBytes(8),
+      cdnKey = "password",
+      archiveCdn = null,
+      plaintextHash = Random.nextBytes(8),
+      incrementalMac = Random.nextBytes(8),
+      incrementalMacChunkSize = 8,
+      width = 100,
+      height = 100,
+      caption = null,
+      blurHash = null,
+      voiceNote = false,
+      borderless = false,
+      stickerLocator = null,
+      gif = false,
+      quote = false,
+      quoteTargetContentType = null,
+      uuid = UUID.randomUUID(),
+      fileName = null,
+      localBackupKey = localBackupKey
+    )
+  }
+}


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 10 Pro, Android 17 (`playStagingSpinner`) — reproduced the reported crash and verified the fix, details below
 * Robolectric: new `AttachmentTableTest_getLocalArchivableAttachments` plus existing `AttachmentTable*` and `backup.v2.local` suites, 42/42
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` syntax

----------

### Description

Fixes #14875.

Attachments from the classic encryption have a `NULL` `data_random`, but `getLocalArchivableAttachments()` reads it with `requireNonNullBlob()`. One such attachment aborts the entire local backup with an NPE, which is what the reporter is hitting.  They can no longer create backups at all, though v1 `.backup` files worked on the same data. The same read exists in `getLocalArchivableAttachmentsForPlaintextExport()`.

Two changes:

**1. Let the null random through (`AttachmentTable`).** `LocalArchivableAttachment.random` becomes nullable, both queries use `requireBlob`, and `getDataStream()` accepts a null random. It already picks `ClassicDecryptingPartInputStream` whenever a random isn't a modern 32-byte value, so the decryption side needed no changes — this restores the nullable handling `FullBackupExporter.openAttachmentStream()` had for v1 backups. `random` has exactly one consumer (`getAttachmentStream` → `getDataStream`), so the nullable widening doesn't propagate further.

I chose this over adding `AND data_random IS NOT NULL` to the queries: the guard is a smaller diff, but it would silently *exclude* these attachments from local backups that v1 included, which seems worse than a crash you can see.

**2. Widen per-attachment failure handling (`LocalArchiver`).** Device testing turned up a second problem in the same path. `source()` — which opens and MAC-verifies the attachment — sits *outside* the `try` that records `readWriteFailures`, so any failure while opening an attachment escapes to the job rather than being recorded. And a failure to decrypt surfaces as `IllegalArgumentException` (from `SecretKeySpec` when an install has no classic keys), not `IOException`, so the existing catch wouldn't have caught it even if it were correctly scoped. The loop already maintains `createFailures`/`readWriteFailures` accumulators, so per-attachment resilience is clearly the intent; this makes the scope match. There's precedent for the broader catch in `ArchiveFileSystem.deleteUnusedFiles()`.

### Testing

**Device.** Built onto a Pixel 10 Pro against a staging account with five attachments, then set `data_random = NULL` on one row to simulate a classic-era attachment. Same database state and same action each time, only the binary differing:

*On `main`* the reported crash, reproduced exactly:
```
W/LocalArchiveJob: java.lang.NullPointerException
    at CursorExtensionsKt.requireNonNullBlob(CursorExtensions.kt:62)
    at AttachmentTable.getLocalArchivableAttachments(AttachmentTable.kt:628)
    at BackupRepository.exportForLocalBackup(BackupRepository.kt:779)
    at LocalArchiver.export(LocalArchiver.kt:85)
    at LocalArchiveJob.run(LocalArchiveJob.kt:104)
W/LocalArchiveJob: Archive failed. Snapshot temp folder needed to be deleted
W/JobRunner:       Job failed.
```

*With change 1 only*, forcing the attachment to be re-read by clearing the archived copies — the NPE is gone, but the failure moves downstream and takes the process with it:
```
FATAL EXCEPTION: signal-io-bounded-2
java.lang.IllegalArgumentException: Missing argument
    at javax.crypto.spec.SecretKeySpec.<init>
    at ClassicDecryptingPartInputStream.verifyMac(:61)
    at AttachmentTable.getDataStream(:2724)
    at LocalArchiver.export$lambda$3(LocalArchiver.kt:99)
```

*With both changes*, same scenario:
```
W/LocalArchiver:   Unable to save AttachmentId::5
                   java.lang.IllegalArgumentException: Missing argument
I/LocalArchiveJob: Archive finished with result:
                   Success(PartialSuccess(createFailures=[], readWriteFailures=[AttachmentId::5]))
```

To be straight about what that second trace does and doesn't show: my test row is synthetic.  A null random on a *fresh* install (which has no classic keys) pointing at a file that is really modern-encrypted. That combination can't occur naturally, and a genuinely affected install has real classic keys and real classic-encrypted files, so change 1 alone is enough for the reporter. But it did expose that the surrounding failure handling doesn't cover opening an attachment, which is worth fixing regardless.

**Unit.** New `AttachmentTableTest_getLocalArchivableAttachments` covers a classic (null) row, a modern row, and a mixed set; the classic cases reproduce the NPE without the fix. Existing `AttachmentTable*` and `backup.v2.local` suites pass. 42/42 overall.

### Two things I noticed but did not touch

Both are pre-existing and independent of this change; happy to open separate issues if useful.

1. `LocalArchiver` deletes the existing archived file *before* re-archiving when `cipherLength` doesn't match. Since `files/` is shared across all snapshots, a failed re-archive removes that attachment from previously-good snapshots too. Write-to-temp-then-swap would avoid it.
2. `PartialSuccess` is treated as success by `LocalArchiveJob`, so a backup that dropped attachments finalizes and reports success with only a log line recording it.
