### PR TITLE
Fix UNIQUE constraint on storage_service_id during backup and transfer

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/backup/v2/ArchiveErrorCases.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/v2/ArchiveErrorCases.kt
@@ -311,8 +311,8 @@ object ImportSkips {
     return log(sentTimestamp, "Missing admin delete recipient for chat $chatId")
   }
 
-  fun duplicateStorageId(storageId: String): String {
-    return log(0, "Duplicate storage_service_id::$storageId encountered during import. Retrying with new key.")
+  fun duplicateStorageId(): String {
+    return log(0, "Duplicate storage_service_id encountered during import. Retrying with new key.")
   }
 
   private fun log(sentTimestamp: Long, message: String): String {

--- a/app/src/main/java/org/thoughtcrime/securesms/backup/v2/ArchiveErrorCases.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/v2/ArchiveErrorCases.kt
@@ -311,6 +311,10 @@ object ImportSkips {
     return log(sentTimestamp, "Missing admin delete recipient for chat $chatId")
   }
 
+  fun duplicateStorageId(storageId: String): String {
+    return log(0, "Duplicate storage_service_id::$storageId encountered during import. Retrying with new key.")
+  }
+
   private fun log(sentTimestamp: Long, message: String): String {
     return "[SKIP][$sentTimestamp] $message"
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/backup/v2/importer/GroupArchiveImporter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/v2/importer/GroupArchiveImporter.kt
@@ -9,7 +9,9 @@ import android.content.ContentValues
 import org.signal.archive.proto.Group
 import org.signal.core.models.ServiceId
 import org.signal.core.util.Base64
+import org.signal.core.util.logging.Log
 import org.signal.core.util.toInt
+import org.thoughtcrime.securesms.backup.v2.ImportSkips
 import org.signal.libsignal.zkgroup.groups.GroupMasterKey
 import org.signal.libsignal.zkgroup.groups.GroupSecretParams
 import org.signal.storageservice.storage.protos.groups.AccessControl
@@ -40,6 +42,8 @@ import org.whispersystems.signalservice.api.groupsv2.GroupsV2Operations
  * Handles the importing of [ArchiveGroup] models into the local database.
  */
 object GroupArchiveImporter {
+  private val TAG = Log.tag(GroupArchiveImporter::class.java)
+
   fun import(group: ArchiveGroup): RecipientId {
     val masterKey = GroupMasterKey(group.masterKey.toByteArray())
     val groupId = GroupId.v2(masterKey)
@@ -52,22 +56,46 @@ object GroupArchiveImporter {
       snapshot.toLocal(operations)
     }
 
-    val values = ContentValues().apply {
-      put(RecipientTable.GROUP_ID, groupId.toString())
-      put(RecipientTable.AVATAR_COLOR, AvatarColorHash.forGroupId(groupId).serialize())
-      put(RecipientTable.PROFILE_SHARING, group.whitelisted.toInt())
-      put(RecipientTable.BLOCKED, group.blocked.toInt())
-      put(RecipientTable.BLOCKED_AT, group.blockedAtTimestamp)
-      put(RecipientTable.TYPE, RecipientTable.RecipientType.GV2.id)
-      put(RecipientTable.STORAGE_SERVICE_ID, Base64.encodeWithPadding(StorageSyncHelper.generateKey()))
-      put(RecipientTable.AVATAR_COLOR, group.avatarColor?.toLocal()?.serialize())
-      if (group.hideStory) {
-        val extras = RecipientExtras.Builder().hideStory(true).build()
-        put(RecipientTable.EXTRAS, extras.encode())
+    var attempts = 0
+    var recipientId: Long = -1
+    var lastStorageKey: String? = null
+    while (attempts < 5) {
+      val values = ContentValues().apply {
+        put(RecipientTable.GROUP_ID, groupId.toString())
+        put(RecipientTable.AVATAR_COLOR, AvatarColorHash.forGroupId(groupId).serialize())
+        put(RecipientTable.PROFILE_SHARING, group.whitelisted.toInt())
+        put(RecipientTable.BLOCKED, group.blocked.toInt())
+        put(RecipientTable.BLOCKED_AT, group.blockedAtTimestamp)
+        put(RecipientTable.TYPE, RecipientTable.RecipientType.GV2.id)
+        val storageKey = Base64.encodeWithPadding(StorageSyncHelper.generateKey())
+        lastStorageKey = storageKey
+        put(RecipientTable.STORAGE_SERVICE_ID, storageKey)
+        put(RecipientTable.AVATAR_COLOR, group.avatarColor?.toLocal()?.serialize())
+        if (group.hideStory) {
+          val extras = RecipientExtras.Builder().hideStory(true).build()
+          put(RecipientTable.EXTRAS, extras.encode())
+        }
+      }
+
+      recipientId = SignalDatabase.writableDatabase.insert(RecipientTable.TABLE_NAME, null, values)
+      if (recipientId != -1L) {
+        break
+      }
+
+      // Robust: insert returned -1 indicates UNIQUE constraint (most likely storage_service_id)
+      // No string parsing - retry with new key up to 5 times, then skip (1A + 3A)
+      Log.w(TAG, ImportSkips.duplicateStorageId(lastStorageKey ?: "unknown") + " attempt ${attempts + 1}/5 for group $groupId")
+      attempts++
+      if (attempts >= 5) {
+        break
       }
     }
 
-    val recipientId = SignalDatabase.writableDatabase.insert(RecipientTable.TABLE_NAME, null, values)
+    if (recipientId == -1L) {
+      Log.w(TAG, "Failed to import group $groupId after $attempts attempts due to constraints. Skipping.")
+      return RecipientId.UNKNOWN
+    }
+
     val restoredId = SignalDatabase.groups.create(masterKey, decryptedState, groupSendEndorsements = null)
     if (restoredId != null) {
       SignalDatabase.groups.setShowAsStoryState(restoredId, group.storySendMode.toLocal())

--- a/app/src/main/java/org/thoughtcrime/securesms/backup/v2/importer/GroupArchiveImporter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/v2/importer/GroupArchiveImporter.kt
@@ -56,6 +56,13 @@ object GroupArchiveImporter {
       snapshot.toLocal(operations)
     }
 
+    // Idempotent restore: the group may already exist (transfer + restore overlap).
+    val preExisting = SignalDatabase.recipients.getByGroupId(groupId)
+    if (preExisting.isPresent) {
+      Log.i(TAG, "Group $groupId already exists as ${preExisting.get()}, reusing.")
+      return preExisting.get()
+    }
+
     var attempts = 0
     var recipientId: Long = -1
     var lastStorageKey: String? = null
@@ -85,6 +92,11 @@ object GroupArchiveImporter {
       val lastKeyBytes = try { lastStorageKey?.let { Base64.decode(it) } } catch (e: Exception) { null }
       val storageExists = lastKeyBytes != null && SignalDatabase.recipients.getByStorageId(lastKeyBytes) != null
       if (!storageExists) {
+        val existingByGroup = SignalDatabase.recipients.getByGroupId(groupId)
+        if (existingByGroup.isPresent) {
+          Log.w(TAG, "Insert failed for group $groupId - group already exists as ${existingByGroup.get()}, reusing.")
+          return existingByGroup.get()
+        }
         Log.w(TAG, "Insert failed for group $groupId, storage ${lastStorageKey ?: "unknown"} not found - not a storage collision, skipping")
         break
       }

--- a/app/src/main/java/org/thoughtcrime/securesms/backup/v2/importer/GroupArchiveImporter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/v2/importer/GroupArchiveImporter.kt
@@ -67,7 +67,7 @@ object GroupArchiveImporter {
     var attempts = 0
     var recipientId: Long = -1
     var lastStorageKey: String? = null
-    while (attempts < 5) {
+    while (attempts < StorageSyncHelper.MAX_STORAGE_ID_ATTEMPTS) {
       val values = ContentValues().apply {
         put(RecipientTable.GROUP_ID, groupId.toString())
         put(RecipientTable.PROFILE_SHARING, group.whitelisted.toInt())
@@ -108,9 +108,9 @@ object GroupArchiveImporter {
         Log.w(TAG, "Insert failed for group $groupId, storage key not found - not a storage collision, skipping")
         break
       }
-      Log.w(TAG, ImportSkips.duplicateStorageId() + " attempt ${attempts + 1}/5 for group $groupId")
+      Log.w(TAG, ImportSkips.duplicateStorageId() + " attempt ${attempts + 1}/${StorageSyncHelper.MAX_STORAGE_ID_ATTEMPTS} for group $groupId")
       attempts++
-      if (attempts >= 5) {
+      if (attempts >= StorageSyncHelper.MAX_STORAGE_ID_ATTEMPTS) {
         break
       }
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/backup/v2/importer/GroupArchiveImporter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/v2/importer/GroupArchiveImporter.kt
@@ -62,7 +62,6 @@ object GroupArchiveImporter {
     while (attempts < 5) {
       val values = ContentValues().apply {
         put(RecipientTable.GROUP_ID, groupId.toString())
-        put(RecipientTable.AVATAR_COLOR, AvatarColorHash.forGroupId(groupId).serialize())
         put(RecipientTable.PROFILE_SHARING, group.whitelisted.toInt())
         put(RecipientTable.BLOCKED, group.blocked.toInt())
         put(RecipientTable.BLOCKED_AT, group.blockedAtTimestamp)

--- a/app/src/main/java/org/thoughtcrime/securesms/backup/v2/importer/GroupArchiveImporter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/v2/importer/GroupArchiveImporter.kt
@@ -105,10 +105,10 @@ object GroupArchiveImporter {
           Log.w(TAG, "Insert failed for group $groupId - group already exists as ${existingByGroup.get()}, reusing.")
           return existingByGroup.get()
         }
-        Log.w(TAG, "Insert failed for group $groupId, storage ${lastStorageKey ?: "unknown"} not found - not a storage collision, skipping")
+        Log.w(TAG, "Insert failed for group $groupId, storage key not found - not a storage collision, skipping")
         break
       }
-      Log.w(TAG, ImportSkips.duplicateStorageId(lastStorageKey ?: "unknown") + " attempt ${attempts + 1}/5 for group $groupId")
+      Log.w(TAG, ImportSkips.duplicateStorageId() + " attempt ${attempts + 1}/5 for group $groupId")
       attempts++
       if (attempts >= 5) {
         break

--- a/app/src/main/java/org/thoughtcrime/securesms/backup/v2/importer/GroupArchiveImporter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/v2/importer/GroupArchiveImporter.kt
@@ -67,7 +67,7 @@ object GroupArchiveImporter {
         put(RecipientTable.BLOCKED, group.blocked.toInt())
         put(RecipientTable.BLOCKED_AT, group.blockedAtTimestamp)
         put(RecipientTable.TYPE, RecipientTable.RecipientType.GV2.id)
-        val storageKey = Base64.encodeWithPadding(StorageSyncHelper.generateKey())
+        val storageKey = Base64.encodeWithPadding(StorageSyncHelper.generateUniqueStorageId())
         lastStorageKey = storageKey
         put(RecipientTable.STORAGE_SERVICE_ID, storageKey)
         put(RecipientTable.AVATAR_COLOR, group.avatarColor?.toLocal()?.serialize())
@@ -82,8 +82,13 @@ object GroupArchiveImporter {
         break
       }
 
-      // Robust: insert returned -1 indicates UNIQUE constraint (most likely storage_service_id)
-      // No string parsing - retry with new key up to 5 times, then skip (1A + 3A)
+      // Distinguish storage collision vs other constraint via SELECT (no string parsing)
+      val lastKeyBytes = try { lastStorageKey?.let { Base64.decode(it) } } catch (e: Exception) { null }
+      val storageExists = lastKeyBytes != null && SignalDatabase.recipients.getByStorageId(lastKeyBytes) != null
+      if (!storageExists) {
+        Log.w(TAG, "Insert failed for group $groupId, storage ${lastStorageKey ?: "unknown"} not found - not a storage collision, skipping")
+        break
+      }
       Log.w(TAG, ImportSkips.duplicateStorageId(lastStorageKey ?: "unknown") + " attempt ${attempts + 1}/5 for group $groupId")
       attempts++
       if (attempts >= 5) {

--- a/app/src/main/java/org/thoughtcrime/securesms/backup/v2/importer/GroupArchiveImporter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/v2/importer/GroupArchiveImporter.kt
@@ -6,6 +6,7 @@
 package org.thoughtcrime.securesms.backup.v2.importer
 
 import android.content.ContentValues
+import android.database.sqlite.SQLiteConstraintException
 import org.signal.archive.proto.Group
 import org.signal.core.models.ServiceId
 import org.signal.core.util.Base64
@@ -83,7 +84,14 @@ object GroupArchiveImporter {
         }
       }
 
-      recipientId = SignalDatabase.writableDatabase.insert(RecipientTable.TABLE_NAME, null, values)
+      // Some database wrappers throw on constraint violation instead of returning -1.
+      // Treat a thrown duplicate exactly like a failed insert.
+      recipientId = try {
+        SignalDatabase.writableDatabase.insert(RecipientTable.TABLE_NAME, null, values)
+      } catch (e: SQLiteConstraintException) {
+        Log.w(TAG, "Insert threw for group $groupId, treating as failed insert: ${e.message}")
+        -1L
+      }
       if (recipientId != -1L) {
         break
       }

--- a/app/src/main/java/org/thoughtcrime/securesms/backup/v2/processor/RecipientArchiveProcessor.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/v2/processor/RecipientArchiveProcessor.kt
@@ -134,8 +134,10 @@ object RecipientArchiveProcessor {
         null
       }
     }
-    if (newId != null) {
+    if (newId != null && !newId.isUnknown) {
       importState.remoteToLocalRecipientId[recipient.id] = newId
+    } else if (newId != null) {
+      Log.w(TAG, "Importer returned unknown id for recipient ${recipient.id}, leaving unmapped.")
     }
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/database/IssueReporter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/IssueReporter.kt
@@ -45,6 +45,7 @@ object IssueReporter {
   const val ISSUE_SLOW_DATABASE_READ = "Slow Database Read"
   const val ISSUE_SLOW_DATABASE_LOCK = "Slow Database Lock"
   const val ISSUE_STORAGE_SYNC_LOOP = "Storage Sync Loop"
+  const val ISSUE_STORAGE_ID_COLLISION_EXHAUSTED = "Storage ID Collision Exhausted"
 
   const val SLOW_WRITE_LOW_PRIORITY_MS = 1_000L
   const val SLOW_WRITE_MEDIUM_PRIORITY_MS = 5_000L

--- a/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
@@ -68,6 +68,7 @@ import org.thoughtcrime.securesms.database.SignalDatabase.Companion.runPostSucce
 import org.thoughtcrime.securesms.database.SignalDatabase.Companion.sessions
 import org.thoughtcrime.securesms.database.SignalDatabase.Companion.threads
 import org.thoughtcrime.securesms.database.model.DistributionListId
+import org.thoughtcrime.securesms.database.model.IssuePriority
 import org.thoughtcrime.securesms.database.model.KeyTransparencyStore
 import org.thoughtcrime.securesms.database.model.RecipientRecord
 import org.thoughtcrime.securesms.database.model.ThreadWithRecipient
@@ -1171,6 +1172,7 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
         }
         if (!rehomed) {
           Log.w(TAG, "Could not re-home recipient ${squatter.id} after 5 attempts; leaving storage_service_id NULL for storage sync repair.")
+          IssueReporter.report(ISSUE_STORAGE_ID_COLLISION_EXHAUSTED, "recipient=${squatter.id}", priority = IssuePriority.HIGH)
         }
       }
 
@@ -4370,7 +4372,14 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
       var attempts = 0
       var mutableValues = ContentValues(contentValues)
       while (attempts < 5) {
-        val id = writableDatabase.insert(TABLE_NAME, null, mutableValues)
+        // Some database wrappers throw on constraint violation instead of returning -1.
+        // Treat a thrown duplicate exactly like a failed insert; anything else stays loud below.
+        val id = try {
+          writableDatabase.insert(TABLE_NAME, null, mutableValues)
+        } catch (e: SQLiteConstraintException) {
+          Log.w(TAG, "Insert threw for $column=$value, treating as failed insert: ${e.message}")
+          -1L
+        }
         if (id >= 0) {
           return GetOrInsertResult(RecipientId.from(id), true)
         }
@@ -4403,6 +4412,7 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
       if (existing.isPresent) {
         return GetOrInsertResult(existing.get(), false)
       }
+      IssueReporter.report(ISSUE_STORAGE_ID_COLLISION_EXHAUSTED, "column=$column attempts=$attempts", priority = IssuePriority.HIGH)
       throw AssertionError("Failed to insert recipient after $attempts retries due to storage_service_id collisions!")
     }
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
@@ -1145,7 +1145,7 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
       val squatter = if (conflictingRecord != null && conflictingRecord.id != Recipient.self().id) conflictingRecord else null
       if (squatter != null) {
         val nullOut = ContentValues().apply { putNull(STORAGE_SERVICE_ID) }
-        writableDatabase.update(TABLE_NAME, nullOut, "$ID = ?", arrayOf(squatter.id.toLong()))
+        writableDatabase.update(TABLE_NAME, nullOut, "$ID = ?", arrayOf(squatter.id.serialize()))
         Log.w(TAG, "Freed storage_service_id $targetStorageIdStr held by recipient ${squatter.id} for account update.")
       }
 
@@ -1164,7 +1164,7 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
             Log.w(TAG, duplicateStorageIdMessage(Base64.encodeWithPadding(candidate)) + " re-home pre-check hit, retry $attempt/5 for recipient ${squatter.id}")
             continue
           }
-          writableDatabase.update(TABLE_NAME, contentValuesOf(STORAGE_SERVICE_ID to Base64.encodeWithPadding(candidate)), "$ID = ?", arrayOf(squatter.id.toLong()))
+          writableDatabase.update(TABLE_NAME, contentValuesOf(STORAGE_SERVICE_ID to Base64.encodeWithPadding(candidate)), "$ID = ?", arrayOf(squatter.id.serialize()))
           Log.w(TAG, "Resolved storage_service_id collision: recipient ${squatter.id} held $targetStorageIdStr, reassigned.")
           rehomed = true
           break

--- a/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
@@ -1139,20 +1139,40 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
 
     writableDatabase.beginTransaction()
     try {
-      // Resolve collision: if another recipient already has the target storage ID,
-      // give them a new unique ID before we claim it for ourselves.
+      // Free the target ID first. NULL never violates the UNIQUE constraint,
+      // so the self update below cannot fail with 2067 no matter who holds the target ID.
       val targetKeyBytes = try { Base64.decode(targetStorageIdStr) } catch (e: Exception) { null }
       val conflictingRecord = targetKeyBytes?.let { getByStorageId(it) }
-      if (conflictingRecord != null && conflictingRecord.id != Recipient.self().id) {
-        val newKeyForConflicting = StorageSyncHelper.generateUniqueStorageId()
-        val newKeyForConflictingStr = Base64.encodeWithPadding(newKeyForConflicting)
-        writableDatabase.update(TABLE_NAME, contentValuesOf(STORAGE_SERVICE_ID to newKeyForConflictingStr), "$ID = ?", arrayOf(conflictingRecord.id.toLong()))
-        Log.w(TAG, "Resolved storage_service_id collision: recipient ${conflictingRecord.id} had $targetStorageIdStr, reassigned to $newKeyForConflictingStr")
+      val squatter = if (conflictingRecord != null && conflictingRecord.id != Recipient.self().id) conflictingRecord else null
+      if (squatter != null) {
+        val nullOut = ContentValues().apply { putNull(STORAGE_SERVICE_ID) }
+        writableDatabase.update(TABLE_NAME, nullOut, "$ID = ?", arrayOf(squatter.id.toLong()))
+        Log.w(TAG, "Freed storage_service_id $targetStorageIdStr held by recipient ${squatter.id} for account update.")
       }
 
       val updateCount = writableDatabase.update(TABLE_NAME, values, "$STORAGE_SERVICE_ID = ?", arrayOf(oldStorageIdStr))
       if (updateCount < 1) {
         throw AssertionError("Account update didn't match any rows!")
+      }
+
+      // Re-home the squatter with a checked direct update. On exhaustion the row
+      // stays NULL and the next storage sync repairs it (group/self/contact healers).
+      if (squatter != null) {
+        var rehomed = false
+        for (attempt in 1..5) {
+          val candidate = StorageSyncHelper.generateKey()
+          if (getByStorageId(candidate) != null) {
+            Log.w(TAG, ImportSkips.duplicateStorageId(Base64.encodeWithPadding(candidate)) + " re-home pre-check hit, retry $attempt/5 for recipient ${squatter.id}")
+            continue
+          }
+          writableDatabase.update(TABLE_NAME, contentValuesOf(STORAGE_SERVICE_ID to Base64.encodeWithPadding(candidate)), "$ID = ?", arrayOf(squatter.id.toLong()))
+          Log.w(TAG, "Resolved storage_service_id collision: recipient ${squatter.id} held $targetStorageIdStr, reassigned.")
+          rehomed = true
+          break
+        }
+        if (!rehomed) {
+          Log.w(TAG, "Could not re-home recipient ${squatter.id} after 5 attempts; leaving storage_service_id NULL for storage sync repair.")
+        }
       }
 
       writableDatabase.setTransactionSuccessful()

--- a/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
@@ -1159,10 +1159,10 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
       // stays NULL and the next storage sync repairs it (group/self/contact healers).
       if (squatter != null) {
         var rehomed = false
-        for (attempt in 1..5) {
+        for (attempt in 1..StorageSyncHelper.MAX_STORAGE_ID_ATTEMPTS) {
           val candidate = StorageSyncHelper.generateKey()
           if (getByStorageId(candidate) != null) {
-            Log.w(TAG, duplicateStorageIdMessage() + " re-home pre-check hit, retry $attempt/5 for recipient ${squatter.id}")
+            Log.w(TAG, duplicateStorageIdMessage() + " re-home pre-check hit, retry $attempt/${StorageSyncHelper.MAX_STORAGE_ID_ATTEMPTS} for recipient ${squatter.id}")
             continue
           }
           writableDatabase.update(TABLE_NAME, contentValuesOf(STORAGE_SERVICE_ID to Base64.encodeWithPadding(candidate)), "$ID = ?", arrayOf(squatter.id.serialize()))
@@ -4371,7 +4371,7 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
     } else {
       var attempts = 0
       var mutableValues = ContentValues(contentValues)
-      while (attempts < 5) {
+      while (attempts < StorageSyncHelper.MAX_STORAGE_ID_ATTEMPTS) {
         // Some database wrappers throw on constraint violation instead of returning -1.
         // Treat a thrown duplicate exactly like a failed insert; anything else stays loud below.
         val id = try {
@@ -4400,7 +4400,7 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
           val newKey = StorageSyncHelper.generateUniqueStorageId()
           val newKeyStr = Base64.encodeWithPadding(newKey)
           mutableValues.put(STORAGE_SERVICE_ID, newKeyStr)
-          Log.w(TAG, duplicateStorageIdMessage() + " attempt ${attempts + 1}/5 for $column=$value -> retrying")
+          Log.w(TAG, duplicateStorageIdMessage() + " attempt ${attempts + 1}/${StorageSyncHelper.MAX_STORAGE_ID_ATTEMPTS} for $column=$value -> retrying")
           attempts++
           continue
         } else {

--- a/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
@@ -95,6 +95,7 @@ import org.thoughtcrime.securesms.recipients.RecipientId
 import org.thoughtcrime.securesms.recipients.RecipientUtil
 import org.thoughtcrime.securesms.service.webrtc.links.CallLinkRoomId
 import org.thoughtcrime.securesms.storage.StorageRecordUpdate
+import org.thoughtcrime.securesms.backup.v2.ImportSkips
 import org.thoughtcrime.securesms.storage.StorageSyncHelper
 import org.thoughtcrime.securesms.storage.StorageSyncModels
 import org.thoughtcrime.securesms.util.IdentityUtil
@@ -4322,17 +4323,30 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
     if (existing.isPresent) {
       return GetOrInsertResult(existing.get(), false)
     } else {
-      val id = writableDatabase.insert(TABLE_NAME, null, contentValues)
-      if (id < 0) {
+      var attempts = 0
+      var mutableValues = contentValues
+      while (attempts < 5) {
+        val id = writableDatabase.insert(TABLE_NAME, null, mutableValues)
+        if (id >= 0) {
+          return GetOrInsertResult(RecipientId.from(id), true)
+        }
+
         existing = getByColumn(column, value)
         if (existing.isPresent) {
           return GetOrInsertResult(existing.get(), false)
+        }
+
+        if (mutableValues.containsKey(STORAGE_SERVICE_ID)) {
+          val newKey = Base64.encodeWithPadding(StorageSyncHelper.generateKey())
+          mutableValues.put(STORAGE_SERVICE_ID, newKey)
+          Log.w(TAG, ImportSkips.duplicateStorageId(newKey) + " attempt ${attempts + 1}/5 for $column=$value")
+          attempts++
+          continue
         } else {
           throw AssertionError("Failed to insert recipient!")
         }
-      } else {
-        return GetOrInsertResult(RecipientId.from(id), true)
       }
+      throw AssertionError("Failed to insert recipient after $attempts retries due to storage_service_id collisions!")
     }
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
@@ -4337,9 +4337,17 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
         }
 
         if (mutableValues.containsKey(STORAGE_SERVICE_ID)) {
-          val newKey = Base64.encodeWithPadding(StorageSyncHelper.generateKey())
-          mutableValues.put(STORAGE_SERVICE_ID, newKey)
-          Log.w(TAG, ImportSkips.duplicateStorageId(newKey) + " attempt ${attempts + 1}/5 for $column=$value")
+          val lastKeyStr = mutableValues.getAsString(STORAGE_SERVICE_ID)
+          val lastKeyBytes = try { Base64.decode(lastKeyStr) } catch (e: Exception) { null }
+          val storageExists = lastKeyBytes != null && getByStorageId(lastKeyBytes) != null
+          if (!storageExists) {
+            Log.w(TAG, "Insert failed for $column=$value, storage $lastKeyStr not found - not a storage collision. Failing fast.")
+            throw AssertionError("Failed to insert recipient! insert returned -1 and storage not found for $column")
+          }
+          val newKey = StorageSyncHelper.generateUniqueStorageId()
+          val newKeyStr = Base64.encodeWithPadding(newKey)
+          mutableValues.put(STORAGE_SERVICE_ID, newKeyStr)
+          Log.w(TAG, ImportSkips.duplicateStorageId(lastKeyStr) + " attempt ${attempts + 1}/5 for $column=$value -> retry with $newKeyStr")
           attempts++
           continue
         } else {

--- a/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
@@ -95,7 +95,6 @@ import org.thoughtcrime.securesms.recipients.RecipientId
 import org.thoughtcrime.securesms.recipients.RecipientUtil
 import org.thoughtcrime.securesms.service.webrtc.links.CallLinkRoomId
 import org.thoughtcrime.securesms.storage.StorageRecordUpdate
-import org.thoughtcrime.securesms.backup.v2.ImportSkips
 import org.thoughtcrime.securesms.storage.StorageSyncHelper
 import org.thoughtcrime.securesms.storage.StorageSyncModels
 import org.thoughtcrime.securesms.util.IdentityUtil
@@ -1162,7 +1161,7 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
         for (attempt in 1..5) {
           val candidate = StorageSyncHelper.generateKey()
           if (getByStorageId(candidate) != null) {
-            Log.w(TAG, ImportSkips.duplicateStorageId(Base64.encodeWithPadding(candidate)) + " re-home pre-check hit, retry $attempt/5 for recipient ${squatter.id}")
+            Log.w(TAG, duplicateStorageIdMessage(Base64.encodeWithPadding(candidate)) + " re-home pre-check hit, retry $attempt/5 for recipient ${squatter.id}")
             continue
           }
           writableDatabase.update(TABLE_NAME, contentValuesOf(STORAGE_SERVICE_ID to Base64.encodeWithPadding(candidate)), "$ID = ?", arrayOf(squatter.id.toLong()))
@@ -4354,6 +4353,10 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
     }
   }
 
+  private fun duplicateStorageIdMessage(storageId: String): String {
+    return "Duplicate storage_service_id::$storageId encountered, retrying with new key."
+  }
+
   private fun getOrInsertByColumn(column: String, value: String, contentValues: ContentValues = contentValuesOf(column to value)): GetOrInsertResult {
     if (TextUtils.isEmpty(value)) {
       throw AssertionError("$column cannot be empty.")
@@ -4388,12 +4391,17 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
           val newKey = StorageSyncHelper.generateUniqueStorageId()
           val newKeyStr = Base64.encodeWithPadding(newKey)
           mutableValues.put(STORAGE_SERVICE_ID, newKeyStr)
-          Log.w(TAG, ImportSkips.duplicateStorageId(lastKeyStr) + " attempt ${attempts + 1}/5 for $column=$value -> retry with $newKeyStr")
+          Log.w(TAG, duplicateStorageIdMessage(lastKeyStr) + " attempt ${attempts + 1}/5 for $column=$value -> retry with $newKeyStr")
           attempts++
           continue
         } else {
           throw AssertionError("Failed to insert recipient!")
         }
+      }
+      // Last resort re-check: a concurrent writer may have won the race while we retried.
+      existing = getByColumn(column, value)
+      if (existing.isPresent) {
+        return GetOrInsertResult(existing.get(), false)
       }
       throw AssertionError("Failed to insert recipient after $attempts retries due to storage_service_id collisions!")
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
@@ -1134,9 +1134,30 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
         .run()
     }
 
-    val updateCount = writableDatabase.update(TABLE_NAME, values, "$STORAGE_SERVICE_ID = ?", arrayOf(Base64.encodeWithPadding(update.old.id.raw)))
-    if (updateCount < 1) {
-      throw AssertionError("Account update didn't match any rows!")
+    val targetStorageIdStr = Base64.encodeWithPadding(update.new.id.raw)
+    val oldStorageIdStr = Base64.encodeWithPadding(update.old.id.raw)
+
+    writableDatabase.beginTransaction()
+    try {
+      // Resolve collision: if another recipient already has the target storage ID,
+      // give them a new unique ID before we claim it for ourselves.
+      val targetKeyBytes = try { Base64.decode(targetStorageIdStr) } catch (e: Exception) { null }
+      val conflictingRecord = targetKeyBytes?.let { getByStorageId(it) }
+      if (conflictingRecord != null && conflictingRecord.id != Recipient.self().id) {
+        val newKeyForConflicting = StorageSyncHelper.generateUniqueStorageId()
+        val newKeyForConflictingStr = Base64.encodeWithPadding(newKeyForConflicting)
+        writableDatabase.update(TABLE_NAME, contentValuesOf(STORAGE_SERVICE_ID to newKeyForConflictingStr), "$ID = ?", arrayOf(conflictingRecord.id.toLong()))
+        Log.w(TAG, "Resolved storage_service_id collision: recipient ${conflictingRecord.id} had $targetStorageIdStr, reassigned to $newKeyForConflictingStr")
+      }
+
+      val updateCount = writableDatabase.update(TABLE_NAME, values, "$STORAGE_SERVICE_ID = ?", arrayOf(oldStorageIdStr))
+      if (updateCount < 1) {
+        throw AssertionError("Account update didn't match any rows!")
+      }
+
+      writableDatabase.setTransactionSuccessful()
+    } finally {
+      writableDatabase.endTransaction()
     }
 
     if (remoteKey != localKey) {
@@ -4324,7 +4345,7 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
       return GetOrInsertResult(existing.get(), false)
     } else {
       var attempts = 0
-      var mutableValues = contentValues
+      var mutableValues = ContentValues(contentValues)
       while (attempts < 5) {
         val id = writableDatabase.insert(TABLE_NAME, null, mutableValues)
         if (id >= 0) {

--- a/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
@@ -1147,7 +1147,7 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
       if (squatter != null) {
         val nullOut = ContentValues().apply { putNull(STORAGE_SERVICE_ID) }
         writableDatabase.update(TABLE_NAME, nullOut, "$ID = ?", arrayOf(squatter.id.serialize()))
-        Log.w(TAG, "Freed storage_service_id $targetStorageIdStr held by recipient ${squatter.id} for account update.")
+        Log.w(TAG, "Freed conflicting storage_service_id held by recipient ${squatter.id} for account update.")
       }
 
       val updateCount = writableDatabase.update(TABLE_NAME, values, "$STORAGE_SERVICE_ID = ?", arrayOf(oldStorageIdStr))
@@ -1162,11 +1162,11 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
         for (attempt in 1..5) {
           val candidate = StorageSyncHelper.generateKey()
           if (getByStorageId(candidate) != null) {
-            Log.w(TAG, duplicateStorageIdMessage(Base64.encodeWithPadding(candidate)) + " re-home pre-check hit, retry $attempt/5 for recipient ${squatter.id}")
+            Log.w(TAG, duplicateStorageIdMessage() + " re-home pre-check hit, retry $attempt/5 for recipient ${squatter.id}")
             continue
           }
           writableDatabase.update(TABLE_NAME, contentValuesOf(STORAGE_SERVICE_ID to Base64.encodeWithPadding(candidate)), "$ID = ?", arrayOf(squatter.id.serialize()))
-          Log.w(TAG, "Resolved storage_service_id collision: recipient ${squatter.id} held $targetStorageIdStr, reassigned.")
+          Log.w(TAG, "Resolved storage_service_id collision: recipient ${squatter.id} re-homed.")
           rehomed = true
           break
         }
@@ -4355,8 +4355,8 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
     }
   }
 
-  private fun duplicateStorageIdMessage(storageId: String): String {
-    return "Duplicate storage_service_id::$storageId encountered, retrying with new key."
+  private fun duplicateStorageIdMessage(): String {
+    return "Duplicate storage_service_id encountered, retrying with new key."
   }
 
   private fun getOrInsertByColumn(column: String, value: String, contentValues: ContentValues = contentValuesOf(column to value)): GetOrInsertResult {
@@ -4400,7 +4400,7 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
           val newKey = StorageSyncHelper.generateUniqueStorageId()
           val newKeyStr = Base64.encodeWithPadding(newKey)
           mutableValues.put(STORAGE_SERVICE_ID, newKeyStr)
-          Log.w(TAG, duplicateStorageIdMessage(lastKeyStr) + " attempt ${attempts + 1}/5 for $column=$value -> retry with $newKeyStr")
+          Log.w(TAG, duplicateStorageIdMessage() + " attempt ${attempts + 1}/5 for $column=$value -> retrying")
           attempts++
           continue
         } else {

--- a/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
@@ -1172,7 +1172,7 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
         }
         if (!rehomed) {
           Log.w(TAG, "Could not re-home recipient ${squatter.id} after 5 attempts; leaving storage_service_id NULL for storage sync repair.")
-          IssueReporter.report(ISSUE_STORAGE_ID_COLLISION_EXHAUSTED, "recipient=${squatter.id}", priority = IssuePriority.HIGH)
+          IssueReporter.report(IssueReporter.ISSUE_STORAGE_ID_COLLISION_EXHAUSTED, "recipient=${squatter.id}", priority = IssuePriority.HIGH)
         }
       }
 
@@ -4412,7 +4412,7 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
       if (existing.isPresent) {
         return GetOrInsertResult(existing.get(), false)
       }
-      IssueReporter.report(ISSUE_STORAGE_ID_COLLISION_EXHAUSTED, "column=$column attempts=$attempts", priority = IssuePriority.HIGH)
+      IssueReporter.report(IssueReporter.ISSUE_STORAGE_ID_COLLISION_EXHAUSTED, "column=$column attempts=$attempts", priority = IssuePriority.HIGH)
       throw AssertionError("Failed to insert recipient after $attempts retries due to storage_service_id collisions!")
     }
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/storage/StorageSyncHelper.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/storage/StorageSyncHelper.kt
@@ -121,7 +121,7 @@ object StorageSyncHelper {
       val key = generateKey()
       if (SignalDatabase.recipients.getByStorageId(key) == null) return key
       val encoded = encodeWithPadding(key)
-      Log.w(TAG, org.thoughtcrime.securesms.backup.v2.ImportSkips.duplicateStorageId(encoded) + " pre-check exists, retry ${it + 1}/5")
+      Log.w(TAG, "Duplicate storage_service_id::$encoded found in pre-check, retry ${it + 1}/5")
     }
     Log.w(TAG, "generateUniqueStorageId: all 5 pre-check retries exhausted, returning unverified key. Caller must handle insert collision.")
     return generateKey()

--- a/app/src/main/java/org/thoughtcrime/securesms/storage/StorageSyncHelper.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/storage/StorageSyncHelper.kt
@@ -123,6 +123,7 @@ object StorageSyncHelper {
       val encoded = encodeWithPadding(key)
       Log.w(TAG, org.thoughtcrime.securesms.backup.v2.ImportSkips.duplicateStorageId(encoded) + " pre-check exists, retry ${it + 1}/5")
     }
+    Log.w(TAG, "generateUniqueStorageId: all 5 pre-check retries exhausted, returning unverified key. Caller must handle insert collision.")
     return generateKey()
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/storage/StorageSyncHelper.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/storage/StorageSyncHelper.kt
@@ -55,6 +55,12 @@ object StorageSyncHelper {
 
   val KEY_GENERATOR: StorageKeyGenerator = StorageKeyGenerator { Util.getSecretBytes(16) }
 
+  /**
+   * How many times callers retry with a fresh storage key after a UNIQUE 2067 collision
+   * before giving up. Shared so the policy stays consistent across all insert paths.
+   */
+  const val MAX_STORAGE_ID_ATTEMPTS = 5
+
   private var keyGenerator = KEY_GENERATOR
 
   private val REFRESH_INTERVAL = TimeUnit.HOURS.toMillis(2)
@@ -117,12 +123,12 @@ object StorageSyncHelper {
    */
   @JvmStatic
   fun generateUniqueStorageId(): ByteArray {
-    repeat(5) {
+    repeat(MAX_STORAGE_ID_ATTEMPTS) {
       val key = generateKey()
       if (SignalDatabase.recipients.getByStorageId(key) == null) return key
-      Log.w(TAG, "Duplicate storage_service_id found in pre-check, retry ${it + 1}/5")
+      Log.w(TAG, "Duplicate storage_service_id found in pre-check, retry ${it + 1}/$MAX_STORAGE_ID_ATTEMPTS")
     }
-    Log.w(TAG, "generateUniqueStorageId: all 5 pre-check retries exhausted, returning unverified key. Caller must handle insert collision.")
+    Log.w(TAG, "generateUniqueStorageId: all $MAX_STORAGE_ID_ATTEMPTS pre-check retries exhausted, returning unverified key. Caller must handle insert collision.")
     return generateKey()
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/storage/StorageSyncHelper.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/storage/StorageSyncHelper.kt
@@ -100,9 +100,30 @@ object StorageSyncHelper {
     return IdDifferenceResult(remoteOnlyKeys, localOnlyKeys, hasTypeMismatch)
   }
 
+  /**
+   * Raw random key, no uniqueness guarantee. For DB inserts into [RecipientTable.STORAGE_SERVICE_ID],
+   * use [generateUniqueStorageId] instead to avoid UNIQUE 2067 (see PR 14973).
+   */
   @JvmStatic
   fun generateKey(): ByteArray {
     return keyGenerator.generate()
+  }
+
+  /**
+   * Generates a storage key that does not already exist in the recipient table.
+   * Use this instead of [generateKey] directly when inserting [RecipientTable.STORAGE_SERVICE_ID].
+   * Future writers must use this helper to avoid UNIQUE 2067 collisions (see PR 14973).
+   * Still requires caller to handle `insert() == -1` race - see [RecipientTable.getOrInsertByColumn].
+   */
+  @JvmStatic
+  fun generateUniqueStorageId(): ByteArray {
+    repeat(5) {
+      val key = generateKey()
+      if (SignalDatabase.recipients.getByStorageId(key) == null) return key
+      val encoded = encodeWithPadding(key)
+      Log.w(TAG, org.thoughtcrime.securesms.backup.v2.ImportSkips.duplicateStorageId(encoded) + " pre-check exists, retry ${it + 1}/5")
+    }
+    return generateKey()
   }
 
   @JvmStatic

--- a/app/src/main/java/org/thoughtcrime/securesms/storage/StorageSyncHelper.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/storage/StorageSyncHelper.kt
@@ -120,8 +120,7 @@ object StorageSyncHelper {
     repeat(5) {
       val key = generateKey()
       if (SignalDatabase.recipients.getByStorageId(key) == null) return key
-      val encoded = encodeWithPadding(key)
-      Log.w(TAG, "Duplicate storage_service_id::$encoded found in pre-check, retry ${it + 1}/5")
+      Log.w(TAG, "Duplicate storage_service_id found in pre-check, retry ${it + 1}/5")
     }
     Log.w(TAG, "generateUniqueStorageId: all 5 pre-check retries exhausted, returning unverified key. Caller must handle insert collision.")
     return generateKey()

--- a/app/src/test/java/org/thoughtcrime/securesms/database/RecipientTableTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/database/RecipientTableTest.kt
@@ -9,6 +9,7 @@ import android.app.Application
 import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isNotEmpty
+import io.mockk.every
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -35,6 +36,7 @@ import org.thoughtcrime.securesms.storage.StorageKeyGenerator
 import org.thoughtcrime.securesms.storage.StorageRecordUpdate
 import org.thoughtcrime.securesms.storage.StorageSyncHelper
 import org.thoughtcrime.securesms.testutil.RecipientTestRule
+import org.thoughtcrime.securesms.util.RemoteConfig
 import org.whispersystems.signalservice.api.storage.SignalAccountRecord
 import org.whispersystems.signalservice.api.storage.StorageId
 import org.whispersystems.signalservice.internal.storage.protos.AccountRecord
@@ -355,6 +357,8 @@ class RecipientTableTest {
 
   @Test
   fun givenPermanentlyTakenStorageKey_whenInsertingRecipient_thenFailsLoudlyInsteadOfLoopingForever() {
+    every { RemoteConfig.internalUser } returns false
+
     val takenKey: ByteArray = Util.getSecretBytes(16)
 
     StorageSyncHelper.setTestKeyGenerator(ScriptedKeyGenerator(takenKey))

--- a/app/src/test/java/org/thoughtcrime/securesms/database/RecipientTableTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/database/RecipientTableTest.kt
@@ -9,7 +9,11 @@ import android.app.Application
 import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isNotEmpty
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -36,7 +40,6 @@ import org.thoughtcrime.securesms.storage.StorageKeyGenerator
 import org.thoughtcrime.securesms.storage.StorageRecordUpdate
 import org.thoughtcrime.securesms.storage.StorageSyncHelper
 import org.thoughtcrime.securesms.testutil.RecipientTestRule
-import org.thoughtcrime.securesms.util.RemoteConfig
 import org.whispersystems.signalservice.api.storage.SignalAccountRecord
 import org.whispersystems.signalservice.api.storage.StorageId
 import org.whispersystems.signalservice.internal.storage.protos.AccountRecord
@@ -357,25 +360,32 @@ class RecipientTableTest {
 
   @Test
   fun givenPermanentlyTakenStorageKey_whenInsertingRecipient_thenFailsLoudlyInsteadOfLoopingForever() {
-    every { RemoteConfig.internalUser } returns false
-
-    val takenKey: ByteArray = Util.getSecretBytes(16)
-
-    StorageSyncHelper.setTestKeyGenerator(ScriptedKeyGenerator(takenKey))
+    // The exhaustion path also files an internal issue report, which drags the
+    // RemoteConfig/SignalStore machinery in. Silence only the reporter here;
+    // this test asserts the bounded-loud behavior, not the telemetry.
+    mockkObject(IssueReporter)
+    every { IssueReporter.report(any(), any(), any(), any(), any(), any()) } just Runs
     try {
-      SignalDatabase.recipients.getOrInsertFromDistributionListId(DistributionListId.from(201L))
-    } finally {
-      StorageSyncHelper.setTestKeyGenerator(null)
-    }
+      val takenKey: ByteArray = Util.getSecretBytes(16)
 
-    StorageSyncHelper.setTestKeyGenerator(StorageKeyGenerator { takenKey })
-    try {
-      SignalDatabase.recipients.getOrInsertFromDistributionListId(DistributionListId.from(202L))
-      fail("Expected bounded retries to exhaust loudly rather than spin forever")
-    } catch (e: AssertionError) {
-      // expected: retries are bounded, total failure is loud so crash reporting flags a broken generator
+      StorageSyncHelper.setTestKeyGenerator(ScriptedKeyGenerator(takenKey))
+      try {
+        SignalDatabase.recipients.getOrInsertFromDistributionListId(DistributionListId.from(201L))
+      } finally {
+        StorageSyncHelper.setTestKeyGenerator(null)
+      }
+
+      StorageSyncHelper.setTestKeyGenerator(StorageKeyGenerator { takenKey })
+      try {
+        SignalDatabase.recipients.getOrInsertFromDistributionListId(DistributionListId.from(202L))
+        fail("Expected bounded retries to exhaust loudly rather than spin forever")
+      } catch (e: AssertionError) {
+        // expected: retries are bounded, total failure is loud so crash reporting flags a broken generator
+      } finally {
+        StorageSyncHelper.setTestKeyGenerator(null)
+      }
     } finally {
-      StorageSyncHelper.setTestKeyGenerator(null)
+      unmockkObject(IssueReporter)
     }
   }
 

--- a/app/src/test/java/org/thoughtcrime/securesms/database/RecipientTableTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/database/RecipientTableTest.kt
@@ -10,11 +10,13 @@ import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isNotEmpty
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -25,9 +27,17 @@ import org.signal.core.models.ServiceId.ACI
 import org.signal.core.models.ServiceId.PNI
 import org.signal.core.util.CursorUtil
 import org.signal.core.util.SqlUtil
+import org.signal.core.util.Util
+import org.thoughtcrime.securesms.database.model.DistributionListId
 import org.thoughtcrime.securesms.profiles.ProfileName
 import org.thoughtcrime.securesms.recipients.RecipientId
+import org.thoughtcrime.securesms.storage.StorageKeyGenerator
+import org.thoughtcrime.securesms.storage.StorageRecordUpdate
+import org.thoughtcrime.securesms.storage.StorageSyncHelper
 import org.thoughtcrime.securesms.testutil.RecipientTestRule
+import org.whispersystems.signalservice.api.storage.SignalAccountRecord
+import org.whispersystems.signalservice.api.storage.StorageId
+import org.whispersystems.signalservice.internal.storage.protos.AccountRecord
 import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
@@ -297,9 +307,87 @@ class RecipientTableTest {
     )
   }
 
+  @Test
+  fun givenAccountUpdateTargetIdHeldByAnotherRecipient_whenApplyingAccountUpdate_thenSelfTakesTargetAndSquatterIsRehomed() {
+    val oldId: ByteArray = Util.getSecretBytes(16)
+    val targetId: ByteArray = Util.getSecretBytes(16)
+
+    SignalDatabase.recipients.updateStorageId(recipients.self, oldId)
+    SignalDatabase.recipients.updateStorageId(other, targetId)
+
+    val update = StorageRecordUpdate(
+      SignalAccountRecord(StorageId.forAccount(oldId), AccountRecord()),
+      SignalAccountRecord(StorageId.forAccount(targetId), AccountRecord())
+    )
+
+    SignalDatabase.recipients.applyStorageSyncAccountUpdate(update)
+
+    val selfStorageId: ByteArray? = SignalDatabase.recipients.getRecord(recipients.self).storageId
+    assertNotNull("Self should hold the target id after the update", selfStorageId)
+    assertArrayEquals(targetId, selfStorageId)
+
+    val squatterStorageId: ByteArray? = SignalDatabase.recipients.getRecord(other).storageId
+    assertNotNull("Squatter should have been re-homed, not left null", squatterStorageId)
+    assertFalse("Squatter must no longer hold the target id", targetId.contentEquals(squatterStorageId))
+  }
+
+  @Test
+  fun givenTakenStorageKey_whenInsertingRecipient_thenSkipsTakenKeyAndSucceeds() {
+    val takenKey: ByteArray = Util.getSecretBytes(16)
+    val freshKey: ByteArray = Util.getSecretBytes(16)
+
+    StorageSyncHelper.setTestKeyGenerator(ScriptedKeyGenerator(takenKey))
+    val first: RecipientId = try {
+      SignalDatabase.recipients.getOrInsertFromDistributionListId(DistributionListId.from(101L))
+    } finally {
+      StorageSyncHelper.setTestKeyGenerator(null)
+    }
+    assertArrayEquals(takenKey, SignalDatabase.recipients.getRecord(first).storageId)
+
+    StorageSyncHelper.setTestKeyGenerator(ScriptedKeyGenerator(takenKey, freshKey))
+    val second: RecipientId = try {
+      SignalDatabase.recipients.getOrInsertFromDistributionListId(DistributionListId.from(102L))
+    } finally {
+      StorageSyncHelper.setTestKeyGenerator(null)
+    }
+    assertArrayEquals(freshKey, SignalDatabase.recipients.getRecord(second).storageId)
+  }
+
+  @Test
+  fun givenPermanentlyTakenStorageKey_whenInsertingRecipient_thenFailsLoudlyInsteadOfLoopingForever() {
+    val takenKey: ByteArray = Util.getSecretBytes(16)
+
+    StorageSyncHelper.setTestKeyGenerator(ScriptedKeyGenerator(takenKey))
+    try {
+      SignalDatabase.recipients.getOrInsertFromDistributionListId(DistributionListId.from(201L))
+    } finally {
+      StorageSyncHelper.setTestKeyGenerator(null)
+    }
+
+    StorageSyncHelper.setTestKeyGenerator(StorageKeyGenerator { takenKey })
+    try {
+      SignalDatabase.recipients.getOrInsertFromDistributionListId(DistributionListId.from(202L))
+      fail("Expected bounded retries to exhaust loudly rather than spin forever")
+    } catch (e: AssertionError) {
+      // expected: retries are bounded, total failure is loud so crash reporting flags a broken generator
+    } finally {
+      StorageSyncHelper.setTestKeyGenerator(null)
+    }
+  }
+
   companion object {
     val ACI_A = ACI.from(UUID.fromString("aaaa0000-5a76-47fa-a98a-7e72c948a82e"))
     val PNI_A = PNI.from(UUID.fromString("aaaa1111-c960-4f6c-8385-671ad2ffb999"))
     const val E164_A = "+12222222222"
   }
+}
+
+/**
+ * Key generator that returns scripted keys in order, then falls back to random keys.
+ * Lets tests force storage id collisions deterministically.
+ */
+private class ScriptedKeyGenerator(vararg keys: ByteArray) : StorageKeyGenerator {
+  private val queue: ArrayDeque<ByteArray> = ArrayDeque(keys.toList())
+
+  override fun generate(): ByteArray = queue.removeFirstOrNull() ?: Util.getSecretBytes(16)
 }

--- a/app/src/test/java/org/thoughtcrime/securesms/database/RecipientTableTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/database/RecipientTableTest.kt
@@ -9,8 +9,8 @@ import android.app.Application
 import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isNotEmpty
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull


### PR DESCRIPTION
Fixes #14954

Enabling backups during device transfer could hit UNIQUE constraint on recipient.storage_service_id (2067) and loop. Group import generated a random key without retry, so collision crashed the flow. Retry with new key up to 5 times and skip on persistent collision.