### PR TITLE
Add setting to strip tracking parameters from links

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/PrivacySettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/PrivacySettingsFragment.kt
@@ -161,6 +161,15 @@ class PrivacySettingsFragment : DSLSettingsFragment(R.string.preferences__privac
         }
       )
 
+      switchPref(
+        title = DSLSettingsText.from(R.string.preferences__remove_link_tracking),
+        summary = DSLSettingsText.from(R.string.preferences__remove_tracking_parameters_from_links),
+        isChecked = state.stripLinkTrackingParameters,
+        onClick = {
+          viewModel.setStripLinkTrackingParametersEnabled(!state.stripLinkTrackingParameters)
+        }
+      )
+
       dividerPref()
 
       sectionHeaderPref(R.string.PrivacySettingsFragment__disappearing_messages)

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/PrivacySettingsState.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/PrivacySettingsState.kt
@@ -4,6 +4,7 @@ data class PrivacySettingsState(
   val blockedCount: Int,
   val readReceipts: Boolean,
   val typingIndicators: Boolean,
+  val stripLinkTrackingParameters: Boolean,
   val screenLock: Boolean,
   val screenLockActivityTimeout: Long,
   val screenSecurity: Boolean,

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/PrivacySettingsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/PrivacySettingsViewModel.kt
@@ -37,6 +37,11 @@ class PrivacySettingsViewModel(
     refresh()
   }
 
+  fun setStripLinkTrackingParametersEnabled(enabled: Boolean) {
+    SignalStore.settings.isStripLinkTrackingParametersEnabled = enabled
+    refresh()
+  }
+
   fun setScreenSecurityEnabled(enabled: Boolean) {
     sharedPreferences.edit().putBoolean(TextSecurePreferences.SCREEN_SECURITY_PREF, enabled).apply()
     refresh()
@@ -71,6 +76,7 @@ class PrivacySettingsViewModel(
       blockedCount = 0,
       readReceipts = TextSecurePreferences.isReadReceiptsEnabled(AppDependencies.application),
       typingIndicators = TextSecurePreferences.isTypingIndicatorsEnabled(AppDependencies.application),
+      stripLinkTrackingParameters = SignalStore.settings.isStripLinkTrackingParametersEnabled,
       screenLock = SignalStore.settings.screenLockEnabled,
       screenLockActivityTimeout = SignalStore.settings.screenLockTimeout,
       screenSecurity = TextSecurePreferences.isScreenSecurityEnabled(AppDependencies.application),

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationItem.java
@@ -155,6 +155,7 @@ import org.thoughtcrime.securesms.util.ProjectionList;
 import org.thoughtcrime.securesms.util.RemoteConfig;
 import org.thoughtcrime.securesms.util.SearchUtil;
 import org.thoughtcrime.securesms.util.SpanUtil;
+import org.thoughtcrime.securesms.util.TrackingParameters;
 import org.thoughtcrime.securesms.util.UrlClickHandler;
 import org.thoughtcrime.securesms.util.VibrateUtil;
 import org.thoughtcrime.securesms.util.ViewUtil;
@@ -1819,7 +1820,8 @@ public final class ConversationItem extends RelativeLayout implements BindableCo
       for (PlaceholderURLSpan placeholder : messageBody.getSpans(0, messageBody.length(), PlaceholderURLSpan.class)) {
         int start = messageBody.getSpanStart(placeholder);
         int end   = messageBody.getSpanEnd(placeholder);
-        URLSpan span = new InterceptableLongClickCopyLinkSpan(placeholder.getValue(),
+        String target = TrackingParameters.stripIfEnabled(placeholder.getValue());
+        URLSpan span = new InterceptableLongClickCopyLinkSpan(target,
                                                               urlClickListener,
                                                               ContextCompat.getColor(getContext(), isReleaseNotes ? R.color.release_notes_bubble_text : R.color.signal_accent_primary),
                                                               isReleaseNotes);

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
@@ -367,6 +367,7 @@ import org.thoughtcrime.securesms.util.PlayStoreUtil
 import org.thoughtcrime.securesms.util.RemoteConfig
 import org.thoughtcrime.securesms.util.SignalLocalMetrics
 import org.thoughtcrime.securesms.util.TextSecurePreferences
+import org.thoughtcrime.securesms.util.TrackingParameters
 import org.thoughtcrime.securesms.util.UriUtil
 import org.thoughtcrime.securesms.util.ViewUtil
 import org.thoughtcrime.securesms.util.atMidnight
@@ -3542,7 +3543,7 @@ class ConversationFragment :
 
     override fun onLinkPreviewClicked(linkPreview: LinkPreview) {
       activity ?: return
-      openLink(linkPreview.url)
+      openLink(TrackingParameters.stripIfEnabled(linkPreview.url))
     }
 
     override fun onQuotedIndicatorClicked(messageRecord: MessageRecord) {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/items/V2ConversationItemTextOnlyViewHolder.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/items/V2ConversationItemTextOnlyViewHolder.kt
@@ -55,6 +55,7 @@ import org.thoughtcrime.securesms.util.Projection
 import org.thoughtcrime.securesms.util.ProjectionList
 import org.thoughtcrime.securesms.util.SearchUtil
 import org.thoughtcrime.securesms.util.SignalLocalMetrics
+import org.thoughtcrime.securesms.util.TrackingParameters
 import org.thoughtcrime.securesms.util.VibrateUtil
 import org.thoughtcrime.securesms.util.ViewUtil
 import org.thoughtcrime.securesms.util.adapter.mapping.MappingModel
@@ -455,7 +456,7 @@ open class V2ConversationItemTextOnlyViewHolder<Model : MappingModel<Model>>(
         val start = messageBody.getSpanStart(placeholder)
         val end = messageBody.getSpanEnd(placeholder)
         val span: URLSpan = InterceptableLongClickCopyLinkSpan(
-          placeholder.value,
+          TrackingParameters.stripIfEnabled(placeholder.value),
           conversationContext.clickListener::onUrlClicked,
           linkColor,
           underline

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/items/V2ConversationItemUtils.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/items/V2ConversationItemUtils.kt
@@ -15,6 +15,7 @@ import org.signal.core.util.addDetectedLinks
 import org.thoughtcrime.securesms.database.model.MessageRecord
 import org.thoughtcrime.securesms.util.InterceptableLongClickCopyLinkSpan
 import org.thoughtcrime.securesms.util.LinkUtil
+import org.thoughtcrime.securesms.util.TrackingParameters
 import org.thoughtcrime.securesms.util.UrlClickHandler
 import org.thoughtcrime.securesms.util.hasOnlyThumbnail
 
@@ -42,7 +43,13 @@ object V2ConversationItemUtils {
       val end = messageBody.getSpanEnd(urlSpan)
       messageBody.removeSpan(urlSpan)
       if (LinkUtil.isLegalUrl(url)) {
-        messageBody.setSpan(InterceptableLongClickCopyLinkSpan(url, urlClickHandler), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        val target = TrackingParameters.stripIfEnabled(url)
+        messageBody.setSpan(
+          InterceptableLongClickCopyLinkSpan(target, urlClickHandler),
+          start,
+          end,
+          Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
       }
     }
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/v2/GroupDescriptionUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/v2/GroupDescriptionUtil.java
@@ -20,6 +20,7 @@ import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.emoji.EmojiTextView;
 import org.thoughtcrime.securesms.util.LinkUtil;
 import org.thoughtcrime.securesms.util.LongClickCopySpan;
+import org.thoughtcrime.securesms.util.TrackingParameters;
 
 public final class GroupDescriptionUtil {
 
@@ -46,7 +47,11 @@ public final class GroupDescriptionUtil {
         int    end   = descriptionSpannable.getSpanEnd(urlSpan);
         descriptionSpannable.removeSpan(urlSpan);
         if (LinkUtil.isLegalUrl(url)) {
-          descriptionSpannable.setSpan(new LongClickCopySpan(url), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+          String target = TrackingParameters.stripIfEnabled(url);
+          descriptionSpannable.setSpan(new LongClickCopySpan(target),
+                                       start,
+                                       end,
+                                       Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
       }
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/keyvalue/SettingsValues.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyvalue/SettingsValues.java
@@ -31,6 +31,8 @@ public final class SettingsValues extends SignalStoreValues {
   public static final String LINK_PREVIEWS          = "settings.link_previews";
   public static final String KEEP_MESSAGES_DURATION = "settings.keep_messages_duration";
 
+  public static final String STRIP_LINK_TRACKING = "settings.strip_link_tracking_parameters";
+
   public static final String PREFER_SYSTEM_CONTACT_PHOTOS = "settings.prefer.system.contact.photos";
 
   private static final String SIGNAL_BACKUP_DIRECTORY        = "settings.signal.backup.directory";
@@ -127,6 +129,7 @@ public final class SettingsValues extends SignalStoreValues {
   @Override
   @NonNull List<String> getKeysToIncludeInBackup() {
     return Arrays.asList(LINK_PREVIEWS,
+                         STRIP_LINK_TRACKING,
                          KEEP_MESSAGES_DURATION,
                          PREFER_SYSTEM_CONTACT_PHOTOS,
                          CALL_DATA_MODE,
@@ -172,6 +175,19 @@ public final class SettingsValues extends SignalStoreValues {
 
   public void setLinkPreviewsEnabled(boolean enabled) {
     putBoolean(LINK_PREVIEWS, enabled);
+  }
+
+  /**
+   * Whether known tracking parameters are stripped from links before they are opened,
+   * copied, or fetched for a preview. Defaults to true so that existing installs get
+   * the protection on upgrade without having to find the setting.
+   */
+  public boolean isStripLinkTrackingParametersEnabled() {
+    return getBoolean(STRIP_LINK_TRACKING, true);
+  }
+
+  public void setStripLinkTrackingParametersEnabled(boolean enabled) {
+    putBoolean(STRIP_LINK_TRACKING, enabled);
   }
 
   public @NonNull KeepMessagesDuration getKeepMessagesDuration() {

--- a/app/src/main/java/org/thoughtcrime/securesms/linkpreview/LinkPreviewRepository.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/linkpreview/LinkPreviewRepository.java
@@ -54,6 +54,7 @@ import org.thoughtcrime.securesms.util.ImageCompressionUtil;
 import org.thoughtcrime.securesms.util.LinkUtil;
 import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.OkHttpUtil;
+import org.thoughtcrime.securesms.util.TrackingParameters;
 import org.whispersystems.signalservice.api.SignalServiceMessageReceiver;
 import org.whispersystems.signalservice.api.groupsv2.GroupLinkNotActiveException;
 import org.whispersystems.signalservice.api.messages.SignalServiceStickerManifest;
@@ -171,7 +172,14 @@ public class LinkPreviewRepository {
   }
 
   private @NonNull RequestController fetchMetadata(@NonNull String url, Consumer<Metadata> callback) {
-    Call call = client.newCall(new Request.Builder().url(url).cacheControl(NO_CACHE).build());
+    // Strip tracking parameters from the outbound request so that generating a
+    // preview doesn't hand the site the sharer's attribution token. Only the request
+    // is cleaned: the URL stored on the LinkPreview has to stay byte-identical to the
+    // one in the message body, because the recipient discards any preview whose URL
+    // isn't present in the body (see DataMessageProcessor.getLinkPreviews).
+    String  requestUrl = TrackingParameters.stripIfEnabled(url);
+    Request request    = new Request.Builder().url(requestUrl).cacheControl(NO_CACHE).build();
+    Call    call       = client.newCall(request);
 
     call.enqueue(new okhttp3.Callback() {
       @Override

--- a/app/src/main/java/org/thoughtcrime/securesms/nicknames/ViewNoteSheet.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/nicknames/ViewNoteSheet.kt
@@ -7,6 +7,7 @@ package org.thoughtcrime.securesms.nicknames
 
 import android.os.Bundle
 import android.text.SpannableString
+import android.text.style.URLSpan
 import android.text.util.Linkify
 import androidx.activity.result.ActivityResultLauncher
 import androidx.compose.foundation.layout.Column
@@ -42,6 +43,7 @@ import org.signal.core.util.getParcelableCompat
 import org.thoughtcrime.securesms.R
 import org.thoughtcrime.securesms.components.emoji.EmojiTextView
 import org.thoughtcrime.securesms.recipients.RecipientId
+import org.thoughtcrime.securesms.util.TrackingParameters
 import org.thoughtcrime.securesms.util.viewModel
 import org.signal.core.ui.R as CoreUiR
 
@@ -163,7 +165,9 @@ private fun ViewNoteBottomSheetContent(
       if (!isInspection) {
         LinkifyCompat.addLinks(spannable, Linkify.EMAIL_ADDRESSES or Linkify.PHONE_NUMBERS)
       }
-      spannable.addDetectedLinks()
+      spannable.addDetectedLinks(
+        spanFactory = { link -> URLSpan(TrackingParameters.stripIfEnabled(link.url)) }
+      )
       it.text = spannable
     }
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/stories/viewer/page/StoryViewerPageFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/stories/viewer/page/StoryViewerPageFragment.kt
@@ -100,6 +100,7 @@ import org.thoughtcrime.securesms.util.LongClickCopySpan
 import org.thoughtcrime.securesms.util.LongClickMovementMethod
 import org.thoughtcrime.securesms.util.MediaUtil
 import org.thoughtcrime.securesms.util.Projection
+import org.thoughtcrime.securesms.util.TrackingParameters
 import org.thoughtcrime.securesms.util.ViewUtil
 import org.thoughtcrime.securesms.util.fragments.requireListener
 import org.thoughtcrime.securesms.util.views.TouchInterceptingFrameLayout
@@ -1013,7 +1014,8 @@ class StoryViewerPageFragment :
       val end = spannable.getSpanEnd(urlSpan)
       spannable.removeSpan(urlSpan)
       if (LinkUtil.isLegalUrl(url)) {
-        spannable.setSpan(LongClickCopySpan(url), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        val target = TrackingParameters.stripIfEnabled(url)
+        spannable.setSpan(LongClickCopySpan(target), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
       }
     }
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/stories/viewer/post/StoryTextLoader.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/stories/viewer/post/StoryTextLoader.kt
@@ -9,6 +9,7 @@ import org.thoughtcrime.securesms.linkpreview.LinkPreview
 import org.thoughtcrime.securesms.stories.StoryTextPostView
 import org.thoughtcrime.securesms.util.CommunicationActions
 import org.thoughtcrime.securesms.util.FragmentDialogs.displayInDialogAboveAnchor
+import org.thoughtcrime.securesms.util.TrackingParameters
 
 /**
  * Render logic for story text posts
@@ -49,7 +50,8 @@ class StoryTextLoader(
 
     contentView.findViewById<TextView>(R.id.url).text = linkPreview.url
     contentView.setOnClickListener {
-      CommunicationActions.openBrowserLink(fragment.requireContext(), linkPreview.url)
+      val target = TrackingParameters.stripIfEnabled(linkPreview.url)
+      CommunicationActions.openBrowserLink(fragment.requireContext(), target)
     }
 
     contentView.measure(

--- a/app/src/main/java/org/thoughtcrime/securesms/util/TrackingParameters.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/TrackingParameters.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.thoughtcrime.securesms.util
+
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import org.thoughtcrime.securesms.keyvalue.SignalStore
+
+/**
+ * Removes tracking parameters from URLs so that opening, copying, or fetching a link
+ * does not hand the destination site the analytics token that was attached to it when
+ * it was shared.
+ *
+ * Only query parameters are ever removed. The scheme, host, port, path, and fragment
+ * are structurally preserved (the result is built with [okhttp3.HttpUrl.newBuilder]),
+ * so a stripped URL can never point at a different destination than the one the user
+ * sees; it can only point at the same destination with less information attached.
+ * Anything that fails to parse as an HTTP(S) URL is returned untouched.
+ *
+ * Parameters fall into two groups:
+ *  - [GLOBAL_PARAMETERS], which are pure analytics tokens no site needs in order to
+ *    resolve a link, and are therefore safe to remove everywhere.
+ *  - [HOST_SCOPED_PARAMETERS], which are tracking tokens on the listed hosts but are
+ *    short, generic names that may well be load-bearing elsewhere (`si`, `s`, `t`), so
+ *    they are only removed on those hosts.
+ */
+object TrackingParameters {
+
+  /** Matches the whole `utm_*` analytics family. */
+  private const val UTM_PREFIX = "utm_"
+
+  /**
+   * Tracking parameters removed regardless of host. Every entry here is a click or
+   * campaign identifier that exists to attribute a visit, never to select what the URL
+   * resolves to.
+   */
+  private val GLOBAL_PARAMETERS: Set<String> = setOf(
+    // Google Ads / DoubleClick
+    "gclid", "gclsrc", "dclid", "gbraid", "wbraid",
+    // Meta
+    "fbclid", "fb_action_ids", "fb_action_types", "fb_source", "fb_ref",
+    // Microsoft / Bing
+    "msclkid",
+    // X / Twitter
+    "twclid",
+    // TikTok
+    "ttclid",
+    // Yandex
+    "yclid", "_openstat",
+    // Mailchimp / Marketo / HubSpot
+    "mc_cid", "mc_eid", "mkt_tok", "_hsenc", "_hsmi", "hsctatracking",
+    // Instagram
+    "igshid", "igsh",
+    // Klaviyo / Vero / Omeda and other mail vendors
+    "vero_conv", "vero_id", "oly_anon_id", "oly_enc_id", "wickedid",
+    // Adobe / generic campaign identifiers
+    "icid", "s_cid", "cmpid", "ncid"
+  )
+
+  /**
+   * Tracking parameters removed only on the hosts that use them for attribution. These
+   * names are too generic to strip globally: `t`, for instance, is a legitimate
+   * timestamp or token parameter on plenty of other sites.
+   *
+   * Keys are matched against the URL host as a domain suffix, so `youtube.com` also covers
+   * `www.youtube.com` and `m.youtube.com`.
+   */
+  private val HOST_SCOPED_PARAMETERS: Map<String, Set<String>> = mapOf(
+    // YouTube renamed the share-source token from `si` to `is` in early 2026. Both are stripped:
+    // `si` still appears throughout existing chat history.
+    "youtube.com" to setOf("si", "is", "feature"),
+    "youtu.be" to setOf("si", "is", "feature"),
+    "spotify.com" to setOf("si"),
+    "facebook.com" to setOf("mibextid", "rdid"),
+    "fb.watch" to setOf("mibextid"),
+    "twitter.com" to setOf("s", "t"),
+    "x.com" to setOf("s", "t")
+  )
+
+  /**
+   * Strips tracking parameters from [url], but only if the user has the setting enabled.
+   *
+   * This is the entry point call sites should use; [strip] is the pure implementation behind it.
+   */
+  @JvmStatic
+  fun stripIfEnabled(url: String): String {
+    return if (SignalStore.settings.isStripLinkTrackingParametersEnabled) {
+      strip(url)
+    } else {
+      url
+    }
+  }
+
+  /**
+   * Strips known tracking parameters from [url], regardless of the user setting.
+   *
+   * Returns [url] unchanged if it cannot be parsed as an HTTP(S) URL, has no query
+   * string, or carries no recognized tracking parameters, so a URL that needs no
+   * cleaning is never rewritten or re-encoded.
+   */
+  @JvmStatic
+  fun strip(url: String): String {
+    val httpUrl = url.toHttpUrlOrNull() ?: return url
+
+    if (httpUrl.querySize == 0) {
+      return url
+    }
+
+    val hostScoped: Set<String> = parametersForHost(httpUrl.host)
+    val toRemove: List<String> = httpUrl.queryParameterNames.filter { isTracking(it, hostScoped) }
+
+    if (toRemove.isEmpty()) {
+      return url
+    }
+
+    val builder = httpUrl.newBuilder()
+    for (name in toRemove) {
+      builder.removeAllQueryParameters(name)
+    }
+
+    return builder.build().toString()
+  }
+
+  private fun isTracking(name: String, hostScoped: Set<String>): Boolean {
+    val normalized = name.lowercase()
+    return normalized.startsWith(UTM_PREFIX) ||
+      normalized in GLOBAL_PARAMETERS ||
+      normalized in hostScoped
+  }
+
+  /** Matches [host] as a domain suffix, so subdomains are covered too. */
+  private fun parametersForHost(host: String): Set<String> {
+    val normalized = host.lowercase()
+
+    return HOST_SCOPED_PARAMETERS
+      .filterKeys { domain -> normalized == domain || normalized.endsWith(".$domain") }
+      .values
+      .flatten()
+      .toSet()
+  }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4287,6 +4287,8 @@
     <string name="preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts">If read receipts are disabled, you won\'t be able to see read receipts from others.</string>
     <string name="preferences__typing_indicators">Typing indicators</string>
     <string name="preferences__if_typing_indicators_are_disabled_you_wont_be_able_to_see_typing_indicators">If typing indicators are disabled, you won\'t be able to see typing indicators from others.</string>
+    <string name="preferences__remove_link_tracking">Remove link tracking</string>
+    <string name="preferences__remove_tracking_parameters_from_links">Remove tracking parameters from links in messages before opening, copying, or previewing them, so sites don\'t learn where the link was shared.</string>
     <string name="preferences__request_keyboard_to_disable">Request keyboard to disable personalized learning.</string>
     <string name="preferences__this_setting_is_not_a_guarantee">This setting is not a guarantee, and your keyboard may ignore it.</string>
     <string name="preferences__incognito_keyboard_learn_more" translatable="false">https://support.signal.org/hc/articles/360055276112</string>

--- a/app/src/test/java/org/thoughtcrime/securesms/util/TrackingParametersTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/util/TrackingParametersTest.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2026 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.thoughtcrime.securesms.util
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isSameInstanceAs
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import org.junit.Test
+
+class TrackingParametersTest {
+
+  @Test
+  fun `strips the youtube si parameter`() {
+    assertThat(TrackingParameters.strip("https://youtu.be/dQw4w9WgXcQ?si=AbCdEf123"))
+      .isEqualTo("https://youtu.be/dQw4w9WgXcQ")
+  }
+
+  @Test
+  fun `strips si on youtube subdomains`() {
+    assertThat(TrackingParameters.strip("https://m.youtube.com/watch?v=dQw4w9WgXcQ&si=AbCdEf123"))
+      .isEqualTo("https://m.youtube.com/watch?v=dQw4w9WgXcQ")
+  }
+
+  @Test
+  fun `strips the youtube is parameter, which replaced si in early 2026`() {
+    assertThat(TrackingParameters.strip("https://youtu.be/dQw4w9WgXcQ?is=AbCdEf123"))
+      .isEqualTo("https://youtu.be/dQw4w9WgXcQ")
+    assertThat(TrackingParameters.strip("https://www.youtube.com/shorts/dQw4w9WgXcQ?is=AbCdEf123"))
+      .isEqualTo("https://www.youtube.com/shorts/dQw4w9WgXcQ")
+  }
+
+  @Test
+  fun `keeps is on hosts that are not in the host-scoped list`() {
+    val url = "https://example.com/thing?is=true"
+
+    assertThat(TrackingParameters.strip(url)).isSameInstanceAs(url)
+  }
+
+  @Test
+  fun `keeps si on hosts that are not in the host-scoped list`() {
+    val url = "https://example.com/thing?si=meaningful"
+    assertThat(TrackingParameters.strip(url)).isSameInstanceAs(url)
+  }
+
+  @Test
+  fun `strips the whole utm family anywhere`() {
+    val url = "https://example.com/a?utm_source=news&utm_medium=email&utm_campaign=spring&id=7"
+
+    assertThat(TrackingParameters.strip(url)).isEqualTo("https://example.com/a?id=7")
+  }
+
+  @Test
+  fun `strips fbclid and igshid globally`() {
+    assertThat(TrackingParameters.strip("https://www.instagram.com/p/ABC/?igshid=xyz"))
+      .isEqualTo("https://www.instagram.com/p/ABC/")
+    assertThat(TrackingParameters.strip("https://example.com/article?fbclid=IwAR123"))
+      .isEqualTo("https://example.com/article")
+
+    // On a non-Instagram host, so this fails if igshid is ever demoted to a host rule.
+    assertThat(TrackingParameters.strip("https://example.com/a?igshid=xyz&keep=1"))
+      .isEqualTo("https://example.com/a?keep=1")
+  }
+
+  @Test
+  fun `strips facebook mibextid`() {
+    assertThat(TrackingParameters.strip("https://www.facebook.com/somepage?mibextid=ZbWKwL"))
+      .isEqualTo("https://www.facebook.com/somepage")
+  }
+
+  @Test
+  fun `strips twitter s and t only on twitter and x`() {
+    assertThat(TrackingParameters.strip("https://x.com/user/status/123?s=20&t=AbCd"))
+      .isEqualTo("https://x.com/user/status/123")
+    assertThat(TrackingParameters.strip("https://twitter.com/user/status/123?s=20"))
+      .isEqualTo("https://twitter.com/user/status/123")
+
+    val other = "https://example.com/search?s=query&t=1700000000"
+    assertThat(TrackingParameters.strip(other)).isSameInstanceAs(other)
+  }
+
+  @Test
+  fun `matches parameter names case-insensitively`() {
+    assertThat(TrackingParameters.strip("https://example.com/a?UTM_Source=x&FBCLID=y&keep=1"))
+      .isEqualTo("https://example.com/a?keep=1")
+  }
+
+  @Test
+  fun `removes a valueless tracking parameter`() {
+    assertThat(TrackingParameters.strip("https://example.com/a?fbclid&keep=1"))
+      .isEqualTo("https://example.com/a?keep=1")
+  }
+
+  @Test
+  fun `removes every occurrence of a repeated tracking parameter`() {
+    val url = "https://example.com/a?utm_source=one&keep=1&utm_source=two"
+
+    assertThat(TrackingParameters.strip(url)).isEqualTo("https://example.com/a?keep=1")
+  }
+
+  @Test
+  fun `preserves the order of the remaining parameters`() {
+    assertThat(TrackingParameters.strip("https://example.com/a?b=2&utm_source=x&a=1&c=3"))
+      .isEqualTo("https://example.com/a?b=2&a=1&c=3")
+  }
+
+  @Test
+  fun `preserves the fragment`() {
+    assertThat(TrackingParameters.strip("https://example.com/a?utm_source=x#section-2"))
+      .isEqualTo("https://example.com/a#section-2")
+  }
+
+  @Test
+  fun `preserves port path and userinfo`() {
+    assertThat(TrackingParameters.strip("https://example.com:8443/deep/path.html?gclid=1&q=hello"))
+      .isEqualTo("https://example.com:8443/deep/path.html?q=hello")
+  }
+
+  @Test
+  fun `returns the original instance when there is nothing to strip`() {
+    val noQuery = "https://example.com/a"
+    val onlyRealParams = "https://example.com/a?q=hello&page=2"
+
+    assertThat(TrackingParameters.strip(noQuery)).isSameInstanceAs(noQuery)
+    assertThat(TrackingParameters.strip(onlyRealParams)).isSameInstanceAs(onlyRealParams)
+  }
+
+  @Test
+  fun `returns the original instance for unparseable or non-http input`() {
+    val notAUrl = "this is not a url"
+    val mailto = "mailto:someone@example.com?utm_source=x"
+    val custom = "signal://example?utm_source=x"
+
+    assertThat(TrackingParameters.strip(notAUrl)).isSameInstanceAs(notAUrl)
+    assertThat(TrackingParameters.strip(mailto)).isSameInstanceAs(mailto)
+    assertThat(TrackingParameters.strip(custom)).isSameInstanceAs(custom)
+  }
+
+  @Test
+  fun `works over plain http`() {
+    assertThat(TrackingParameters.strip("http://example.com/a?utm_medium=email"))
+      .isEqualTo("http://example.com/a")
+  }
+
+  /**
+   * The security-relevant invariant: stripping can only ever remove query parameters.
+   * If it could change the scheme, host, port, path, or fragment then a cleaned link
+   * could point somewhere other than what the user was shown.
+   */
+  @Test
+  fun `never changes anything but the query`() {
+    val urls = listOf(
+      "https://youtu.be/dQw4w9WgXcQ?si=AbCdEf123",
+      "https://example.com:8443/deep/path.html?gclid=1&q=hello#frag",
+      "https://user.example.com/a/b/c?utm_source=x&utm_content=y",
+      "http://example.com/%E2%9C%93?fbclid=1",
+      "https://x.com/user/status/123?s=20&t=AbCd"
+    )
+
+    for (url in urls) {
+      val original = url.toHttpUrlOrNull()!!
+      val stripped = TrackingParameters.strip(url).toHttpUrlOrNull()!!
+
+      assertThat(stripped.scheme).isEqualTo(original.scheme)
+      assertThat(stripped.host).isEqualTo(original.host)
+      assertThat(stripped.port).isEqualTo(original.port)
+      assertThat(stripped.encodedPath).isEqualTo(original.encodedPath)
+      assertThat(stripped.fragment).isEqualTo(original.fragment)
+    }
+  }
+}


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel XL, Android 10
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Links shared from Facebook, Instagram, YouTube and similar platforms carry per-share tracking
tokens: e.g. `fbclid`, `igshid`, YouTube's `si`, X's `s`/`t`, the whole `utm_*` family. These are not
generic analytics: a `si` or `t` token is minted for a specific share by a specific account, so
when the recipient taps the link, the destination site learns that those two people are in contact
and that the link travelled between them. Signal protects the message but clicking the link exposes
the relationship to a third party anyway.

This adds a Privacy setting (on by default) that removes known tracking parameters from a link
**at the moment it is opened, copied, or fetched for a preview**.

#### Message content is never modified

This is the central design constraint, and it is what distinguishes this from
[#9125](https://github.com/signalapp/Signal-Android/pull/9125) (see below).

Text that was sent to you is rendered exactly as the sender wrote it. Nothing rewrites a
message body, inbound or outbound. What changes is only:

1. the URL a tap hands to the browser,
2. the URL a long-press copies,
3. the URL of Signal's *own* outbound HTTP request when generating a link preview.

The reasoning:

- A received message is the sender's content and the client authenticated it. Silently editing it
  would make quoting, search, and "what did they actually send me?" unreliable, and would mean the
  rendered text no longer matches what was received.
- Rewriting *outgoing* bodies is worse, not better. A `LinkPreview.url` must appear verbatim in the
  message body or every recipient discards the preview
  (`DataMessageProcessor.getLinkPreviews` → `presentInBody`). Cleaning the attached preview URL
  therefore requires also editing the body the user typed. This PR sidesteps that entirely: only
  the sender's own preview fetch is cleaned, so the preview still renders for recipients.

Because the visible text is left alone, the displayed URL and the tap target can differ. That
is safe here: the cleaned URL is rebuilt with `HttpUrl.newBuilder()`, so scheme, host, port,
path and fragment are carried over untouched and **only query parameters can change**. A
cleaned link is always the same destination with less attached, never a different one. There
is a test asserting exactly that (`never changes anything but the query`), because it is
the property the whole design rests on.

#### Parameter selection

Two tiers:

- **Global**: removed everywhere: the `utm_*` prefix family, `fbclid`, `gclid`/`gclsrc`/`dclid`/
  `gbraid`/`wbraid`, `msclkid`, `twclid`, `ttclid`, `yclid`, `_openstat`, `igshid`, `mc_cid`/
  `mc_eid`, `mkt_tok`, `_hsenc` and similar. Every one is a click/campaign identifier that
  attributes a visit; none select what the URL resolves to.
- **Host-scoped**: names too generic to strip globally, matched by domain suffix so subdomains are
  covered: `is`/`si`/`feature` on YouTube, `si` on Spotify, `mibextid` on Facebook, `s`/`t` on
  twitter.com and x.com. `t` is a legitimate timestamp parameter on plenty of other sites, so
  it is never touched off those hosts.

A URL that parses to nothing strippable is returned as the same instance, so links that need no
cleaning are never re-encoded or normalised as a side effect.

#### Prior art

There is no **open** issues or PRs for this. There are two relevant discussions:

- **[Community forum #16467 "Clean Sent Links (strip tracking/UTM parameters)"](https://community.signalusers.org/t/clean-sent-links-strip-tracking-utm-parameters/16467)**,
  open since 2020, 22 posts / 125 likes. Post #23 independently identifies the `si` and `t`
  parameters as "an extremely invasive and powerful way to map an individual's network of
  contacts".
- **[#9125 "Shared links cleaner"](https://github.com/signalapp/Signal-Android/pull/9125)** (2019),
  closed by the stale bot in 2022 without a review on the merits. It cleaned links arriving through
  `ShareActivity`, i.e. it rewrote the text being shared. This new PR is deliberately the complement:
  it never touches text, and instead cleans at the point of use, which also covers links that were
  typed, pasted, or received rather than shared in.

@cody-signal noted on that PR in 2023 that "this sort of thing has been brought up internally a
couple times and is gaining popularity in other products", and pointed the discussion to the forum.

#### On "The answer is not more options"

The contributing guide's first principle argues against adding new settings.

The principle's neighbours seem to explain the rationale: "The user doesn't know what a key is",
"There are no power users", etc. It is aimed at options that expose people to
cryptographic or protocol concepts they should never have to reason about, and at capability handed
to self-identified experts. "Remove link tracking" is not that. It is a phrase users already meet
in Firefox, Safari and Brave, all of which ship this behaviour, and understanding it requires no
model of anything Signal does internally.

There is also direct precedent in the same screen area: **Generate link previews** is already a
user-facing toggle, and it exists for the same reason: the feature discloses something to a third
party, and some users want to decide about that disclosure. This setting is the same category of
control over the same category of disclosure.

There is a failure mode where some site treats a listed global parameter for another purpose.
The host-scoped tier exists to make that unlikely, but a user-recoverable solution (the setting)
provides a way around this in a pinch.

That said, if folks disagree, the setting is trivial to remove. I am happy to push that version instead,
and would rather land the protection without the toggle than not land it.

The setting defaults to on for new *and* existing installs. This too, I'm fine
switching this to "off by default"; I'd rather have the feature available than not. :)

#### Scope

Stripping happens for:
- message body links (tap and long-press-copy)
- styled/formatted links
- link-preview card taps
- text-story preview taps
- story replies
- group descriptions
- contact notes
- outbound preview fetch

Deliberately excluded:
- the og:image thumbnail fetch (the site's own asset, no share provenance to leak, and CDN URLs can carry signed parameters)
- the *share* actions in `StoryContextMenu` / `MediaOverviewContextMenu`, which hand `text/plain` to another app rather than explicitly opening a link.

#### Testing

- 17 new unit tests in `TrackingParametersTest`, covering each parameter tier, case-insensitive
  matching, valueless and repeated parameters, parameter order preservation, fragment/port/path
  preservation, non-HTTP and unparseable input, and the "only the query changes" invariant.
- Full app unit suite green: 297 suites, 3397 tests, 0 failures, 0 errors
  (`./gradlew :Signal-Android:testPlayProdDebugUnitTest`).
- `./gradlew :Signal-Android:ktlintCheck :fast-lint:fastLint checkStopship` clean.
- `./gradlew format` produces no diff.
- Manually verified on a `playStagingDebug` build against the
  **staging** environment: the setting is present and on for a fresh install, and links behave as
  described above when enabled.
