### PR TITLE
Preserve share intent URI permissions across the passphrase prompt

### DIFF
--- a/app/src/androidTest/java/org/thoughtcrime/securesms/PassphraseUriPermissionTest.kt
+++ b/app/src/androidTest/java/org/thoughtcrime/securesms/PassphraseUriPermissionTest.kt
@@ -1,0 +1,221 @@
+package org.thoughtcrime.securesms
+
+import android.content.ClipData
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.isEmpty
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Covers the URI grant bookkeeping that keeps a share intent usable across the passphrase prompt.
+ *
+ * Rather than exercising real grants -- which would require a second package to observe, since the app implicitly
+ * holds permission on its own providers -- these tests wrap the context and record what
+ * [PassphraseRequiredActivity.revokePreservedUriPermissions] targets. That makes the URI extraction and flag
+ * selection observable, which is where the interesting edge cases live.
+ */
+@RunWith(AndroidJUnit4::class)
+class PassphraseUriPermissionTest {
+
+  companion object {
+    private const val AUTHORITY = "content://org.thoughtcrime.securesms.test"
+
+    private val READ = Intent.FLAG_GRANT_READ_URI_PERMISSION
+    private val WRITE = Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+  }
+
+  private val appContext: Context = ApplicationProvider.getApplicationContext()
+
+  /** Captures revocations instead of performing them. */
+  private class RecordingContext(base: Context) : ContextWrapper(base) {
+    val revoked = mutableListOf<Pair<Uri, Int>>()
+
+    override fun revokeUriPermission(targetPackage: String?, uri: Uri, modeFlags: Int) {
+      revoked += uri to modeFlags
+    }
+  }
+
+  private fun contentUri(id: Int): Uri = Uri.parse("$AUTHORITY/$id")
+
+  private fun revoke(intent: Intent?): List<Pair<Uri, Int>> {
+    val recorder = RecordingContext(appContext)
+    PassphraseRequiredActivity.revokePreservedUriPermissions(recorder, intent)
+    return recorder.revoked
+  }
+
+  @Test
+  fun givenNullIntent_whenIRevoke_thenIExpectNoRevocations() {
+    assertThat(revoke(null)).isEmpty()
+  }
+
+  @Test
+  fun givenIntentWithoutGrantFlags_whenIRevoke_thenIExpectNoRevocations() {
+    val intent = Intent(Intent.ACTION_SEND).apply {
+      putExtra(Intent.EXTRA_STREAM, contentUri(1))
+    }
+
+    assertThat(revoke(intent)).isEmpty()
+  }
+
+  @Test
+  fun givenGrantFlagsButNoUris_whenIRevoke_thenIExpectNoRevocations() {
+    val intent = Intent(Intent.ACTION_SEND).apply {
+      addFlags(READ)
+      putExtra(Intent.EXTRA_TEXT, "no uris here")
+    }
+
+    assertThat(revoke(intent)).isEmpty()
+  }
+
+  @Test
+  fun givenIntentWithDataUri_whenIRevoke_thenIExpectThatUriRevoked() {
+    val uri = contentUri(1)
+    val intent = Intent(Intent.ACTION_VIEW, uri).apply {
+      addFlags(READ)
+    }
+
+    assertThat(revoke(intent)).containsExactlyInAnyOrder(uri to READ)
+  }
+
+  @Test
+  fun givenSingleStreamExtra_whenIRevoke_thenIExpectThatUriRevoked() {
+    val uri = contentUri(1)
+    val intent = Intent(Intent.ACTION_SEND).apply {
+      addFlags(READ)
+      putExtra(Intent.EXTRA_STREAM, uri)
+    }
+
+    assertThat(revoke(intent)).containsExactlyInAnyOrder(uri to READ)
+  }
+
+  @Test
+  fun givenMultipleStreamExtras_whenIRevoke_thenIExpectEveryUriRevoked() {
+    val first = contentUri(1)
+    val second = contentUri(2)
+    val intent = Intent(Intent.ACTION_SEND_MULTIPLE).apply {
+      addFlags(READ)
+      putParcelableArrayListExtra(Intent.EXTRA_STREAM, arrayListOf(first, second))
+    }
+
+    assertThat(revoke(intent)).containsExactlyInAnyOrder(first to READ, second to READ)
+  }
+
+  @Test
+  fun givenClipDataUris_whenIRevoke_thenIExpectEveryUriRevoked() {
+    val first = contentUri(1)
+    val second = contentUri(2)
+    val intent = Intent(Intent.ACTION_SEND).apply {
+      addFlags(READ)
+      clipData = ClipData.newRawUri("first", first).apply {
+        addItem(ClipData.Item(second))
+      }
+    }
+
+    assertThat(revoke(intent)).containsExactlyInAnyOrder(first to READ, second to READ)
+  }
+
+  @Test
+  fun givenUriNestedInClipDataIntent_whenIRevoke_thenIExpectNestedUriRevoked() {
+    val outer = contentUri(1)
+    val nested = contentUri(2)
+
+    val nestedIntent = Intent(Intent.ACTION_VIEW, nested)
+    val intent = Intent(Intent.ACTION_SEND).apply {
+      addFlags(READ)
+      putExtra(Intent.EXTRA_STREAM, outer)
+      clipData = ClipData.newIntent("nested", nestedIntent)
+    }
+
+    assertThat(revoke(intent)).containsExactlyInAnyOrder(outer to READ, nested to READ)
+  }
+
+  @Test
+  fun givenStreamExtraOnNestedIntent_whenIRevoke_thenIExpectNestedUriRevoked() {
+    val nested = contentUri(1)
+
+    val nestedIntent = Intent(Intent.ACTION_SEND).apply {
+      putExtra(Intent.EXTRA_STREAM, nested)
+    }
+    val intent = Intent(Intent.ACTION_SEND).apply {
+      addFlags(READ)
+      clipData = ClipData.newIntent("nested", nestedIntent)
+    }
+
+    assertThat(revoke(intent)).containsExactlyInAnyOrder(nested to READ)
+  }
+
+  @Test
+  fun givenNonContentSchemes_whenIRevoke_thenIExpectThemSkipped() {
+    val content = contentUri(1)
+    val intent = Intent(Intent.ACTION_SEND).apply {
+      addFlags(READ)
+      putParcelableArrayListExtra(
+        Intent.EXTRA_STREAM,
+        arrayListOf(
+          content,
+          Uri.parse("file:///sdcard/photo.jpg"),
+          Uri.parse("https://signal.org/logo.png")
+        )
+      )
+    }
+
+    assertThat(revoke(intent)).containsExactlyInAnyOrder(content to READ)
+  }
+
+  @Test
+  fun givenBothGrantFlags_whenIRevoke_thenIExpectEachFlagRevokedSeparately() {
+    val uri = contentUri(1)
+    val intent = Intent(Intent.ACTION_SEND).apply {
+      addFlags(READ or WRITE)
+      putExtra(Intent.EXTRA_STREAM, uri)
+    }
+
+    assertThat(revoke(intent)).containsExactlyInAnyOrder(uri to READ, uri to WRITE)
+  }
+
+  @Test
+  fun givenOnlyWriteFlag_whenIRevoke_thenIExpectReadLeftAlone() {
+    val uri = contentUri(1)
+    val intent = Intent(Intent.ACTION_SEND).apply {
+      addFlags(WRITE)
+      putExtra(Intent.EXTRA_STREAM, uri)
+    }
+
+    assertThat(revoke(intent)).containsExactlyInAnyOrder(uri to WRITE)
+  }
+
+  @Test
+  fun givenTheSameUriTwice_whenIRevoke_thenIExpectItRevokedOnce() {
+    val uri = contentUri(1)
+    val intent = Intent(Intent.ACTION_SEND, uri).apply {
+      addFlags(READ)
+      putExtra(Intent.EXTRA_STREAM, uri)
+      clipData = ClipData.newRawUri("dupe", uri)
+    }
+
+    assertThat(revoke(intent)).containsExactlyInAnyOrder(uri to READ)
+  }
+
+  @Test
+  fun givenIntentWithoutPreservedMarker_whenICheck_thenIExpectFalse() {
+    assertThat(PassphraseRequiredActivity.hasPreservedUriPermissions(Intent())).isFalse()
+  }
+
+  @Test
+  fun givenIntentCarryingPreservedMarker_whenICheck_thenIExpectTrue() {
+    val prompt = Intent().apply {
+      putExtra("next_intent_uri_grants_preserved", true)
+    }
+
+    assertThat(PassphraseRequiredActivity.hasPreservedUriPermissions(prompt)).isTrue()
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/PassphraseActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/PassphraseActivity.java
@@ -38,6 +38,7 @@ public abstract class PassphraseActivity extends BaseActivity {
 
   private KeyCachingService keyCachingService;
   private MasterSecret masterSecret;
+  private boolean nextIntentHandled;
 
   protected void setMasterSecret(MasterSecret masterSecret) {
     this.masterSecret = masterSecret;
@@ -59,13 +60,18 @@ public abstract class PassphraseActivity extends BaseActivity {
         masterSecret = null;
         cleanup();
 
-        Intent nextIntent = getIntent().getParcelableExtra("next_intent");
+        Intent nextIntent = getIntent().getParcelableExtra(PassphraseRequiredActivity.NEXT_INTENT_EXTRA);
         if (nextIntent != null) {
             try {
                 startActivity(nextIntent);
                 overridePendingTransition(R.anim.fade_in, R.anim.fade_out);
             } catch (java.lang.SecurityException e) {
                 Log.w(TAG, "Access permission not passed from PassphraseActivity, retry sharing.");
+            } finally {
+                if (PassphraseRequiredActivity.hasPreservedUriPermissions(getIntent())) {
+                    PassphraseRequiredActivity.revokePreservedUriPermissions(PassphraseActivity.this, nextIntent);
+                }
+                nextIntentHandled = true;
             }
         }
         finish();
@@ -75,4 +81,14 @@ public abstract class PassphraseActivity extends BaseActivity {
         keyCachingService = null;
       }
   };
+
+  @Override
+  protected void onDestroy() {
+    if (!nextIntentHandled && isFinishing() && !isChangingConfigurations() && PassphraseRequiredActivity.hasPreservedUriPermissions(getIntent())) {
+      Intent nextIntent = getIntent().getParcelableExtra(PassphraseRequiredActivity.NEXT_INTENT_EXTRA);
+      PassphraseRequiredActivity.revokePreservedUriPermissions(PassphraseActivity.this, nextIntent);
+    }
+
+    super.onDestroy();
+  }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/PassphraseRequiredActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/PassphraseRequiredActivity.java
@@ -1,10 +1,15 @@
 package org.thoughtcrime.securesms;
 
 import android.content.BroadcastReceiver;
+import android.content.ClipData;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
+import android.os.Parcelable;
 
 import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
@@ -40,6 +45,8 @@ import org.thoughtcrime.securesms.util.AppStartup;
 import org.thoughtcrime.securesms.util.Environment;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 public abstract class PassphraseRequiredActivity extends BaseActivity implements MasterSecretListener {
@@ -47,6 +54,9 @@ public abstract class PassphraseRequiredActivity extends BaseActivity implements
 
   public static final String LOCALE_EXTRA      = "locale_extra";
   public static final String NEXT_INTENT_EXTRA = "next_intent";
+
+  private static final String NEXT_INTENT_URI_GRANTS_PRESERVED = "next_intent_uri_grants_preserved";
+  private static final int[]  URI_ACCESS_FLAGS                  = { Intent.FLAG_GRANT_READ_URI_PERMISSION, Intent.FLAG_GRANT_WRITE_URI_PERMISSION };
 
   private static final int STATE_NORMAL              = 0;
   private static final int STATE_CREATE_PASSPHRASE   = 1;
@@ -243,8 +253,14 @@ public abstract class PassphraseRequiredActivity extends BaseActivity implements
   }
 
   private Intent getPromptPassphraseIntent() {
-    Intent intent = getRoutedIntent(PassphrasePromptActivity.class, getIntent());
+    Intent nextIntent = getIntent();
+    Intent intent      = getRoutedIntent(PassphrasePromptActivity.class, nextIntent);
     intent.putExtra(PassphrasePromptActivity.FROM_FOREGROUND, AppForegroundObserver.isForegrounded());
+
+    if (preserveUriPermissionsForNextIntent(this, nextIntent)) {
+      intent.putExtra(NEXT_INTENT_URI_GRANTS_PRESERVED, true);
+    }
+
     return intent;
   }
 
@@ -326,6 +342,165 @@ public abstract class PassphraseRequiredActivity extends BaseActivity implements
     final Intent intent = new Intent(this, destination);
     if (nextIntent != null)   intent.putExtra(NEXT_INTENT_EXTRA, nextIntent);
     return intent;
+  }
+
+  /**
+   * Temporary URI grants delivered by {@link Intent#FLAG_GRANT_READ_URI_PERMISSION} and/or
+   * {@link Intent#FLAG_GRANT_WRITE_URI_PERMISSION} are normally owned by the activity that receives them and are
+   * revoked as soon as that activity is destroyed. Locking routes the original activity to the passphrase prompt and
+   * finishes it, so a share intent (e.g. {@code ACTION_SEND} with {@code EXTRA_STREAM}) would lose access to its
+   * content URIs before it can be relaunched after unlock. Re-grant the same access to our own package without an
+   * activity owner so it survives until the prompt relaunches the intent, at which point it is promptly revoked.
+   * <p>
+   * Revoking a grant that was made to a specific package requires {@link Context#revokeUriPermission(String, Uri, int)},
+   * which is API 26+. Below that we could create the grant but never reliably drop it again, which would trade a
+   * broken share for a leaked permission. So the whole mechanism is gated: older devices keep the previous behaviour
+   * of losing the grant at the lock boundary.
+   */
+  private static boolean preserveUriPermissionsForNextIntent(@NonNull Context context, @Nullable Intent intent) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+      return false;
+    }
+
+    if (intent == null) {
+      return false;
+    }
+
+    final int accessFlags = intent.getFlags() & (Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+    if (accessFlags == 0) {
+      return false;
+    }
+
+    final List<Uri> uris = getUrisFromIntent(intent);
+    if (uris.isEmpty()) {
+      return false;
+    }
+
+    boolean granted = false;
+
+    for (Uri uri : uris) {
+      if (!ContentResolver.SCHEME_CONTENT.equals(uri.getScheme())) {
+        continue;
+      }
+
+      for (int flag : URI_ACCESS_FLAGS) {
+        if ((accessFlags & flag) == 0) {
+          continue;
+        }
+
+        try {
+          context.grantUriPermission(context.getPackageName(), uri, flag);
+          granted = true;
+        } catch (SecurityException | IllegalArgumentException e) {
+          Log.w(TAG, "Unable to preserve URI permission for " + uri, e);
+        }
+      }
+    }
+
+    return granted;
+  }
+
+  static boolean hasPreservedUriPermissions(@NonNull Intent intent) {
+    return intent.getBooleanExtra(NEXT_INTENT_URI_GRANTS_PRESERVED, false);
+  }
+
+  /**
+   * Revokes only the ownerless grants created by {@link #preserveUriPermissionsForNextIntent(Context, Intent)}.
+   * The new activity receives its own activity-scoped grant when {@code nextIntent} is started, so revoking the
+   * package-scoped grant immediately after launch does not break the share.
+   */
+  static void revokePreservedUriPermissions(@NonNull Context context, @Nullable Intent intent) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+      return;
+    }
+
+    if (intent == null) {
+      return;
+    }
+
+    final int accessFlags = intent.getFlags() & (Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+    if (accessFlags == 0) {
+      return;
+    }
+
+    for (Uri uri : getUrisFromIntent(intent)) {
+      if (!ContentResolver.SCHEME_CONTENT.equals(uri.getScheme())) {
+        continue;
+      }
+
+      for (int flag : URI_ACCESS_FLAGS) {
+        if ((accessFlags & flag) == 0) {
+          continue;
+        }
+
+        try {
+          context.revokeUriPermission(context.getPackageName(), uri, flag);
+        } catch (SecurityException | IllegalArgumentException e) {
+          Log.w(TAG, "Unable to revoke preserved URI permission for " + uri, e);
+        }
+      }
+    }
+  }
+
+  private static @NonNull List<Uri> getUrisFromIntent(@NonNull Intent intent) {
+    final List<Uri> uris = new ArrayList<>();
+
+    addUri(uris, intent.getData());
+    addUrisFromClipData(uris, intent.getClipData(), 0);
+
+    final Bundle extras = intent.getExtras();
+    if (extras != null) {
+      addUrisFromStreamExtra(uris, extras.get(Intent.EXTRA_STREAM));
+    }
+
+    return uris;
+  }
+
+  private static void addUrisFromClipData(@NonNull List<Uri> uris, @Nullable ClipData clipData, int depth) {
+    if (clipData == null || depth > 3) {
+      return;
+    }
+
+    for (int i = 0; i < clipData.getItemCount(); i++) {
+      ClipData.Item item = clipData.getItemAt(i);
+      addUri(uris, item.getUri());
+
+      final Intent nestedIntent = item.getIntent();
+      if (nestedIntent != null) {
+        addUri(uris, nestedIntent.getData());
+        addUrisFromClipData(uris, nestedIntent.getClipData(), depth + 1);
+
+        final Bundle nestedExtras = nestedIntent.getExtras();
+        if (nestedExtras != null) {
+          addUrisFromStreamExtra(uris, nestedExtras.get(Intent.EXTRA_STREAM));
+        }
+      }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void addUrisFromStreamExtra(@NonNull List<Uri> uris, @Nullable Object streamExtra) {
+    if (streamExtra instanceof Uri) {
+      addUri(uris, (Uri) streamExtra);
+    } else if (streamExtra instanceof Iterable) {
+      for (Object value : (Iterable) streamExtra) {
+        if (value instanceof Uri) {
+          addUri(uris, (Uri) value);
+        }
+      }
+    } else if (streamExtra instanceof Parcelable[]) {
+      for (Parcelable value : (Parcelable[]) streamExtra) {
+        if (value instanceof Uri) {
+          addUri(uris, (Uri) value);
+        }
+      }
+    }
+  }
+
+  private static void addUri(@NonNull List<Uri> uris, @Nullable Uri uri) {
+    if (uri != null && !uris.contains(uri)) {
+      uris.add(uri);
+    }
   }
 
   private Intent getConversationListIntent() {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Pixel 8 API 37.1, Android 17
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

**Problem**

When Signal is passphrase-locked and content is shared into it, the share loses access to its content URIs. `PassphraseRequiredActivity` routes the incoming intent to the passphrase prompt and finishes the activity that received it; temporary URI grants are owned by that activity, so they are revoked on destroy — before the intent can be relaunched after unlock.

**Fix**

Before routing, re-grant the same access to our own package so it survives the handoff. Revoke it once the prompt relaunches the intent, and also when the prompt is dismissed without unlocking, so the grant never outlives the share.

URIs are collected from `getData()`, `EXTRA_STREAM` (single, `Iterable`, `Parcelable[]`), and `ClipData`, including intents nested in `ClipData` items up to a bounded depth. Non-`content://` URIs are skipped.

**API gating**

The package-targeted `revokeUriPermission` overload is API 26+. Below that the grant could be created but never reliably dropped, trading a broken share for a leaked permission — so the mechanism is gated and older versions keep existing behaviour.

**Testing**

Added `PassphraseUriPermissionTest`, 15 instrumentation tests covering extraction from each URI source, nested `ClipData` intents, scheme filtering, per-flag revocation, and dedup.

- `connectedPlayProdDebugAndroidTest` — 15/15 passing on an API 36 emulator
- `lintPlayProdDebug` — clean
- `./gradlew format` — no changes

### Related issues

Fixes #14248
References #8354 (same underlying share-from-locked bug)
