### PR TITLE
Respect explicit stay-connected-in-background opt-out despite FCM failures

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/data/DataAndStorageSettingsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/data/DataAndStorageSettingsViewModel.kt
@@ -73,7 +73,7 @@ class DataAndStorageSettingsViewModel(
   }
 
   private fun applyForceWebsocketMode(enabled: Boolean) {
-    SignalStore.settings.forceWebsocketMode = if (enabled) ForceWebsocketMode.ENABLED_BY_USER else ForceWebsocketMode.DISABLED
+    SignalStore.settings.forceWebsocketMode = if (enabled) ForceWebsocketMode.ENABLED_BY_USER else ForceWebsocketMode.DISABLED_BY_USER
     if (!enabled) {
       IncomingMessageObserver.stopForegroundService(AppDependencies.application)
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/keyvalue/SettingsValues.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyvalue/SettingsValues.java
@@ -619,8 +619,10 @@ public final class SettingsValues extends SignalStoreValues {
     }
   }
 
+  // DISABLED is the "never touched" default. FcmRefreshJob only auto-enables from DISABLED, not
+  // DISABLED_BY_USER, so an explicit opt-out survives even if FCM keeps failing.
   public enum ForceWebsocketMode {
-    DISABLED(0), ENABLED_BY_USER(1), ENABLED_AUTOMATICALLY(2);
+    DISABLED(0), ENABLED_BY_USER(1), ENABLED_AUTOMATICALLY(2), DISABLED_BY_USER(3);
 
     private final int value;
 
@@ -629,7 +631,7 @@ public final class SettingsValues extends SignalStoreValues {
     }
 
     public boolean isEnabled() {
-      return this != DISABLED;
+      return this == ENABLED_BY_USER || this == ENABLED_AUTOMATICALLY;
     }
 
     public int serialize() {
@@ -644,6 +646,8 @@ public final class SettingsValues extends SignalStoreValues {
           return ENABLED_BY_USER;
         case 2:
           return ENABLED_AUTOMATICALLY;
+        case 3:
+          return DISABLED_BY_USER;
         default:
           throw new IllegalArgumentException("Bad value: " + value);
       }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S26 Ultra, Android 17
 * Google Pixel 10 Pro, Android 17
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixes #14909

Currently, ForceWebsocketMode.DISABLED is used for two different scenarios:
- The default state (when a user has never touched the "Stay connected in background" toggle).
- The state when a user manually turns that setting off.

Because the app can't tell these two states apart, the automatic fallback logic breaks. Normally as far as I understand, if FCM (push notifications) fails for 3+ days, the app automatically enables WebSocket mode as a safety net. But because manual opt-outs look identical to the untouched default, the app keeps re-enabling WebSocket mode in the background even if the user explicitly turned it off. From the user's perspective, the setting just keeps resetting itself.

This showed up in the reporter's logs: FCM failed with FIS_AUTH_ERROR, so the app auto-enabled WebSocket mode. Every time the user turned it off, the next background sync saw DISABLED and immediately flipped it back on.

What this PR changes:
- Adds a new DISABLED_BY_USER state that is only set when someone manually toggles the setting off.
- Adjusts FcmRefreshJob so the automatic fallback only triggers on the untouched default state (DISABLED), ensuring manual user choices are actually respected.

### Testing
- Tested the new state logic and verified that the toggle updates correctly.