### PR TITLE
fix camera zoom ratio sync

### DIFF
--- a/feature/camera/src/main/java/org/signal/camera/CameraScreenViewModel.kt
+++ b/feature/camera/src/main/java/org/signal/camera/CameraScreenViewModel.kt
@@ -176,6 +176,8 @@ class CameraScreenViewModel : ViewModel() {
     } else if (zoomRange != _state.value.zoomRange) {
       Log.d(TAG, "Bound lens reaches $zoomRange")
       _state.value = _state.value.copy(zoomRange = zoomRange)
+    } else if (zoomState.zoomRatio != _state.value.zoomRatio) {
+      _state.value = _state.value.copy(zoomRatio = zoomState.zoomRatio)
     }
   }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel 10
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fixes #14975 by syncing zoomRatio in the zoomRangeObserver if states don't match.
I am not sure if resetting the zoom to one is the actual intended behaviour, but this will fix the ui inconsistency.
I tested it in the demo.camera app and everything worked there in my tests.
