### PR TITLE
Play animated GIF avatars in the contact/group detail header and fullscreen preview

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/AvatarPreviewActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/AvatarPreviewActivity.java
@@ -3,6 +3,7 @@ package org.thoughtcrime.securesms;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.drawable.Animatable;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.transition.TransitionInflater;
@@ -129,6 +130,9 @@ public final class AvatarPreviewActivity extends PassphraseRequiredActivity {
                 @Override
                 public void onResourceReady(@NonNull Drawable resource, @Nullable Transition<? super Drawable> transition) {
                   avatar.setImageDrawable(resource);
+                  if (resource instanceof Animatable) {
+                    ((Animatable) resource).start();
+                  }
                   startPostponedEnterTransition();
                 }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/AvatarPreviewActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/AvatarPreviewActivity.java
@@ -3,8 +3,6 @@ package org.thoughtcrime.securesms;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.content.res.Resources;
-import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.transition.TransitionInflater;
@@ -15,7 +13,6 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.app.ActivityOptionsCompat;
-import androidx.core.graphics.drawable.RoundedBitmapDrawableFactory;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.DataSource;
@@ -109,31 +106,29 @@ public final class AvatarPreviewActivity extends PassphraseRequiredActivity {
 
       Drawable fallbackDrawable = new FallbackAvatarDrawable(context, fallbackAvatar);
 
-      Resources resources = this.getResources();
-
+      // Not asBitmap(), so an animated GIF avatar can actually play here.
       Glide.with(this)
-              .asBitmap()
               .load(contactPhoto)
               .fallback(fallbackDrawable)
               .error(fallbackDrawable)
               .diskCacheStrategy(DiskCacheStrategy.ALL)
-              .addListener(new RequestListener<Bitmap>() {
+              .addListener(new RequestListener<Drawable>() {
                 @Override
-                public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Bitmap> target, boolean isFirstResource) {
+                public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Drawable> target, boolean isFirstResource) {
                   Log.w(TAG, "Unable to load avatar, or avatar removed, closing");
                   finish();
                   return false;
                 }
 
                 @Override
-                public boolean onResourceReady(Bitmap resource, Object model, Target<Bitmap> target, DataSource dataSource, boolean isFirstResource) {
+                public boolean onResourceReady(Drawable resource, Object model, Target<Drawable> target, DataSource dataSource, boolean isFirstResource) {
                   return false;
                 }
               })
-              .into(new CustomTarget<Bitmap>() {
+              .into(new CustomTarget<Drawable>() {
                 @Override
-                public void onResourceReady(@NonNull Bitmap resource, @Nullable Transition<? super Bitmap> transition) {
-                  avatar.setImageDrawable(RoundedBitmapDrawableFactory.create(resources, resource));
+                public void onResourceReady(@NonNull Drawable resource, @Nullable Transition<? super Drawable> transition) {
+                  avatar.setImageDrawable(resource);
                   startPostponedEnterTransition();
                 }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/avatar/view/AvatarView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/avatar/view/AvatarView.kt
@@ -71,8 +71,10 @@ class AvatarView @JvmOverloads constructor(
   /**
    * Displays Note-to-Self
    */
-  fun displayChatAvatar(recipient: Recipient) {
-    avatar.setAvatar(recipient)
+  fun displayChatAvatar(recipient: Recipient, animateAvatar: Boolean = false) {
+    avatar.buildOptions()
+      .withAnimateAvatar(animateAvatar)
+      .load(recipient)
   }
 
   /**

--- a/app/src/main/java/org/thoughtcrime/securesms/components/AvatarImageView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/AvatarImageView.java
@@ -3,6 +3,7 @@ package org.thoughtcrime.securesms.components;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Bitmap;
+import android.graphics.drawable.Animatable;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 
@@ -340,6 +341,9 @@ public final class AvatarImageView extends AppCompatImageView {
     @Override
     public void onResourceReady(@NonNull Drawable resource, @Nullable Transition<? super Drawable> transition) {
       setImageDrawable(resource);
+      if (resource instanceof Animatable) {
+        ((Animatable) resource).start();
+      }
     }
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/components/AvatarImageView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/AvatarImageView.java
@@ -224,7 +224,7 @@ public final class AvatarImageView extends AppCompatImageView {
           if (wasUnblurred) {
             blurred = shouldBlur;
             request = request.transition(DrawableTransitionOptions.withCrossFade(200));
-          } else {
+          } else if (!avatarOptions.animateAvatar) {
             request = request.dontAnimate();
           }
 
@@ -349,12 +349,14 @@ public final class AvatarImageView extends AppCompatImageView {
     private final boolean useSelfProfileAvatar;
     private final boolean useBlurGradient;
     private final int     fixedSize;
+    private final boolean animateAvatar;
 
     private AvatarOptions(@NonNull Builder builder) {
       this.quickContactEnabled  = builder.quickContactEnabled;
       this.useSelfProfileAvatar = builder.useSelfProfileAvatar;
       this.useBlurGradient      = builder.useBlurGradient;
       this.fixedSize            = builder.fixedSize;
+      this.animateAvatar        = builder.animateAvatar;
     }
 
     public static final class Builder {
@@ -365,6 +367,7 @@ public final class AvatarImageView extends AppCompatImageView {
       private boolean useSelfProfileAvatar = false;
       private boolean useBlurGradient      = false;
       private int     fixedSize            = -1;
+      private boolean animateAvatar        = false;
 
       private Builder(@NonNull AvatarImageView avatarImageView) {
         this.avatarImageView = avatarImageView;
@@ -387,6 +390,11 @@ public final class AvatarImageView extends AppCompatImageView {
 
       public @NonNull Builder withFixedSize(@Px @IntRange(from = 1) int fixedSize) {
         this.fixedSize = fixedSize;
+        return this;
+      }
+
+      public @NonNull Builder withAnimateAvatar(boolean animateAvatar) {
+        this.animateAvatar = animateAvatar;
         return this;
       }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/conversation/ConversationSettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/conversation/ConversationSettingsFragment.kt
@@ -315,6 +315,7 @@ class ConversationSettingsFragment :
           .withQuickContactEnabled(false)
           .withUseSelfProfileAvatar(false)
           .withFixedSize(ViewUtil.dpToPx(80))
+          .withAnimateAvatar(true)
           .load(state.recipient)
 
         if (!state.recipient.isSelf) {

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/conversation/preferences/AvatarPreference.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/conversation/preferences/AvatarPreference.kt
@@ -63,7 +63,7 @@ object AvatarPreference {
       }
 
       avatar.setStoryRingFromState(model.storyViewState)
-      avatar.displayChatAvatar(model.recipient)
+      avatar.displayChatAvatar(model.recipient, animateAvatar = true)
       avatar.disableQuickContact()
       avatar.setOnClickListener { model.onAvatarClick(avatar) }
     }


### PR DESCRIPTION
### Contributor checklist

- [x] I am following the Code Style Guidelines
- [x] I have tested my contribution on these devices:
  - Samsung Galaxy S26 Ultra, Android 17
  - Google Pixel 10 Pro, Android 17
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` syntax
  _(no tracked issue for this — not filed as a bug, just noticed the behavior)_

---
### Description

Signal Desktop renders avatars as a plain `<img>`/CSS `background-image`, so an animated GIF avatar (e.g. a phone's system contact photo synced to a linked device, or an animated Signal profile photo) plays natively via Chromium. On Android, every avatar is frozen to its first frame regardless of source format, because `AvatarImageView.setAvatar()` unconditionally calls Glide's `.dontAnimate()`.

Animating every avatar everywhere needs system resources. GIFs decode and redraw every frame, which is real cost in a scrolling list with dozens of recycled avatar views on screen at once. So instead of removing `dontAnimate()` globally, this adds an opt-in `AvatarOptions.animateAvatar` flag (default `false`, so every existing call site keeps today's behavior unchanged) and **only** turns it on in the two places where exactly one avatar is ever shown at a time:

- The large avatar in the conversation-settings / recipient & group details header (`ConversationSettingsFragment`).
- The dedicated fullscreen avatar viewer (`AvatarPreviewActivity`), which previously always requested `.asBitmap()`. It has been sitched to a plain `Drawable` request so an animated `GifDrawable` can be returned there at all.

Chat list rows, contact lists, group member lists, call log, etc. are untouched. They keep `dontAnimate()` to save system resources and keep performance.

**Known limitation:** this only helps animated *GIF* avatars. Signal Android's Glide setup (`SignalGlideComponents`) registers a decoder for `InputStream -> GifDrawable`, but has no equivalent for animated WebP. An animated-WebP avatar would still render as static after this change.
Adding that would mean registering a separate animated-WebP decoder in the Glide pipeline, which felt like a bigger, separate change for me and is IMO out of scope here.

### Testing

Tested on a real device with a contact whose avatar is an animated GIF: it now plays in both the conversation-settings header and the fullscreen preview, while chat-list/contact-list rows remain static as intended.