### PR TITLE
Fix HE-AAC transcoding with decoded PCM format

### DIFF
--- a/lib/video/src/main/java/org/thoughtcrime/securesms/video/videoconverter/AudioTrackConverter.java
+++ b/lib/video/src/main/java/org/thoughtcrime/securesms/video/videoconverter/AudioTrackConverter.java
@@ -38,18 +38,19 @@ final class AudioTrackConverter {
     final long mInputDuration;
 
     private final MediaExtractor mAudioExtractor;
+    private final MediaCodecInfo mAudioCodecInfo;
     private final MediaCodec mAudioDecoder;
-    private final MediaCodec mAudioEncoder;
+    private MediaCodec mAudioEncoder;
 
     private final ByteBuffer            instanceSampleBuffer = ByteBuffer.allocateDirect(SAMPLE_BUFFER_SIZE);
     private final MediaCodec.BufferInfo instanceBufferInfo   = new MediaCodec.BufferInfo();
 
     private final ByteBuffer[] mAudioDecoderInputBuffers;
     private ByteBuffer[] mAudioDecoderOutputBuffers;
-    private final ByteBuffer[] mAudioEncoderInputBuffers;
+    private ByteBuffer[] mAudioEncoderInputBuffers;
     private ByteBuffer[] mAudioEncoderOutputBuffers;
     private final MediaCodec.BufferInfo mAudioDecoderOutputBufferInfo;
-    private final MediaCodec.BufferInfo mAudioEncoderOutputBufferInfo;
+    private MediaCodec.BufferInfo mAudioEncoderOutputBufferInfo;
 
     MediaFormat mEncoderOutputAudioFormat;
 
@@ -99,13 +100,13 @@ final class AudioTrackConverter {
         mAudioExtractor = audioExtractor;
         mAudioBitrate = audioBitrate;
 
-        final MediaCodecInfo audioCodecInfo = MediaConverter.selectCodec(OUTPUT_AUDIO_MIME_TYPE);
-        if (audioCodecInfo == null) {
+        mAudioCodecInfo = MediaConverter.selectCodec(OUTPUT_AUDIO_MIME_TYPE);
+        if (mAudioCodecInfo == null) {
             // Don't fail CTS if they don't have an AAC codec (not here, anyway).
             Log.e(TAG, "Unable to find an appropriate codec for " + OUTPUT_AUDIO_MIME_TYPE);
             throw new FileNotFoundException();
         }
-        if (VERBOSE) Log.d(TAG, "audio found codec: " + audioCodecInfo.getName());
+        if (VERBOSE) Log.d(TAG, "audio found codec: " + mAudioCodecInfo.getName());
 
         final MediaFormat inputAudioFormat = mAudioExtractor.getTrackFormat(audioInputTrack);
         mInputDuration = inputAudioFormat.containsKey(MediaFormat.KEY_DURATION) ? inputAudioFormat.getLong(MediaFormat.KEY_DURATION) : 0;
@@ -117,27 +118,12 @@ final class AudioTrackConverter {
 
         if (VERBOSE) Log.d(TAG, "audio skipping transcoding: " + skipTrancode);
 
-        final MediaFormat outputAudioFormat =
-                MediaFormat.createAudioFormat(
-                        OUTPUT_AUDIO_MIME_TYPE,
-                        inputAudioFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE),
-                        inputAudioFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT));
-        outputAudioFormat.setInteger(MediaFormat.KEY_BIT_RATE, audioBitrate);
-        outputAudioFormat.setInteger(MediaFormat.KEY_AAC_PROFILE, OUTPUT_AUDIO_AAC_PROFILE);
-        outputAudioFormat.setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, SAMPLE_BUFFER_SIZE);
-
-        // Create a MediaCodec for the desired codec, then configure it as an encoder with
-        // our desired properties. Request a Surface to use for input.
-        mAudioEncoder = createAudioEncoder(audioCodecInfo, outputAudioFormat);
         // Create a MediaCodec for the decoder, based on the extractor's format.
         mAudioDecoder = createAudioDecoder(inputAudioFormat);
 
         mAudioDecoderInputBuffers = mAudioDecoder.getInputBuffers();
         mAudioDecoderOutputBuffers = mAudioDecoder.getOutputBuffers();
-        mAudioEncoderInputBuffers = mAudioEncoder.getInputBuffers();
-        mAudioEncoderOutputBuffers = mAudioEncoder.getOutputBuffers();
         mAudioDecoderOutputBufferInfo = new MediaCodec.BufferInfo();
-        mAudioEncoderOutputBufferInfo = new MediaCodec.BufferInfo();
 
         if (mTimeFrom > 0) {
             mAudioExtractor.seekTo(mTimeFrom * 1000, MediaExtractor.SEEK_TO_PREVIOUS_SYNC);
@@ -233,10 +219,16 @@ final class AudioTrackConverter {
                 break;
             }
             if (decoderOutputBufferIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
-                if (VERBOSE) {
-                    MediaFormat decoderOutputAudioFormat = mAudioDecoder.getOutputFormat();
-                    Log.d(TAG, "audio decoder: output format changed: " + decoderOutputAudioFormat);
-                }
+                Preconditions.checkState("audio decoder changed its output format again?", mAudioEncoder == null);
+
+                MediaFormat decoderOutputAudioFormat = mAudioDecoder.getOutputFormat();
+                if (VERBOSE) Log.d(TAG, "audio decoder: output format changed: " + decoderOutputAudioFormat);
+
+                MediaFormat encoderInputAudioFormat = createEncoderInputFormat(decoderOutputAudioFormat, mAudioBitrate);
+                mAudioEncoder = createAudioEncoder(mAudioCodecInfo, encoderInputAudioFormat);
+                mAudioEncoderInputBuffers = mAudioEncoder.getInputBuffers();
+                mAudioEncoderOutputBuffers = mAudioEncoder.getOutputBuffers();
+                mAudioEncoderOutputBufferInfo = new MediaCodec.BufferInfo();
                 break;
             }
             if (VERBOSE) {
@@ -266,7 +258,7 @@ final class AudioTrackConverter {
         }
 
         // Feed the pending decoded audio buffer to the audio encoder.
-        while (mPendingAudioDecoderOutputBufferIndex != -1) {
+        while (mPendingAudioDecoderOutputBufferIndex != -1 && mAudioEncoder != null) {
             if (VERBOSE) {
                 Log.d(TAG, "audio decoder: attempting to process pending buffer: " + mPendingAudioDecoderOutputBufferIndex);
             }
@@ -313,7 +305,7 @@ final class AudioTrackConverter {
         }
 
         // Poll frames from the audio encoder and send them to the muxer.
-        while (!mAudioEncoderDone && (mEncoderOutputAudioFormat == null || mMuxer != null)) {
+        while (mAudioEncoder != null && !mAudioEncoderDone && (mEncoderOutputAudioFormat == null || mMuxer != null)) {
             final int encoderOutputBufferIndex = mAudioEncoder.dequeueOutputBuffer(mAudioEncoderOutputBufferInfo, TIMEOUT_USEC);
             if (encoderOutputBufferIndex == MediaCodec.INFO_TRY_AGAIN_LATER) {
                 if (VERBOSE) Log.d(TAG, "no audio encoder output buffer");
@@ -466,6 +458,31 @@ final class AudioTrackConverter {
         encoder.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE);
         encoder.start();
         return encoder;
+    }
+
+    /**
+     * AAC decoders can expose a different PCM format than the compressed track advertises. In
+     * particular, HE-AAC uses SBR and parametric stereo to expand a low-rate mono core into a
+     * higher-rate stereo output. The encoder consumes decoded PCM, so configuring it from the
+     * compressed input format makes it interpret the bytes at the wrong rate and channel count.
+     */
+    static @NonNull MediaFormat createEncoderInputFormat(final @NonNull MediaFormat decoderOutputFormat,
+                                                          final int audioBitrate) {
+        final MediaFormat encoderInputFormat = MediaFormat.createAudioFormat(
+                OUTPUT_AUDIO_MIME_TYPE,
+                decoderOutputFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE),
+                decoderOutputFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT));
+
+        encoderInputFormat.setInteger(MediaFormat.KEY_BIT_RATE, audioBitrate);
+        encoderInputFormat.setInteger(MediaFormat.KEY_AAC_PROFILE, OUTPUT_AUDIO_AAC_PROFILE);
+        encoderInputFormat.setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, SAMPLE_BUFFER_SIZE);
+
+        if (decoderOutputFormat.containsKey(MediaFormat.KEY_PCM_ENCODING)) {
+            encoderInputFormat.setInteger(MediaFormat.KEY_PCM_ENCODING,
+                                          decoderOutputFormat.getInteger(MediaFormat.KEY_PCM_ENCODING));
+        }
+
+        return encoderInputFormat;
     }
 
     private static int getAndSelectAudioTrackIndex(MediaExtractor extractor) {

--- a/lib/video/src/test/java/org/thoughtcrime/securesms/video/videoconverter/AudioTrackConverterTest.java
+++ b/lib/video/src/test/java/org/thoughtcrime/securesms/video/videoconverter/AudioTrackConverterTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package org.thoughtcrime.securesms.video.videoconverter;
+
+import static org.junit.Assert.assertEquals;
+
+import android.media.AudioFormat;
+import android.media.MediaCodecInfo;
+import android.media.MediaFormat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public final class AudioTrackConverterTest {
+
+  @Test
+  public void createEncoderInputFormat_usesDecodedPcmFormat() {
+    MediaFormat decoderOutputFormat = MediaFormat.createAudioFormat(MediaFormat.MIMETYPE_AUDIO_RAW, 44_100, 2);
+    decoderOutputFormat.setInteger(MediaFormat.KEY_PCM_ENCODING, AudioFormat.ENCODING_PCM_16BIT);
+
+    MediaFormat encoderInputFormat = AudioTrackConverter.createEncoderInputFormat(decoderOutputFormat, 128_000);
+
+    assertEquals(MediaFormat.MIMETYPE_AUDIO_AAC, encoderInputFormat.getString(MediaFormat.KEY_MIME));
+    assertEquals(44_100, encoderInputFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE));
+    assertEquals(2, encoderInputFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT));
+    assertEquals(128_000, encoderInputFormat.getInteger(MediaFormat.KEY_BIT_RATE));
+    assertEquals(MediaCodecInfo.CodecProfileLevel.AACObjectLC,
+                 encoderInputFormat.getInteger(MediaFormat.KEY_AAC_PROFILE));
+    assertEquals(AudioFormat.ENCODING_PCM_16BIT,
+                 encoderInputFormat.getInteger(MediaFormat.KEY_PCM_ENCODING));
+  }
+}


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I tested this on a physical Android device with the public HE-AACv2 sample from #12674; device details are omitted for privacy
- [x] My contribution is fully baked and ready to be merged as is
- [x] The fixed issue is mentioned in the first commit with `Fixes #12674`

----------

### Description
Fixes #12674.

HE-AAC can expose different compressed-core and decoded PCM formats. In the public reproduction, MediaExtractor reports a 22.05 kHz mono core while the decoder outputs 44.1 kHz stereo PCM. AudioTrackConverter currently configures its AAC encoder from the compressed format before the decoder reveals that output, so the encoder interprets four times the PCM byte rate as 22.05 kHz mono. The result is slow, deep-pitched audio.

This delays encoder creation until `INFO_OUTPUT_FORMAT_CHANGED` and configures it from the decoder's actual PCM sample rate, channel count, and encoding.

Verification:
- Targeted video-module compile and regression test pass on current `main`.
- Full public-sample transcode produces AAC-LC 44.1 kHz stereo audio lasting 15.743 s for a 15.701 s source.
- A 2 s–8 s trimmed transcode produces 5.944 s of audio and 5.987 s of video.
- The existing AAC remux path remains valid.