### PR TITLE
Fix external apps opening inside Signal's task

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
@@ -129,7 +129,7 @@ import org.signal.core.util.concurrent.LifecycleDisposable
 import org.signal.core.util.concurrent.ListenableFuture
 import org.signal.core.util.concurrent.addTo
 import org.signal.core.util.dp
-import org.signal.core.util.encourageNewBrowserTab
+import org.signal.core.util.prepareExternalLink
 import org.signal.core.util.logging.Log
 import org.signal.core.util.orNull
 import org.signal.core.util.requireDrawable
@@ -911,7 +911,7 @@ class ConversationFragment :
   }
 
   private fun openLink(url: String) {
-    startActivity(Intent(Intent.ACTION_VIEW, url.toUri()).encourageNewBrowserTab())
+    startActivity(Intent(Intent.ACTION_VIEW, url.toUri()).prepareExternalLink())
   }
 
   //endregion

--- a/app/src/main/java/org/thoughtcrime/securesms/util/LongClickCopySpan.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/LongClickCopySpan.java
@@ -35,6 +35,16 @@ public class LongClickCopySpan extends URLSpan {
     this.underline = underline;
   }
 
+    /**
+   * {@link URLSpan}'s default implementation starts the intent without
+   * {@link android.content.Intent#FLAG_ACTIVITY_NEW_TASK}, which pushes the handling app's activity onto our task. Route through
+   * {@link CommunicationActions#openBrowserLink} instead so every link we hand off behaves the same way, wherever it was tapped.
+   */
+  @Override
+  public void onClick(View widget) {
+    CommunicationActions.openBrowserLink(widget.getContext(), getURL());
+  }
+
   void onLongClick(View widget) {
     Context context = widget.getContext();
     String preparedUrl = prepareUrl(getURL());

--- a/app/src/test/java/org/thoughtcrime/securesms/util/LongClickCopySpanTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/util/LongClickCopySpanTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.thoughtcrime.securesms.util
+
+import android.app.Activity
+import android.app.Application
+import android.content.Intent
+import android.view.View
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * [LongClickCopySpan] is the click target for links in the story viewer, the long-message view, message details and starred messages —
+ * every surface whose [UrlClickHandler] declines the click. [android.text.style.URLSpan]'s default launch omits
+ * [Intent.FLAG_ACTIVITY_NEW_TASK], which would push the handling app onto our own task.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class LongClickCopySpanTest {
+
+  @Test
+  fun `a clicked link is handed to the other app in its own task`() {
+    val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+
+    LongClickCopySpan("https://signal.org/").onClick(View(activity))
+
+    val intent = shadowOf(activity).nextStartedActivity
+    assertEquals(Intent.ACTION_VIEW, intent.action)
+    assertEquals("https://signal.org/", intent.dataString)
+    assertNotEquals(0, intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK)
+  }
+}

--- a/core/util/src/main/java/org/signal/core/util/IntentExtensions.kt
+++ b/core/util/src/main/java/org/signal/core/util/IntentExtensions.kt
@@ -7,13 +7,20 @@ import android.provider.Browser
 import java.util.UUID
 
 /**
+ * Prepares an intent that hands a link off to whichever app handles it.
+ *
  * Encourages the browser to open this link in a new tab rather than re-using an existing one. The random application id prevents browsers from
  * associating this link with a tab we previously opened.
+ *
+ * FLAG_ACTIVITY_NEW_TASK gives the link its own task. Without it the handling app's activity is pushed onto our task, so Recents shows a single
+ * card with our icon that actually contains the other app, and its back stack is tangled with ours. Note that the browser extras above only
+ * influence browsers, so they do nothing for a link that a non-browser app has registered to handle.
  */
-fun Intent.encourageNewBrowserTab(): Intent {
+fun Intent.prepareExternalLink(): Intent {
   return apply {
     putExtra(Browser.EXTRA_APPLICATION_ID, UUID.randomUUID().toString())
     putExtra(Browser.EXTRA_CREATE_NEW_TAB, true)
+    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
   }
 }
 

--- a/core/util/src/main/java/org/signal/core/util/LinkActions.kt
+++ b/core/util/src/main/java/org/signal/core/util/LinkActions.kt
@@ -5,7 +5,6 @@
 
 package org.signal.core.util
 
-import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
@@ -18,10 +17,14 @@ object LinkActions {
   @JvmStatic
   fun openUrl(context: Context, url: String, onError: (OpenUrlError) -> Unit) {
     try {
+      // FLAG_ACTIVITY_NEW_TASK is required when starting from a non-Activity context, but it is
+      // wanted in every case: without it the target app's activity is pushed onto our own task, so
+      // Recents shows a single card with the Signal icon that actually contains the other app.
+      // Giving the link its own task also means an already-running instance of the target app is
+      // brought forward rather than duplicated inside our stack.
       val intent = Intent(Intent.ACTION_VIEW, url.toUri())
-      if (context !is Activity) {
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-      }
+        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
       context.startActivity(intent)
     } catch (_: ActivityNotFoundException) {
       Log.w(TAG, "Unable to open URL: no browser activity found")

--- a/core/util/src/test/java/org/signal/core/util/LinkActionsTest.kt
+++ b/core/util/src/test/java/org/signal/core/util/LinkActionsTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.signal.core.util
+
+import android.app.Activity
+import android.app.Application
+import android.content.Intent
+import android.provider.Browser
+import androidx.core.net.toUri
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.isTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, application = Application::class)
+class LinkActionsTest {
+
+  private val url = "https://signal.org/"
+
+  @Test
+  fun `link opened from an activity is given its own task`() {
+    val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+
+    var errored = false
+    LinkActions.openUrl(activity, url) { errored = true }
+
+    val intent = shadowOf(activity).nextStartedActivity
+
+    assertThat(errored).isFalse()
+    assertThat(intent.action).isEqualTo(Intent.ACTION_VIEW)
+    assertThat(intent.dataString).isEqualTo(url)
+    assertThat(intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK).isNotEqualTo(0)
+  }
+
+  @Test
+  fun `link opened from a non-activity context is given its own task`() {
+    val application = RuntimeEnvironment.getApplication()
+
+    var errored = false
+    LinkActions.openUrl(application, url) { errored = true }
+
+    val intent = shadowOf(application).nextStartedActivity
+
+    assertThat(errored).isFalse()
+    assertThat(intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK).isNotEqualTo(0)
+  }
+
+  @Test
+  fun `missing browser reports an error instead of throwing`() {
+    val application = RuntimeEnvironment.getApplication()
+    shadowOf(application).checkActivities(true)
+
+    var error: LinkActions.OpenUrlError? = null
+    LinkActions.openUrl(application, url) { error = it }
+
+    assertThat(error == LinkActions.OpenUrlError.NoBrowserFound).isTrue()
+  }
+}
+
+/**
+ * [prepareExternalLink] is what the conversation screen uses to hand a tapped link to another app.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, application = Application::class)
+class IntentExtensionsTest {
+
+  @Test
+  fun `a link handed to another app is given its own task`() {
+    val intent = Intent(Intent.ACTION_VIEW, "https://x.com/someone/status/1".toUri()).prepareExternalLink()
+
+    assertThat(intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK).isNotEqualTo(0)
+  }
+
+  @Test
+  fun `a link handed to another app still asks the browser for a new tab`() {
+    val intent = Intent(Intent.ACTION_VIEW, "https://signal.org/".toUri()).prepareExternalLink()
+
+    assertThat(intent.getBooleanExtra(Browser.EXTRA_CREATE_NEW_TAB, false)).isTrue()
+    assertThat(intent.getStringExtra(Browser.EXTRA_APPLICATION_ID) != null).isTrue()
+  }
+}


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
  * Vivo V2036, Android 13. The reporter's setup (X installed, Android 16) isn't directly reproducible here — no non-browser app on this device claims https links, and Chrome is immune — so I built a minimal stub registered for `signal.org` with `launchMode="standard"` and its own `taskAffinity` to stand in for X, and captured before/after against real builds of `main` with and without this patch.
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` syntax

----------

### Description

Tapping a link handled by a non-browser app launches that app into Signal's task. Recents shows one card with Signal's icon and label whose contents are the other app, and the other app lands on top of Signal's back stack instead of beside it.

<img src="https://raw.githubusercontent.com/theabhishekchandra/Signal-Android/issue-14946-screenshots/recents-before-after.png" width="820">

Same device, same tap on a link, only this patch differing. On the left the single Recents card is labelled **Signal (Staging)** but its contents are the other app; on the right the other app has its own card and Signal keeps its own. The red screen is the stub standing in for X.

Three paths hand a URL to another app, and none set `FLAG_ACTIVITY_NEW_TASK`:

1. **`LinkActions.openUrl`** — via `CommunicationActions.openBrowserLink` (~71 call sites). It set the flag only when the context was *not* an Activity. That guard comes from 26cb17e25c ("Fix browser not opening in certain contexts"), added because Android **requires** the flag from a non-Activity context. It was never a decision about task placement — on the Activity path the flag was just missing.

2. **`ConversationFragment.openLink`** — used by `onUrlClicked` and `onLinkPreviewClicked`. Builds its own intent and never goes through `LinkActions`. The `Browser.EXTRA_CREATE_NEW_TAB` / `EXTRA_APPLICATION_ID` extras only influence browsers, so they do nothing for a link a non-browser app has registered to handle.

3. **`LongClickCopySpan`** — never overrode `onClick`, so it inherited `URLSpan`'s bare `startActivity`. This is the click target wherever the `UrlClickHandler` declines: the **story viewer** (which uses the span directly, with no handler), the **long-message view**, **message details** and **starred messages**.

`LongClickCopySpan` now delegates to `openBrowserLink` instead of re-implementing the launch, so this reduces the number of parallel link launchers rather than adding another. `encourageNewBrowserTab()` is renamed `prepareExternalLink()`, since it no longer only concerns browser tabs.

**Scope.** Only observable when a **non-browser** app handles the link. Chrome's `ChromeTabbedActivity` is `singleTask` and always takes its own task regardless of the flag, so browser links behave identically before and after.

**Why `NEW_TASK` is safe here**
- No Custom Tabs anywhere in the tree, so nothing relies on staying in-task.
- Signal's own https handlers (`StickerPackPreviewActivity`, `DeepLinkEntryActivity`) both use the default `taskAffinity`, so a `signal.me` / `signal.art` link reuses the existing Signal task rather than creating a second Signal card.
- Back navigation is preserved — verified on device, Back from the other app still returns to Signal.

### Verification

Unit tests in `LinkActionsTest` and `LongClickCopySpanTest`; the flag assertions fail against current `main` and pass with this change (confirmed by stashing each fix independently).

On device (Vivo V2036, Android 13), same build and same tap, only the patch differing:

| | Signal task | other app's task | flags Signal sent |
|---|---|---|---|
| `main` | 359 | **359** (same task, `sz=2`) | `0x0` |
| with fix | 361 | **362** (own task) | `0x10000000` |

On `main` the single Recents card is labelled "Signal" but its contents are the other app, and Back from it lands on Signal's own screen. With the fix there are two cards.
