### PR TITLE
Fix call log merging older calls incorrectly (#14712)

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/calls/log/CallEventCache.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/calls/log/CallEventCache.kt
@@ -137,7 +137,7 @@ class CallEventCache(
     }
 
     private fun isWithinTimeout(parent: CacheRecord, child: CacheRecord): Boolean {
-      return (child.timestamp - parent.timestamp) <= 4.hours.inWholeMilliseconds
+      return Math.abs(parent.timestamp - child.timestamp) <= 4.hours.inWholeMilliseconds
     }
 
     private fun canUserBeginCall(peer: Recipient, decryptedGroup: ByteArray?): CallLogRow.CanStartCall {


### PR DESCRIPTION
**Description**
Fixes #14712 

Noticed that older calls (sometimes months old) were getting improperly merged into recent call log entries. 

Tracked it down to `CallEventCache.kt`. The DB query returns calls sorted descending by time, so `parent` is always newer than `child`. The timeout check was doing `(child.timestamp - parent.timestamp)`, which results in a negative number. Because a negative number is always `<= 4 hours`, it was bypassing the check and clustering every older call it found until the chain broke.

Fixed by just wrapping the delta in `Math.abs()` so the 4-hour window evaluates correctly regardless of list order.