### PR TITLE
Fix message notification vibration toggle bug

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/notifications/NotificationsSettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/notifications/NotificationsSettingsFragment.kt
@@ -219,7 +219,7 @@ open class DefaultNotificationsSettingsCallbacks(
   }
 
   override fun setMessageNotificationVibration(enabled: Boolean) {
-    viewModel.setMessageNotificationsEnabled(enabled)
+    viewModel.setMessageNotificationVibration(enabled)
   }
 
   override fun setMessasgeNotificationLedColor(selection: String) {
@@ -441,7 +441,7 @@ fun NotificationsSettingsScreen(
             text = stringResource(R.string.preferences__vibrate),
             checked = state.messageNotificationsState.vibrateEnabled,
             enabled = state.messageNotificationsState.notificationsEnabled,
-            onCheckChanged = callbacks::setMessageNotificationsEnabled
+            onCheckChanged = callbacks::setMessageNotificationVibration
           )
         }
 


### PR DESCRIPTION
This change fixes a bug in the notification settings screen. Before this fix, toggling the vibration for message notifications would mistakenly toggle the entire notification system. I have updated the code to ensure that changing the vibration setting only affects vibration as expected.