### PR TITLE
Fix story playback after viewing own recipient sheet

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/bottomsheet/RecipientBottomSheetDialogFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/recipients/ui/bottomsheet/RecipientBottomSheetDialogFragment.kt
@@ -14,6 +14,7 @@ import android.view.ViewGroup
 import android.widget.ProgressBar
 import android.widget.TextView
 import android.widget.Toast
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -70,8 +71,19 @@ class RecipientBottomSheetDialogFragment : FixedRoundedCornerBottomSheetDialogFr
     fun show(fragmentManager: FragmentManager, recipientId: RecipientId, groupId: GroupId?) {
       val recipient = Recipient.resolved(recipientId)
       if (recipient.isSelf) {
-        AboutSheet.create(recipient, groupId as? GroupId.V2)
-          .show(fragmentManager, BottomSheetUtil.STANDARD_BOTTOM_SHEET_FRAGMENT_TAG)
+        val aboutSheet = AboutSheet.create(recipient, groupId as? GroupId.V2)
+
+        val aboutSheetDestructionCallback = object : FragmentManager.FragmentLifecycleCallbacks() {
+          override fun onFragmentDestroyed(fm: FragmentManager, f: Fragment) {
+            if (f == aboutSheet) {
+              fragmentManager.unregisterFragmentLifecycleCallbacks(this)
+              (f.parentFragment as? Callback)?.onRecipientBottomSheetDismissed()
+            }
+          }
+        }
+        fragmentManager.registerFragmentLifecycleCallbacks(aboutSheetDestructionCallback, false)
+
+        aboutSheet.show(fragmentManager, BottomSheetUtil.STANDARD_BOTTOM_SHEET_FRAGMENT_TAG)
       } else {
         val args = Bundle()
         val fragment = RecipientBottomSheetDialogFragment()


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Google Pixel 6a, Android 17
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Commit a886e5f9a09 changed `RecipientBottomSheetDialogFragment.show()` so that when a user's own profile is opened, it creates `AboutSheet` instead. The change introduced a regression in `RecipientBottomSheetDialogFragment`'s contract:
- Caller uses `RecipientBottomSheetDialogFragment.show()` to display the bottom sheet.
- After the bottom sheet is dismissed, the caller's fragment would get its `Callback.onRecipientBottomSheetDismissed()` called, if it has implemented it.

With the `AboutSheet` flow that is no longer true - `AboutSheet` has no means to invoke the callback.

There are two places that are affected by the regression:
- Story playback (`StoryViewerPageFragment`):
  - When the user clicks on their own avatar image, playback is paused until the bottom sheet is dismissed.
  - In the absence of the callback the playback says paused.
- Group's "Search Members" page (Group->Settings->Search):
  - The callback is used to refresh group members after the page was obscured by the bottom sheet.

This PR fixes #14960

### Change

`RecipientBottomSheetDialogFragment`:
- When `AboutSheet` is shown, install a fragment lifecycle callback.
- When destruction of `AboutSheet` is detected, invoke the callback.