### PR TITLE
Handle shares of content URIs without permission grants gracefully

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ResolvedShareData.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ResolvedShareData.kt
@@ -40,11 +40,3 @@ sealed class ResolvedShareData {
     override fun toMultiShareArgs(): MultiShareArgs = throw UnsupportedOperationException()
   }
 }
-
-enum class ShareError {
-  /** The shared content could not be read because the sending app did not grant URI access. */
-  ACCESS_DENIED,
-
-  /** Any other failure while trying to read the shared content. */
-  UNKNOWN
-}

--- a/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ResolvedShareData.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ResolvedShareData.kt
@@ -36,7 +36,15 @@ sealed class ResolvedShareData {
     }
   }
 
-  object Failure : ResolvedShareData() {
+  data class Failure(val error: ShareError) : ResolvedShareData() {
     override fun toMultiShareArgs(): MultiShareArgs = throw UnsupportedOperationException()
   }
+}
+
+enum class ShareError {
+  /** The shared content could not be read because the sending app did not grant URI access. */
+  ACCESS_DENIED,
+
+  /** Any other failure while trying to read the shared content. */
+  UNKNOWN
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ShareActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ShareActivity.kt
@@ -135,7 +135,10 @@ class ShareActivity : PassphraseRequiredActivity(), MultiselectForwardFragment.C
       when (shareState.loadState) {
         ShareState.ShareDataLoadState.Init -> Unit
         is ShareState.ShareDataLoadState.Failed -> {
-          showShareError(shareState.loadState.error)
+          if (!viewModel.hasShareErrorBeenShown()) {
+            viewModel.markShareErrorShown()
+            showShareError(shareState.loadState.error)
+          }
           finish()
         }
         is ShareState.ShareDataLoadState.Loaded -> {

--- a/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ShareActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ShareActivity.kt
@@ -134,7 +134,10 @@ class ShareActivity : PassphraseRequiredActivity(), MultiselectForwardFragment.C
     lifecycleDisposable += viewModel.state.observeOn(AndroidSchedulers.mainThread()).subscribe { shareState ->
       when (shareState.loadState) {
         ShareState.ShareDataLoadState.Init -> Unit
-        ShareState.ShareDataLoadState.Failed -> finish()
+        is ShareState.ShareDataLoadState.Failed -> {
+          showShareError(shareState.loadState.error)
+          finish()
+        }
         is ShareState.ShareDataLoadState.Loaded -> {
           val directShareTarget = this.directShareTarget
           if (directShareTarget != null) {
@@ -348,6 +351,15 @@ class ShareActivity : PassphraseRequiredActivity(), MultiselectForwardFragment.C
         finish()
       }
     }
+  }
+
+  private fun showShareError(error: ShareError) {
+    val message = when (error) {
+      ShareError.ACCESS_DENIED -> R.string.ShareActivity__could_not_access_shared_content
+      ShareError.UNKNOWN -> R.string.ShareActivity__could_not_share_content
+    }
+
+    Toast.makeText(this, message, Toast.LENGTH_LONG).show()
   }
 
   private fun handleIntentError(intentError: IntentError) {

--- a/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ShareError.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ShareError.kt
@@ -1,0 +1,12 @@
+package org.thoughtcrime.securesms.sharing.v2
+
+/**
+ * Reasons a share could not be resolved into shareable data.
+ */
+enum class ShareError {
+  /** The shared content could not be read because the sending app did not grant URI access. */
+  ACCESS_DENIED,
+
+  /** Any other failure while trying to read the shared content. */
+  UNKNOWN
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ShareRepository.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ShareRepository.kt
@@ -30,10 +30,9 @@ class ShareRepository(context: Context) {
 
   @NonNull
   @WorkerThread
-  @Throws(IOException::class)
   private fun resolve(multiShareExternal: UnresolvedShareData.ExternalSingleShare): ResolvedShareData {
     if (!multiShareExternal.isInternalShare && !UriUtil.isValidExternalUri(appContext, multiShareExternal.uri)) {
-      return ResolvedShareData.Failure
+      return ResolvedShareData.Failure(ShareError.UNKNOWN)
     }
 
     val uri = multiShareExternal.uri
@@ -45,8 +44,11 @@ class ShareRepository(context: Context) {
       appContext.contentResolver.openInputStream(uri)
     } catch (e: SecurityException) {
       Log.w(TAG, "Failed to read stream!", e)
-      null
-    } ?: return ResolvedShareData.Failure
+      return ResolvedShareData.Failure(ShareError.ACCESS_DENIED)
+    } catch (e: IOException) {
+      Log.w(TAG, "Failed to read stream!", e)
+      return ResolvedShareData.Failure(ShareError.UNKNOWN)
+    } ?: return ResolvedShareData.Failure(ShareError.UNKNOWN)
 
     val blobUri: Uri = try {
       AppDependencies.blobs
@@ -56,7 +58,7 @@ class ShareRepository(context: Context) {
         .createForSingleSessionOnDisk(appContext)
     } catch (e: IOException) {
       Log.e(TAG, "Failed to get blob uri")
-      return ResolvedShareData.Failure
+      return ResolvedShareData.Failure(ShareError.UNKNOWN)
     }
 
     return ResolvedShareData.ExternalUri(
@@ -77,14 +79,19 @@ class ShareRepository(context: Context) {
       }
 
     if (mimeTypes.isEmpty()) {
-      return ResolvedShareData.Failure
+      return ResolvedShareData.Failure(ShareError.UNKNOWN)
     }
 
+    var accessBlocked = false
     val media: List<Media> = mimeTypes.toList()
       .take(RemoteConfig.maxAttachmentCount)
       .map { (uri, mimeType) ->
         val stream: InputStream = try {
           appContext.contentResolver.openInputStream(uri)
+        } catch (e: SecurityException) {
+          Log.w(TAG, "Failed to open: $uri", e)
+          accessBlocked = true
+          null
         } catch (e: IOException) {
           Log.w(TAG, "Failed to open: $uri")
           null
@@ -122,8 +129,10 @@ class ShareRepository(context: Context) {
 
     return if (media.isNotEmpty()) {
       ResolvedShareData.Media(media, externalMultiShare.text)
+    } else if (accessBlocked) {
+      ResolvedShareData.Failure(ShareError.ACCESS_DENIED)
     } else {
-      ResolvedShareData.Failure
+      ResolvedShareData.Failure(ShareError.UNKNOWN)
     }
   }
 
@@ -131,25 +140,42 @@ class ShareRepository(context: Context) {
     private val TAG = Log.tag(ShareRepository::class.java)
 
     private fun getMimeType(context: Context, uri: Uri, mimeType: String?, fileExtension: String? = null): String {
-      var updatedMimeType = MediaUtil.getMimeType(context, uri, fileExtension)
+      var updatedMimeType = try {
+        MediaUtil.getMimeType(context, uri, fileExtension)
+      } catch (e: SecurityException) {
+        Log.w(TAG, "Failed to query mime type!", e)
+        null
+      }
       if (updatedMimeType == null) {
         updatedMimeType = MediaUtil.getCorrectedMimeType(mimeType)
       }
       return updatedMimeType ?: MediaUtil.UNKNOWN
     }
 
-    @Throws(IOException::class)
     private fun getSize(context: Context, uri: Uri): Long {
       var size: Long = 0
 
-      context.contentResolver.query(uri, null, null, null, null).use { cursor ->
-        if (cursor != null && cursor.moveToFirst() && cursor.getColumnIndex(OpenableColumns.SIZE) >= 0) {
-          size = cursor.getLong(cursor.getColumnIndexOrThrow(OpenableColumns.SIZE))
+      try {
+        context.contentResolver.query(uri, null, null, null, null).use { cursor ->
+          if (cursor != null && cursor.moveToFirst() && cursor.getColumnIndex(OpenableColumns.SIZE) >= 0) {
+            size = cursor.getLong(cursor.getColumnIndexOrThrow(OpenableColumns.SIZE))
+          }
         }
+      } catch (e: SecurityException) {
+        Log.w(TAG, "Failed to query size!", e)
+        return 0
       }
 
       if (size <= 0) {
-        size = MediaUtil.getMediaSize(context, uri)
+        try {
+          size = MediaUtil.getMediaSize(context, uri)
+        } catch (e: SecurityException) {
+          Log.w(TAG, "Failed to read media size!", e)
+          return 0
+        } catch (e: IOException) {
+          Log.w(TAG, "Failed to read media size!", e)
+          return 0
+        }
       }
 
       return size
@@ -160,11 +186,16 @@ class ShareRepository(context: Context) {
         return uri.lastPathSegment
       }
 
-      context.contentResolver.query(uri, null, null, null, null).use { cursor ->
-        if (cursor != null && cursor.moveToFirst() && cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME) >= 0) {
-          return cursor.getString(cursor.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME))
+      try {
+        context.contentResolver.query(uri, null, null, null, null).use { cursor ->
+          if (cursor != null && cursor.moveToFirst() && cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME) >= 0) {
+            return cursor.getString(cursor.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME))
+          }
         }
+      } catch (e: SecurityException) {
+        Log.w(TAG, "Failed to query file name!", e)
       }
+
       return null
     }
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ShareRepository.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ShareRepository.kt
@@ -38,15 +38,15 @@ class ShareRepository(context: Context) {
     val uri = multiShareExternal.uri
     val size = getSize(appContext, uri)
     val name = getFileName(appContext, uri)
-    val mimeType = getMimeType(appContext, uri, multiShareExternal.mimeType, name?.substringAfterLast('.', ""))
+    val mimeType = getMimeType(appContext, uri, multiShareExternal.mimeType, name?.substringAfterLast('.', "")).mimeType
 
     val stream: InputStream = try {
       appContext.contentResolver.openInputStream(uri)
     } catch (e: SecurityException) {
-      Log.w(TAG, "Failed to read stream!", e)
+      Log.w(TAG, "Failed to read stream: $uri", e)
       return ResolvedShareData.Failure(ShareError.ACCESS_DENIED)
     } catch (e: IOException) {
-      Log.w(TAG, "Failed to read stream!", e)
+      Log.w(TAG, "Failed to read stream: $uri", e)
       return ResolvedShareData.Failure(ShareError.UNKNOWN)
     } ?: return ResolvedShareData.Failure(ShareError.UNKNOWN)
 
@@ -71,85 +71,111 @@ class ShareRepository(context: Context) {
   @NonNull
   @WorkerThread
   private fun resolve(externalMultiShare: UnresolvedShareData.ExternalMultiShare): ResolvedShareData {
-    val mimeTypes: Map<Uri, String> = externalMultiShare.uris
+    val mimeTypeResolutions: List<Pair<Uri, MimeTypeResolution>> = externalMultiShare.uris
       .filter { externalMultiShare.isInternalShare || UriUtil.isValidExternalUri(appContext, it) }
-      .associateWith { uri -> getMimeType(appContext, uri, null) }
-      .filterValues {
-        MediaUtil.isImageType(it) || MediaUtil.isVideoType(it)
+      .map { uri -> uri to getMimeType(appContext, uri, null) }
+
+    // If any URI's provider denied the metadata query, the share cannot be completed: fail loudly
+    // rather than silently dropping the user's selection.
+    if (mimeTypeResolutions.any { it.second.accessDenied }) {
+      return ResolvedShareData.Failure(ShareError.ACCESS_DENIED)
+    }
+
+    val mimeTypes: Map<Uri, String> = mimeTypeResolutions
+      .filter {
+        MediaUtil.isImageType(it.second.mimeType) || MediaUtil.isVideoType(it.second.mimeType)
       }
+      .take(RemoteConfig.maxAttachmentCount)
+      .associate { it.first to it.second.mimeType }
 
     if (mimeTypes.isEmpty()) {
       return ResolvedShareData.Failure(ShareError.UNKNOWN)
     }
 
-    var accessBlocked = false
-    val media: List<Media> = mimeTypes.toList()
-      .take(RemoteConfig.maxAttachmentCount)
-      .map { (uri, mimeType) ->
-        val stream: InputStream = try {
-          appContext.contentResolver.openInputStream(uri)
-        } catch (e: SecurityException) {
-          Log.w(TAG, "Failed to open: $uri", e)
-          accessBlocked = true
-          null
-        } catch (e: IOException) {
-          Log.w(TAG, "Failed to open: $uri")
-          null
-        } ?: return@map null
+    val mediaResults: List<MediaResult> = mimeTypes.toList()
+      .map { (uri, mimeType) -> resolveMedia(uri, mimeType) }
 
-        val size = getSize(appContext, uri)
-        val dimens: Pair<Int, Int> = MediaUtil.getDimensions(appContext, mimeType, uri)
-        val duration = 0L
-        val blobUri = try {
-          AppDependencies.blobs
-            .forData(stream, size)
-            .withMimeType(mimeType)
-            .createForSingleSessionOnDisk(appContext)
-        } catch (e: IOException) {
-          Log.w(TAG, "Failed create blob uri")
-          return@map null
-        }
+    // Same as above: if URI access was denied for any item, fail the whole share so the user
+    // learns why instead of silently sharing a subset of their selection.
+    if (mediaResults.any { it is MediaResult.AccessDenied }) {
+      return ResolvedShareData.Failure(ShareError.ACCESS_DENIED)
+    }
 
-        Media(
-          uri = blobUri,
-          contentType = mimeType,
-          date = System.currentTimeMillis(),
-          width = dimens.first,
-          height = dimens.second,
-          size = size,
-          duration = duration,
-          isBorderless = false,
-          isVideoGif = false,
-          bucketId = Media.ALL_MEDIA_BUCKET_ID,
-          caption = null,
-          transformProperties = null,
-          fileName = null
-        )
-      }.filterNotNull()
+    val media: List<Media> = mediaResults.filterIsInstance<MediaResult.Success>().map { it.media }
 
     return if (media.isNotEmpty()) {
       ResolvedShareData.Media(media, externalMultiShare.text)
-    } else if (accessBlocked) {
-      ResolvedShareData.Failure(ShareError.ACCESS_DENIED)
     } else {
       ResolvedShareData.Failure(ShareError.UNKNOWN)
     }
   }
 
+  @WorkerThread
+  private fun resolveMedia(uri: Uri, mimeType: String): MediaResult {
+    val stream: InputStream = try {
+      appContext.contentResolver.openInputStream(uri)
+    } catch (e: SecurityException) {
+      Log.w(TAG, "Failed to open: $uri", e)
+      return MediaResult.AccessDenied
+    } catch (e: IOException) {
+      Log.w(TAG, "Failed to open: $uri", e)
+      return MediaResult.Unavailable
+    } ?: return MediaResult.Unavailable
+
+    val size = getSize(appContext, uri)
+    val dimens: Pair<Int, Int> = MediaUtil.getDimensions(appContext, mimeType, uri)
+    val duration = 0L
+    val blobUri = try {
+      AppDependencies.blobs
+        .forData(stream, size)
+        .withMimeType(mimeType)
+        .createForSingleSessionOnDisk(appContext)
+    } catch (e: IOException) {
+      Log.w(TAG, "Failed create blob uri")
+      return MediaResult.Unavailable
+    }
+
+    return MediaResult.Success(
+      Media(
+        uri = blobUri,
+        contentType = mimeType,
+        date = System.currentTimeMillis(),
+        width = dimens.first,
+        height = dimens.second,
+        size = size,
+        duration = duration,
+        isBorderless = false,
+        isVideoGif = false,
+        bucketId = Media.ALL_MEDIA_BUCKET_ID,
+        caption = null,
+        transformProperties = null,
+        fileName = null
+      )
+    )
+  }
+
   companion object {
     private val TAG = Log.tag(ShareRepository::class.java)
 
-    private fun getMimeType(context: Context, uri: Uri, mimeType: String?, fileExtension: String? = null): String {
-      var updatedMimeType = try {
-        MediaUtil.getMimeType(context, uri, fileExtension)
+    /**
+     * Result of a mime type lookup. [accessDenied] is set when the provider rejected the query
+     * with a [SecurityException], which indicates the sending app did not grant URI access.
+     */
+    private data class MimeTypeResolution(val mimeType: String, val accessDenied: Boolean)
+
+    private fun getMimeType(context: Context, uri: Uri, mimeType: String?, fileExtension: String? = null): MimeTypeResolution {
+      var updatedMimeType: String? = null
+      var accessDenied = false
+      try {
+        updatedMimeType = MediaUtil.getMimeType(context, uri, fileExtension)
       } catch (e: SecurityException) {
-        Log.w(TAG, "Failed to query mime type!", e)
-        null
+        Log.w(TAG, "Failed to query mime type: $uri", e)
+        accessDenied = true
       }
       if (updatedMimeType == null) {
         updatedMimeType = MediaUtil.getCorrectedMimeType(mimeType)
       }
-      return updatedMimeType ?: MediaUtil.UNKNOWN
+      return MimeTypeResolution(updatedMimeType ?: MediaUtil.UNKNOWN, accessDenied)
     }
 
     private fun getSize(context: Context, uri: Uri): Long {
@@ -162,18 +188,15 @@ class ShareRepository(context: Context) {
           }
         }
       } catch (e: SecurityException) {
-        Log.w(TAG, "Failed to query size!", e)
+        Log.w(TAG, "Failed to query size: $uri", e)
         return 0
       }
 
       if (size <= 0) {
         try {
           size = MediaUtil.getMediaSize(context, uri)
-        } catch (e: SecurityException) {
-          Log.w(TAG, "Failed to read media size!", e)
-          return 0
         } catch (e: IOException) {
-          Log.w(TAG, "Failed to read media size!", e)
+          Log.w(TAG, "Failed to read media size: $uri", e)
           return 0
         }
       }
@@ -193,10 +216,19 @@ class ShareRepository(context: Context) {
           }
         }
       } catch (e: SecurityException) {
-        Log.w(TAG, "Failed to query file name!", e)
+        Log.w(TAG, "Failed to query file name: $uri", e)
       }
 
       return null
     }
+  }
+
+  /**
+   * Outcome of resolving a single URI into a shareable [Media] within a multi-share.
+   */
+  private sealed class MediaResult {
+    data class Success(val media: Media) : MediaResult()
+    object AccessDenied : MediaResult()
+    object Unavailable : MediaResult()
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ShareState.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ShareState.kt
@@ -6,6 +6,6 @@ data class ShareState(
   sealed class ShareDataLoadState {
     object Init : ShareDataLoadState()
     data class Loaded(val resolvedShareData: ResolvedShareData) : ShareDataLoadState()
-    object Failed : ShareDataLoadState()
+    data class Failed(val error: ShareError) : ShareDataLoadState()
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ShareViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ShareViewModel.kt
@@ -25,6 +25,7 @@ class ShareViewModel(
   private val store = RxStore(ShareState())
   private val disposables = CompositeDisposable()
   private val eventSubject = PublishSubject.create<ShareEvent>()
+  private var shareErrorShown = false
 
   val state: Flowable<ShareState> = store.stateFlowable
   val events: Observable<ShareEvent> = eventSubject
@@ -80,6 +81,16 @@ class ShareViewModel(
 
   private fun moveToFailedState(error: ShareError) {
     store.update { it.copy(loadState = ShareState.ShareDataLoadState.Failed(error)) }
+  }
+
+  /**
+   * Whether the current failure has already been surfaced to the user. Prevents the share error
+   * toast from being shown again when the activity is recreated while the state is still failed.
+   */
+  fun hasShareErrorBeenShown(): Boolean = shareErrorShown
+
+  fun markShareErrorShown() {
+    shareErrorShown = true
   }
 
   private fun Throwable.toShareError(): ShareError {

--- a/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ShareViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ShareViewModel.kt
@@ -33,15 +33,18 @@ class ShareViewModel(
     disposables += shareRepository.resolve(unresolvedShareData).subscribeBy(
       onSuccess = { data ->
         when (data) {
-          ResolvedShareData.Failure -> {
-            moveToFailedState()
+          is ResolvedShareData.Failure -> {
+            moveToFailedState(data.error)
           }
           else -> {
             store.update { it.copy(loadState = ShareState.ShareDataLoadState.Loaded(data)) }
           }
         }
       },
-      onError = this::moveToFailedState
+      onError = { throwable ->
+        Log.w(TAG, "Could not load share data.", throwable)
+        moveToFailedState(throwable.toShareError())
+      }
     )
   }
 
@@ -75,9 +78,15 @@ class ShareViewModel(
     store.dispose()
   }
 
-  private fun moveToFailedState(throwable: Throwable? = null) {
-    Log.w(TAG, "Could not load share data.", throwable)
-    store.update { it.copy(loadState = ShareState.ShareDataLoadState.Failed) }
+  private fun moveToFailedState(error: ShareError) {
+    store.update { it.copy(loadState = ShareState.ShareDataLoadState.Failed(error)) }
+  }
+
+  private fun Throwable.toShareError(): ShareError {
+    return when (this) {
+      is SecurityException -> ShareError.ACCESS_DENIED
+      else -> ShareError.UNKNOWN
+    }
   }
 
   class Factory(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5451,7 +5451,7 @@
     <!-- Toast when the incoming intent is invalid -->
     <string name="ShareActivity__could_not_get_share_data_from_intent">Could not get share data from intent.</string>
     <!-- Toast when Signal could not access content shared to it because the sending app did not grant permission -->
-    <string name="ShareActivity__could_not_access_shared_content">Signal couldn\'t access the shared content. The sending app didn\'t grant the necessary permission.</string>
+    <string name="ShareActivity__could_not_access_shared_content">Signal couldn\'t access the shared content. The sending app didn\'t grant permission for it.</string>
     <!-- Toast when Signal could not load content shared to it -->
     <string name="ShareActivity__could_not_share_content">Signal couldn\'t load the shared content.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5450,6 +5450,10 @@
     <string name="ShareActivity__comma_s">, %1$s</string>
     <!-- Toast when the incoming intent is invalid -->
     <string name="ShareActivity__could_not_get_share_data_from_intent">Could not get share data from intent.</string>
+    <!-- Toast when Signal could not access content shared to it because the sending app did not grant permission -->
+    <string name="ShareActivity__could_not_access_shared_content">Signal couldn\'t access the shared content. The sending app didn\'t grant the necessary permission.</string>
+    <!-- Toast when Signal could not load content shared to it -->
+    <string name="ShareActivity__could_not_share_content">Signal couldn\'t load the shared content.</string>
 
     <!-- MultiShareDialogs -->
     <string name="MultiShareDialogs__failed_to_send_to_some_users">Failed to send to some users</string>

--- a/app/src/test/java/org/thoughtcrime/securesms/sharing/v2/ShareRepositoryTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/sharing/v2/ShareRepositoryTest.kt
@@ -17,6 +17,10 @@ import assertk.assertions.isInstanceOf
 import assertk.assertions.isNull
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.junit.After
+import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
@@ -27,13 +31,14 @@ import org.signal.core.util.logging.Log
 import org.thoughtcrime.securesms.dependencies.AppDependencies
 import org.thoughtcrime.securesms.testutil.MockAppDependenciesRule
 import org.thoughtcrime.securesms.testutil.SystemOutLogger
+import org.thoughtcrime.securesms.util.RemoteConfig
 import java.io.ByteArrayInputStream
 import java.io.IOException
 
 /**
  * Verifies that [ShareRepository] resolves external share data gracefully when the sending app
  * has not granted access to a content URI (e.g. AOSP Contacts sharing a vCard without
- * `FLAG_GRANT_READ_URI_PERMISSION`), rather than throwing or failing silently without user feedback.
+ * FLAG_GRANT_READ_URI_PERMISSION), rather than throwing or failing silently without user feedback.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, application = Application::class)
@@ -50,7 +55,20 @@ class ShareRepositoryTest {
     }
   }
 
+  @Before
+  fun setup() {
+    mockkObject(RemoteConfig)
+    every { RemoteConfig.maxAttachmentCount } returns 32
+  }
+
+  @After
+  fun tearDown() {
+    unmockkObject(RemoteConfig)
+  }
+
   private val vCardUri: Uri = Uri.parse("content://com.android.contacts/contacts/as_vcard/42")
+  private val photoUriOne: Uri = Uri.parse("content://com.example.shareprovider/media/1")
+  private val photoUriTwo: Uri = Uri.parse("content://com.example.shareprovider/media/2")
 
   @Test
   fun givenSecurityExceptionFromResolver_whenResolveSingleShare_thenReturnAccessDeniedFailure() {
@@ -103,6 +121,70 @@ class ShareRepositoryTest {
     assertThat(externalUri.text).isNull()
   }
 
+  @Test
+  fun givenSecurityExceptionFromMimeLookupOnAllUris_whenResolveMultiShare_thenReturnAccessDeniedFailure() {
+    val resolver = mockk<ContentResolver>(relaxed = true)
+    every { resolver.getType(any()) } throws SecurityException("No URI grant")
+
+    val repository = repositoryWith(resolver)
+    val result = repository.resolve(unresolvedMultiShare()).blockingGet()
+
+    assertThat(result).isEqualTo(ResolvedShareData.Failure(ShareError.ACCESS_DENIED))
+  }
+
+  @Test
+  fun givenSecurityExceptionFromMimeLookupOnOneUri_whenResolveMultiShare_thenReturnAccessDeniedFailure() {
+    val resolver = mockk<ContentResolver>(relaxed = true)
+    every { resolver.getType(photoUriOne) } returns "image/jpeg"
+    every { resolver.getType(photoUriTwo) } throws SecurityException("No URI grant")
+    every { resolver.openInputStream(any()) } returns ByteArrayInputStream(ByteArray(64))
+
+    val repository = repositoryWith(resolver)
+    val result = repository.resolve(unresolvedMultiShare()).blockingGet()
+
+    assertThat(result).isEqualTo(ResolvedShareData.Failure(ShareError.ACCESS_DENIED))
+  }
+
+  @Test
+  fun givenSecurityExceptionFromStreamOnOneUri_whenResolveMultiShare_thenReturnAccessDeniedFailure() {
+    val resolver = mockk<ContentResolver>(relaxed = true)
+    every { resolver.getType(any()) } returns "image/jpeg"
+    every { resolver.openInputStream(photoUriOne) } returns ByteArrayInputStream(ByteArray(64))
+    every { resolver.openInputStream(photoUriTwo) } throws SecurityException("No URI grant")
+
+    val repository = repositoryWith(resolver)
+    val result = repository.resolve(unresolvedMultiShare()).blockingGet()
+
+    assertThat(result).isEqualTo(ResolvedShareData.Failure(ShareError.ACCESS_DENIED))
+  }
+
+  @Test
+  fun givenIOExceptionFromStreams_whenResolveMultiShare_thenReturnUnknownFailure() {
+    val resolver = mockk<ContentResolver>(relaxed = true)
+    every { resolver.getType(any()) } returns "image/jpeg"
+    every { resolver.openInputStream(any()) } throws IOException("Failed to open")
+
+    val repository = repositoryWith(resolver)
+    val result = repository.resolve(unresolvedMultiShare()).blockingGet()
+
+    assertThat(result).isEqualTo(ResolvedShareData.Failure(ShareError.UNKNOWN))
+  }
+
+  @Test
+  fun givenReadableMultiShareUris_whenResolveMultiShare_thenResolveMedia() {
+    val resolver = mockk<ContentResolver>(relaxed = true)
+    every { resolver.getType(any()) } returns "image/jpeg"
+    every { resolver.openInputStream(any()) } answers { ByteArrayInputStream(ByteArray(64)) }
+    every { AppDependencies.blobs.forData(any(), any()) } returns mockk(relaxed = true)
+
+    val repository = repositoryWith(resolver)
+    val result = repository.resolve(unresolvedMultiShare()).blockingGet()
+
+    assertThat(result).isInstanceOf(ResolvedShareData.Media::class)
+    val media = result as ResolvedShareData.Media
+    assertThat(media.media.size).isEqualTo(2)
+  }
+
   private fun repositoryWith(resolver: ContentResolver): ShareRepository {
     val context = mockk<Context>(relaxed = true)
     every { context.applicationContext } returns context
@@ -113,5 +195,9 @@ class ShareRepositoryTest {
 
   private fun unresolvedSingleShare(): UnresolvedShareData.ExternalSingleShare {
     return UnresolvedShareData.ExternalSingleShare(vCardUri, "text/x-vcard", null, false)
+  }
+
+  private fun unresolvedMultiShare(): UnresolvedShareData.ExternalMultiShare {
+    return UnresolvedShareData.ExternalMultiShare(listOf(photoUriOne, photoUriTwo), null, false)
   }
 }

--- a/app/src/test/java/org/thoughtcrime/securesms/sharing/v2/ShareRepositoryTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/sharing/v2/ShareRepositoryTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.thoughtcrime.securesms.sharing.v2
+
+import android.app.Application
+import android.content.ContentResolver
+import android.content.Context
+import android.database.Cursor
+import android.net.Uri
+import android.provider.OpenableColumns
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNull
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.BeforeClass
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.signal.core.util.logging.Log
+import org.thoughtcrime.securesms.dependencies.AppDependencies
+import org.thoughtcrime.securesms.testutil.MockAppDependenciesRule
+import org.thoughtcrime.securesms.testutil.SystemOutLogger
+import java.io.ByteArrayInputStream
+import java.io.IOException
+
+/**
+ * Verifies that [ShareRepository] resolves external share data gracefully when the sending app
+ * has not granted access to a content URI (e.g. AOSP Contacts sharing a vCard without
+ * `FLAG_GRANT_READ_URI_PERMISSION`), rather than throwing or failing silently without user feedback.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, application = Application::class)
+class ShareRepositoryTest {
+
+  @get:Rule
+  val appDependencies = MockAppDependenciesRule()
+
+  companion object {
+    @BeforeClass
+    @JvmStatic
+    fun setUpClass() {
+      Log.initialize(SystemOutLogger())
+    }
+  }
+
+  private val vCardUri: Uri = Uri.parse("content://com.android.contacts/contacts/as_vcard/42")
+
+  @Test
+  fun givenSecurityExceptionFromResolver_whenResolveSingleShare_thenReturnAccessDeniedFailure() {
+    val resolver = mockk<ContentResolver>(relaxed = true)
+    every { resolver.query(any(), any(), any(), any(), any()) } throws SecurityException("No URI grant")
+    every { resolver.openInputStream(any()) } throws SecurityException("No URI grant")
+    every { resolver.getType(any()) } throws SecurityException("No URI grant")
+
+    val repository = repositoryWith(resolver)
+    val result = repository.resolve(unresolvedSingleShare()).blockingGet()
+
+    assertThat(result).isEqualTo(ResolvedShareData.Failure(ShareError.ACCESS_DENIED))
+  }
+
+  @Test
+  fun givenIOExceptionFromResolver_whenResolveSingleShare_thenReturnUnknownFailure() {
+    val resolver = mockk<ContentResolver>(relaxed = true)
+    every { resolver.query(any(), any(), any(), any(), any()) } throws SecurityException("No URI grant")
+    every { resolver.openInputStream(any()) } throws IOException("Failed to open")
+    every { resolver.getType(any()) } throws SecurityException("No URI grant")
+
+    val repository = repositoryWith(resolver)
+    val result = repository.resolve(unresolvedSingleShare()).blockingGet()
+
+    assertThat(result).isEqualTo(ResolvedShareData.Failure(ShareError.UNKNOWN))
+  }
+
+  @Test
+  fun givenReadableVCardUri_whenResolveSingleShare_thenResolveExternalUri() {
+    val resolver = mockk<ContentResolver>(relaxed = true)
+    val cursor = mockk<Cursor>(relaxed = true)
+    every { cursor.moveToFirst() } returns true
+    every { cursor.getColumnIndex(OpenableColumns.SIZE) } returns 0
+    every { cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME) } returns 1
+    every { cursor.getColumnIndexOrThrow(OpenableColumns.SIZE) } returns 0
+    every { cursor.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME) } returns 1
+    every { cursor.getLong(0) } returns 2048L
+    every { cursor.getString(1) } returns "contact.vcf"
+    every { resolver.query(any(), any(), any(), any(), any()) } returns cursor
+    every { resolver.getType(any()) } returns "text/x-vcard"
+    every { resolver.openInputStream(any()) } returns ByteArrayInputStream(ByteArray(64))
+    every { AppDependencies.blobs.forData(any(), any()) } returns mockk(relaxed = true)
+
+    val repository = repositoryWith(resolver)
+    val result = repository.resolve(unresolvedSingleShare()).blockingGet()
+
+    assertThat(result).isInstanceOf(ResolvedShareData.ExternalUri::class)
+    val externalUri = result as ResolvedShareData.ExternalUri
+    assertThat(externalUri.mimeType).isEqualTo("text/x-vcard")
+    assertThat(externalUri.text).isNull()
+  }
+
+  private fun repositoryWith(resolver: ContentResolver): ShareRepository {
+    val context = mockk<Context>(relaxed = true)
+    every { context.applicationContext } returns context
+    every { context.packageName } returns "org.thoughtcrime.securesms"
+    every { context.contentResolver } returns resolver
+    return ShareRepository(context)
+  }
+
+  private fun unresolvedSingleShare(): UnresolvedShareData.ExternalSingleShare {
+    return UnresolvedShareData.ExternalSingleShare(vCardUri, "text/x-vcard", null, false)
+  }
+}

--- a/app/src/test/java/org/thoughtcrime/securesms/sharing/v2/ShareViewModelTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/sharing/v2/ShareViewModelTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.thoughtcrime.securesms.sharing.v2
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import io.mockk.every
+import io.mockk.mockk
+import io.reactivex.rxjava3.core.Single
+import org.junit.Test
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+/**
+ * Verifies that [ShareViewModel] maps share resolution failures to the correct [ShareError]
+ * in the failed state, and that the share error is only surfaced once.
+ */
+class ShareViewModelTest {
+
+  private val repository = mockk<ShareRepository>()
+
+  @Test
+  fun givenAccessDeniedFailureFromRepository_whenResolve_thenStateIsFailedWithAccessDenied() {
+    every { repository.resolve(any()) } returns Single.just<ResolvedShareData>(ResolvedShareData.Failure(ShareError.ACCESS_DENIED))
+
+    val viewModel = viewModel()
+
+    assertThat(awaitFailedState(viewModel)).isEqualTo(ShareState.ShareDataLoadState.Failed(ShareError.ACCESS_DENIED))
+  }
+
+  @Test
+  fun givenSecurityExceptionFromRepository_whenResolve_thenStateIsFailedWithAccessDenied() {
+    every { repository.resolve(any()) } returns Single.error<ResolvedShareData>(SecurityException("No URI grant"))
+
+    val viewModel = viewModel()
+
+    assertThat(awaitFailedState(viewModel)).isEqualTo(ShareState.ShareDataLoadState.Failed(ShareError.ACCESS_DENIED))
+  }
+
+  @Test
+  fun givenIOExceptionFromRepository_whenResolve_thenStateIsFailedWithUnknown() {
+    every { repository.resolve(any()) } returns Single.error<ResolvedShareData>(IOException("Failed to open"))
+
+    val viewModel = viewModel()
+
+    assertThat(awaitFailedState(viewModel)).isEqualTo(ShareState.ShareDataLoadState.Failed(ShareError.UNKNOWN))
+  }
+
+  @Test
+  fun givenFailedState_whenShareErrorShown_thenRemainsFailedAndOnlyShownOnce() {
+    every { repository.resolve(any()) } returns Single.just<ResolvedShareData>(ResolvedShareData.Failure(ShareError.ACCESS_DENIED))
+
+    val viewModel = viewModel()
+    awaitFailedState(viewModel)
+
+    assertThat(viewModel.hasShareErrorBeenShown()).isFalse()
+    viewModel.markShareErrorShown()
+    assertThat(viewModel.hasShareErrorBeenShown()).isTrue()
+  }
+
+  private fun viewModel(): ShareViewModel {
+    return ShareViewModel(UnresolvedShareData.ExternalPrimitiveShare("hello"), repository)
+  }
+
+  private fun awaitFailedState(viewModel: ShareViewModel): ShareState.ShareDataLoadState {
+    return viewModel.state
+      .filter { it.loadState is ShareState.ShareDataLoadState.Failed }
+      .timeout(5, TimeUnit.SECONDS)
+      .blockingFirst()
+      .loadState
+  }
+}


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Pixel 8 API 37.1, Android 17
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

Related issue: #14617

## Problem

When an app shares a `content://` URI **without** `FLAG_GRANT_READ_URI_PERMISSION` (e.g. AOSP/GrapheneOS Contacts sharing a vCard, see #14617), Signal cannot read the URI unless it holds the provider's own permission (e.g. `READ_CONTACTS`).

The failure mode was bad:
- `ShareRepository.getSize()`/`getFileName()`/`getMimeType()` call `ContentResolver.query()` / `getType()` with **no exception handling**, so a `SecurityException` propagated as an RxJava error instead of a share failure.
- Either way, `ShareActivity` just called `finish()` — the user got a share sheet that flashes and closes with **zero feedback**.

## What changed

**ShareRepository** — all `ContentResolver` reads are wrapped:
- `query()` (size/file name), `getType()` (mime type), and `openInputStream()` now catch `SecurityException` / `IOException`.
- `SecurityException` produces `ResolvedShareData.Failure(ShareError.ACCESS_DENIED)`; other failures produce `ShareError.UNKNOWN`.
- Covers both single-share and multi-share resolvers.

**UX** — the silent `finish()` is replaced with a toast before finishing:
- `ACCESS_DENIED` → "Signal couldn't access the shared content. The sending app didn't grant the necessary permission."
- `UNKNOWN` → "Signal couldn't load the shared content."

**Tests** — new `ShareRepositoryTest` (Robolectric) covering:
- `SecurityException` from the resolver → `Failure(ACCESS_DENIED)` (the vCard scenario from #14617)
- `IOException` → `Failure(UNKNOWN)`
- readable vCard URI → resolved `ExternalUri` with correct mime type

## Notes

This is a **defensive/UX fix** on Signal's side. When the sending app doesn't grant URI access and Signal lacks the provider permission, the share physically cannot be read (platform limitation) — the complementary sender-side fix is GrapheneOS/platform_packages_apps_Contacts#25. With this change, users at least learn why instead of seeing a silent flash, and other apps sharing the same way don't produce confusing silent failures.

**Multi-share behavior:** if *any* selected item's provider denies URI access (at `getType()` or `openInputStream()`), the whole share fails with the `ACCESS_DENIED` toast instead of silently sharing the remaining subset.

Fixes #14617 behaviourally: the failure is now graceful and explainable instead of a silent flash. The contact still cannot be shared until the sending app grants URI access (GrapheneOS/platform_packages_apps_Contacts#25). Related: #12324, #6520.


