### PR TITLE
Fix UNIQUE constraint on storage_service_id during backup and transfer

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/backup/v2/ArchiveErrorCases.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/v2/ArchiveErrorCases.kt
@@ -311,6 +311,10 @@ object ImportSkips {
     return log(sentTimestamp, "Missing admin delete recipient for chat $chatId")
   }
 
+  fun duplicateStorageId(storageId: String): String {
+    return log(0, "Duplicate storage_service_id::$storageId encountered during import. Retrying with new key.")
+  }
+
   private fun log(sentTimestamp: Long, message: String): String {
     return "[SKIP][$sentTimestamp] $message"
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/backup/v2/importer/GroupArchiveImporter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/v2/importer/GroupArchiveImporter.kt
@@ -9,7 +9,9 @@ import android.content.ContentValues
 import org.signal.archive.proto.Group
 import org.signal.core.models.ServiceId
 import org.signal.core.util.Base64
+import org.signal.core.util.logging.Log
 import org.signal.core.util.toInt
+import org.thoughtcrime.securesms.backup.v2.ImportSkips
 import org.signal.libsignal.zkgroup.groups.GroupMasterKey
 import org.signal.libsignal.zkgroup.groups.GroupSecretParams
 import org.signal.storageservice.storage.protos.groups.AccessControl
@@ -40,6 +42,8 @@ import org.whispersystems.signalservice.api.groupsv2.GroupsV2Operations
  * Handles the importing of [ArchiveGroup] models into the local database.
  */
 object GroupArchiveImporter {
+  private val TAG = Log.tag(GroupArchiveImporter::class.java)
+
   fun import(group: ArchiveGroup): RecipientId {
     val masterKey = GroupMasterKey(group.masterKey.toByteArray())
     val groupId = GroupId.v2(masterKey)
@@ -52,22 +56,46 @@ object GroupArchiveImporter {
       snapshot.toLocal(operations)
     }
 
-    val values = ContentValues().apply {
-      put(RecipientTable.GROUP_ID, groupId.toString())
-      put(RecipientTable.AVATAR_COLOR, AvatarColorHash.forGroupId(groupId).serialize())
-      put(RecipientTable.PROFILE_SHARING, group.whitelisted.toInt())
-      put(RecipientTable.BLOCKED, group.blocked.toInt())
-      put(RecipientTable.BLOCKED_AT, group.blockedAtTimestamp)
-      put(RecipientTable.TYPE, RecipientTable.RecipientType.GV2.id)
-      put(RecipientTable.STORAGE_SERVICE_ID, Base64.encodeWithPadding(StorageSyncHelper.generateKey()))
-      put(RecipientTable.AVATAR_COLOR, group.avatarColor?.toLocal()?.serialize())
-      if (group.hideStory) {
-        val extras = RecipientExtras.Builder().hideStory(true).build()
-        put(RecipientTable.EXTRAS, extras.encode())
+    var attempts = 0
+    var recipientId: Long = -1
+    var lastStorageKey: String? = null
+    while (attempts < 5) {
+      val values = ContentValues().apply {
+        put(RecipientTable.GROUP_ID, groupId.toString())
+        put(RecipientTable.AVATAR_COLOR, AvatarColorHash.forGroupId(groupId).serialize())
+        put(RecipientTable.PROFILE_SHARING, group.whitelisted.toInt())
+        put(RecipientTable.BLOCKED, group.blocked.toInt())
+        put(RecipientTable.BLOCKED_AT, group.blockedAtTimestamp)
+        put(RecipientTable.TYPE, RecipientTable.RecipientType.GV2.id)
+        val storageKey = Base64.encodeWithPadding(StorageSyncHelper.generateKey())
+        lastStorageKey = storageKey
+        put(RecipientTable.STORAGE_SERVICE_ID, storageKey)
+        put(RecipientTable.AVATAR_COLOR, group.avatarColor?.toLocal()?.serialize())
+        if (group.hideStory) {
+          val extras = RecipientExtras.Builder().hideStory(true).build()
+          put(RecipientTable.EXTRAS, extras.encode())
+        }
+      }
+
+      recipientId = SignalDatabase.writableDatabase.insert(RecipientTable.TABLE_NAME, null, values)
+      if (recipientId != -1L) {
+        break
+      }
+
+      // Robust: insert returned -1 indicates UNIQUE constraint (most likely storage_service_id)
+      // No string parsing - retry with new key up to 5 times, then skip (1A + 3A)
+      Log.w(TAG, ImportSkips.duplicateStorageId(lastStorageKey ?: "unknown") + " attempt ${attempts + 1}/5 for group $groupId")
+      attempts++
+      if (attempts >= 5) {
+        break
       }
     }
 
-    val recipientId = SignalDatabase.writableDatabase.insert(RecipientTable.TABLE_NAME, null, values)
+    if (recipientId == -1L) {
+      Log.w(TAG, "Failed to import group $groupId after $attempts attempts due to constraints. Skipping.")
+      return RecipientId.UNKNOWN
+    }
+
     val restoredId = SignalDatabase.groups.create(masterKey, decryptedState, groupSendEndorsements = null)
     if (restoredId != null) {
       SignalDatabase.groups.setShowAsStoryState(restoredId, group.storySendMode.toLocal())

--- a/app/src/main/java/org/thoughtcrime/securesms/backup/v2/importer/GroupArchiveImporter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/backup/v2/importer/GroupArchiveImporter.kt
@@ -67,7 +67,7 @@ object GroupArchiveImporter {
         put(RecipientTable.BLOCKED, group.blocked.toInt())
         put(RecipientTable.BLOCKED_AT, group.blockedAtTimestamp)
         put(RecipientTable.TYPE, RecipientTable.RecipientType.GV2.id)
-        val storageKey = Base64.encodeWithPadding(StorageSyncHelper.generateKey())
+        val storageKey = Base64.encodeWithPadding(StorageSyncHelper.generateUniqueStorageId())
         lastStorageKey = storageKey
         put(RecipientTable.STORAGE_SERVICE_ID, storageKey)
         put(RecipientTable.AVATAR_COLOR, group.avatarColor?.toLocal()?.serialize())
@@ -82,8 +82,13 @@ object GroupArchiveImporter {
         break
       }
 
-      // Robust: insert returned -1 indicates UNIQUE constraint (most likely storage_service_id)
-      // No string parsing - retry with new key up to 5 times, then skip (1A + 3A)
+      // Distinguish storage collision vs other constraint via SELECT (no string parsing)
+      val lastKeyBytes = try { lastStorageKey?.let { Base64.decode(it) } } catch (e: Exception) { null }
+      val storageExists = lastKeyBytes != null && SignalDatabase.recipients.getByStorageId(lastKeyBytes) != null
+      if (!storageExists) {
+        Log.w(TAG, "Insert failed for group $groupId, storage ${lastStorageKey ?: "unknown"} not found - not a storage collision, skipping")
+        break
+      }
       Log.w(TAG, ImportSkips.duplicateStorageId(lastStorageKey ?: "unknown") + " attempt ${attempts + 1}/5 for group $groupId")
       attempts++
       if (attempts >= 5) {

--- a/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
@@ -95,6 +95,7 @@ import org.thoughtcrime.securesms.recipients.RecipientId
 import org.thoughtcrime.securesms.recipients.RecipientUtil
 import org.thoughtcrime.securesms.service.webrtc.links.CallLinkRoomId
 import org.thoughtcrime.securesms.storage.StorageRecordUpdate
+import org.thoughtcrime.securesms.backup.v2.ImportSkips
 import org.thoughtcrime.securesms.storage.StorageSyncHelper
 import org.thoughtcrime.securesms.storage.StorageSyncModels
 import org.thoughtcrime.securesms.util.IdentityUtil
@@ -4322,17 +4323,30 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
     if (existing.isPresent) {
       return GetOrInsertResult(existing.get(), false)
     } else {
-      val id = writableDatabase.insert(TABLE_NAME, null, contentValues)
-      if (id < 0) {
+      var attempts = 0
+      var mutableValues = contentValues
+      while (attempts < 5) {
+        val id = writableDatabase.insert(TABLE_NAME, null, mutableValues)
+        if (id >= 0) {
+          return GetOrInsertResult(RecipientId.from(id), true)
+        }
+
         existing = getByColumn(column, value)
         if (existing.isPresent) {
           return GetOrInsertResult(existing.get(), false)
+        }
+
+        if (mutableValues.containsKey(STORAGE_SERVICE_ID)) {
+          val newKey = Base64.encodeWithPadding(StorageSyncHelper.generateKey())
+          mutableValues.put(STORAGE_SERVICE_ID, newKey)
+          Log.w(TAG, ImportSkips.duplicateStorageId(newKey) + " attempt ${attempts + 1}/5 for $column=$value")
+          attempts++
+          continue
         } else {
           throw AssertionError("Failed to insert recipient!")
         }
-      } else {
-        return GetOrInsertResult(RecipientId.from(id), true)
       }
+      throw AssertionError("Failed to insert recipient after $attempts retries due to storage_service_id collisions!")
     }
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTable.kt
@@ -4337,9 +4337,17 @@ open class RecipientTable(context: Context, databaseHelper: SignalDatabase) : Da
         }
 
         if (mutableValues.containsKey(STORAGE_SERVICE_ID)) {
-          val newKey = Base64.encodeWithPadding(StorageSyncHelper.generateKey())
-          mutableValues.put(STORAGE_SERVICE_ID, newKey)
-          Log.w(TAG, ImportSkips.duplicateStorageId(newKey) + " attempt ${attempts + 1}/5 for $column=$value")
+          val lastKeyStr = mutableValues.getAsString(STORAGE_SERVICE_ID)
+          val lastKeyBytes = try { Base64.decode(lastKeyStr) } catch (e: Exception) { null }
+          val storageExists = lastKeyBytes != null && getByStorageId(lastKeyBytes) != null
+          if (!storageExists) {
+            Log.w(TAG, "Insert failed for $column=$value, storage $lastKeyStr not found - not a storage collision. Failing fast.")
+            throw AssertionError("Failed to insert recipient! insert returned -1 and storage not found for $column")
+          }
+          val newKey = StorageSyncHelper.generateUniqueStorageId()
+          val newKeyStr = Base64.encodeWithPadding(newKey)
+          mutableValues.put(STORAGE_SERVICE_ID, newKeyStr)
+          Log.w(TAG, ImportSkips.duplicateStorageId(lastKeyStr) + " attempt ${attempts + 1}/5 for $column=$value -> retry with $newKeyStr")
           attempts++
           continue
         } else {

--- a/app/src/main/java/org/thoughtcrime/securesms/storage/StorageSyncHelper.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/storage/StorageSyncHelper.kt
@@ -100,9 +100,30 @@ object StorageSyncHelper {
     return IdDifferenceResult(remoteOnlyKeys, localOnlyKeys, hasTypeMismatch)
   }
 
+  /**
+   * Raw random key, no uniqueness guarantee. For DB inserts into [RecipientTable.STORAGE_SERVICE_ID],
+   * use [generateUniqueStorageId] instead to avoid UNIQUE 2067 (see PR 14973).
+   */
   @JvmStatic
   fun generateKey(): ByteArray {
     return keyGenerator.generate()
+  }
+
+  /**
+   * Generates a storage key that does not already exist in the recipient table.
+   * Use this instead of [generateKey] directly when inserting [RecipientTable.STORAGE_SERVICE_ID].
+   * Future writers must use this helper to avoid UNIQUE 2067 collisions (see PR 14973).
+   * Still requires caller to handle `insert() == -1` race - see [RecipientTable.getOrInsertByColumn].
+   */
+  @JvmStatic
+  fun generateUniqueStorageId(): ByteArray {
+    repeat(5) {
+      val key = generateKey()
+      if (SignalDatabase.recipients.getByStorageId(key) == null) return key
+      val encoded = encodeWithPadding(key)
+      Log.w(TAG, org.thoughtcrime.securesms.backup.v2.ImportSkips.duplicateStorageId(encoded) + " pre-check exists, retry ${it + 1}/5")
+    }
+    return generateKey()
   }
 
   @JvmStatic


### PR DESCRIPTION
Fixes #14954

Enabling backups during device transfer could hit UNIQUE constraint on recipient.storage_service_id (2067) and loop. Group import generated a random key without retry, so collision crashed the flow. Retry with new key up to 5 times and skip on persistent collision.