### PR TITLE
Keep ShareActivity alive when locked to preserve shared URI permissions

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/PassphraseActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/PassphraseActivity.java
@@ -67,6 +67,8 @@ public abstract class PassphraseActivity extends BaseActivity {
             } catch (java.lang.SecurityException e) {
                 Log.w(TAG, "Access permission not passed from PassphraseActivity, retry sharing.");
             }
+        } else {
+          setResult(RESULT_OK);
         }
         finish();
       }

--- a/app/src/main/java/org/thoughtcrime/securesms/PassphraseRequiredActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/PassphraseRequiredActivity.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -66,6 +68,7 @@ public abstract class PassphraseRequiredActivity extends BaseActivity implements
 
   private SignalServiceNetworkAccess networkAccess;
   private BroadcastReceiver          clearKeyReceiver;
+  private ActivityResultLauncher<Intent> promptPassphraseLauncher;
 
   @Override
   protected final void onCreate(Bundle savedInstanceState) {
@@ -73,6 +76,19 @@ public abstract class PassphraseRequiredActivity extends BaseActivity implements
     AppStartup.getInstance().onCriticalRenderEventStart();
     this.networkAccess = AppDependencies.getSignalServiceNetworkAccess();
     onPreCreate();
+
+    if (shouldStayAliveOnLock()) {
+      this.promptPassphraseLauncher = registerForActivityResult(
+        new ActivityResultContracts.StartActivityForResult(),
+        result -> {
+          if (result.getResultCode() == RESULT_OK) {
+            onAppUnlocked();
+          } else {
+            finish();
+          }
+        }
+      );
+    }
 
     final boolean locked = KeyCachingService.isLocked(this);
     routeApplicationState(locked);
@@ -82,6 +98,9 @@ public abstract class PassphraseRequiredActivity extends BaseActivity implements
     if (!isFinishing()) {
       initializeClearKeyReceiver();
       onCreate(savedInstanceState, true);
+      if (!locked) {
+        onAppUnlocked();
+      }
     }
 
     AppStartup.getInstance().onCriticalRenderEventEnd();
@@ -90,6 +109,15 @@ public abstract class PassphraseRequiredActivity extends BaseActivity implements
 
   protected void onPreCreate() {}
   protected void onCreate(Bundle savedInstanceState, boolean ready) {}
+
+  /**
+   * Called once the application is unlocked and the activity is ready.
+   */
+  protected void onAppUnlocked() {}
+
+  protected boolean shouldStayAliveOnLock() {
+    return false;
+  }
 
   @Override
   protected void onDestroy() {
@@ -138,6 +166,12 @@ public abstract class PassphraseRequiredActivity extends BaseActivity implements
 
   private void routeApplicationState(boolean locked) {
     final int applicationState = getApplicationState(locked);
+    if (applicationState == STATE_PROMPT_PASSPHRASE && shouldStayAliveOnLock() && promptPassphraseLauncher != null) {
+      Intent intent = new Intent(this, PassphrasePromptActivity.class);
+      intent.putExtra(PassphrasePromptActivity.FROM_FOREGROUND, AppForegroundObserver.isForegrounded());
+      promptPassphraseLauncher.launch(intent);
+      return;
+    }
     Intent    intent           = getIntentForState(applicationState);
     if (intent != null) {
       Log.d(TAG, "routeApplicationState(), intent: " + intent.getComponent());

--- a/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ShareActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/sharing/v2/ShareActivity.kt
@@ -66,7 +66,7 @@ class ShareActivity : PassphraseRequiredActivity(), MultiselectForwardFragment.C
 
   private lateinit var finishOnOkResultLauncher: ActivityResultLauncher<Intent>
   private lateinit var unresolvedShareData: UnresolvedShareData
-
+  private var isShareInitialized: Boolean = false
   private val viewModel: ShareViewModel by viewModels {
     ShareViewModel.Factory(unresolvedShareData, ShareRepository(this))
   }
@@ -76,12 +76,31 @@ class ShareActivity : PassphraseRequiredActivity(), MultiselectForwardFragment.C
       .let { ConversationUtil.getRecipientId(it) }
       ?.takeUnless { it.isUnknown }
 
+  override fun shouldStayAliveOnLock(): Boolean = true
+
   override fun onPreCreate() {
     super.onPreCreate()
     dynamicTheme.onCreate(this)
   }
 
   override fun onCreate(savedInstanceState: Bundle?, ready: Boolean) {
+    super.onCreate(savedInstanceState, ready)
+
+    finishOnOkResultLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+      if (it.resultCode == Activity.RESULT_OK) {
+        finish()
+      }
+    }
+  }
+
+  override fun onAppUnlocked() {
+    initializeShare()
+  }
+
+  private fun initializeShare() {
+    if (isShareInitialized) return
+    isShareInitialized = true
+
     setContentView(R.layout.multiselect_forward_activity)
 
     val isIntentValid = getUnresolvedShareData().either(
@@ -98,12 +117,6 @@ class ShareActivity : PassphraseRequiredActivity(), MultiselectForwardFragment.C
     if (!isIntentValid) {
       finish()
       return
-    }
-
-    finishOnOkResultLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-      if (it.resultCode == Activity.RESULT_OK) {
-        finish()
-      }
     }
 
     lifecycleDisposable.bindTo(this)


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/main/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Samsung Galaxy S23, Android 15
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixes #14968
Fixes an issue where sharing media or files from an external app to Signal while screen lock is enabled causes the share to fail with a SecurityException. This was caused by PassphraseRequiredActivity finishing ShareActivity when locked, which immediately revoked Android's temporary URI read permissions before the user could unlock. We now allow ShareActivity to stay alive across the lock prompt and initialize via a new onAppUnlocked() hook, preserving URI permissions without duplicating authentication logic.

