### PR TITLE
Preserve text draft after sending externally shared media

### DIFF
--- a/app/src/androidTest/java/org/thoughtcrime/securesms/main/MainNavigationLaunchTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/main/MainNavigationLaunchTest.kt
@@ -29,15 +29,25 @@ import org.thoughtcrime.securesms.R
 import org.thoughtcrime.securesms.calls.log.CallLogFragment
 import org.thoughtcrime.securesms.conversation.ConversationArgs
 import org.thoughtcrime.securesms.conversation.ConversationIntents
+import org.thoughtcrime.securesms.conversation.MessageSendType
 import org.thoughtcrime.securesms.conversation.v2.ConversationFragment
 import org.thoughtcrime.securesms.conversationlist.ConversationListArchiveFragment
 import org.thoughtcrime.securesms.conversationlist.ConversationListFragment
+import org.thoughtcrime.securesms.database.DraftTable
+import org.thoughtcrime.securesms.database.SignalDatabase
+import org.thoughtcrime.securesms.database.model.MessageRecord
+import org.thoughtcrime.securesms.database.model.MmsMessageRecord
+import org.thoughtcrime.securesms.database.model.StoryType
+import org.thoughtcrime.securesms.database.withAttachments
 import org.thoughtcrime.securesms.dependencies.AppDependencies
+import org.thoughtcrime.securesms.keyvalue.SignalStore
+import org.thoughtcrime.securesms.mediasend.MediaSendActivityResult
 import org.thoughtcrime.securesms.mediasend.v2.MediaSelectionActivity
 import org.thoughtcrime.securesms.recipients.Recipient
 import org.thoughtcrime.securesms.recipients.RecipientId
 import org.thoughtcrime.securesms.stories.landing.StoriesLandingFragment
 import org.thoughtcrime.securesms.testing.SignalActivityRule
+import org.thoughtcrime.securesms.util.MessageTableTestUtils
 import java.io.ByteArrayOutputStream
 import java.util.Collections
 import java.util.concurrent.CountDownLatch
@@ -145,6 +155,73 @@ class MainNavigationLaunchTest {
       check(launched.recorder.createdArgs.size == 1) {
         "Expected exactly one ConversationFragment for image share, got ${launched.recorder.createdArgs.size}"
       }
+    }
+  }
+
+  @Test
+  fun warmStart_plainExternalImage_cancel_restoresExistingTextDraft() {
+    val draftText = "draft that must survive image share"
+    val threadId = seedTextDraft(draftText)
+    val media = realJpegMedia()
+
+    launchSync(notificationToConversationIntent(recipient)).use { launched ->
+      awaitComposerText(launched, draftText)
+      val mediaSend = launchPlainExternalImageShare(launched, media)
+
+      finishMediaEditor(mediaSend)
+
+      awaitComposerText(launched, draftText)
+      awaitPersistedTextDraft(threadId, draftText)
+    }
+  }
+
+  @Test
+  fun warmStart_plainExternalImage_send_restoresExistingTextDraftWithoutUsingItAsCaption() {
+    val draftText = "draft that must not become a caption"
+    val threadId = seedTextDraft(draftText)
+    val media = realJpegMedia()
+
+    launchSync(notificationToConversationIntent(recipient)).use { launched ->
+      awaitComposerText(launched, draftText)
+      val mediaSend = launchPlainExternalImageShare(launched, media)
+      val messagesBeforeSend = messageIds(threadId)
+
+      finishMediaEditor(mediaSend, mediaSendResult(media))
+
+      awaitComposerText(launched, draftText)
+      awaitPersistedTextDraft(threadId, draftText)
+      assertNewOutgoingImageMessage(threadId, messagesBeforeSend, media, draftText)
+    }
+  }
+
+  @Test
+  fun recreate_whilePlainExternalImageEditorOpen_sendPreservesExistingTextDraft() {
+    val draftText = "draft that must survive recreation"
+    val threadId = seedTextDraft(draftText)
+    val media = realJpegMedia()
+
+    launchSync(notificationToConversationIntent(recipient)).use { launched ->
+      awaitComposerText(launched, draftText)
+      val mediaSend = launchPlainExternalImageShare(launched, media)
+      val originalActivity = launched.activity
+      val originalFragment = runOnMainSync { launched.recorder.latestActive() }
+      val fragmentCount = launched.recorder.createdArgs.size
+
+      runOnMainSync { launched.activity.recreate() }
+
+      await(timeoutMs = 15_000, description = "MainActivity and ConversationFragment recreated behind the media editor") {
+        launched.activity !== originalActivity &&
+          launched.recorder.createdArgs.size > fragmentCount &&
+          launched.recorder.latestActive() !== originalFragment
+      }
+      awaitComposerText(launched, draftText)
+      val messagesBeforeSend = messageIds(threadId)
+
+      finishMediaEditor(mediaSend, mediaSendResult(media))
+
+      awaitComposerText(launched, draftText)
+      awaitPersistedTextDraft(threadId, draftText)
+      assertNewOutgoingImageMessage(threadId, messagesBeforeSend, media, draftText)
     }
   }
 
@@ -608,6 +685,150 @@ class MainNavigationLaunchTest {
       transformProperties = null,
       fileName = null
     )
+  }
+
+  private fun seedTextDraft(text: String): Long {
+    val threadId = SignalDatabase.threads.getOrCreateThreadIdFor(Recipient.resolved(recipient))
+    SignalDatabase.drafts.replaceDrafts(
+      threadId,
+      DraftTable.Drafts(listOf(DraftTable.Draft(DraftTable.Draft.TEXT, text)))
+    )
+    return threadId
+  }
+
+  private fun launchPlainExternalImageShare(launched: LaunchedActivity, media: Media): MediaSelectionActivity {
+    val timestamp = maxOf(System.currentTimeMillis(), SignalStore.misc.lastProcessedShareDataTimestamp + 1)
+    val intent = shareToConversationIntent(
+      recipient = recipient,
+      blob = media.uri,
+      mimeType = checkNotNull(media.contentType),
+      shareDataTimestamp = timestamp
+    )
+
+    runOnMainSync {
+      InstrumentationRegistry.getInstrumentation().callActivityOnNewIntent(launched.activity, intent)
+    }
+
+    return launched.awaitActivity(MediaSelectionActivity::class.java, timeoutMs = 20_000)
+  }
+
+  private fun mediaSendResult(media: Media): MediaSendActivityResult {
+    return MediaSendActivityResult(
+      recipientId = recipient,
+      nonUploadedMedia = listOf(media),
+      body = "",
+      messageSendType = MessageSendType.SignalMessageSendType,
+      isViewOnce = false,
+      mentions = emptyList(),
+      bodyRanges = null,
+      storyType = StoryType.NONE
+    )
+  }
+
+  private fun finishMediaEditor(activity: MediaSelectionActivity, result: MediaSendActivityResult? = null) {
+    runOnMainSync {
+      if (result == null) {
+        activity.setResult(Activity.RESULT_CANCELED)
+      } else {
+        activity.setResult(
+          Activity.RESULT_OK,
+          Intent().putExtra(MediaSendActivityResult.EXTRA_RESULT, result)
+        )
+      }
+      activity.finish()
+    }
+  }
+
+  private fun awaitPersistedTextDraft(threadId: Long, expected: String) {
+    await(timeoutMs = 15_000, description = "database draft remains \"$expected\"") {
+      SignalDatabase.drafts
+        .getDrafts(threadId)
+        .firstOrNull { it.type == DraftTable.Draft.TEXT }
+        ?.value == expected
+    }
+  }
+
+  private fun messageIds(threadId: Long): Set<Long> {
+    return MessageTableTestUtils.getMessages(threadId).mapTo(mutableSetOf()) { it.id }
+  }
+
+  private fun assertNewOutgoingImageMessage(threadId: Long, previousMessageIds: Set<Long>, expectedMedia: Media, draftText: String) {
+    try {
+      await(timeoutMs = 15_000, description = "a new message to be inserted") {
+        newMessagesWithAttachments(threadId, previousMessageIds).isNotEmpty()
+      }
+    } catch (e: IllegalStateException) {
+      val observedMessages = newMessagesWithAttachments(threadId, previousMessageIds)
+      throw IllegalStateException(
+        "${e.message}\n${describeMessagesAfterBaseline(observedMessages, previousMessageIds)}",
+        e
+      )
+    }
+
+    val newMessages = newMessagesWithAttachments(threadId, previousMessageIds)
+    val observedState = describeMessagesAfterBaseline(newMessages, previousMessageIds)
+    val newOutgoingMessages = newMessages.filter { it.isOutgoing }
+
+    check(newOutgoingMessages.size == 1) {
+      "Expected exactly one new outgoing message, got ${newOutgoingMessages.map { it.id }}\n$observedState"
+    }
+
+    val message = newOutgoingMessages.single()
+    check(message is MmsMessageRecord) { "Expected an outgoing MMS, got ${message.javaClass.name}\n$observedState" }
+    check(message.containsMediaSlide()) { "Expected the outgoing MMS to contain a media slide\n$observedState" }
+    check(message.body.isNullOrEmpty()) { "Expected no outgoing body/caption, got ${message.body}\n$observedState" }
+    check(message.body != draftText) { "Existing draft was used as the outgoing message body\n$observedState" }
+
+    val imageSlides = message.slideDeck.slides.filter { it.hasImage() }
+    check(imageSlides.size == 1) {
+      "Expected exactly one image attachment, got ${message.slideDeck.slides.map { it.contentType }}\n$observedState"
+    }
+    check(imageSlides.single().contentType == expectedMedia.contentType) {
+      "Expected image content type ${expectedMedia.contentType}, got ${imageSlides.single().contentType}\n$observedState"
+    }
+    check(imageSlides.single().fileSize == expectedMedia.size) {
+      "Expected image size ${expectedMedia.size}, got ${imageSlides.single().fileSize}\n$observedState"
+    }
+    check(imageSlides.single().caption.orElse(null).isNullOrEmpty()) {
+      "Expected no image caption, got ${imageSlides.single().caption.orElse(null)}\n$observedState"
+    }
+  }
+
+  private fun newMessagesWithAttachments(threadId: Long, previousMessageIds: Set<Long>): List<MessageRecord> {
+    return MessageTableTestUtils
+      .getMessages(threadId)
+      .filter { it.id !in previousMessageIds }
+      .withAttachments()
+  }
+
+  private fun describeMessagesAfterBaseline(messages: List<MessageRecord>, previousMessageIds: Set<Long>): String {
+    if (messages.isEmpty()) {
+      return "No new message exists after previousMessageIds=$previousMessageIds"
+    }
+
+    return buildString {
+      appendLine("Messages created after previousMessageIds=$previousMessageIds:")
+      messages.forEach { message ->
+        val mmsMessage = message as? MmsMessageRecord
+        val slides = mmsMessage?.slideDeck?.slides.orEmpty()
+        appendLine(
+          "- id=${message.id}, recordClass=${message.javaClass.name}, isOutgoing=${message.isOutgoing}, " +
+            "body=${message.body}, containsMediaSlide=${mmsMessage?.containsMediaSlide() ?: "n/a"}, slideCount=${slides.size}"
+        )
+        slides.forEachIndexed { index, slide ->
+          val isMedia = slide.hasImage() ||
+            slide.hasVideo() ||
+            slide.hasAudio() ||
+            slide.hasDocument() ||
+            slide.hasSticker() ||
+            slide.hasViewOnce()
+          appendLine(
+            "  slide[$index]: contentType=${slide.contentType}, uri=${slide.uri}, fileSize=${slide.fileSize}, " +
+              "hasImage=${slide.hasImage()}, isMedia=$isMedia, caption=${slide.caption.orElse(null)}"
+          )
+        }
+      }
+    }.trimEnd()
   }
 
   /**

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
@@ -430,6 +430,7 @@ class ConversationFragment :
 
     private const val ACTION_PINNED_SHORTCUT = "action_pinned_shortcut"
     private const val SAVED_STATE_IS_SEARCH_REQUESTED = "is_search_requested"
+    private const val SAVED_STATE_IS_PLAIN_EXTERNAL_IMAGE_SHARE_PENDING = "is_plain_external_image_share_pending"
     private const val EMOJI_SEARCH_FRAGMENT_TAG = "EmojiSearchFragment"
     private const val MESSAGE_DETAILS_TAG = "MessageDetailsFragment"
 
@@ -592,6 +593,8 @@ class ConversationFragment :
       field = value
       viewModel.setIsSearchRequested(value)
     }
+
+  private var isPlainExternalImageSharePending: Boolean = false
 
   private var previousPage: KeyboardPage? = null
   private var previousPages: Set<KeyboardPage>? = null
@@ -801,12 +804,14 @@ class ConversationFragment :
     super.onViewStateRestored(savedInstanceState)
 
     isSearchRequested = savedInstanceState?.getBoolean(SAVED_STATE_IS_SEARCH_REQUESTED, false) ?: args.isWithSearchOpen
+    isPlainExternalImageSharePending = savedInstanceState?.getBoolean(SAVED_STATE_IS_PLAIN_EXTERNAL_IMAGE_SHARE_PENDING, false) ?: false
   }
 
   override fun onSaveInstanceState(outState: Bundle) {
     super.onSaveInstanceState(outState)
 
     outState.putBoolean(SAVED_STATE_IS_SEARCH_REQUESTED, isSearchRequested)
+    outState.putBoolean(SAVED_STATE_IS_PLAIN_EXTERNAL_IMAGE_SHARE_PENDING, isPlainExternalImageSharePending)
   }
 
   override fun onStart() {
@@ -1444,15 +1449,7 @@ class ConversationFragment :
       this::handleReplyToMessage
     ).attachToRecyclerView(binding.conversationItemRecycler)
 
-    viewModel
-      .inputReadyState
-      .take(1)
-      .flatMapMaybe { inputReadyState ->
-        draftViewModel.loadShareOrDraftData()
-          .map { inputReadyState to it }
-      }
-      .subscribeBy { (inputReadyState, data) -> handleShareOrDraftData(inputReadyState, data) }
-      .addTo(disposables)
+    loadShareOrDraftData()
 
     disposables.add(
       draftViewModel
@@ -2190,6 +2187,15 @@ class ConversationFragment :
       }
 
       is ShareOrDraftData.SetMedia -> {
+        if (
+          args.shareDataTimestamp > 0 &&
+          args.media.isNullOrEmpty() &&
+          args.draftText == null &&
+          data.text == null &&
+          data.mediaType == SlideFactory.MediaType.IMAGE
+        ) {
+          isPlainExternalImageSharePending = true
+        }
         composeText.setDraftText(data.text)
         setMedia(data.media, data.mediaType)
       }
@@ -2204,6 +2210,18 @@ class ConversationFragment :
         conversationActivityResultContracts.launchMediaEditor(data.mediaList, recipientId, data.text)
       }
     }
+  }
+
+  private fun loadShareOrDraftData() {
+    viewModel
+      .inputReadyState
+      .take(1)
+      .flatMapMaybe { inputReadyState ->
+        draftViewModel.loadShareOrDraftData()
+          .map { inputReadyState to it }
+      }
+      .subscribeBy { (inputReadyState, data) -> handleShareOrDraftData(inputReadyState, data) }
+      .addTo(disposables)
   }
 
   private fun handleScheduledMessagesCountChange(count: Int) {
@@ -2553,6 +2571,7 @@ class ConversationFragment :
     preUploadResults: List<MessageSender.PreUploadResult> = emptyList(),
     bypassPreSendSafetyNumberCheck: Boolean = false,
     isViewOnce: Boolean = false,
+    clearDraftOnComplete: Boolean = true,
     afterSendComplete: () -> Unit = {}
   ) {
     val threadRecipient = viewModel.recipientSnapshot
@@ -2629,7 +2648,7 @@ class ConversationFragment :
       }
       .subscribeBy(
         onComplete = {
-          onSendComplete()
+          onSendComplete(clearDraftOnComplete)
           afterSendComplete()
         },
         onError = {
@@ -2639,7 +2658,7 @@ class ConversationFragment :
       )
   }
 
-  private fun onSendComplete() {
+  private fun onSendComplete(clearDraft: Boolean = true) {
     if (isDetached || activity?.isFinishing == true) {
       return
     }
@@ -2649,7 +2668,9 @@ class ConversationFragment :
 
     updateLinkPreviewState()
 
-    draftViewModel.clearDraft()
+    if (clearDraft) {
+      draftViewModel.clearDraft()
+    }
 
     inputPanel.exitEditMessageMode()
 
@@ -4556,7 +4577,13 @@ class ConversationFragment :
     }
 
     override fun onMediaSend(result: MediaSendActivityResult?) {
+      val restoreDraftAfterMedia = isPlainExternalImageSharePending
+      isPlainExternalImageSharePending = false
+
       if (result == null) {
+        if (restoreDraftAfterMedia) {
+          loadShareOrDraftData()
+        }
         return
       }
 
@@ -4564,11 +4591,14 @@ class ConversationFragment :
       if (result.recipientId != recipientSnapshot?.id) {
         Log.w(TAG, "Result's recipientId did not match ours! Result: " + result.recipientId + ", Ours: " + recipientSnapshot?.id)
         toast(R.string.ConversationActivity_error_sending_media)
+        if (restoreDraftAfterMedia) {
+          loadShareOrDraftData()
+        }
         return
       }
 
       if (result.isPushPreUpload) {
-        sendPreUploadMediaMessage(result)
+        sendPreUploadMediaMessage(result, restoreDraftAfterMedia)
         return
       }
 
@@ -4600,16 +4630,20 @@ class ConversationFragment :
         scheduledDate = result.scheduledTime,
         slideDeck = SlideDeck().apply { slides.forEach { addSlide(it) } },
         contacts = emptyList(),
-        clearCompose = true,
+        clearCompose = !restoreDraftAfterMedia,
         linkPreviews = emptyList(),
         isViewOnce = result.isViewOnce,
-        bypassPreSendSafetyNumberCheck = true
+        bypassPreSendSafetyNumberCheck = true,
+        clearDraftOnComplete = !restoreDraftAfterMedia
       ) {
         viewModel.deleteSlideData(slides)
+        if (restoreDraftAfterMedia) {
+          loadShareOrDraftData()
+        }
       }
     }
 
-    private fun sendPreUploadMediaMessage(result: MediaSendActivityResult) {
+    private fun sendPreUploadMediaMessage(result: MediaSendActivityResult, restoreDraftAfterMedia: Boolean) {
       sendMessage(
         body = result.body,
         mentions = result.mentions,
@@ -4619,12 +4653,17 @@ class ConversationFragment :
         scheduledDate = result.scheduledTime,
         slideDeck = null,
         contacts = emptyList(),
-        clearCompose = true,
+        clearCompose = !restoreDraftAfterMedia,
         linkPreviews = emptyList(),
         preUploadResults = result.preUploadResults,
         isViewOnce = result.isViewOnce,
-        bypassPreSendSafetyNumberCheck = true
-      )
+        bypassPreSendSafetyNumberCheck = true,
+        clearDraftOnComplete = !restoreDraftAfterMedia
+      ) {
+        if (restoreDraftAfterMedia) {
+          loadShareOrDraftData()
+        }
+      }
     }
 
     override fun onContactSelect(uri: Uri?) {


### PR DESCRIPTION
### First time contributor checklist

- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist

- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
  * A024 (Nothing Phone 3), Android 16
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Fixes #14207.

Launching Signal through a plain external image share could replace the visible composer contents and then erase a preexisting text draft when the image was sent. The draft could also be incorrectly carried into media handling as message or caption text, and fragment/activity recreation while the media editor was open made restoration unreliable.

There are two independent draft-deletion paths during send:

1. `clearCompose` clears the composer, whose text watcher can persist that empty value.
2. Send completion calls `DraftViewModel.clearDraft()` independently of composer clearing.

This change adds a separate `clearDraftOnComplete` control and disables both controls only while handling the narrow plain-external-image restoration path. The existing draft is then reloaded through the existing share-or-draft completion mechanism after cancellation, recipient mismatch, or successful media handling. The pending restoration state is saved across fragment recreation.

`clearDraftOnComplete` cannot safely be inferred from `clearCompose`: existing sticker, contact, keyboard-image, normal attachment, and other send callers that use `clearCompose = false` still need their current completion-time draft behavior. Defaults preserve those callers unchanged.

Regression coverage verifies that:

- canceling the editor restores the visible and persisted draft;
- sending creates exactly one hydrated outgoing MMS with exactly one JPEG attachment;
- the preexisting draft is neither the outgoing message body nor attachment caption;
- MIME type and fixture size match;
- the draft remains visible and persisted after send; and
- recreation observes a genuinely new activity and fragment hierarchy before completing the send.

Validation:

- `./gradlew format --no-daemon -Dorg.gradle.jvmargs="-Xmx4g" --max-workers=2` — passed.
- `./gradlew testPlayStagingDebugUnitTest --tests org.thoughtcrime.securesms.conversation.drafts.DraftRepositoryTest compilePlayStagingDebugKotlin compilePlayStagingDebugAndroidTestKotlin --no-daemon -Dorg.gradle.jvmargs="-Xmx4g" --max-workers=2` — passed.
- Verified on physical device A024 (Android 16): all three targeted `MainNavigationLaunchTest` instrumentation tests passed, covering external-image cancellation, successful sending without using the existing draft as the message body or attachment caption, and activity/fragment recreation while the media editor was open.

Broader immediate send-error UI restoration remains outside this patch. Both destructive draft-clearing paths are disabled before media processing begins, so the persisted text draft remains protected in that case.
