### PR TITLE
Show links in the Links tab even when no preview was fetched.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/MediaTable.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/MediaTable.kt
@@ -4,11 +4,15 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.database.Cursor
 import androidx.compose.runtime.Immutable
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
 import org.signal.core.util.logging.Log
 import org.signal.core.util.requireInt
 import org.signal.core.util.requireLong
 import org.signal.core.util.requireString
 import org.thoughtcrime.securesms.attachments.DatabaseAttachment
+import org.thoughtcrime.securesms.linkpreview.LinkPreviewUtil
 import org.thoughtcrime.securesms.recipients.RecipientId
 import org.thoughtcrime.securesms.util.MediaUtil
 import org.thoughtcrime.securesms.util.MediaUtil.SlideType
@@ -67,6 +71,7 @@ class MediaTable internal constructor(context: Context?, databaseHelper: SignalD
         ${MessageTable.TABLE_NAME}.${MessageTable.THREAD_ID},
         ${MessageTable.TABLE_NAME}.${MessageTable.FROM_RECIPIENT_ID},
         ${ThreadTable.TABLE_NAME}.${ThreadTable.RECIPIENT_ID} as $THREAD_RECIPIENT_ID,
+        ${MessageTable.TABLE_NAME}.${MessageTable.BODY},
         ${MessageTable.TABLE_NAME}.${MessageTable.LINK_PREVIEWS},
         ${AttachmentTable.TABLE_NAME}.${AttachmentTable.MESSAGE_ID} as $MEDIA_MESSAGE_ID
       FROM
@@ -173,6 +178,7 @@ class MediaTable internal constructor(context: Context?, databaseHelper: SignalD
         ${MessageTable.TABLE_NAME}.${MessageTable.THREAD_ID},
         ${MessageTable.TABLE_NAME}.${MessageTable.FROM_RECIPIENT_ID},
         ${ThreadTable.TABLE_NAME}.${ThreadTable.RECIPIENT_ID} as $THREAD_RECIPIENT_ID,
+        ${MessageTable.TABLE_NAME}.${MessageTable.BODY},
         ${MessageTable.TABLE_NAME}.${MessageTable.LINK_PREVIEWS},
         ${MessageTable.TABLE_NAME}.${MessageTable.ID} as $MEDIA_MESSAGE_ID
       FROM
@@ -183,7 +189,10 @@ class MediaTable internal constructor(context: Context?, databaseHelper: SignalD
         LEFT JOIN ${ThreadTable.TABLE_NAME} ON ${ThreadTable.TABLE_NAME}.${ThreadTable.ID} = ${MessageTable.TABLE_NAME}.${MessageTable.THREAD_ID}
       WHERE
         ${MessageTable.TABLE_NAME}.${MessageTable.THREAD_ID} __EQUALITY__ ? AND
-        ${MessageTable.TABLE_NAME}.${MessageTable.LINK_PREVIEWS} IS NOT NULL AND
+        (
+          ${MessageTable.TABLE_NAME}.${MessageTable.LINK_PREVIEWS} IS NOT NULL OR
+          __BODY_LINK_FILTER__
+        ) AND
         ${MessageTable.TABLE_NAME}.${MessageTable.VIEW_ONCE} = 0 AND
         ${MessageTable.TABLE_NAME}.${MessageTable.STORY_TYPE} = 0 AND
         ${MessageTable.TABLE_NAME}.${MessageTable.LATEST_REVISION_ID} IS NULL AND
@@ -207,6 +216,21 @@ class MediaTable internal constructor(context: Context?, databaseHelper: SignalD
           )
         )"""
     )
+
+    private fun applyBodyLinkFilter(query: String, includeBodyLinks: Boolean): String {
+      val filter = if (includeBodyLinks) {
+        """
+          (
+            ${AttachmentTable.TABLE_NAME}.${AttachmentTable.ID} IS NULL AND
+            ${MessageTable.TABLE_NAME}.${MessageTable.BODY} LIKE '%https://%'
+          )
+        """.trimIndent()
+      } else {
+        "0"
+      }
+
+      return query.replace("__BODY_LINK_FILTER__", filter)
+    }
 
     private fun applyEqualityOperator(threadId: Long, query: String): String {
       val isAllThreads = threadId == ALL_THREADS.toLong()
@@ -270,7 +294,7 @@ class MediaTable internal constructor(context: Context?, databaseHelper: SignalD
       Sorting.Oldest -> " ORDER BY ${MessageTable.TABLE_NAME}.${MessageTable.DATE_SENT} ASC"
       Sorting.Largest -> " ORDER BY ${AttachmentTable.TABLE_NAME}.${AttachmentTable.DATA_SIZE} DESC"
     }
-    val query = applyEqualityOperator(threadId, LINK_MEDIA_QUERY) + orderBy
+    val query = applyEqualityOperator(threadId, applyBodyLinkFilter(LINK_MEDIA_QUERY, includeBodyLinks = true)) + orderBy
     val args = arrayOf(threadId.toString())
     return readableDatabase.rawQuery(query, args)
   }
@@ -278,7 +302,7 @@ class MediaTable internal constructor(context: Context?, databaseHelper: SignalD
   @JvmOverloads
   fun getAllMediaForThread(threadId: Long, sorting: Sorting, limit: Int = 0): Cursor {
     val allMediaSubquery = applyEqualityOperator(threadId, applyIndexHint(ALL_MEDIA_QUERY, threadId, sorting))
-    val linkSubquery = applyEqualityOperator(threadId, LINK_MEDIA_QUERY)
+    val linkSubquery = applyEqualityOperator(threadId, applyBodyLinkFilter(LINK_MEDIA_QUERY, includeBodyLinks = true))
 
     val orderBy = when (sorting) {
       Sorting.Newest -> " ORDER BY $MEDIA_MESSAGE_ID DESC"
@@ -348,7 +372,8 @@ class MediaTable internal constructor(context: Context?, databaseHelper: SignalD
     val messageId: Long,
     val date: Long,
     val isOutgoing: Boolean,
-    val linkPreviewJson: String? = null
+    val linkUrl: String? = null,
+    val linkTitle: String? = null
   ) {
 
     val contentType: String?
@@ -357,9 +382,11 @@ class MediaTable internal constructor(context: Context?, databaseHelper: SignalD
     companion object {
       @JvmStatic
       fun from(cursor: Cursor): MediaRecord {
-        val linkPreviewIdx = cursor.getColumnIndex(MessageTable.LINK_PREVIEWS)
         val attachmentIdIdx = cursor.getColumnIndex(AttachmentTable.ID)
         val hasAttachment = attachmentIdIdx != -1 && !cursor.isNull(attachmentIdIdx)
+        val storedPreview: JSONObject? = parseStoredPreview(cursor.optionalString(MessageTable.LINK_PREVIEWS))
+        val storedUrl: String? = storedPreview?.nonEmptyString("url")
+
         return MediaRecord(
           attachment = if (hasAttachment) SignalDatabase.attachments.getAttachment(cursor) else null,
           recipientId = RecipientId.from(cursor.requireLong(MessageTable.FROM_RECIPIENT_ID)),
@@ -372,8 +399,40 @@ class MediaTable internal constructor(context: Context?, databaseHelper: SignalD
             cursor.requireLong(MessageTable.DATE_RECEIVED)
           },
           isOutgoing = MessageTypes.isOutgoingMessageType(cursor.requireLong(MessageTable.TYPE)),
-          linkPreviewJson = if (linkPreviewIdx != -1) cursor.getString(linkPreviewIdx) else null
+          linkUrl = storedUrl ?: findLinkInBody(cursor.optionalString(MessageTable.BODY)),
+          linkTitle = if (storedUrl != null) storedPreview?.nonEmptyString("title") else null
         )
+      }
+
+      private fun parseStoredPreview(serialized: String?): JSONObject? {
+        if (serialized.isNullOrEmpty()) {
+          return null
+        }
+
+        return try {
+          val previews = JSONArray(serialized)
+          if (previews.length() > 0) previews.getJSONObject(0) else null
+        } catch (e: JSONException) {
+          Log.w(TAG, "Unable to parse stored link previews.", e)
+          null
+        }
+      }
+
+      private fun findLinkInBody(body: String?): String? {
+        if (body.isNullOrEmpty()) {
+          return null
+        }
+
+        return LinkPreviewUtil.findValidPreviewUrls(body).findFirst().map { it.url }.orElse(null)
+      }
+
+      private fun JSONObject.nonEmptyString(name: String): String? {
+        return optString(name, "").takeIf { it.isNotEmpty() }
+      }
+
+      private fun Cursor.optionalString(column: String): String? {
+        val index = getColumnIndex(column)
+        return if (index != -1) getString(index) else null
       }
     }
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/database/loaders/GroupedThreadMediaLoader.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/loaders/GroupedThreadMediaLoader.java
@@ -78,7 +78,13 @@ public final class GroupedThreadMediaLoader extends AsyncTaskLoader<GroupedThrea
 
     try (Cursor cursor = ThreadMediaLoader.createThreadMediaCursor(context, threadId, mediaType, sorting, limit)) {
       while (cursor != null && cursor.moveToNext()) {
-        mediaGrouping.add(MediaTable.MediaRecord.from(cursor));
+        MediaTable.MediaRecord record = MediaTable.MediaRecord.from(cursor);
+
+        if (record.getAttachment() == null && record.getLinkUrl() == null) {
+          continue;
+        }
+
+        mediaGrouping.add(record);
       }
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/mediaoverview/MediaGalleryAllAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediaoverview/MediaGalleryAllAdapter.java
@@ -36,9 +36,6 @@ import java.util.stream.Collectors;
 import com.bumptech.glide.RequestManager;
 import com.codewaves.stickyheadergrid.StickyHeaderGridAdapter;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.signal.core.util.ByteSize;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.attachments.DatabaseAttachment;
@@ -155,7 +152,7 @@ final class MediaGalleryAllAdapter extends StickyHeaderGridAdapter {
   public int getSectionItemViewType(int section, int offset) {
     MediaTable.MediaRecord mediaRecord = media.get(section, offset);
 
-    if (mediaRecord.getLinkPreviewJson() != null) return LINK_DETAIL;
+    if (mediaRecord.getLinkUrl() != null) return LINK_DETAIL;
     if (mediaRecord.getAttachment() == null) return 0;
 
     Slide slide = MediaUtil.getSlideForAttachment(mediaRecord.getAttachment());
@@ -697,7 +694,9 @@ final class MediaGalleryAllAdapter extends StickyHeaderGridAdapter {
 
     @Override
     public void bind(@NonNull Context context, @NonNull MediaTable.MediaRecord mediaRecord, @Nullable Slide slide) {
-      parseLinkPreview(mediaRecord);
+      this.linkUrl   = mediaRecord.getLinkUrl();
+      this.linkTitle = mediaRecord.getLinkTitle();
+
       super.bind(context, mediaRecord, slide);
       this.slide = slide;
 
@@ -754,23 +753,6 @@ final class MediaGalleryAllAdapter extends StickyHeaderGridAdapter {
         thumbnailView.clear(requestManager);
       }
       super.unbind();
-    }
-
-    private void parseLinkPreview(@NonNull MediaTable.MediaRecord mediaRecord) {
-      linkUrl   = "";
-      linkTitle = "";
-      if (mediaRecord.getLinkPreviewJson() != null) {
-        try {
-          JSONArray json = new JSONArray(mediaRecord.getLinkPreviewJson());
-          if (json.length() > 0) {
-            JSONObject preview = json.getJSONObject(0);
-            linkUrl   = preview.optString("url", "");
-            linkTitle = preview.optString("title", "");
-          }
-        } catch (JSONException e) {
-          // ignore
-        }
-      }
     }
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/mediaoverview/MediaOverviewContextMenu.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediaoverview/MediaOverviewContextMenu.kt
@@ -14,7 +14,6 @@ import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Single
 import io.reactivex.rxjava3.kotlin.subscribeBy
 import io.reactivex.rxjava3.schedulers.Schedulers
-import org.json.JSONArray
 import org.signal.core.util.concurrent.LifecycleDisposable
 import org.signal.core.util.dp
 import org.signal.core.util.logging.Log
@@ -26,7 +25,6 @@ import org.thoughtcrime.securesms.conversation.mutiselect.forward.MultiselectFor
 import org.thoughtcrime.securesms.conversation.mutiselect.forward.MultiselectForwardFragmentArgs
 import org.thoughtcrime.securesms.database.MediaTable
 import org.thoughtcrime.securesms.database.SignalDatabase
-import org.thoughtcrime.securesms.linkpreview.LinkPreview
 import org.thoughtcrime.securesms.mms.PartAuthority
 import org.thoughtcrime.securesms.sharing.v2.ShareActivity
 import org.signal.core.ui.R as CoreUiR
@@ -66,7 +64,7 @@ class MediaOverviewContextMenu(
   }
 
   private fun getForwardActionItem(mediaRecord: MediaTable.MediaRecord): ActionItem? {
-    if (mediaRecord.linkPreviewJson != null) {
+    if (mediaRecord.linkUrl != null) {
       return null
     }
 
@@ -87,7 +85,7 @@ class MediaOverviewContextMenu(
   }
 
   private fun getShareActionItem(mediaRecord: MediaTable.MediaRecord): ActionItem? {
-    if (mediaRecord.linkPreviewJson != null) {
+    if (mediaRecord.linkUrl != null) {
       return getShareLinkActionItem(mediaRecord)
     }
 
@@ -119,13 +117,7 @@ class MediaOverviewContextMenu(
   }
 
   private fun getShareLinkActionItem(mediaRecord: MediaTable.MediaRecord): ActionItem? {
-    val url = try {
-      val jsonPreviews = JSONArray(mediaRecord.linkPreviewJson)
-      LinkPreview.deserialize(jsonPreviews.getJSONObject(0).toString()).url
-    } catch (e: Exception) {
-      Log.w(TAG, "Failed to deserialize link preview", e)
-      return null
-    }
+    val url = mediaRecord.linkUrl ?: return null
 
     return ActionItem(
       iconRes = CoreUiR.drawable.symbol_share_android_24,

--- a/app/src/main/java/org/thoughtcrime/securesms/mediaoverview/MediaOverviewPageFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediaoverview/MediaOverviewPageFragment.java
@@ -60,9 +60,6 @@ import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.SystemWindowInsetsSetter;
 import org.thoughtcrime.securesms.util.ViewUtil;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-
 import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.Collection;
@@ -322,11 +319,8 @@ public final class MediaOverviewPageFragment extends LoggingFragment
       return;
     }
 
-    if (mediaRecord.getLinkPreviewJson() != null) {
-      String url = parseLinkUrl(mediaRecord.getLinkPreviewJson());
-      if (url != null && !url.isEmpty()) {
-        CommunicationActions.openBrowserLink(context, url);
-      }
+    if (mediaRecord.getLinkUrl() != null) {
+      CommunicationActions.openBrowserLink(context, mediaRecord.getLinkUrl());
       return;
     }
 
@@ -399,18 +393,6 @@ public final class MediaOverviewPageFragment extends LoggingFragment
         Toast.makeText(context, R.string.ConversationItem_unable_to_open_media, Toast.LENGTH_LONG).show();
       }
     }
-
-  private static @Nullable String parseLinkUrl(@NonNull String linkPreviewJson) {
-    try {
-      JSONArray json = new JSONArray(linkPreviewJson);
-      if (json.length() > 0) {
-        return json.getJSONObject(0).optString("url", "");
-      }
-    } catch (JSONException e) {
-      // ignore
-    }
-    return null;
-  }
 
   @Override
   public void onMediaLongClicked(@NonNull View view, MediaTable.MediaRecord mediaRecord) {

--- a/app/src/test/java/org/thoughtcrime/securesms/database/MediaTableTest_getLinkMediaForThread.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/database/MediaTableTest_getLinkMediaForThread.kt
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2026 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.thoughtcrime.securesms.database
+
+import android.app.Application
+import android.content.ContentValues
+import android.database.Cursor
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.containsOnly
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.thoughtcrime.securesms.database.MediaTable.MediaRecord
+import org.thoughtcrime.securesms.recipients.Recipient
+import org.thoughtcrime.securesms.recipients.RecipientId
+import org.thoughtcrime.securesms.testutil.RecipientTestRule
+
+@Suppress("ClassName")
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, application = Application::class)
+class MediaTableTest_getLinkMediaForThread {
+
+  @get:Rule
+  val harness = RecipientTestRule()
+
+  private var nextSentTime: Long = 1000
+
+  private lateinit var other: RecipientId
+  private var threadId: Long = 0
+
+  @Before
+  fun setUp() {
+    other = harness.createRecipient("Other Person")
+    threadId = SignalDatabase.threads.getOrCreateThreadIdFor(Recipient.resolved(other))
+  }
+
+  @Test
+  fun givenMessageWithStoredPreview_whenQueryingLinks_thenIncludedUsingThePreviewUrlAndTitle() {
+    insertMessage(body = "look at https://signal.org", linkPreviews = previewJson("https://signal.org", "Signal"))
+
+    val record = linkRecords().single()
+
+    assertThat(record.linkUrl).isEqualTo("https://signal.org")
+    assertThat(record.linkTitle).isEqualTo("Signal")
+  }
+
+  @Test
+  fun givenStoredPreviewWithBlankTitle_whenQueryingLinks_thenTitleIsNullRatherThanEmpty() {
+    insertMessage(body = "https://signal.org", linkPreviews = previewJson("https://signal.org", ""))
+
+    assertThat(linkRecords().single().linkTitle).isNull()
+  }
+
+  @Test
+  fun givenStoredPreviewDisagreesWithBody_whenQueryingLinks_thenThePreviewWins() {
+    insertMessage(body = "https://body.org", linkPreviews = previewJson("https://preview.org", "Preview"))
+
+    assertThat(linkRecords().single().linkUrl).isEqualTo("https://preview.org")
+  }
+
+  @Test
+  fun givenStoredPreviewIsAnEmptyJsonArray_whenQueryingLinks_thenItFallsBackToTheBody() {
+    insertMessage(body = "https://signal.org", linkPreviews = "[]")
+
+    assertThat(linkRecords().single().linkUrl).isEqualTo("https://signal.org")
+  }
+
+  @Test
+  fun givenStoredPreviewIsUnparsable_whenQueryingLinks_thenItFallsBackToTheBody() {
+    insertMessage(body = "https://signal.org", linkPreviews = "not json")
+
+    assertThat(linkRecords().single().linkUrl).isEqualTo("https://signal.org")
+  }
+
+  @Test
+  fun givenTextOnlyMessageWithLinkInBody_whenQueryingLinks_thenIncludedUsingTheBodyUrl() {
+    insertMessage(body = "have a look at https://signal.org today")
+
+    val record = linkRecords().single()
+
+    assertThat(record.linkUrl).isEqualTo("https://signal.org")
+    assertThat(record.linkTitle).isNull()
+  }
+
+  @Test
+  fun givenIncomingMessageWithLinkInBody_whenQueryingLinks_thenIncluded() {
+    insertMessage(body = "https://signal.org", fromRecipientId = other, outgoing = false)
+
+    assertThat(linkRecords().single().linkUrl).isEqualTo("https://signal.org")
+  }
+
+  @Test
+  fun givenBodyWithSeveralLinks_whenQueryingLinks_thenTheFirstIsUsed() {
+    insertMessage(body = "https://first.org and then https://second.org")
+
+    assertThat(linkRecords().single().linkUrl).isEqualTo("https://first.org")
+  }
+
+  @Test
+  fun givenBodyWithNoLink_whenQueryingLinks_thenExcluded() {
+    insertMessage(body = "just some ordinary text")
+
+    assertThat(linkRecords()).isEmpty()
+  }
+
+  @Test
+  fun givenNullBodyAndNoPreview_whenQueryingLinks_thenExcluded() {
+    insertMessage(body = null)
+
+    assertThat(linkRecords()).isEmpty()
+  }
+
+  @Test
+  fun givenBodiesThatMatchTheLikeButHoldNoUsableLink_whenQueryingLinks_thenRowsComeBackWithNoLink() {
+    // SQLite cannot tell a link from an arbitrary string, so these rows do come back from the query and
+    // have neither a link nor an attachment. GroupedThreadMediaLoader has to drop them before they reach
+    // the adapter; see GroupedThreadMediaLoaderTest_linkMedia.
+    insertMessage(body = "https://localhost/admin")
+    insertMessage(body = "https://example.com")
+    insertMessage(body = "https://192.168.1.10")
+    insertMessage(body = "the string https:// on its own")
+
+    val records = linkRecords()
+
+    assertThat(records).hasSize(4)
+    assertThat(records.map { it.linkUrl }).containsOnly(null)
+    assertThat(records.map { it.attachment }).containsOnly(null)
+  }
+
+  @Test
+  fun givenHttpRatherThanHttpsLinkInBody_whenQueryingLinks_thenExcluded() {
+    insertMessage(body = "http://signal.org")
+
+    assertThat(linkRecords()).isEmpty()
+  }
+
+  @Test
+  fun givenBareDomainInBody_whenQueryingLinks_thenExcluded() {
+    insertMessage(body = "signal.org")
+
+    assertThat(linkRecords()).isEmpty()
+  }
+
+  @Test
+  fun givenMessageWithAttachmentAndLinkInBody_whenQueryingLinks_thenExcluded() {
+    val messageId = insertMessage(body = "a photo and https://signal.org")
+    insertAttachment(messageId)
+
+    assertThat(linkRecords()).isEmpty()
+  }
+
+  @Test
+  fun givenViewOnceMessageWithLinkInBody_whenQueryingLinks_thenExcluded() {
+    insertMessage(body = "https://signal.org", viewOnce = true)
+
+    assertThat(linkRecords()).isEmpty()
+  }
+
+  @Test
+  fun givenStoryWithLinkInBody_whenQueryingLinks_thenExcluded() {
+    insertMessage(body = "https://signal.org", storyType = 1)
+
+    assertThat(linkRecords()).isEmpty()
+  }
+
+  @Test
+  fun givenScheduledMessageWithLinkInBody_whenQueryingLinks_thenExcluded() {
+    insertMessage(body = "https://signal.org", scheduledDate = 1L)
+
+    assertThat(linkRecords()).isEmpty()
+  }
+
+  @Test
+  fun givenSupersededRevisionWithLinkInBody_whenQueryingLinks_thenOnlyTheLatestRevisionIsIncluded() {
+    val latest = insertMessage(body = "https://edited.org")
+    insertMessage(body = "https://original.org", latestRevisionId = latest)
+
+    assertThat(linkRecords().map { it.linkUrl }).containsExactly("https://edited.org")
+  }
+
+  @Test
+  fun givenLinkInAnotherThread_whenQueryingLinks_thenExcluded() {
+    val stranger = harness.createRecipient("Stranger")
+    val otherThread = SignalDatabase.threads.getOrCreateThreadIdFor(Recipient.resolved(stranger))
+    insertMessage(body = "https://elsewhere.org", threadId = otherThread)
+
+    assertThat(linkRecords()).isEmpty()
+  }
+
+  @Test
+  fun givenSeveralLinks_whenQueryingLinks_thenNewestSortsMostRecentFirstAndOldestReverses() {
+    insertMessage(body = "https://first.org", sentTime = 100)
+    insertMessage(body = "https://second.org", sentTime = 200)
+    insertMessage(body = "https://third.org", sentTime = 300)
+
+    assertThat(linkRecords(MediaTable.Sorting.Newest).map { it.linkUrl })
+      .containsExactly("https://third.org", "https://second.org", "https://first.org")
+
+    assertThat(linkRecords(MediaTable.Sorting.Oldest).map { it.linkUrl })
+      .containsExactly("https://first.org", "https://second.org", "https://third.org")
+  }
+
+  @Test
+  fun givenMessageWithStoredPreview_whenQueryingAllMedia_thenItIsStillIncluded() {
+    insertMessage(body = "https://signal.org", linkPreviews = previewJson("https://signal.org", "Signal"))
+
+    assertThat(allMediaRecords().map { it.linkUrl }).containsExactly("https://signal.org")
+  }
+
+  private fun linkRecords(sorting: MediaTable.Sorting = MediaTable.Sorting.Newest): List<MediaRecord> {
+    return SignalDatabase.media.getLinkMediaForThread(threadId, sorting).readRecords()
+  }
+
+  private fun allMediaRecords(sorting: MediaTable.Sorting = MediaTable.Sorting.Newest): List<MediaRecord> {
+    return SignalDatabase.media.getAllMediaForThread(threadId, sorting).readRecords()
+  }
+
+  private fun Cursor.readRecords(): List<MediaRecord> {
+    return use { cursor ->
+      buildList {
+        while (cursor.moveToNext()) {
+          add(MediaRecord.from(cursor))
+        }
+      }
+    }
+  }
+
+  private fun previewJson(url: String, title: String): String {
+    return """[{"url":"$url","title":"$title","description":"","date":0,"attachmentId":null}]"""
+  }
+
+  private fun insertMessage(
+    body: String?,
+    linkPreviews: String? = null,
+    threadId: Long = this.threadId,
+    fromRecipientId: RecipientId = harness.self,
+    outgoing: Boolean = true,
+    viewOnce: Boolean = false,
+    storyType: Int = 0,
+    scheduledDate: Long = -1,
+    latestRevisionId: Long? = null,
+    sentTime: Long = nextSentTime++
+  ): Long {
+    val values = ContentValues().apply {
+      put(MessageTable.DATE_SENT, sentTime)
+      put(MessageTable.DATE_RECEIVED, sentTime)
+      put(MessageTable.THREAD_ID, threadId)
+      put(MessageTable.FROM_RECIPIENT_ID, fromRecipientId.serialize())
+      put(MessageTable.TO_RECIPIENT_ID, if (outgoing) other.serialize() else harness.self.serialize())
+      put(MessageTable.TYPE, if (outgoing) MessageTypes.BASE_SENT_TYPE or MessageTypes.PUSH_MESSAGE_BIT else MessageTypes.BASE_INBOX_TYPE or MessageTypes.PUSH_MESSAGE_BIT)
+      put(MessageTable.BODY, body)
+      put(MessageTable.LINK_PREVIEWS, linkPreviews)
+      put(MessageTable.VIEW_ONCE, if (viewOnce) 1 else 0)
+      put(MessageTable.STORY_TYPE, storyType)
+      put(MessageTable.SCHEDULED_DATE, scheduledDate)
+      put(MessageTable.LATEST_REVISION_ID, latestRevisionId)
+    }
+
+    return SignalDatabase.writableDatabase.insert(MessageTable.TABLE_NAME, null, values)
+  }
+
+  private fun insertAttachment(messageId: Long): Long {
+    return SignalDatabase.writableDatabase.insert(
+      AttachmentTable.TABLE_NAME,
+      null,
+      ContentValues().apply {
+        put(AttachmentTable.MESSAGE_ID, messageId)
+        put(AttachmentTable.TRANSFER_STATE, AttachmentTable.TRANSFER_PROGRESS_DONE)
+        put(AttachmentTable.CONTENT_TYPE, "image/jpeg")
+        put(AttachmentTable.DATA_FILE, "/tmp/not-a-real-file")
+        put(AttachmentTable.DATA_SIZE, 1024)
+      }
+    )
+  }
+}

--- a/app/src/test/java/org/thoughtcrime/securesms/database/loaders/GroupedThreadMediaLoaderTest_linkMedia.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/database/loaders/GroupedThreadMediaLoaderTest_linkMedia.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.thoughtcrime.securesms.database.loaders
+
+import android.app.Application
+import android.content.ContentValues
+import androidx.test.core.app.ApplicationProvider
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.thoughtcrime.securesms.database.MediaTable
+import org.thoughtcrime.securesms.database.MessageTable
+import org.thoughtcrime.securesms.database.MessageTypes
+import org.thoughtcrime.securesms.database.SignalDatabase
+import org.thoughtcrime.securesms.recipients.Recipient
+import org.thoughtcrime.securesms.recipients.RecipientId
+import org.thoughtcrime.securesms.testutil.RecipientTestRule
+
+@Suppress("ClassName")
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, application = Application::class)
+class GroupedThreadMediaLoaderTest_linkMedia {
+
+  @get:Rule
+  val harness = RecipientTestRule()
+
+  private lateinit var other: RecipientId
+  private var threadId: Long = 0
+  private var nextSentTime: Long = 1000
+
+  @Before
+  fun setUp() {
+    other = harness.createRecipient("Other Person")
+    threadId = SignalDatabase.threads.getOrCreateThreadIdFor(Recipient.resolved(other))
+  }
+
+  @Test
+  fun givenBodiesThatMatchTheQueryButHoldNoUsableLink_whenLoadingLinkMedia_thenOnlyTheRealLinkIsKept() {
+    insertMessage("look at https://signal.org")
+    insertMessage("https://localhost/admin")
+    insertMessage("https://example.com")
+    insertMessage("https://192.168.1.10")
+    insertMessage("the string https:// on its own")
+
+    val loaded = loadLinkMedia()
+
+    assertThat(loaded.map { it.linkUrl }).containsExactly("https://signal.org")
+  }
+
+  private fun loadLinkMedia(): List<MediaTable.MediaRecord> {
+    val loader = GroupedThreadMediaLoader(
+      ApplicationProvider.getApplicationContext(),
+      threadId,
+      MediaLoader.MediaType.LINK,
+      MediaTable.Sorting.Oldest,
+      0
+    )
+
+    val grouped = requireNotNull(loader.loadInBackground())
+
+    return buildList {
+      for (section in 0 until grouped.sectionCount) {
+        for (item in 0 until grouped.getSectionItemCount(section)) {
+          add(grouped.get(section, item))
+        }
+      }
+    }
+  }
+
+  private fun insertMessage(body: String): Long {
+    val sentTime = nextSentTime++
+    val values = ContentValues().apply {
+      put(MessageTable.DATE_SENT, sentTime)
+      put(MessageTable.DATE_RECEIVED, sentTime)
+      put(MessageTable.THREAD_ID, threadId)
+      put(MessageTable.FROM_RECIPIENT_ID, harness.self.serialize())
+      put(MessageTable.TO_RECIPIENT_ID, other.serialize())
+      put(MessageTable.TYPE, MessageTypes.BASE_SENT_TYPE or MessageTypes.PUSH_MESSAGE_BIT)
+      put(MessageTable.BODY, body)
+    }
+
+    return SignalDatabase.writableDatabase.insert(MessageTable.TABLE_NAME, null, values)
+  }
+}


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices: Samsung Galaxy S24 (SM-S921B), Android 15
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #14789` syntax

----------

### Description

Fixes #14789.

Links were only included in the conversation's Links tab when
`message.link_previews` was populated. As a result, valid links whose preview was
dismissed, unavailable, or not fetched were excluded.

This change also considers message bodies that contain valid links. Candidate rows
are pre-filtered in SQLite and then validated using
`LinkPreviewUtil.findValidPreviewUrls`, so existing Signal URL validation is reused.

The change is limited to the read path and does not modify message storage or wire
format.

### Testing

Added tests covering:

- stored link previews
- body-only links
- incoming and outgoing messages
- excluded message types
- sorting
- invalid coarse SQL matches
- loader filtering for rows that cannot be rendered

Also verified:

- `./gradlew format`
- `ktlintCheck`