### PR TITLE
Render UltraHDR images in the full-screen media preview

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/ZoomingImageView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/ZoomingImageView.java
@@ -8,6 +8,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.widget.FrameLayout;
 
+import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.exifinterface.media.ExifInterface;
@@ -24,14 +25,18 @@ import org.signal.core.util.logging.Log;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.subsampling.AttachmentBitmapDecoder;
 import org.thoughtcrime.securesms.components.subsampling.AttachmentRegionDecoder;
+import org.thoughtcrime.securesms.components.subsampling.GainmapReporter;
+import org.thoughtcrime.securesms.components.subsampling.UltraHdrSupport;
 import org.signal.glide.decryptableuri.DecryptableUri;
 import org.thoughtcrime.securesms.mms.PartAuthority;
 import org.thoughtcrime.securesms.util.ActionRequestListener;
+import org.signal.core.util.ThreadUtil;
 import org.signal.core.util.bitmaps.BitmapUtil;
 import org.thoughtcrime.securesms.util.MediaUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 
 public class ZoomingImageView extends FrameLayout {
@@ -50,6 +55,8 @@ public class ZoomingImageView extends FrameLayout {
 
   private final PhotoView                 gifView;
   private final SubsamplingScaleImageView subsamplingImageView;
+
+  private @Nullable OnGainmapDetectedListener gainmapDetectedListener;
 
   public ZoomingImageView(Context context) {
     this(context, null);
@@ -84,6 +91,22 @@ public class ZoomingImageView extends FrameLayout {
     this.subsamplingImageView.setOnLongClickListener(l);
   }
 
+  /**
+   * Fired at most once per loaded image, on the main thread, if the decoded image carried an
+   * UltraHDR gain map.
+   */
+  public void setOnGainmapDetectedListener(@Nullable OnGainmapDetectedListener listener) {
+    this.gainmapDetectedListener = listener;
+  }
+
+  public interface OnGainmapDetectedListener {
+    /**
+     * Called when the image currently loaded into this view was decoded with an UltraHDR gain map.
+     */
+    @MainThread
+    void onGainmapDetected();
+  }
+
   @SuppressLint("StaticFieldLeak")
   public void setImageUri(@NonNull RequestManager requestManager, @NonNull Uri uri, @NonNull String contentType, @NonNull Runnable onMediaReady) {
     if (MediaUtil.isGif(contentType)) {
@@ -91,7 +114,7 @@ public class ZoomingImageView extends FrameLayout {
       setImageViewUri(requestManager, uri, onMediaReady);
     } else {
       Log.i(TAG, "Loading in subsampling image view...");
-      setSubsamplingImageViewUri(uri);
+      setSubsamplingImageViewUri(uri, contentType);
       onMediaReady.run();
     }
   }
@@ -108,9 +131,17 @@ public class ZoomingImageView extends FrameLayout {
                  .into(gifView);
   }
 
-  private void setSubsamplingImageViewUri(@NonNull Uri uri) {
-    subsamplingImageView.setBitmapDecoderFactory(new AttachmentBitmapDecoderFactory());
-    subsamplingImageView.setRegionDecoderFactory(new AttachmentRegionDecoderFactory());
+  private void setSubsamplingImageViewUri(@NonNull Uri uri, @NonNull String contentType) {
+    final GainmapReporter reporter;
+    if (UltraHdrSupport.isEligible(uri, contentType)) {
+      Log.i(TAG, "Checking for an Ultra HDR gain map on this image.");
+      reporter = new GainmapLatch(this);
+    } else {
+      reporter = null;
+    }
+
+    subsamplingImageView.setBitmapDecoderFactory(new AttachmentBitmapDecoderFactory(reporter));
+    subsamplingImageView.setRegionDecoderFactory(new AttachmentRegionDecoderFactory(reporter));
 
     subsamplingImageView.setVisibility(View.VISIBLE);
     gifView.setVisibility(View.GONE);
@@ -143,17 +174,53 @@ public class ZoomingImageView extends FrameLayout {
     subsamplingImageView.recycle();
   }
 
+  @MainThread
+  private void notifyGainmapDetected() {
+    Log.i(TAG, "Ultra HDR gain map present in preview image.");
+    if (gainmapDetectedListener != null) {
+      gainmapDetectedListener.onGainmapDetected();
+    }
+  }
+
+  private static class GainmapLatch implements GainmapReporter {
+    private final ZoomingImageView view;
+    private final AtomicBoolean    reported = new AtomicBoolean(false);
+
+    GainmapLatch(@NonNull ZoomingImageView view) {
+      this.view = view;
+    }
+
+    @Override
+    public void onGainmapPresent() {
+      if (reported.compareAndSet(false, true)) {
+        ThreadUtil.runOnMain(view::notifyGainmapDetected);
+      }
+    }
+  }
+
   private static class AttachmentBitmapDecoderFactory implements DecoderFactory<AttachmentBitmapDecoder> {
+    private final @Nullable GainmapReporter reporter;
+
+    AttachmentBitmapDecoderFactory(@Nullable GainmapReporter reporter) {
+      this.reporter = reporter;
+    }
+
     @Override
     public AttachmentBitmapDecoder make() throws IllegalAccessException, InstantiationException {
-      return new AttachmentBitmapDecoder();
+      return new AttachmentBitmapDecoder(reporter);
     }
   }
 
   private static class AttachmentRegionDecoderFactory implements DecoderFactory<AttachmentRegionDecoder> {
+    private final @Nullable GainmapReporter reporter;
+
+    AttachmentRegionDecoderFactory(@Nullable GainmapReporter reporter) {
+      this.reporter = reporter;
+    }
+
     @Override
     public AttachmentRegionDecoder make() throws IllegalAccessException, InstantiationException {
-      return new AttachmentRegionDecoder();
+      return new AttachmentRegionDecoder(reporter);
     }
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/components/subsampling/AttachmentBitmapDecoder.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/subsampling/AttachmentBitmapDecoder.java
@@ -6,6 +6,8 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
 
+import androidx.annotation.Nullable;
+
 import com.davemorrissey.labs.subscaleview.decoder.ImageDecoder;
 import com.davemorrissey.labs.subscaleview.decoder.SkiaImageDecoder;
 
@@ -15,7 +17,11 @@ import java.io.InputStream;
 
 public class AttachmentBitmapDecoder implements ImageDecoder{
 
-  public AttachmentBitmapDecoder() {}
+  private final @Nullable GainmapReporter reporter;
+
+  public AttachmentBitmapDecoder(@Nullable GainmapReporter reporter) {
+    this.reporter = reporter;
+  }
 
   @Override
   public Bitmap decode(Context context, Uri uri) throws Exception {
@@ -33,6 +39,13 @@ public class AttachmentBitmapDecoder implements ImageDecoder{
 
       if (bitmap == null) {
         throw new RuntimeException("Skia image region decoder returned null bitmap - image format may not be supported");
+      }
+
+      // SubsamplingScaleImageView reaches this decoder both for a preview source and, from
+      // initialiseBaseLayer(), for any image that fits at native resolution inside the canvas max bitmap
+      // size -- the common case for Signal attachments. Both decoders therefore have to report.
+      if (reporter != null && UltraHdrSupport.hasGainmap(bitmap)) {
+        reporter.onGainmapPresent();
       }
 
       return bitmap;

--- a/app/src/main/java/org/thoughtcrime/securesms/components/subsampling/AttachmentRegionDecoder.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/subsampling/AttachmentRegionDecoder.java
@@ -9,6 +9,8 @@ import android.graphics.Point;
 import android.graphics.Rect;
 import android.net.Uri;
 
+import androidx.annotation.Nullable;
+
 import com.davemorrissey.labs.subscaleview.decoder.ImageRegionDecoder;
 import com.davemorrissey.labs.subscaleview.decoder.SkiaImageRegionDecoder;
 
@@ -21,9 +23,15 @@ public class AttachmentRegionDecoder implements ImageRegionDecoder {
 
   private static final String TAG = Log.tag(AttachmentRegionDecoder.class);
 
+  private final @Nullable GainmapReporter reporter;
+
   private SkiaImageRegionDecoder passthrough;
 
   private BitmapRegionDecoder bitmapRegionDecoder;
+
+  public AttachmentRegionDecoder(@Nullable GainmapReporter reporter) {
+    this.reporter = reporter;
+  }
 
   @Override
   public Point init(Context context, Uri uri) throws Exception {
@@ -58,6 +66,13 @@ public class AttachmentRegionDecoder implements ImageRegionDecoder {
 
       if (bitmap == null) {
         throw new RuntimeException("Skia image decoder returned null bitmap - image format may not be supported");
+      }
+
+      // The tiling half of the pair: SubsamplingScaleImageView only keeps this decoder when the image does not
+      // fit at native resolution inside the canvas max bitmap size, otherwise initialiseBaseLayer() recycles it
+      // and hands the load to AttachmentBitmapDecoder. Both decoders therefore have to report.
+      if (reporter != null && UltraHdrSupport.hasGainmap(bitmap)) {
+        reporter.onGainmapPresent();
       }
 
       return bitmap;

--- a/app/src/main/java/org/thoughtcrime/securesms/components/subsampling/GainmapReporter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/subsampling/GainmapReporter.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.thoughtcrime.securesms.components.subsampling;
+
+import androidx.annotation.AnyThread;
+
+/**
+ * Callback used by the preview decoders to report that the image they just decoded carries an
+ * UltraHDR gain map. Called from SubsamplingScaleImageView's decode worker threads, possibly many
+ * times (once per tile); implementations must be idempotent and thread-safe.
+ */
+public interface GainmapReporter {
+  /**
+   * Reports that a decoded bitmap carried an UltraHDR gain map.
+   */
+  @AnyThread
+  void onGainmapPresent();
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/components/subsampling/UltraHdrSupport.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/subsampling/UltraHdrSupport.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.thoughtcrime.securesms.components.subsampling;
+
+import android.graphics.Bitmap;
+import android.net.Uri;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.thoughtcrime.securesms.mms.PartAuthority;
+import org.thoughtcrime.securesms.util.MediaUtil;
+
+/**
+ * Helpers for detecting UltraHDR (gain map bearing) images in the full-screen media preview.
+ */
+public final class UltraHdrSupport {
+
+  private UltraHdrSupport() {}
+
+  /**
+   * Whether we should install gain-map-aware decoders for this attachment. This is a cheap
+   * pre-filter only; the authoritative answer comes from {@link #hasGainmap(Bitmap)} on the
+   * decoded bitmap.
+   * <p>
+   * This is the feature floor for the whole HDR preview, and it is API 35 rather than 34 because that is where
+   * {@code Window#setDesiredHdrHeadroom} arrives. Without it the compositor picks the headroom itself and
+   * visibly dims the SDR chrome (toolbar, caption, album rail) sharing the preview window, so on API 34 there
+   * is nothing worth detecting a gain map for.
+   */
+  public static boolean isEligible(@NonNull Uri uri, @Nullable String contentType) {
+    return Build.VERSION.SDK_INT >= 35 &&
+           isGainmapCapableContentType(contentType) &&
+           PartAuthority.isLocalUri(uri);
+  }
+
+  /**
+   * Whether the provided bitmap carries an UltraHDR gain map.
+   * <p>
+   * The API 34 guard here is {@link Bitmap#hasGainmap()}'s own availability floor, not the preview's feature
+   * floor -- callers only reach this after {@link #isEligible(Uri, String)} has already applied the latter.
+   */
+  public static boolean hasGainmap(@Nullable Bitmap bitmap) {
+    return Build.VERSION.SDK_INT >= 34 && bitmap != null && bitmap.hasGainmap();
+  }
+
+  /**
+   * Containers that can carry a gain map. This is deliberately wider than what every platform version can
+   * actually parse -- JPEG is the only one guaranteed to report a gain map today, while HEIC/HEIF depends on
+   * the platform's codec. Listing them costs nothing (a bitmap without a gain map simply never reports) and
+   * avoids a second code change when a platform gains HEIF gain map decoding.
+   */
+  private static boolean isGainmapCapableContentType(@Nullable String contentType) {
+    return MediaUtil.isJpegType(contentType) ||
+           MediaUtil.isHeicType(contentType) ||
+           MediaUtil.isHeifType(contentType);
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/mediapreview/ImageMediaPreviewPageFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediapreview/ImageMediaPreviewPageFragment.java
@@ -20,6 +20,7 @@ import org.thoughtcrime.securesms.util.MediaUtil;
 public final class ImageMediaPreviewPageFragment extends MediaPreviewPageFragment {
 
   private MediaPreviewPlayerControlView bottomBarControlView;
+  private ZoomingImageView              zoomingImageView;
 
   private MediaPreviewViewModel viewModel;
   private LifecycleDisposable   lifecycleDisposable;
@@ -33,13 +34,13 @@ public final class ImageMediaPreviewPageFragment extends MediaPreviewPageFragmen
   public View onCreateView(LayoutInflater inflater, ViewGroup container,
                            Bundle savedInstanceState)
   {
-    View             view             = inflater.inflate(R.layout.media_preview_image_fragment, container, false);
-    RequestManager   requestManager   = Glide.with(requireActivity());
-    Bundle           arguments        = requireArguments();
-    Uri              uri              = arguments.getParcelable(DATA_URI);
-    String           contentType      = arguments.getString(DATA_CONTENT_TYPE);
-    ZoomingImageView zoomingImageView = view.findViewById(R.id.zooming_image_view);
+    View           view           = inflater.inflate(R.layout.media_preview_image_fragment, container, false);
+    RequestManager requestManager = Glide.with(requireActivity());
+    Bundle         arguments      = requireArguments();
+    Uri            uri            = arguments.getParcelable(DATA_URI);
+    String         contentType    = arguments.getString(DATA_CONTENT_TYPE);
 
+    zoomingImageView    = view.findViewById(R.id.zooming_image_view);
     viewModel           = new ViewModelProvider(requireActivity()).get(MediaPreviewViewModel.class);
     lifecycleDisposable = new LifecycleDisposable();
 
@@ -48,6 +49,8 @@ public final class ImageMediaPreviewPageFragment extends MediaPreviewPageFragmen
     if (!MediaUtil.isImageType(contentType)) {
       throw new AssertionError("This fragment can only display images");
     }
+
+    zoomingImageView.setOnGainmapDetectedListener(() -> viewModel.setHdrCapable(uri));
 
     //noinspection ConstantConditions
     zoomingImageView.setImageUri(requestManager, uri, contentType, () -> events.onMediaReady());
@@ -60,6 +63,15 @@ public final class ImageMediaPreviewPageFragment extends MediaPreviewPageFragmen
     }));
 
     return view;
+  }
+
+  @Override
+  public void onDestroyView() {
+    if (zoomingImageView != null) {
+      zoomingImageView.setOnGainmapDetectedListener(null);
+      zoomingImageView = null;
+    }
+    super.onDestroyView();
   }
 
   @Override

--- a/app/src/main/java/org/thoughtcrime/securesms/mediapreview/MediaPreviewActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediapreview/MediaPreviewActivity.kt
@@ -1,11 +1,14 @@
 package org.thoughtcrime.securesms.mediapreview
 
 import android.content.Context
+import android.content.pm.ActivityInfo
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup.LayoutParams
 import android.widget.ImageView
 import androidx.activity.viewModels
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.transition.addListener
 import androidx.core.view.animation.PathInterpolatorCompat
@@ -14,12 +17,15 @@ import androidx.fragment.app.commit
 import com.google.android.material.shape.ShapeAppearanceModel
 import com.google.android.material.transition.platform.MaterialContainerTransform
 import com.google.android.material.transition.platform.MaterialContainerTransformSharedElementCallback
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import org.signal.core.util.concurrent.LifecycleDisposable
+import org.signal.core.util.logging.Log
 import org.thoughtcrime.securesms.PassphraseRequiredActivity
 import org.thoughtcrime.securesms.R
 import org.thoughtcrime.securesms.components.voice.VoiceNoteMediaController
 import org.thoughtcrime.securesms.components.voice.VoiceNoteMediaControllerOwner
 import org.thoughtcrime.securesms.util.WindowUtil
+import java.util.concurrent.TimeUnit
 
 class MediaPreviewActivity : PassphraseRequiredActivity(), VoiceNoteMediaControllerOwner {
 
@@ -32,6 +38,8 @@ class MediaPreviewActivity : PassphraseRequiredActivity(), VoiceNoteMediaControl
   }
 
   private lateinit var transitionImageView: ImageView
+
+  private var isWindowStarted = false
 
   override fun attachBaseContext(newBase: Context) {
     delegate.localNightMode = AppCompatDelegate.MODE_NIGHT_YES
@@ -84,6 +92,7 @@ class MediaPreviewActivity : PassphraseRequiredActivity(), VoiceNoteMediaControl
     }
 
     super.onCreate(savedInstanceState, ready)
+    lifecycleDisposable.bindTo(this)
     setTheme(R.style.TextSecure_MediaPreview)
     setContentView(R.layout.activity_media_preview)
 
@@ -127,6 +136,20 @@ class MediaPreviewActivity : PassphraseRequiredActivity(), VoiceNoteMediaControl
       viewModel.setIsInSharedAnimation(false)
     }
 
+    if (Build.VERSION.SDK_INT >= 35) {
+      // ViewPager2 reports the newly selected page as soon as the snap target is decided, i.e. while the
+      // settle animation is still running and both pages are on screen. Writing the window color mode there
+      // rebuilds the HWUI surface mid-scroll, so in a mixed HDR/SDR album a fast flick would rebuild it once
+      // per page. Debouncing collapses a flick into a single write once the pager has come to rest.
+      // A delayed write can never strand the window in HDR: onStop() and finishAfterTransition() both clear
+      // synchronously, and applyWindowColorMode() refuses to raise HDR unless the window is started.
+      lifecycleDisposable += viewModel.state
+        .map { it.shouldRenderHdr }
+        .distinctUntilChanged()
+        .debounce(COLOR_MODE_SETTLE_DELAY_MS, TimeUnit.MILLISECONDS, AndroidSchedulers.mainThread())
+        .subscribe { applyWindowColorMode(it) }
+    }
+
     voiceNoteMediaController = VoiceNoteMediaController(this, false)
 
     WindowUtil.clearLightStatusBar(window)
@@ -142,12 +165,25 @@ class MediaPreviewActivity : PassphraseRequiredActivity(), VoiceNoteMediaControl
     }
   }
 
+  override fun onStart() {
+    super.onStart()
+    isWindowStarted = true
+    applyWindowColorMode(viewModel.shouldRenderHdr)
+  }
+
+  override fun onStop() {
+    isWindowStarted = false
+    applyWindowColorMode(false)
+    super.onStop()
+  }
+
   override fun onPause() {
     super.onPause()
     MediaPreviewCache.drawable = null
   }
 
   override fun finishAfterTransition() {
+    applyWindowColorMode(false)
     if (viewModel.shouldFinishAfterTransition(args.initialMediaUri)) {
       super.finishAfterTransition()
     } else {
@@ -155,8 +191,56 @@ class MediaPreviewActivity : PassphraseRequiredActivity(), VoiceNoteMediaControl
     }
   }
 
+  /**
+   * Applies the desired window color mode. This activity is the sole writer of [android.view.Window.setColorMode];
+   * HDR is only ever requested while the window is started and the display can actually present it.
+   *
+   * The API 35 floor is [android.view.Window.setDesiredHdrHeadroom]: below that the compositor picks the headroom
+   * itself and visibly dims the SDR chrome (toolbar, caption, album rail) sharing this window, so raising HDR
+   * would cost more than it buys. It matches the floor
+   * [org.thoughtcrime.securesms.components.subsampling.UltraHdrSupport.isEligible] applies at decode time.
+   */
+  private fun applyWindowColorMode(wantHdr: Boolean) {
+    if (Build.VERSION.SDK_INT < 35) {
+      return
+    }
+
+    val target = if (wantHdr && isWindowStarted && isDisplayHdrCapable()) {
+      ActivityInfo.COLOR_MODE_HDR
+    } else {
+      ActivityInfo.COLOR_MODE_DEFAULT
+    }
+
+    if (window.colorMode == target) {
+      return
+    }
+
+    Log.i(TAG, "Changing window color mode. hdr=${target == ActivityInfo.COLOR_MODE_HDR}")
+    window.colorMode = target
+    window.desiredHdrHeadroom = if (target == ActivityInfo.COLOR_MODE_HDR) MIXED_CONTENT_HDR_HEADROOM else 0f
+  }
+
+  /** The API 34 floor is [android.view.Display.isHdrSdrRatioAvailable]'s own, not the preview's; callers are already above it. */
+  @RequiresApi(34)
+  private fun isDisplayHdrCapable(): Boolean {
+    return try {
+      display?.isHdrSdrRatioAvailable == true
+    } catch (e: Exception) {
+      Log.w(TAG, "Unable to query display HDR capability.", e)
+      false
+    }
+  }
+
   companion object {
+    private val TAG = Log.tag(MediaPreviewActivity::class)
+
     private const val FRAGMENT_TAG = "media_preview_fragment"
     const val SHARED_ELEMENT_TRANSITION_NAME = "thumb"
+
+    /** Google's published "mixed content, mostly HDR" headroom. The preview keeps SDR chrome in the same window. */
+    private const val MIXED_CONTENT_HDR_HEADROOM = 3f
+
+    /** How long the page selection must stay put before we pay for a window color mode change. */
+    private const val COLOR_MODE_SETTLE_DELAY_MS = 200L
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/mediapreview/MediaPreviewFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediapreview/MediaPreviewFragment.kt
@@ -134,7 +134,8 @@ class MediaPreviewFragment :
       viewModel
         .state
         .distinctUntilChanged { t1, t2 ->
-          // this is all fields except for [isInSharedAnimation], which is explicitly excluded.
+          // This is all fields except for [isInSharedAnimation] and [hdrCapableUris], which are
+          // explicitly excluded. Neither affects anything bindCurrentState renders.
           (
             t1.mediaRecords == t2.mediaRecords &&
               t1.loadState == t2.loadState &&

--- a/app/src/main/java/org/thoughtcrime/securesms/mediapreview/MediaPreviewState.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediapreview/MediaPreviewState.kt
@@ -1,5 +1,6 @@
 package org.thoughtcrime.securesms.mediapreview
 
+import android.net.Uri
 import android.text.SpannableString
 import org.signal.core.models.media.Media
 import org.thoughtcrime.securesms.database.MediaTable
@@ -13,7 +14,16 @@ data class MediaPreviewState(
   val leftIsRecent: Boolean = false,
   val albums: Map<Long, List<Media>> = mapOf(),
   val messageBodies: Map<Long, SpannableString> = mapOf(),
-  val isInSharedAnimation: Boolean = true
+  val isInSharedAnimation: Boolean = true,
+  val hdrCapableUris: Set<Uri> = emptySet()
 ) {
   enum class LoadState { INIT, DATA_LOADED, MEDIA_READY }
+
+  /** The uri of the media on the currently-visible page, or null if the position is not backed by a record. */
+  val currentMediaUri: Uri?
+    get() = mediaRecords.getOrNull(position)?.attachment?.displayUri
+
+  /** True when the currently-visible page is a known UltraHDR image and no shared-element transition is running. */
+  val shouldRenderHdr: Boolean
+    get() = !isInSharedAnimation && currentMediaUri?.let { hdrCapableUris.contains(it) } == true
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/mediapreview/MediaPreviewViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediapreview/MediaPreviewViewModel.kt
@@ -53,6 +53,21 @@ class MediaPreviewViewModel : ViewModel() {
     store.update { it.copy(isInSharedAnimation = isInSharedAnimation) }
   }
 
+  /**
+   * Records that the media at [uri] decoded with an UltraHDR gain map. Monotonic and additive: a
+   * gain map never disappears, and the set is bounded by the number of HDR images the user actually
+   * views in this activity.
+   */
+  fun setHdrCapable(uri: Uri) {
+    store.update { oldState ->
+      if (oldState.hdrCapableUris.contains(uri)) oldState else oldState.copy(hdrCapableUris = oldState.hdrCapableUris + uri)
+    }
+  }
+
+  /** Synchronous read for [MediaPreviewActivity.onStart], where there is no pending Rx emission to react to. */
+  val shouldRenderHdr: Boolean
+    get() = store.state.shouldRenderHdr
+
   fun shouldFinishAfterTransition(initialMediaUri: Uri): Boolean {
     return currentPosition in store.state.mediaRecords.indices && store.state.mediaRecords[currentPosition].toMedia()?.uri == initialMediaUri
   }

--- a/app/src/test/java/org/thoughtcrime/securesms/mediapreview/MediaPreviewStateTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/mediapreview/MediaPreviewStateTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.thoughtcrime.securesms.mediapreview
+
+import android.app.Application
+import android.net.Uri
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.thoughtcrime.securesms.attachments.DatabaseAttachment
+import org.thoughtcrime.securesms.database.MediaTable
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, application = Application::class)
+class MediaPreviewStateTest {
+
+  private val hdrUri: Uri = Uri.parse("content://org.thoughtcrime.securesms/part/111")
+  private val sdrUri: Uri = Uri.parse("content://org.thoughtcrime.securesms/part/222")
+
+  @Test
+  fun `shouldRenderHdr is false when no uris have been recorded`() {
+    val state = MediaPreviewState(
+      mediaRecords = listOf(recordFor(hdrUri)),
+      position = 0,
+      isInSharedAnimation = false
+    )
+
+    assertThat(state.currentMediaUri).isEqualTo(hdrUri)
+    assertThat(state.shouldRenderHdr).isFalse()
+  }
+
+  @Test
+  fun `shouldRenderHdr is true when the current page is recorded and no transition is running`() {
+    val state = MediaPreviewState(
+      mediaRecords = listOf(recordFor(hdrUri)),
+      position = 0,
+      isInSharedAnimation = false,
+      hdrCapableUris = setOf(hdrUri)
+    )
+
+    assertThat(state.shouldRenderHdr).isTrue()
+  }
+
+  @Test
+  fun `shouldRenderHdr is false while a shared element transition is running`() {
+    val state = MediaPreviewState(
+      mediaRecords = listOf(recordFor(hdrUri)),
+      position = 0,
+      isInSharedAnimation = true,
+      hdrCapableUris = setOf(hdrUri)
+    )
+
+    assertThat(state.shouldRenderHdr).isFalse()
+  }
+
+  @Test
+  fun `shouldRenderHdr is false when only another page is recorded`() {
+    val state = MediaPreviewState(
+      mediaRecords = listOf(recordFor(sdrUri), recordFor(hdrUri)),
+      position = 0,
+      isInSharedAnimation = false,
+      hdrCapableUris = setOf(hdrUri)
+    )
+
+    assertThat(state.currentMediaUri).isEqualTo(sdrUri)
+    assertThat(state.shouldRenderHdr).isFalse()
+  }
+
+  @Test
+  fun `shouldRenderHdr is false when the position is out of bounds`() {
+    val state = MediaPreviewState(
+      mediaRecords = listOf(recordFor(hdrUri)),
+      position = 5,
+      isInSharedAnimation = false,
+      hdrCapableUris = setOf(hdrUri)
+    )
+
+    assertThat(state.currentMediaUri).isNull()
+    assertThat(state.shouldRenderHdr).isFalse()
+  }
+
+  @Test
+  fun `shouldRenderHdr is false when there are no media records`() {
+    val state = MediaPreviewState(
+      mediaRecords = emptyList(),
+      position = 0,
+      isInSharedAnimation = false,
+      hdrCapableUris = setOf(hdrUri)
+    )
+
+    assertThat(state.currentMediaUri).isNull()
+    assertThat(state.shouldRenderHdr).isFalse()
+  }
+
+  @Test
+  fun `shouldRenderHdr is false when the current record has no attachment`() {
+    val state = MediaPreviewState(
+      mediaRecords = listOf(recordFor(null)),
+      position = 0,
+      isInSharedAnimation = false,
+      hdrCapableUris = setOf(hdrUri)
+    )
+
+    assertThat(state.currentMediaUri).isNull()
+    assertThat(state.shouldRenderHdr).isFalse()
+  }
+
+  @Test
+  fun `shouldRenderHdr follows the position as the user pages`() {
+    val state = MediaPreviewState(
+      mediaRecords = listOf(recordFor(hdrUri), recordFor(sdrUri)),
+      position = 0,
+      isInSharedAnimation = false,
+      hdrCapableUris = setOf(hdrUri)
+    )
+
+    assertThat(state.shouldRenderHdr).isTrue()
+    assertThat(state.copy(position = 1).shouldRenderHdr).isFalse()
+  }
+
+  private fun recordFor(uri: Uri?): MediaTable.MediaRecord {
+    val record: MediaTable.MediaRecord = mockk()
+
+    if (uri == null) {
+      every { record.attachment } returns null
+    } else {
+      val attachment: DatabaseAttachment = mockk()
+      every { attachment.displayUri } returns uri
+      every { record.attachment } returns attachment
+    }
+
+    return record
+  }
+}


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S26 Ultra, Android 16, HDR 
 * Google Pixel 8 Pro, Android 16, HDR
 * Google Pixel 2, Android 11, SDR
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Issue
Signal Android already sends and receives UltraHDR (gain map) JPEGs intact; the same images render in HDR on Signal Desktop for Windows and macOS. Android displayed only their SDR base image.

### Fix
Decoding needed no change. BitmapFactory and BitmapRegionDecoder already attach a Gainmap on API 34+, and SubsamplingScaleImageView already draws it to the hardware canvas. A gain map is simply not applied unless the activity opts its window in via Window.setColorMode(COLOR_MODE_HDR).

The decoders now report when a decoded bitmap carries a gain map, the preview records to which media that applies, and MediaPreviewActivity raises the window color mode while such an image is the current page, clearing it on stop and on exit. Window.setDesiredHdrHeadroom() caps the headroom so SDR chrome sharing the window does not dim; that API is why the feature requires Android 15 (API 35) rather than 14.

### Notes
Scope is the full-screen preview only. Conversation thumbnails still render SDR -- Glide's transformations copy the bitmap through a Canvas, which drops the gain map -- and would need a gain-map-preserving decode path plus an HDR window for the whole conversation list.

Note that images must be sent at the high-quality setting to retain their gain map; at standard quality they are rescaled during compression and the gain map is lost.